### PR TITLE
r/aws_cloudfront_distribution: Support trusted_key_groups argument

### DIFF
--- a/.changelog/18644.txt
+++ b/.changelog/18644.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudfront_distribution: Add `trusted_key_groups` argument
+```

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -178,6 +178,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"trusted_key_groups": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"trusted_signers": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -351,6 +356,12 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"target_origin_id": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+						"trusted_key_groups": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"trusted_signers": {
 							Type:     schema.TypeList,
@@ -613,6 +624,35 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"trusted_key_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"items": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key_group_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"key_pair_ids": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			// Terraform AWS Provider 3.0 name change:
 			// enables TF Plugin SDK to ignore pre-existing attribute state
 			// associated with previous naming i.e. active_trusted_signers
@@ -765,6 +805,9 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 	}
 
 	// Update other attributes outside of DistributionConfig
+	if err := d.Set("trusted_key_groups", flattenCloudfrontActiveTrustedKeyGroups(resp.Distribution.ActiveTrustedKeyGroups)); err != nil {
+		return fmt.Errorf("error setting trusted_key_groups: %w", err)
+	}
 	if err := d.Set("trusted_signers", flattenCloudfrontActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners)); err != nil {
 		return fmt.Errorf("error setting trusted_signers: %w", err)
 	}

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -317,6 +317,9 @@ of several sub-resources - these resources are laid out below.
     CloudFront to route requests to when a request matches the path pattern
     either for a cache behavior or for the default cache behavior.
 
+* `trusted_key_groups` (Optional) - A list of key group IDs that CloudFront can use to validate signed URLs or signed cookies.
+See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
+
 * `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content.
 See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
 
@@ -538,6 +541,12 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The current status of the distribution. `Deployed` if the
     distribution's information is fully propagated throughout the Amazon
     CloudFront system.
+
+* `trusted_key_groups` - List of nested attributes for active trusted key groups, if the distribution is set up to serve private content with signed URLs
+    * `enabled` - `true` if any of the key groups have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies
+    * `items` - List of nested attributes for each key group
+        * `key_group_id` - The ID of the key group that contains the public keys
+        * `key_pair_ids` - Set of CloudFront key pair IDs
 
 * `trusted_signers` - List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs
     * `enabled` - `true` if any of the AWS accounts listed as trusted signers have active CloudFront key pairs


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/15912

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudFrontDistribution_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution_ -timeout 180m
=== RUN   TestAccAWSCloudFrontDistribution_disappears
=== PAUSE TestAccAWSCloudFrontDistribution_disappears
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
=== PAUSE TestAccAWSCloudFrontDistribution_S3Origin
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== PAUSE TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_customOrigin
=== RUN   TestAccAWSCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccAWSCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccAWSCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccAWSCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_multiOrigin
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccAWSCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccAWSCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
=== PAUSE TestAccAWSCloudFrontDistribution_HTTP11Config
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== PAUSE TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedKeyGroups
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedKeyGroups
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== RUN   TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn
=== PAUSE TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn
=== RUN   TestAccAWSCloudFrontDistribution_Enabled
=== PAUSE TestAccAWSCloudFrontDistribution_Enabled
=== RUN   TestAccAWSCloudFrontDistribution_RetainOnDelete
=== PAUSE TestAccAWSCloudFrontDistribution_RetainOnDelete
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== RUN   TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccAWSCloudFrontDistribution_WaitForDeployment
=== PAUSE TestAccAWSCloudFrontDistribution_WaitForDeployment
=== RUN   TestAccAWSCloudFrontDistribution_OriginGroups
=== PAUSE TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_disappears
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_WaitForDeployment
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedKeyGroups
=== CONT  TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_RetainOnDelete
=== CONT  TestAccAWSCloudFrontDistribution_Enabled
=== CONT  TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== CONT  TestAccAWSCloudFrontDistribution_originPolicyDefault
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (253.38s)
=== CONT  TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_disappears (285.12s)
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (13.16s)
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (9.96s)
=== CONT  TestAccAWSCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (309.02s)
=== CONT  TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (310.02s)
=== CONT  TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedKeyGroups (310.17s)
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (311.58s)
=== CONT  TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (314.01s)
=== CONT  TestAccAWSCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn (319.86s)
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn (321.59s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (331.31s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (342.71s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (461.53s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (461.66s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (461.82s)
--- PASS: TestAccAWSCloudFrontDistribution_originPolicyDefault (463.61s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy (463.65s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (464.20s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (476.67s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (534.86s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (678.49s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (427.49s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (382.20s)
--- PASS: TestAccAWSCloudFrontDistribution_originPolicyOrdered (391.02s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (400.02s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (401.96s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (401.24s)
--- PASS: TestAccAWSCloudFrontDistribution_forwardedValuesToCachePolicy (571.22s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (614.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	926.576s
```

Added trusted_key_groups support for aws_cloudfront_distribution resource. Thank you for your review!

