### PR TITLE
tests/r/security_group: Add sweeper concurrency

### DIFF
--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -73,11 +73,8 @@ func testSweepSecurityGroups(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error describing EC2 Security Groups for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		// Any errors didn't prevent gathering some sweeping work, so do it.
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 Security Groups for %s: %w", region, err))
-		}
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 Security Groups for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Output from acceptance testing: NA

```
2021/04/08 00:16:05 [DEBUG] Security Group destroy: sg-0c83901c9e757f55d
2021/04/08 00:16:05 [DEBUG] Security Group destroy: sg-09aafd52d69555d9e
2021/04/08 00:16:06 [DEBUG] Waiting for state to become: [success]
2021/04/08 00:16:06 [DEBUG] Waiting for state to become: [success]
```