### PR TITLE
tests/r/vpc: Add sweeper concurrency

### DIFF
--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -80,11 +80,8 @@ func testSweepVPCs(region string) error {
 		errs = multierror.Append(errs, fmt.Errorf("error describing EC2 VPCs for %s: %w", region, err))
 	}
 
-	if len(sweepResources) > 0 {
-		// Any errors didn't prevent gathering some sweeping work, so do it.
-		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 VPCs for %s: %w", region, err))
-		}
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 VPCs for %s: %w", region, err))
 	}
 
 	if testSweepSkipSweepError(errs.ErrorOrNil()) {

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -39,67 +38,61 @@ func init() {
 
 func testSweepVPCs(region string) error {
 	client, err := sharedClientForRegion(region)
+
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
+
 	conn := client.(*AWSClient).ec2conn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
 	input := &ec2.DescribeVpcsInput{}
-	var sweeperErrs *multierror.Error
 
 	err = conn.DescribeVpcsPages(input, func(page *ec2.DescribeVpcsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
 		for _, vpc := range page.Vpcs {
 			if vpc == nil {
 				continue
 			}
 
 			id := aws.StringValue(vpc.VpcId)
-			input := &ec2.DeleteVpcInput{
-				VpcId: vpc.VpcId,
-			}
 
 			if aws.BoolValue(vpc.IsDefault) {
 				log.Printf("[DEBUG] Skipping default EC2 VPC: %s", id)
 				continue
 			}
 
-			log.Printf("[INFO] Deleting EC2 VPC: %s", id)
+			r := resourceAwsVpc()
+			d := r.Data(nil)
+			d.SetId(id)
 
-			// Handle EC2 eventual consistency
-			err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-				_, err := conn.DeleteVpc(input)
-				if isAWSErr(err, "DependencyViolation", "") {
-					return resource.RetryableError(err)
-				}
-				if err != nil {
-					return resource.NonRetryableError(err)
-				}
-				return nil
-			})
-
-			if isResourceTimeoutError(err) {
-				_, err = conn.DeleteVpc(input)
-			}
-
-			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting EC2 VPC (%s): %w", id, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-			}
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
 
 		return !lastPage
 	})
 
-	if testSweepSkipSweepError(err) {
-		log.Printf("[WARN] Skipping EC2 VPC sweep for %s: %s", region, err)
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing EC2 VPCs for %s: %w", region, err))
+	}
+
+	if len(sweepResources) > 0 {
+		// Any errors didn't prevent gathering some sweeping work, so do it.
+		if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 VPCs for %s: %w", region, err))
+		}
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping EC2 VPCs sweep for %s: %s", region, errs)
 		return nil
 	}
 
-	if err != nil {
-		return fmt.Errorf("Error describing vpcs: %s", err)
-	}
-
-	return sweeperErrs.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSVpc_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15334

Output from acceptance testing: NA

```
2021/04/08 00:24:26 [DEBUG] Skipping default EC2 VPC: vpc-a196d5d9
2021/04/08 00:24:26 [INFO] Deleting VPC: vpc-0447f40cfc55424fb
2021/04/08 00:24:26 [INFO] Deleting VPC: vpc-0941b7908592e47ea
2021/04/08 00:24:26 [DEBUG] Waiting for state to become: [success]
2021/04/08 00:24:26 [DEBUG] Waiting for state to become: [success]
```