### PR TITLE
resource/aws_xray_sampling_rule fix rule name max length

### DIFF
--- a/.changelog/18667.txt
+++ b/.changelog/18667.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ resource/aws_xray_sampling_rule: Change the maximum length of `rule_name` from 128 to 32
+```

--- a/aws/resource_aws_xray_sampling_rule.go
+++ b/aws/resource_aws_xray_sampling_rule.go
@@ -27,7 +27,7 @@ func resourceAwsXraySamplingRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
+				ValidateFunc: validation.StringLenBetween(1, 32),
 			},
 			"resource_arn": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
The maximum length of the X-Ray rule name is 32 chars according to [AWS documentation](https://docs.aws.amazon.com/xray/latest/api/API_SamplingRule.html#xray-Type-SamplingRule-RuleName). Currently, the validation is set to a maximum of 128 which causes 400 HTTP status code to be returned from AWS when provided name is longer than 32.
```
Error: error creating XRay Sampling Rule: ValidationException: 
	status code: 400, request id: xxxxx
```
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSXraySamplingRule_ -timeout 180m
=== RUN   TestAccAWSXraySamplingRule_basic
=== PAUSE TestAccAWSXraySamplingRule_basic
=== RUN   TestAccAWSXraySamplingRule_update
=== PAUSE TestAccAWSXraySamplingRule_update
=== RUN   TestAccAWSXraySamplingRule_tags
=== PAUSE TestAccAWSXraySamplingRule_tags
=== RUN   TestAccAWSXraySamplingRule_disappears
=== PAUSE TestAccAWSXraySamplingRule_disappears
=== CONT  TestAccAWSXraySamplingRule_basic
=== CONT  TestAccAWSXraySamplingRule_disappears
=== CONT  TestAccAWSXraySamplingRule_tags
=== CONT  TestAccAWSXraySamplingRule_update
--- PASS: TestAccAWSXraySamplingRule_disappears (16.97s)
--- PASS: TestAccAWSXraySamplingRule_basic (21.84s)
--- PASS: TestAccAWSXraySamplingRule_update (34.63s)
--- PASS: TestAccAWSXraySamplingRule_tags (48.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.320s
```
