### PR TITLE
provider: Support default tags (resources aws_x*)

### DIFF
--- a/.changelog/18710.txt
+++ b/.changelog/18710.txt
@@ -1,4 +1,0 @@
-```release-note:enhancement
-resource/aws_xray_group: Support provider-wide default tags.
-resource/aws_xray_sampling_rule: Support provider-wide default tags.
-```

--- a/.changelog/18710.txt
+++ b/.changelog/18710.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_xray_group: Add default tags support.
+resource/aws_xray_sampling_rule: Add default tags support.
+```

--- a/.changelog/18710.txt
+++ b/.changelog/18710.txt
@@ -1,4 +1,4 @@
 ```release-note:enhancement
-resource/aws_xray_group: Add default tags support.
-resource/aws_xray_sampling_rule: Add default tags support.
+resource/aws_xray_group: Support provider-wide default tags.
+resource/aws_xray_sampling_rule: Support provider-wide default tags.
 ```

--- a/website/docs/r/xray_group.html.markdown
+++ b/website/docs/r/xray_group.html.markdown
@@ -23,7 +23,7 @@ resource "aws_xray_group" "example" {
 
 * `group_name` - (Required) The name of the group.
 * `filter_expression` - (Required) The filter expression defining criteria by which to group traces. more info can be found in official [docs](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html).
-* `tags` - (Optional) Key-value mapping of resource tags
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
@@ -31,6 +31,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ARN of the Group.
 * `arn` - The ARN of the Group.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/xray_sampling_rule.html.markdown
+++ b/website/docs/r/xray_sampling_rule.html.markdown
@@ -46,7 +46,7 @@ resource "aws_xray_sampling_rule" "example" {
 * `url_path` - (Required) Matches the path from a request URL.
 * `version` - (Required) The version of the sampling rule format (`1` )
 * `attributes` - (Optional) Matches attributes derived from the request.
-* `tags` - (Optional) Key-value mapping of resource tags
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
@@ -54,6 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the sampling rule.
 * `arn` - The ARN of the sampling rule.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7926

Adds default tags support for:

`aws_xray_group`
`aws_xray_sampling_rule`
