### PR TITLE
r/codedeploy_deployment_group - add attributes & tagging support

### DIFF
--- a/.changelog/18716.txt
+++ b/.changelog/18716.txt
@@ -9,3 +9,7 @@ resource/aws_codedeploy_deployment_group: Add `tags` argument
 ```release-note:enhancement
 resource/aws_codedeploy_deployment_group: Add plan time validation for `terminate_blue_instances_on_deployment_success.termination_wait_time_in_minutes`, `service_role_arn`, `load_balancer_info.target_group_pair_info.prod_traffic_route.listener_arns`, `load_balancer_info.target_group_pair_info.test_traffic_route.listener_arns`, `trigger_configuration.trigger_target_arn`
 ```
+
+```release-note:enhancement
+resource/aws_codedeploy_deployment_group: Updating `deployment_group_name` doesnt recreate group
+```

--- a/.changelog/18716.txt
+++ b/.changelog/18716.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_codedeploy_deployment_group: Add `arn`, `compute_platform`, and `deployment_group_id` attributes
+```
+
+```release-note:enhancement
+resource/aws_codedeploy_deployment_group: Add `tags` argument
+```
+
+```release-note:enhancement
+resource/aws_codedeploy_deployment_group: Add plan time validation for `terminate_blue_instances_on_deployment_success.termination_wait_time_in_minutes`, `service_role_arn`, `load_balancer_info.target_group_pair_info.prod_traffic_route.listener_arns`, `load_balancer_info.target_group_pair_info.test_traffic_route.listener_arns`, `trigger_configuration.trigger_target_arn`
+```

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -70,12 +70,19 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(0, 100),
 			},
-
+			"compute_platform": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"deployment_group_name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 100),
+			},
+			"deployment_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"deployment_style": {
@@ -589,7 +596,7 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 			return nil
 		}
 
-		return err
+		return fmt.Errorf("Error reading CodeDeploy deployment group (%s): %w", d.Id(), err)
 	}
 
 	group := resp.DeploymentGroupInfo
@@ -600,13 +607,15 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 		Service:   "codedeploy",
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("deploymentgroup:%s:%s", appName, groupName),
+		Resource:  fmt.Sprintf("deploymentgroup:%s/%s", appName, groupName),
 	}.String()
 
 	d.Set("arn", groupArn)
 	d.Set("app_name", appName)
 	d.Set("deployment_config_name", group.DeploymentConfigName)
 	d.Set("deployment_group_name", group.DeploymentGroupName)
+	d.Set("deployment_group_id", group.DeploymentGroupId)
+	d.Set("compute_platform", group.ComputePlatform)
 	d.Set("service_role_arn", group.ServiceRoleArn)
 
 	autoScalingGroups := make([]string, len(group.AutoScalingGroups))

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
@@ -60,6 +61,10 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"app_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -81,22 +86,16 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"deployment_option": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  codedeploy.DeploymentOptionWithoutTrafficControl,
-							ValidateFunc: validation.StringInSlice([]string{
-								codedeploy.DeploymentOptionWithTrafficControl,
-								codedeploy.DeploymentOptionWithoutTrafficControl,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      codedeploy.DeploymentOptionWithoutTrafficControl,
+							ValidateFunc: validation.StringInSlice(codedeploy.DeploymentOption_Values(), false),
 						},
 						"deployment_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  codedeploy.DeploymentTypeInPlace,
-							ValidateFunc: validation.StringInSlice([]string{
-								codedeploy.DeploymentTypeInPlace,
-								codedeploy.DeploymentTypeBlueGreen,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      codedeploy.DeploymentTypeInPlace,
+							ValidateFunc: validation.StringInSlice(codedeploy.DeploymentType_Values(), false),
 						},
 					},
 				},
@@ -116,12 +115,9 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action_on_timeout": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codedeploy.DeploymentReadyActionContinueDeployment,
-											codedeploy.DeploymentReadyActionStopDeployment,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(codedeploy.DeploymentReadyAction_Values(), false),
 									},
 									"wait_time_in_minutes": {
 										Type:     schema.TypeInt,
@@ -139,12 +135,9 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codedeploy.GreenFleetProvisioningActionDiscoverExisting,
-											codedeploy.GreenFleetProvisioningActionCopyAutoScalingGroup,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(codedeploy.GreenFleetProvisioningAction_Values(), false),
 									},
 								},
 							},
@@ -157,16 +150,14 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codedeploy.InstanceActionTerminate,
-											codedeploy.InstanceActionKeepAlive,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(codedeploy.InstanceAction_Values(), false),
 									},
 									"termination_wait_time_in_minutes": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtMost(2880),
 									},
 								},
 							},
@@ -176,8 +167,9 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 			},
 
 			"service_role_arn": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"alarm_configuration": {
@@ -258,7 +250,10 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 												"listener_arns": {
 													Type:     schema.TypeSet,
 													Required: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type:         schema.TypeString,
+														ValidateFunc: validateArn,
+													},
 												},
 											},
 										},
@@ -287,7 +282,10 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 												"listener_arns": {
 													Type:     schema.TypeSet,
 													Required: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type:         schema.TypeString,
+														ValidateFunc: validateArn,
+													},
 												},
 											},
 										},
@@ -448,19 +446,8 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Required: true,
 							Set:      schema.HashString,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									codedeploy.TriggerEventTypeDeploymentStart,
-									codedeploy.TriggerEventTypeDeploymentSuccess,
-									codedeploy.TriggerEventTypeDeploymentFailure,
-									codedeploy.TriggerEventTypeDeploymentStop,
-									codedeploy.TriggerEventTypeDeploymentRollback,
-									codedeploy.TriggerEventTypeDeploymentReady,
-									codedeploy.TriggerEventTypeInstanceStart,
-									codedeploy.TriggerEventTypeInstanceSuccess,
-									codedeploy.TriggerEventTypeInstanceFailure,
-									codedeploy.TriggerEventTypeInstanceReady,
-								}, false),
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice(codedeploy.TriggerEventType_Values(), false),
 							},
 						},
 
@@ -470,13 +457,15 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 						},
 
 						"trigger_target_arn": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
 						},
 					},
 				},
 				Set: resourceAwsCodeDeployTriggerConfigHash,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -493,6 +482,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 		ApplicationName:     aws.String(applicationName),
 		DeploymentGroupName: aws.String(deploymentGroupName),
 		ServiceRoleArn:      aws.String(serviceRoleArn),
+		Tags:                keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().CodedeployTags(),
 	}
 
 	if attr, ok := d.GetOk("deployment_style"); ok {
@@ -581,6 +571,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 
 func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codedeployconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	log.Printf("[DEBUG] Reading CodeDeploy DeploymentGroup %s", d.Id())
 
@@ -590,7 +581,7 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "DeploymentGroupDoesNotExistException" {
+		if isAWSErr(err, codedeploy.ErrCodeDeploymentGroupDoesNotExistException, "") {
 			log.Printf("[INFO] CodeDeployment DeploymentGroup %s not found", d.Get("deployment_group_name").(string))
 			d.SetId("")
 			return nil
@@ -599,57 +590,79 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	d.Set("app_name", resp.DeploymentGroupInfo.ApplicationName)
-	d.Set("deployment_config_name", resp.DeploymentGroupInfo.DeploymentConfigName)
-	d.Set("deployment_group_name", resp.DeploymentGroupInfo.DeploymentGroupName)
-	d.Set("service_role_arn", resp.DeploymentGroupInfo.ServiceRoleArn)
+	group := resp.DeploymentGroupInfo
+	appName := aws.StringValue(group.ApplicationName)
+	groupName := aws.StringValue(group.DeploymentGroupName)
+	groupArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "codedeploy",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("deploymentgroup:%s:%s", appName, groupName),
+	}.String()
 
-	autoScalingGroups := make([]string, len(resp.DeploymentGroupInfo.AutoScalingGroups))
-	for i, autoScalingGroup := range resp.DeploymentGroupInfo.AutoScalingGroups {
+	d.Set("arn", groupArn)
+	d.Set("app_name", appName)
+	d.Set("deployment_config_name", group.DeploymentConfigName)
+	d.Set("deployment_group_name", group.DeploymentGroupName)
+	d.Set("service_role_arn", group.ServiceRoleArn)
+
+	autoScalingGroups := make([]string, len(group.AutoScalingGroups))
+	for i, autoScalingGroup := range group.AutoScalingGroups {
 		autoScalingGroups[i] = aws.StringValue(autoScalingGroup.Name)
 	}
 	if err := d.Set("autoscaling_groups", autoScalingGroups); err != nil {
 		return fmt.Errorf("error setting autoscaling_groups: %s", err)
 	}
 
-	if err := d.Set("deployment_style", flattenDeploymentStyle(resp.DeploymentGroupInfo.DeploymentStyle)); err != nil {
+	if err := d.Set("deployment_style", flattenDeploymentStyle(group.DeploymentStyle)); err != nil {
 		return err
 	}
 
-	if err := d.Set("ec2_tag_set", ec2TagSetToMap(resp.DeploymentGroupInfo.Ec2TagSet)); err != nil {
+	if err := d.Set("ec2_tag_set", ec2TagSetToMap(group.Ec2TagSet)); err != nil {
 		return err
 	}
 
-	if err := d.Set("ec2_tag_filter", ec2TagFiltersToMap(resp.DeploymentGroupInfo.Ec2TagFilters)); err != nil {
+	if err := d.Set("ec2_tag_filter", ec2TagFiltersToMap(group.Ec2TagFilters)); err != nil {
 		return err
 	}
 
-	if err := d.Set("ecs_service", flattenCodeDeployEcsServices(resp.DeploymentGroupInfo.EcsServices)); err != nil {
+	if err := d.Set("ecs_service", flattenCodeDeployEcsServices(group.EcsServices)); err != nil {
 		return fmt.Errorf("error setting ecs_service: %s", err)
 	}
 
-	if err := d.Set("on_premises_instance_tag_filter", onPremisesTagFiltersToMap(resp.DeploymentGroupInfo.OnPremisesInstanceTagFilters)); err != nil {
+	if err := d.Set("on_premises_instance_tag_filter", onPremisesTagFiltersToMap(group.OnPremisesInstanceTagFilters)); err != nil {
 		return err
 	}
 
-	if err := d.Set("trigger_configuration", triggerConfigsToMap(resp.DeploymentGroupInfo.TriggerConfigurations)); err != nil {
+	if err := d.Set("trigger_configuration", triggerConfigsToMap(group.TriggerConfigurations)); err != nil {
 		return err
 	}
 
-	if err := d.Set("auto_rollback_configuration", autoRollbackConfigToMap(resp.DeploymentGroupInfo.AutoRollbackConfiguration)); err != nil {
+	if err := d.Set("auto_rollback_configuration", autoRollbackConfigToMap(group.AutoRollbackConfiguration)); err != nil {
 		return err
 	}
 
-	if err := d.Set("alarm_configuration", alarmConfigToMap(resp.DeploymentGroupInfo.AlarmConfiguration)); err != nil {
+	if err := d.Set("alarm_configuration", alarmConfigToMap(group.AlarmConfiguration)); err != nil {
 		return err
 	}
 
-	if err := d.Set("load_balancer_info", flattenLoadBalancerInfo(resp.DeploymentGroupInfo.LoadBalancerInfo)); err != nil {
+	if err := d.Set("load_balancer_info", flattenLoadBalancerInfo(group.LoadBalancerInfo)); err != nil {
 		return err
 	}
 
-	if err := d.Set("blue_green_deployment_config", flattenBlueGreenDeploymentConfig(resp.DeploymentGroupInfo.BlueGreenDeploymentConfiguration)); err != nil {
+	if err := d.Set("blue_green_deployment_config", flattenBlueGreenDeploymentConfig(group.BlueGreenDeploymentConfiguration)); err != nil {
 		return err
+	}
+
+	tags, err := keyvaluetags.CodedeployListTags(conn, groupArn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for CodeDeploy Deployment Group (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -658,113 +671,123 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codedeployconn
 
-	// required fields
-	applicationName := d.Get("app_name").(string)
-	deploymentGroupName := d.Get("deployment_group_name").(string)
-	serviceRoleArn := d.Get("service_role_arn").(string)
+	if d.HasChangeExcept("tags") {
+		// required fields
+		applicationName := d.Get("app_name").(string)
+		deploymentGroupName := d.Get("deployment_group_name").(string)
+		serviceRoleArn := d.Get("service_role_arn").(string)
 
-	input := codedeploy.UpdateDeploymentGroupInput{
-		ApplicationName:            aws.String(applicationName),
-		CurrentDeploymentGroupName: aws.String(deploymentGroupName),
-		ServiceRoleArn:             aws.String(serviceRoleArn),
-	}
-
-	if d.HasChange("deployment_group_name") {
-		_, n := d.GetChange("deployment_group_name")
-		input.NewDeploymentGroupName = aws.String(n.(string))
-	}
-
-	if d.HasChange("deployment_style") {
-		_, n := d.GetChange("deployment_style")
-		input.DeploymentStyle = expandDeploymentStyle(n.([]interface{}))
-	}
-
-	if d.HasChange("deployment_config_name") {
-		_, n := d.GetChange("deployment_config_name")
-		input.DeploymentConfigName = aws.String(n.(string))
-	}
-
-	// include (original or new) autoscaling groups when blue_green_deployment_config changes except for ECS
-	if _, isEcs := d.GetOk("ecs_service"); d.HasChange("autoscaling_groups") || (d.HasChange("blue_green_deployment_config") && !isEcs) {
-		_, n := d.GetChange("autoscaling_groups")
-		input.AutoScalingGroups = expandStringSet(n.(*schema.Set))
-	}
-
-	// TagFilters aren't like tags. They don't append. They simply replace.
-	if d.HasChange("on_premises_instance_tag_filter") {
-		_, n := d.GetChange("on_premises_instance_tag_filter")
-		onPremFilters := buildOnPremTagFilters(n.(*schema.Set).List())
-		input.OnPremisesInstanceTagFilters = onPremFilters
-	}
-
-	if d.HasChange("ec2_tag_set") {
-		_, n := d.GetChange("ec2_tag_set")
-		ec2TagSet := buildEC2TagSet(n.(*schema.Set).List())
-		input.Ec2TagSet = ec2TagSet
-	}
-
-	if d.HasChange("ec2_tag_filter") {
-		_, n := d.GetChange("ec2_tag_filter")
-		ec2Filters := buildEC2TagFilters(n.(*schema.Set).List())
-		input.Ec2TagFilters = ec2Filters
-	}
-
-	if d.HasChange("ecs_service") {
-		input.EcsServices = expandCodeDeployEcsServices(d.Get("ecs_service").([]interface{}))
-	}
-
-	if d.HasChange("trigger_configuration") {
-		_, n := d.GetChange("trigger_configuration")
-		triggerConfigs := buildTriggerConfigs(n.(*schema.Set).List())
-		input.TriggerConfigurations = triggerConfigs
-	}
-
-	if d.HasChange("auto_rollback_configuration") {
-		_, n := d.GetChange("auto_rollback_configuration")
-		input.AutoRollbackConfiguration = buildAutoRollbackConfig(n.([]interface{}))
-	}
-
-	if d.HasChange("alarm_configuration") {
-		_, n := d.GetChange("alarm_configuration")
-		input.AlarmConfiguration = buildAlarmConfig(n.([]interface{}))
-	}
-
-	if d.HasChange("load_balancer_info") {
-		_, n := d.GetChange("load_balancer_info")
-		input.LoadBalancerInfo = expandLoadBalancerInfo(n.([]interface{}))
-	}
-
-	if d.HasChange("blue_green_deployment_config") {
-		_, n := d.GetChange("blue_green_deployment_config")
-		input.BlueGreenDeploymentConfiguration = expandBlueGreenDeploymentConfig(n.([]interface{}))
-	}
-
-	log.Printf("[DEBUG] Updating CodeDeploy DeploymentGroup %s", d.Id())
-
-	var err error
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err = conn.UpdateDeploymentGroup(&input)
-
-		if isAWSErr(err, codedeploy.ErrCodeInvalidRoleException, "") {
-			return resource.RetryableError(err)
+		input := codedeploy.UpdateDeploymentGroupInput{
+			ApplicationName:            aws.String(applicationName),
+			CurrentDeploymentGroupName: aws.String(deploymentGroupName),
+			ServiceRoleArn:             aws.String(serviceRoleArn),
 		}
 
-		if isAWSErr(err, codedeploy.ErrCodeInvalidTriggerConfigException, "Topic ARN") {
-			return resource.RetryableError(err)
+		if d.HasChange("deployment_group_name") {
+			_, n := d.GetChange("deployment_group_name")
+			input.NewDeploymentGroupName = aws.String(n.(string))
 		}
 
+		if d.HasChange("deployment_style") {
+			_, n := d.GetChange("deployment_style")
+			input.DeploymentStyle = expandDeploymentStyle(n.([]interface{}))
+		}
+
+		if d.HasChange("deployment_config_name") {
+			_, n := d.GetChange("deployment_config_name")
+			input.DeploymentConfigName = aws.String(n.(string))
+		}
+
+		// include (original or new) autoscaling groups when blue_green_deployment_config changes except for ECS
+		if _, isEcs := d.GetOk("ecs_service"); d.HasChange("autoscaling_groups") || (d.HasChange("blue_green_deployment_config") && !isEcs) {
+			_, n := d.GetChange("autoscaling_groups")
+			input.AutoScalingGroups = expandStringSet(n.(*schema.Set))
+		}
+
+		// TagFilters aren't like tags. They don't append. They simply replace.
+		if d.HasChange("on_premises_instance_tag_filter") {
+			_, n := d.GetChange("on_premises_instance_tag_filter")
+			onPremFilters := buildOnPremTagFilters(n.(*schema.Set).List())
+			input.OnPremisesInstanceTagFilters = onPremFilters
+		}
+
+		if d.HasChange("ec2_tag_set") {
+			_, n := d.GetChange("ec2_tag_set")
+			ec2TagSet := buildEC2TagSet(n.(*schema.Set).List())
+			input.Ec2TagSet = ec2TagSet
+		}
+
+		if d.HasChange("ec2_tag_filter") {
+			_, n := d.GetChange("ec2_tag_filter")
+			ec2Filters := buildEC2TagFilters(n.(*schema.Set).List())
+			input.Ec2TagFilters = ec2Filters
+		}
+
+		if d.HasChange("ecs_service") {
+			input.EcsServices = expandCodeDeployEcsServices(d.Get("ecs_service").([]interface{}))
+		}
+
+		if d.HasChange("trigger_configuration") {
+			_, n := d.GetChange("trigger_configuration")
+			triggerConfigs := buildTriggerConfigs(n.(*schema.Set).List())
+			input.TriggerConfigurations = triggerConfigs
+		}
+
+		if d.HasChange("auto_rollback_configuration") {
+			_, n := d.GetChange("auto_rollback_configuration")
+			input.AutoRollbackConfiguration = buildAutoRollbackConfig(n.([]interface{}))
+		}
+
+		if d.HasChange("alarm_configuration") {
+			_, n := d.GetChange("alarm_configuration")
+			input.AlarmConfiguration = buildAlarmConfig(n.([]interface{}))
+		}
+
+		if d.HasChange("load_balancer_info") {
+			_, n := d.GetChange("load_balancer_info")
+			input.LoadBalancerInfo = expandLoadBalancerInfo(n.([]interface{}))
+		}
+
+		if d.HasChange("blue_green_deployment_config") {
+			_, n := d.GetChange("blue_green_deployment_config")
+			input.BlueGreenDeploymentConfiguration = expandBlueGreenDeploymentConfig(n.([]interface{}))
+		}
+
+		log.Printf("[DEBUG] Updating CodeDeploy DeploymentGroup %s", d.Id())
+
+		var err error
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			_, err = conn.UpdateDeploymentGroup(&input)
+
+			if isAWSErr(err, codedeploy.ErrCodeInvalidRoleException, "") {
+				return resource.RetryableError(err)
+			}
+
+			if isAWSErr(err, codedeploy.ErrCodeInvalidTriggerConfigException, "Topic ARN") {
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		})
+
+		if isResourceTimeoutError(err) {
+			_, err = conn.UpdateDeploymentGroup(&input)
+		}
 		if err != nil {
-			return resource.NonRetryableError(err)
+			return fmt.Errorf("Error updating CodeDeploy deployment group: %s", err)
 		}
-
-		return nil
-	})
-
-	if isResourceTimeoutError(err) {
-		_, err = conn.UpdateDeploymentGroup(&input)
 	}
-	if err != nil {
-		return fmt.Errorf("Error updating CodeDeploy deployment group: %s", err)
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.CodedeployUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating CodeDeploy Deployment Group (%s) tags: %w", d.Get("arn").(string), err)
+		}
 	}
 
 	return resourceAwsCodeDeployDeploymentGroupRead(d, meta)
@@ -779,7 +802,14 @@ func resourceAwsCodeDeployDeploymentGroupDelete(d *schema.ResourceData, meta int
 		DeploymentGroupName: aws.String(d.Get("deployment_group_name").(string)),
 	})
 
-	return err
+	if err != nil {
+		if isAWSErr(err, codedeploy.ErrCodeDeploymentGroupDoesNotExistException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // buildOnPremTagFilters converts raw schema lists into a list of

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -77,7 +77,6 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 			"deployment_group_name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 100),
 			},
 			"deployment_group_id": {

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -161,7 +161,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
-
+	resourceName := "aws_codedeploy_deployment_group.test"
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -173,17 +173,17 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroupOnPremiseTags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
+						resourceName, "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+						resourceName, "deployment_group_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+						resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.*", map[string]string{
+						resourceName, "on_premises_instance_tag_filter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "on_premises_instance_tag_filter.*", map[string]string{
 						"key":   "filterkey",
 						"type":  "KEY_AND_VALUE",
 						"value": "filtervalue",
@@ -191,9 +191,9 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -202,6 +202,7 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_disappears(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -213,8 +214,31 @@ func TestAccAWSCodeDeployDeploymentGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
-					testAccAWSCodeDeployDeploymentGroupDisappears(&group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCodeDeployDeploymentGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_disappears_app(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, codedeploy.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCodeDeployApp(), "aws_codedeploy_app.test"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -224,6 +248,7 @@ func TestAccAWSCodeDeployDeploymentGroup_disappears(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -236,11 +261,11 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
+						resourceName, "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+						resourceName, "deployment_group_name", "tf-acc-test-"+rName),
 					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger", []string{
 						"DeploymentFailure",
 					}),
@@ -249,11 +274,11 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
+						resourceName, "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+						resourceName, "deployment_group_name", "tf-acc-test-"+rName),
 					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger", []string{
 						"DeploymentFailure",
 						"DeploymentSuccess",
@@ -261,9 +286,9 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -272,6 +297,7 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 
 func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -284,11 +310,11 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
+						resourceName, "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+						resourceName, "deployment_group_name", "tf-acc-test-"+rName),
 					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger-1", []string{
 						"DeploymentFailure",
 					}),
@@ -302,11 +328,11 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
+						resourceName, "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+						resourceName, "deployment_group_name", "tf-acc-test-"+rName),
 					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger-1", []string{
 						"DeploymentFailure",
 						"DeploymentStart",
@@ -321,9 +347,9 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -332,6 +358,7 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 
 func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -344,20 +371,20 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *tes
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
+						resourceName, "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
+						resourceName, "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
+						resourceName, "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -366,6 +393,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *tes
 
 func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -378,34 +406,34 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *tes
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
+						resourceName, "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
+						resourceName, "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
+						resourceName, "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
 				Config: test_config_auto_rollback_configuration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
+						resourceName, "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
+						resourceName, "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "2"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_STOP_ON_ALARM"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
+						resourceName, "auto_rollback_configuration.0.events.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_STOP_ON_ALARM"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -414,6 +442,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *tes
 
 func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -426,28 +455,28 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
+						resourceName, "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
+						resourceName, "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
+						resourceName, "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
 				Config: test_config_auto_rollback_configuration_none(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
+						resourceName, "auto_rollback_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -456,6 +485,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 
 func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -468,33 +498,33 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *te
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
+						resourceName, "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
+						resourceName, "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
+						resourceName, "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
 				Config: test_config_auto_rollback_configuration_disable(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
+						resourceName, "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "false"),
+						resourceName, "auto_rollback_configuration.0.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
+						resourceName, "auto_rollback_configuration.0.events.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "auto_rollback_configuration.0.events.*", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -503,6 +533,7 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *te
 
 func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -515,22 +546,22 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
+						resourceName, "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
+						resourceName, "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm"),
+						resourceName, "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						resourceName, "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -539,6 +570,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 
 func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -551,38 +583,38 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T)
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
+						resourceName, "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
+						resourceName, "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm"),
+						resourceName, "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						resourceName, "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
 				Config: test_config_alarm_configuration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
+						resourceName, "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
+						resourceName, "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "2"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm-2"),
+						resourceName, "alarm_configuration.0.alarms.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm-2"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "true"),
+						resourceName, "alarm_configuration.0.ignore_poll_alarm_failure", "true"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -591,6 +623,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T)
 
 func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -603,30 +636,30 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T)
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
+						resourceName, "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
+						resourceName, "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm"),
+						resourceName, "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						resourceName, "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
 				Config: test_config_alarm_configuration_none(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
+						resourceName, "alarm_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -635,6 +668,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T)
 
 func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -647,37 +681,37 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
+						resourceName, "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
+						resourceName, "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm"),
+						resourceName, "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						resourceName, "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
 				Config: test_config_alarm_configuration_disable(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
+						resourceName, "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "false"),
+						resourceName, "alarm_configuration.0.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
-					resource.TestCheckTypeSetElemAttr("aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.*", "test-alarm"),
+						resourceName, "alarm_configuration.0.alarms.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "alarm_configuration.0.alarms.*", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						resourceName, "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -687,6 +721,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T
 // When no configuration is provided, a deploymentStyle object with default values is computed
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -699,19 +734,19 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 			{
 				Config: test_config_deployment_style_default(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option"),
+						resourceName, "deployment_style.0.deployment_option"),
 					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type"),
+						resourceName, "deployment_style.0.deployment_type"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -720,6 +755,7 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -732,27 +768,27 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 			{
 				Config: test_config_deployment_style_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -761,6 +797,7 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -773,31 +810,31 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 			{
 				Config: test_config_deployment_style_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 				),
 			},
 			{
 				Config: test_config_deployment_style_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
+						resourceName, "deployment_style.0.deployment_type", "IN_PLACE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -807,6 +844,7 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 // Delete reverts to default configuration. It does not remove the deployment_style block
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -819,31 +857,31 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 			{
 				Config: test_config_deployment_style_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 				),
 			},
 			{
 				Config: test_config_deployment_style_default(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
+						resourceName, "deployment_style.0.deployment_type", "IN_PLACE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -852,6 +890,7 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -864,20 +903,20 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -886,6 +925,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -898,12 +938,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
@@ -911,20 +951,20 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group-2",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -933,6 +973,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -945,12 +986,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
@@ -958,15 +999,15 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_none(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "0"),
+						resourceName, "load_balancer_info.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -975,6 +1016,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -987,21 +1029,21 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
 			{
 				Config: test_config_load_balancer_info_target_group_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.target_group_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.target_group_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1010,6 +1052,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
 
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1022,12 +1065,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
 			{
 				Config: test_config_load_balancer_info_target_group_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.target_group_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.target_group_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
@@ -1035,20 +1078,20 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
 			{
 				Config: test_config_load_balancer_info_target_group_info_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.target_group_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.target_group_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group-2",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1057,6 +1100,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
 
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1069,12 +1113,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
 			{
 				Config: test_config_load_balancer_info_target_group_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.target_group_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.target_group_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
@@ -1082,15 +1126,15 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
 			{
 				Config: test_config_load_balancer_info_target_group_info_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "0"),
+						resourceName, "load_balancer_info.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1099,6 +1143,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
 
 func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1111,27 +1156,27 @@ func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_cre
 			{
 				Config: test_config_in_place_deployment_with_traffic_control_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
+						resourceName, "deployment_style.0.deployment_type", "IN_PLACE"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1140,6 +1185,7 @@ func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_cre
 
 func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1152,19 +1198,19 @@ func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_upd
 			{
 				Config: test_config_in_place_deployment_with_traffic_control_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
+						resourceName, "deployment_style.0.deployment_type", "IN_PLACE"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 				),
@@ -1172,41 +1218,41 @@ func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_upd
 			{
 				Config: test_config_in_place_deployment_with_traffic_control_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1215,6 +1261,7 @@ func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_upd
 
 func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1227,41 +1274,41 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
 			{
 				Config: test_config_blue_green_deployment_config_create_with_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1270,6 +1317,7 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
 
 func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1282,53 +1330,53 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 			{
 				Config: test_config_blue_green_deployment_config_create_with_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_config_update_with_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
 		},
@@ -1337,6 +1385,7 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 
 func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1349,65 +1398,65 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 			{
 				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_config_update_no_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
 		},
@@ -1418,6 +1467,7 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 // from configuration causes an error, because the remote resource still exists.
 func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1430,53 +1480,53 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
 			{
 				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_config_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
+						resourceName, "deployment_style.0.deployment_type", "IN_PLACE"),
 
 					// The state is preserved, but AWS ignores it
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1485,6 +1535,7 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
 
 func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -1497,89 +1548,89 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete(t *testing
 			{
 				Config: test_config_blue_green_deployment_complete(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_complete_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+						resourceName, "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						resourceName, "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						resourceName, "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+						resourceName, "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs("aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.*", map[string]string{
+						resourceName, "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "load_balancer_info.0.elb_info.*", map[string]string{
 						"name": "acc-test-codedeploy-dep-group",
 					}),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
+						resourceName, "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+						resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						resourceName, "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
+						resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -1636,10 +1687,10 @@ func TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.0.name", lbTargetGroupBlueResourceName, "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.1.name", lbTargetGroupGreenResourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.test_traffic_route.#", "0"),
-					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
-					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "30"),
-					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
-					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "30"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "60"),
 				),
 			},
 			{

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -33,6 +33,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "codedeploy", fmt.Sprintf(`deploymentgroup:%s:%s`, "tf-acc-test-"+rName, "tf-acc-test-"+rName)),
 					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
@@ -51,6 +52,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -255,6 +255,7 @@ This functionality is only supported in the following resources:
     - [`aws_athena_workgroup` resource](/docs/providers/aws/r/athena_workgroup.html)
     - [`aws_budgets_budget` resource](/docs/providers/aws/r/budgets_budget.html)
     - [`aws_codedeploy_app` resource](/docs/providers/aws/r/codedeploy_app.html)
+    - [`aws_codedeploy_deployment_group` resource](/docs/providers/aws/r/aws_codedeploy_deployment_group.html)
     - [`aws_cognito_identity_pool` resource](/docs/providers/aws/r/cognito_identity_pool.html)
     - [`aws_cognito_user_pools` data source](/docs/providers/aws/d/cognito_user_pools.html)
     - [`aws_default_vpc_dhcp_options`](/docs/providers/aws/r/default_vpc_dhcp_options.html)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -255,7 +255,7 @@ This functionality is only supported in the following resources:
     - [`aws_athena_workgroup` resource](/docs/providers/aws/r/athena_workgroup.html)
     - [`aws_budgets_budget` resource](/docs/providers/aws/r/budgets_budget.html)
     - [`aws_codedeploy_app` resource](/docs/providers/aws/r/codedeploy_app.html)
-    - [`aws_codedeploy_deployment_group` resource](/docs/providers/aws/r/aws_codedeploy_deployment_group.html)
+    - [`aws_codedeploy_deployment_group` resource](/docs/providers/aws/r/codedeploy_deployment_group.html)
     - [`aws_cognito_identity_pool` resource](/docs/providers/aws/r/cognito_identity_pool.html)
     - [`aws_cognito_user_pools` data source](/docs/providers/aws/d/cognito_user_pools.html)
     - [`aws_default_vpc_dhcp_options`](/docs/providers/aws/r/default_vpc_dhcp_options.html)

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -353,6 +353,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the CodeDeploy deployment group.
 * `id` - Application name and deployment group name.
+* `compute_platform` - The destination platform type for the deployment.
+* `deployment_group_id` - The ID of the CodeDeploy deployment group.
 
 ## Import
 

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -202,6 +202,7 @@ The following arguments are supported:
 * `load_balancer_info` - (Optional) Single configuration block of the load balancer to use in a blue/green deployment (documented below).
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
 * `trigger_configuration` - (Optional) Configuration block(s) of the triggers for the deployment group (documented below).
+* `tags` - (Optional) Key-value map of resource tags
 
 ### alarm_configuration Argument Reference
 
@@ -350,6 +351,7 @@ Add triggers to a Deployment Group to receive notifications about events related
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the CodeDeploy deployment group.
 * `id` - Application name and deployment group name.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #8774

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup_'
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (75.49s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (79.67s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (90.66s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (105.89s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (106.83s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (110.06s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (134.43s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (134.45s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (140.40s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (65.04s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (141.15s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (143.94s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (144.45s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (145.62s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears_app (66.91s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (147.05s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (147.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (158.43s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (164.32s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (168.45s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (168.91s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (84.78s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (139.09s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (91.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (141.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (142.54s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (115.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (123.31s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (127.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (121.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (192.24s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (238.50s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (507.19s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_tags (137.69s)
```
