### PR TITLE
New DataSource - aws_mq_broker_instance_type_offerings

### DIFF
--- a/.changelog/18746.txt
+++ b/.changelog/18746.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_mq_broker_instance_type_offerings
+```

--- a/aws/data_source_aws_mq_broker_instance_type_offerings.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings.go
@@ -2,9 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/mq"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/aws/data_source_aws_mq_broker_instance_type_offerings.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings.go
@@ -1,0 +1,101 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/mq"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceAwsMqBrokerInstanceTypeOfferings() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsMqBrokerInstanceTypeOfferingsRead,
+
+		Schema: map[string]*schema.Schema{
+			"host_instance_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"engine_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					mq.EngineTypeActivemq,
+					mq.EngineTypeRabbitmq,
+				}, false),
+			},
+			"storage_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					mq.BrokerStorageTypeEbs,
+					mq.BrokerStorageTypeEfs,
+				}, false),
+			},
+			"availability_zones": {
+				Type:     schema.TypeSet,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsMqBrokerInstanceTypeOfferingsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mqconn
+
+	input := &mq.DescribeBrokerInstanceOptionsInput{}
+
+	if v, ok := d.GetOk("host_instance_type"); ok {
+		input.HostInstanceType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("engine_type"); ok {
+		input.EngineType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("storage_type"); ok {
+		input.StorageType = aws.String(v.(string))
+	}
+
+	var availabilityZones []string
+
+	for {
+		output, err := conn.DescribeBrokerInstanceOptions(input)
+
+		if err != nil {
+			return fmt.Errorf("error reading MQ Instance Type Offerings: %w", err)
+		}
+
+		if output == nil {
+			break
+		}
+
+		for _, instanceTypeOffering := range output.BrokerInstanceOptions {
+			if instanceTypeOffering == nil {
+				continue
+			}
+			for _, availabilityZone := range instanceTypeOffering.AvailabilityZones {
+				if availabilityZone == nil {
+					continue
+				}
+				availabilityZones = append(availabilityZones, aws.StringValue(availabilityZone.Name))
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	if err := d.Set("availability_zones", availabilityZones); err != nil {
+		return fmt.Errorf("error setting instance_types: %w", err)
+	}
+
+	d.SetId(meta.(*AWSClient).region)
+
+	return nil
+}

--- a/aws/data_source_aws_mq_broker_instance_type_offerings.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings.go
@@ -37,6 +37,7 @@ func dataSourceAwsMqBrokerInstanceTypeOfferings() *schema.Resource {
 			"availability_zones": {
 				Type:     schema.TypeSet,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/aws/data_source_aws_mq_broker_instance_type_offerings.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings.go
@@ -92,6 +92,10 @@ func dataSourceAwsMqBrokerInstanceTypeOfferingsRead(d *schema.ResourceData, meta
 		input.NextToken = output.NextToken
 	}
 
+	if len(availabilityZones) == 0 {
+		return fmt.Errorf("no availability_zones can support criteria supplied in aws_mq_broker_instance_type_offerings; try different criteria")
+	}
+
 	if err := d.Set("availability_zones", availabilityZones); err != nil {
 		return fmt.Errorf("error setting instance_types: %w", err)
 	}

--- a/aws/data_source_aws_mq_broker_instance_type_offerings_test.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings_test.go
@@ -1,0 +1,106 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/mq"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_Filter(t *testing.T) {
+	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2InstanceTypeOfferings(t) },
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigFilter(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_LocationType(t *testing.T) {
+	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAwsMqInstanceBrokerTypeOfferings(t) },
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigLocationType(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", dataSourceName)
+		}
+
+		if v := rs.Primary.Attributes["instance_types.#"]; v == "0" {
+			return fmt.Errorf("expected at least one instance_types result, got none")
+		}
+
+		return nil
+	}
+}
+
+func testAccPreCheckAwsMqInstanceBrokerTypeOfferings(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).mqconn
+
+	input := &mq.DescribeBrokerInstanceOptionsInput{
+		MaxResults: aws.Int64(5),
+	}
+
+	_, err := conn.DescribeBrokerInstanceOptions(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigFilter() string {
+	return `
+data "aws_mq_broker_instance_type_offerings" "test" {
+  filter {
+    name   = "instance-type"
+    values = ["t2.micro", "t3.micro"]
+  }
+}
+`
+}
+
+func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigLocationType() string {
+	return testAccAvailableAZsNoOptInConfig() + `
+data "aws_mq_broker_instance_type_offerings" "test" {
+  filter {
+    name   = "location"
+    values = [data.aws_availability_zones.available.names[0]]
+  }
+
+  location_type = "availability-zone"
+}
+`
+}

--- a/aws/data_source_aws_mq_broker_instance_type_offerings_test.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings_test.go
@@ -10,26 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_Filter(t *testing.T) {
-	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2InstanceTypeOfferings(t) },
-		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigFilter(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_LocationType(t *testing.T) {
+func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_InstanceType(t *testing.T) {
 	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -39,7 +20,64 @@ func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_LocationType(t *testing.T
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigLocationType(),
+				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigHostInstanceType(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_EngineType(t *testing.T) {
+	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAwsMqInstanceBrokerTypeOfferings(t) },
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigEngineType(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_StorageType(t *testing.T) {
+	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAwsMqInstanceBrokerTypeOfferings(t) },
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigStorageType(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_All(t *testing.T) {
+	dataSourceName := "data.aws_mq_broker_instance_type_offerings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAwsMqInstanceBrokerTypeOfferings(t) },
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigAllTypes(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqInstanceBrokerTypeOfferingsInstanceTypes(dataSourceName),
 				),
@@ -81,26 +119,36 @@ func testAccPreCheckAwsMqInstanceBrokerTypeOfferings(t *testing.T) {
 	}
 }
 
-func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigFilter() string {
+func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigHostInstanceType() string {
 	return `
 data "aws_mq_broker_instance_type_offerings" "test" {
-  filter {
-    name   = "instance-type"
-    values = ["t2.micro", "t3.micro"]
-  }
+  host_instance_type = "mq.m5.large"
 }
 `
 }
 
-func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigLocationType() string {
-	return testAccAvailableAZsNoOptInConfig() + `
+func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigEngineType() string {
+	return `
 data "aws_mq_broker_instance_type_offerings" "test" {
-  filter {
-    name   = "location"
-    values = [data.aws_availability_zones.available.names[0]]
-  }
+  engine_type = "RABBITMQ"
+}
+`
+}
 
-  location_type = "availability-zone"
+func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigStorageType() string {
+	return `
+data "aws_mq_broker_instance_type_offerings" "test" {
+  storage_type = "EBS"
+}
+`
+}
+
+func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigAllTypes() string {
+	return `
+data "aws_mq_broker_instance_type_offerings" "test" {
+  storage_type = "EBS"
+  engine_type = "RABBITMQ"
+  host_instance_type = "mq.m5.large"
 }
 `
 }

--- a/aws/data_source_aws_mq_broker_instance_type_offerings_test.go
+++ b/aws/data_source_aws_mq_broker_instance_type_offerings_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/mq"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -146,8 +146,8 @@ data "aws_mq_broker_instance_type_offerings" "test" {
 func testAccAwsMqInstanceBrokerTypeOfferingsDataSourceConfigAllTypes() string {
 	return `
 data "aws_mq_broker_instance_type_offerings" "test" {
-  storage_type = "EBS"
-  engine_type = "RABBITMQ"
+  storage_type       = "EBS"
+  engine_type        = "RABBITMQ"
   host_instance_type = "mq.m5.large"
 }
 `

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -330,6 +330,7 @@ func Provider() *schema.Provider {
 			"aws_lex_intent":                                 dataSourceAwsLexIntent(),
 			"aws_lex_slot_type":                              dataSourceAwsLexSlotType(),
 			"aws_mq_broker":                                  dataSourceAwsMqBroker(),
+			"aws_mq_broker_instance_type_offerings":          dataSourceAwsMqBrokerInstanceTypeOfferings(),
 			"aws_msk_cluster":                                dataSourceAwsMskCluster(),
 			"aws_msk_configuration":                          dataSourceAwsMskConfiguration(),
 			"aws_nat_gateway":                                dataSourceAwsNatGateway(),

--- a/website/docs/d/mq_broker_instance_type_offerings.html.markdown
+++ b/website/docs/d/mq_broker_instance_type_offerings.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "MQ"
+layout: "aws"
+page_title: "AWS: aws_mq_broker_instance_type_offerings"
+description: |-
+  Provides a list of availability zones that can deploy an MQ Broker with specified criteria.
+---
+
+# Data Source: aws_mq_broker_instance_type_offerings
+
+Provides a list of availability zones that can deploy an MQ Broker with specified criteria. Availability zones
+are based on the current active region.
+
+## Example Usage
+
+```terraform
+data "aws_mq_broker_instance_type_offerings" "test" {
+  storage_type = "EBS"
+  engine_type = "RABBITMQ"
+  host_instance_type = "mq.m5.large"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `storage_type` - (Optional) Storage type. 
+  * Valid values are `EBS` and `EFS`
+* `engine_type` - (Optional) MQ Broker engine type
+  * Valid values are `RABBITMQ` and `ACTIVEMQ`
+* `host_instance_type` - (Optional) The size of the instance
+
+## Attributes Reference
+
+The following attributes are exported.
+* `availability_zones` - List of availability zones that an MQ Broker of the specified type could be deployed

--- a/website/docs/d/mq_broker_instance_type_offerings.html.markdown
+++ b/website/docs/d/mq_broker_instance_type_offerings.html.markdown
@@ -9,7 +9,8 @@ description: |-
 # Data Source: aws_mq_broker_instance_type_offerings
 
 Provides a list of availability zones that can deploy an MQ Broker with specified criteria. Availability zones
-are based on the current active region.
+are based on the current active region. If no availability zones can support the criteria given,
+an error will be thrown.
 
 ## Example Usage
 
@@ -33,5 +34,5 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported.
-* `availability_zones` - List of availability zones that an MQ Broker of the specified type could be deployed
+The following attributes are exported
+* `availability_zones` - List of availability zones that can deploy an MQ Broker with specified criteria

--- a/website/docs/d/mq_broker_instance_type_offerings.html.markdown
+++ b/website/docs/d/mq_broker_instance_type_offerings.html.markdown
@@ -16,8 +16,8 @@ an error will be thrown.
 
 ```terraform
 data "aws_mq_broker_instance_type_offerings" "test" {
-  storage_type = "EBS"
-  engine_type = "RABBITMQ"
+  storage_type       = "EBS"
+  engine_type        = "RABBITMQ"
   host_instance_type = "mq.m5.large"
 }
 ```
@@ -26,13 +26,12 @@ data "aws_mq_broker_instance_type_offerings" "test" {
 
 The following arguments are supported:
 
-* `storage_type` - (Optional) Storage type. 
-  * Valid values are `EBS` and `EFS`
-* `engine_type` - (Optional) MQ Broker engine type
-  * Valid values are `RABBITMQ` and `ACTIVEMQ`
+* `storage_type` - (Optional) Storage type. Valid values are `EBS` and `EFS`
+* `engine_type` - (Optional) MQ Broker engine type. Valid values are `RABBITMQ` and `ACTIVEMQ`
 * `host_instance_type` - (Optional) The size of the instance
 
 ## Attributes Reference
 
-The following attributes are exported
+The following attributes are exported:
+
 * `availability_zones` - List of availability zones that can deploy an MQ Broker with specified criteria


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This PR adds a new data source for determining which availability zones can support Amazon MQ Brokers.
It is based on [this](https://docs.aws.amazon.com/amazon-mq/latest/api-reference/broker-instance-options.html) API endpoint, or [this](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/mq/describe-broker-instance-options.html) AWS CLI command.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_* -timeout 180m
=== RUN   TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_InstanceType
=== PAUSE TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_InstanceType
=== RUN   TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_EngineType
=== PAUSE TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_EngineType
=== RUN   TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_StorageType
=== PAUSE TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_StorageType
=== RUN   TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_All
=== PAUSE TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_All
=== CONT  TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_InstanceType
=== CONT  TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_StorageType
=== CONT  TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_EngineType
=== CONT  TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_All
--- PASS: TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_All (11.15s)
--- PASS: TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_InstanceType (18.95s)
--- PASS: TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_EngineType (20.15s)
--- PASS: TestAccAwsMqInstanceBrokerTypeOfferingsDataSource_StorageType (20.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       20.667s
```
