### PR TITLE
[WIP] include additional kinesis-settings in dms endpoint

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -367,9 +367,15 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	case "kinesis":
 		request.KinesisSettings = &dms.KinesisSettings{
-			MessageFormat:        aws.String(d.Get("kinesis_settings.0.message_format").(string)),
-			ServiceAccessRoleArn: aws.String(d.Get("kinesis_settings.0.service_access_role_arn").(string)),
-			StreamArn:            aws.String(d.Get("kinesis_settings.0.stream_arn").(string)),
+			MessageFormat:               aws.String(d.Get("kinesis_settings.0.message_format").(string)),
+			ServiceAccessRoleArn:        aws.String(d.Get("kinesis_settings.0.service_access_role_arn").(string)),
+			StreamArn:                   aws.String(d.Get("kinesis_settings.0.stream_arn").(string)),
+			IncludeTransactionDetails:   aws.Bool(d.Get("kinesis_settings.0.include_transaction_details").(bool)),
+			IncludePartitionValue:       aws.Bool(d.Get("kinesis_settings.0.include_partition_value").(bool)),
+			PartitionIncludeSchemaTable: aws.Bool(d.Get("kinesis_settings.0.partition_include_schema_table").(bool)),
+			IncludeTableAlterOperations: aws.Bool(d.Get("kinesis_settings.0.include_table_alter_operations").(bool)),
+			IncludeControlDetails:       aws.Bool(d.Get("kinesis_settings.0.include_control_details").(bool)),
+			IncludeNullAndEmpty:         aws.Bool(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
 		}
 	case "mongodb":
 		request.MongoDbSettings = &dms.MongoDbSettings{
@@ -596,6 +602,12 @@ func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 			request.KinesisSettings = &dms.KinesisSettings{
 				ServiceAccessRoleArn: aws.String(d.Get("kinesis_settings.0.service_access_role_arn").(string)),
 				StreamArn:            aws.String(d.Get("kinesis_settings.0.stream_arn").(string)),
+				IncludeTransactionDetails:   aws.Bool(d.Get("kinesis_settings.0.include_transaction_details").(bool)),
+				IncludePartitionValue:       aws.Bool(d.Get("kinesis_settings.0.include_partition_value").(bool)),
+				PartitionIncludeSchemaTable: aws.Bool(d.Get("kinesis_settings.0.partition_include_schema_table").(bool)),
+				IncludeTableAlterOperations: aws.Bool(d.Get("kinesis_settings.0.include_table_alter_operations").(bool)),
+				IncludeControlDetails:       aws.Bool(d.Get("kinesis_settings.0.include_control_details").(bool)),
+				IncludeNullAndEmpty:         aws.Bool(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
 			}
 			request.EngineName = aws.String(d.Get("engine_name").(string)) // Must be included (should be 'kinesis')
 			hasChanges = true
@@ -802,6 +814,11 @@ func flattenDmsKinesisSettings(settings *dms.KinesisSettings) []map[string]inter
 		"message_format":          aws.StringValue(settings.MessageFormat),
 		"service_access_role_arn": aws.StringValue(settings.ServiceAccessRoleArn),
 		"stream_arn":              aws.StringValue(settings.StreamArn),
+		"include_transaction_details":    aws.BoolValue(settings.IncludeTransactionDetails),
+		"include_partition_value":        aws.BoolValue(settings.IncludePartitionValue),
+		"partition_include_schema_table": aws.BoolValue(settings.PartitionIncludeSchemaTable),
+		"include_control_details":        aws.BoolValue(settings.IncludeControlDetails),
+		"include_null_and_empty":         aws.BoolValue(settings.IncludeNullAndEmpty),
 	}
 
 	return []map[string]interface{}{m}


### PR DESCRIPTION
added the following settings:
IncludeTransactionDetails
IncludePartitionValue
PartitionIncludeSchemaTable
IncludeTableAlterOperations
IncludeControlDetails
IncludeNullAndEmpty

I am not  a programmer, not am I able to check if this is correct, but I thought I would make the effort to start this pull request because in a project that I am working on we needed to have these settings.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
