### PR TITLE
docs: Security Groups: Add IPv6 examples

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -32,18 +32,20 @@ resource "aws_security_group" "allow_tls" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
-    description = "TLS from VPC"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = [aws_vpc.main.cidr_block]
+    description      = "TLS from VPC"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
   }
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {
@@ -121,10 +123,11 @@ resource "aws_security_group" "example" {
   # ... other configuration ...
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 ```

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -23,7 +23,7 @@ a conflict of rule settings and will overwrite rules.
 
 ## Example Usage
 
-Basic usage
+### Basic Usage
 
 ```terraform
 resource "aws_security_group" "allow_tls" {
@@ -54,69 +54,7 @@ resource "aws_security_group" "allow_tls" {
 }
 ```
 
-## Argument Reference
-
-The following arguments are supported:
-
-* `name` - (Optional, Forces new resource) The name of the security group. If omitted, Terraform will
-assign a random, unique name
-* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified
-  prefix. Conflicts with `name`.
-* `description` - (Optional, Forces new resource) The security group description. Defaults to
-  "Managed by Terraform". Cannot be "". __NOTE__: This field maps to the AWS
-  `GroupDescription` attribute, for which there is no Update API. If you'd like
-  to classify your security groups in a way that can be updated, use `tags`.
-* `ingress` - (Optional) Can be specified multiple times for each
-   ingress rule. Each ingress block supports fields documented below.
-   This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-* `egress` - (Optional, VPC only) Can be specified multiple times for each
-      egress rule. Each egress block supports fields documented below.
-      This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-* `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the
-Security Groups attached ingress and egress rules before deleting the rule
-itself. This is normally not needed, however certain AWS services such as
-Elastic Map Reduce may automatically add required rules to security groups used
-with the service, and those rules may contain a cyclic dependency that prevent
-the security groups from being destroyed without removing the dependency first.
-Default `false`
-* `vpc_id` - (Optional, Forces new resource) The VPC ID.
-* `tags` - (Optional) A map of tags to assign to the resource.
-
-The `ingress` block supports:
-
-* `cidr_blocks` - (Optional) List of CIDR blocks.
-* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-* `prefix_list_ids` - (Optional) List of Prefix List IDs.
-* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp" or "icmpv6")
-* `protocol` - (Required) The protocol. If you select a protocol of "-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0.  The supported values are defined in the "IpProtocol" argument on the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using with Terraform 0.12.x and above, please make sure that the value of the protocol is specified as lowercase when using with older version of Terraform to avoid an issue during upgrade.
-* `security_groups` - (Optional) List of security group Group Names if using
-    EC2-Classic, or Group IDs if using a VPC.
-* `self` - (Optional) If true, the security group itself will be added as
-     a source to this ingress rule.
-* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
-* `description` - (Optional) Description of this ingress rule.
-
-The `egress` block supports:
-
-* `cidr_blocks` - (Optional) List of CIDR blocks.
-* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-* `prefix_list_ids` - (Optional) List of Prefix List IDs.
-* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp")
-* `protocol` - (Required) The protocol. If you select a protocol of
-"-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0.  The supported values are defined in the "IpProtocol" argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
-* `security_groups` - (Optional) List of security group Group Names if using
-    EC2-Classic, or Group IDs if using a VPC.
-* `self` - (Optional) If true, the security group itself will be added as
-     a source to this egress rule.
-* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
-* `description` - (Optional) Description of this egress rule.
-
-~> **NOTE on Egress rules:** By default, AWS creates an `ALLOW ALL` egress rule when creating a
-new Security Group inside of a VPC. When creating a new Security
-Group inside a VPC, **Terraform will remove this default rule**, and require you
-specifically re-create it if you desire that rule. We feel this leads to fewer
-surprises in terms of controlling your egress rules. If you desire this rule to
-be in place, you can use this `egress` block:
+~> **NOTE on Egress rules:** By default, AWS creates an `ALLOW ALL` egress rule when creating a new Security Group inside of a VPC. When creating a new Security Group inside a VPC, **Terraform will remove this default rule**, and require you specifically re-create it if you desire that rule. We feel this leads to fewer surprises in terms of controlling your egress rules. If you desire this rule to be in place, you can use this `egress` block:
 
 ```terraform
 resource "aws_security_group" "example" {
@@ -132,7 +70,7 @@ resource "aws_security_group" "example" {
 }
 ```
 
-## Usage with prefix list IDs
+### Usage With Prefix List IDs
 
 Prefix Lists are either managed by AWS internally, or created by the customer using a
 [Prefix List resource](ec2_managed_prefix_list.html). Prefix Lists provided by
@@ -158,18 +96,60 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 
 You can also find a specific Prefix List using the `aws_prefix_list` data source.
 
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. __NOTE__: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
+* `egress` - (Optional, VPC only) Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+* `ingress` - (Optional) Configuration block for egress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `name` - (Optional, Forces new resource) Name of the security group. If omitted, Terraform will assign a random, unique name.
+* `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
+* `tags` - (Optional) Map of tags to assign to the resource.
+* `vpc_id` - (Optional, Forces new resource) VPC ID.
+
+### ingress
+
+The following arguments are required:
+
+* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp` or `icmpv6`).
+* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
+
+The following arguments are optional:
+
+* `cidr_blocks` - (Optional) List of CIDR blocks.
+* `description` - (Optional) Description of this ingress rule.
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of Prefix List IDs.
+* `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0.  The supported values are defined in the `IpProtocol` argument on the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using with Terraform 0.12.x and above, please make sure that the value of the protocol is specified as lowercase when using with older version of Terraform to avoid an issue during upgrade.
+* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
+
+### egress
+
+The following arguments are required:
+
+* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp`)
+* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
+
+The following arguments are optional:
+
+* `cidr_blocks` - (Optional) List of CIDR blocks.
+* `description` - (Optional) Description of this egress rule.
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of Prefix List IDs.
+* `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0.  The supported values are defined in the `IpProtocol` argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
+* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the security group
-* `arn` - The ARN of the security group
-* `vpc_id` - The VPC ID.
-* `owner_id` - The owner ID.
-* `name` - The name of the security group
-* `description` - The description of the security group
-* `ingress` - The ingress rules. See above for more.
-* `egress` - The egress rules. See above for more.
+* `arn` - ARN of the security group.
+* `id` - ID of the security group.
+* `owner_id` - Owner ID.
 
 ## Timeouts
 

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -38,26 +38,7 @@ resource "aws_security_group_rule" "example" {
 }
 ```
 
-## Argument Reference
-
-The following arguments are supported:
-
-* `type` - (Required) The type of rule being created. Valid options are `ingress` (inbound)
-or `egress` (outbound).
-* `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be specified with `source_security_group_id`.
-* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-* `prefix_list_ids` - (Optional) List of Prefix List IDs.
-* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp" or "icmpv6").
-* `protocol` - (Required) The protocol. If not icmp, icmpv6, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
-* `security_group_id` - (Required) The security group to apply this rule to.
-* `source_security_group_id` - (Optional) The security group id to allow access to/from,
-     depending on the `type`. Cannot be specified with `cidr_blocks` and `self`.
-* `self` - (Optional) If true, the security group itself will be added as
-     a source to this ingress rule. Cannot be specified with `source_security_group_id`.
-* `to_port` - (Required) The end port (or ICMP code if protocol is "icmp").
-* `description` - (Optional) Description of the rule.
-
-## Usage with prefix list IDs
+### Usage With Prefix List IDs
 
 Prefix Lists are either managed by AWS internally, or created by the customer using a
 [Managed Prefix List resource](ec2_managed_prefix_list.html). Prefix Lists provided by
@@ -83,24 +64,37 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 
 You can also find a specific Prefix List using the `aws_prefix_list` data source.
 
+## Argument Reference
+
+The following arguments are required:
+
+* `from_port` - (Required) Start port (or ICMP type number if protocol is "icmp" or "icmpv6").
+* `protocol` - (Required) Protocol. If not icmp, icmpv6, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+* `security_group_id` - (Required) Security group to apply this rule to.
+* `to_port` - (Required) End port (or ICMP code if protocol is "icmp").
+* `type` - (Required) Type of rule being created. Valid options are `ingress` (inbound)
+or `egress` (outbound).
+
+The following arguments are optional:
+
+* `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be specified with `source_security_group_id`.
+* `description` - (Optional) Description of the rule.
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of Prefix List IDs.
+* `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule. Cannot be specified with `source_security_group_id`.
+* `source_security_group_id` - (Optional) Security group id to allow access to/from, depending on the `type`. Cannot be specified with `cidr_blocks` and `self`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the security group rule
-* `type` - The type of rule, `ingress` or `egress`
-* `from_port` - The start port (or ICMP type number if protocol is "icmp")
-* `to_port` - The end port (or ICMP code if protocol is "icmp")
-* `protocol` – The protocol used
-* `description` – Description of the rule
+* `id` - ID of the security group rule.
 
 ## Import
 
 Security Group Rules can be imported using the `security_group_id`, `type`, `protocol`, `from_port`, `to_port`, and source(s)/destination(s) (e.g. `cidr_block`) separated by underscores (`_`). All parts are required.
 
 Not all rule permissions (e.g., not all of a rule's CIDR blocks) need to be imported for Terraform to manage rule permissions. However, importing some of a rule's permissions but not others, and then making changes to the rule will result in the creation of an additional rule to capture the updated permissions. Rule permissions that were not imported are left intact in the original rule.
-
-### Examples
 
 Import an ingress rule in security group `sg-6e616f6d69` for TCP port 8000 with an IPv4 destination CIDR of `10.0.3.0/24`:
 

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -33,6 +33,7 @@ resource "aws_security_group_rule" "example" {
   to_port           = 65535
   protocol          = "tcp"
   cidr_blocks       = [aws_vpc.example.cidr_block]
+  ipv6_cidr_blocks  = [aws_vpc.example.ipv6_cidr_block]
   security_group_id = "sg-123456"
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Updates the docs to show examples of using IPv6 CIDR blocks with security groups.