### PR TITLE
New Glue Data sources - Glue Connection and Glue Data Catalog Encryption Settings

### DIFF
--- a/.changelog/18802.txt
+++ b/.changelog/18802.txt
@@ -3,5 +3,5 @@ aws_glue_connection
 ```
 
 ```release-note:new-data-source
-aws_glue_connection
+aws_glue_data_catalog_encryption_settings
 ```

--- a/.changelog/18802.txt
+++ b/.changelog/18802.txt
@@ -1,0 +1,7 @@
+```release-note:new-data-source
+aws_glue_connection
+```
+
+```release-note:new-data-source
+aws_glue_connection
+```

--- a/aws/data_source_aws_glue_connection.go
+++ b/aws/data_source_aws_glue_connection.go
@@ -43,6 +43,9 @@ func dataSourceAwsGlueConnection() *schema.Resource {
 func dataSourceAwsGlueConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*AWSClient).glueconn
 	catalogID, connectionName, err := decodeGlueConnectionID(d.Id())
+	if err != nil {
+		return diag.Errorf("error decoding Glue Connection %s: %s", d.Id(), err)
+	}
 	input := &glue.GetConnectionInput{
 		CatalogId: aws.String(catalogID),
 		Name:      aws.String(connectionName),

--- a/aws/data_source_aws_glue_connection.go
+++ b/aws/data_source_aws_glue_connection.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceAwsGlueConnection() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAwsGlueConnectionRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"catalog_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"connection_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsGlueConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).glueconn
+	catalogID, connectionName, err := decodeGlueConnectionID(d.Id())
+	input := &glue.GetConnectionInput{
+		CatalogId: aws.String(catalogID),
+		Name:      aws.String(connectionName),
+	}
+	output, err := conn.GetConnection(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return diag.Errorf("error Glue Connection (%s) not found", d.Id())
+		}
+		return diag.Errorf("error reading Glue Connection (%s): %s", d.Id(), err)
+	}
+	d.Set("catalog_id", catalogID)
+	d.Set("creation_time", aws.TimeValue(output.Connection.CreationTime).Format(time.RFC3339))
+	d.Set("connection_type", output.Connection.ConnectionType)
+	d.Set("name", connectionName)
+	return nil
+}

--- a/aws/data_source_aws_glue_connection_test.go
+++ b/aws/data_source_aws_glue_connection_test.go
@@ -48,9 +48,13 @@ func testAccDataSourceAwsGlueConnectionCheck(name string) resource.TestCheckFunc
 func testAccDataSourceAwsGlueConnectionConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_connection" "test" {
-  name                  = %[1]q
-  connection_type       = "NETWORK"
-  connection_properties = {}
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://terraformacctesting.com/testdatabase"
+    PASSWORD            = "testpassword"
+    USERNAME            = "testusername"
+  }
+
+  name = "%s"
 }
 
 data "aws_glue_connection" "test" {

--- a/aws/data_source_aws_glue_connection_test.go
+++ b/aws/data_source_aws_glue_connection_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceAwsGlueConnection_basic(t *testing.T) {
+	resourceName := "aws_glue_connection.test"
+	datasourceName := "data.aws_glue_connection.test"
+	rName := fmt.Sprintf("tf-testacc-glue-connection-%s", acctest.RandString(13))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, glue.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsGlueConnectionConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsGlueConnectionCheck(datasourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "catalog_id", resourceName, "catalog_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "creation_time", resourceName, "creation_time"),
+					resource.TestCheckResourceAttrPair(datasourceName, "connection_type", resourceName, "connection_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsGlueConnectionCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsGlueConnectionConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  name                  = %[1]q
+  connection_type       = "NETWORK"
+  connection_properties = {}
+  
+}
+
+data "aws_glue_connection" "test" {
+  id = aws_glue_connection.test.id
+}
+`, rName)
+}

--- a/aws/data_source_aws_glue_connection_test.go
+++ b/aws/data_source_aws_glue_connection_test.go
@@ -51,7 +51,6 @@ resource "aws_glue_connection" "test" {
   name                  = %[1]q
   connection_type       = "NETWORK"
   connection_properties = {}
-  
 }
 
 data "aws_glue_connection" "test" {

--- a/aws/data_source_aws_glue_data_catalog_encryption_settings.go
+++ b/aws/data_source_aws_glue_data_catalog_encryption_settings.go
@@ -1,0 +1,1 @@
+package aws

--- a/aws/data_source_aws_glue_data_catalog_encryption_settings.go
+++ b/aws/data_source_aws_glue_data_catalog_encryption_settings.go
@@ -1,1 +1,56 @@
 package aws
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceAwsGlueDataCatalogEncryptionSettings() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAwsGlueDataCatalogEncryptionSettingsRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"connection_password_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"connection_password_kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"encryption_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"encryption_kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsGlueDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).glueconn
+	input := &glue.GetDataCatalogEncryptionSettingsInput{
+		CatalogId: aws.String(d.Id()),
+	}
+	out, err := conn.GetDataCatalogEncryptionSettings(input)
+	if err != nil {
+		return diag.Errorf("Error reading Glue Data Catalog Encryption Settings: %s", err)
+	}
+	d.SetId(d.Id())
+	d.Set("connection_password_encrypted", out.DataCatalogEncryptionSettings.ConnectionPasswordEncryption.ReturnConnectionPasswordEncrypted)
+	d.Set("connection_password_kms_key_arn", out.DataCatalogEncryptionSettings.ConnectionPasswordEncryption.AwsKmsKeyId)
+	d.Set("encryption_mode", out.DataCatalogEncryptionSettings.EncryptionAtRest.CatalogEncryptionMode)
+	d.Set("connection_password_encrypted", out.DataCatalogEncryptionSettings.EncryptionAtRest.SseAwsKmsKeyId)
+	return nil
+}

--- a/aws/data_source_aws_glue_data_catalog_encryption_settings.go
+++ b/aws/data_source_aws_glue_data_catalog_encryption_settings.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/aws/data_source_aws_glue_data_catalog_encryption_settings_test.go
+++ b/aws/data_source_aws_glue_data_catalog_encryption_settings_test.go
@@ -1,0 +1,1 @@
+package aws

--- a/aws/data_source_aws_glue_data_catalog_encryption_settings_test.go
+++ b/aws/data_source_aws_glue_data_catalog_encryption_settings_test.go
@@ -1,1 +1,64 @@
 package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceAwsGlueDataCatalogEncryptionSettings_basic(t *testing.T) {
+	resourceName := "aws_glue_data_catalog_encryption_settings.test"
+	datasourceName := "data.aws_glue_data_catalog_encryption_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, glue.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsGlueDataCatalogEncryptionSettingsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsGlueDataCatalogEncryptionSettingsCheck(datasourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "connection_password_encrypted", resourceName, "connection_password_encrypted"),
+					resource.TestCheckResourceAttrPair(datasourceName, "connection_password_kms_key_arn", resourceName, "connection_password_kms_key_arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "encryption_mode", resourceName, "encryption_mode"),
+					resource.TestCheckResourceAttrPair(datasourceName, "connection_password_encrypted", resourceName, "connection_password_encrypted"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsGlueDataCatalogEncryptionSettingsCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsGlueDataCatalogEncryptionSettingsConfig() string {
+	return `
+resource "aws_glue_data_catalog_encryption_settings" "test" {
+  data_catalog_encryption_settings {
+    connection_password_encryption {
+      return_connection_password_encrypted = false
+    }
+
+    encryption_at_rest {
+      catalog_encryption_mode = "DISABLED"
+    }
+  }
+}
+
+data "aws_glue_data_catalog_encryption_settings" "test" {
+  id = aws_glue_data_catalog_encryption_settings.test.id
+}
+`
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -284,6 +284,7 @@ func Provider() *schema.Provider {
 			"aws_elasticache_replication_group":              dataSourceAwsElasticacheReplicationGroup(),
 			"aws_elb_hosted_zone_id":                         dataSourceAwsElbHostedZoneId(),
 			"aws_elb_service_account":                        dataSourceAwsElbServiceAccount(),
+			"aws_glue_connection":                            dataSourceAwsGlueConnection(),
 			"aws_glue_script":                                dataSourceAwsGlueScript(),
 			"aws_guardduty_detector":                         dataSourceAwsGuarddutyDetector(),
 			"aws_iam_account_alias":                          dataSourceAwsIamAccountAlias(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -285,6 +285,7 @@ func Provider() *schema.Provider {
 			"aws_elb_hosted_zone_id":                         dataSourceAwsElbHostedZoneId(),
 			"aws_elb_service_account":                        dataSourceAwsElbServiceAccount(),
 			"aws_glue_connection":                            dataSourceAwsGlueConnection(),
+			"aws_glue_data_catalog_encryption_settings":      dataSourceAwsGlueDataCatalogEncryptionSettings(),
 			"aws_glue_script":                                dataSourceAwsGlueScript(),
 			"aws_guardduty_detector":                         dataSourceAwsGuarddutyDetector(),
 			"aws_iam_account_alias":                          dataSourceAwsIamAccountAlias(),

--- a/website/docs/d/glue_connection.html.markdown
+++ b/website/docs/d/glue_connection.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_connection"
+description: |-
+  Get information on an AWS Glue Connection
+---
+
+# Data Source: aws_glue_connection
+
+This data source can be used to fetch information about a specific Glue Connection.
+
+## Example Usage
+
+```terraform
+data "aws_glue_connection" "example" {
+  id = "123456789123:connection"
+}
+```
+
+## Argument Reference
+
+* `id` - (Required) A concatenation of the catalog ID and connection name. For example, if your account ID is 
+`123456789123` and the connection name is `conn` then the ID is `123456789123:conn`.
+
+## Attributes Reference
+
+* `catalog_id` - The catalog ID of the Glue Connection.
+
+* `name` - The name of the Glue Connection.
+
+* `creation_time` - The time of creation of the Glue Connection.
+
+* `connection_type` - The type of Glue Connection.

--- a/website/docs/d/glue_connection.html.markdown
+++ b/website/docs/d/glue_connection.html.markdown
@@ -20,7 +20,7 @@ data "aws_glue_connection" "example" {
 
 ## Argument Reference
 
-* `id` - (Required) A concatenation of the catalog ID and connection name. For example, if your account ID is 
+* `id` - (Required) A concatenation of the catalog ID and connection name. For example, if your account ID is
 `123456789123` and the connection name is `conn` then the ID is `123456789123:conn`.
 
 ## Attributes Reference

--- a/website/docs/d/glue_data_catalog_encryption_settings.html.markdown
+++ b/website/docs/d/glue_data_catalog_encryption_settings.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_data_catalog_encryption_settings"
+description: |-
+  Get information on AWS Glue Data Catalog Encryption Settings
+---
+
+# Data Source: aws_glue_data_catalog_encryption_settings
+
+This data source can be used to fetch information about AWS Glue Data Catalog Encryption Settings.
+
+## Example Usage
+
+```terraform
+data "aws_glue_data_catalog_encryption_settings" "example" {
+  id = "123456789123"
+}
+```
+
+## Argument Reference
+
+* `id` - (Required) The ID of the Data Catalog. This is typically the AWS account ID.
+
+## Attributes Reference
+
+* `connection_password_encrypted` - A boolean value which specifies whether connection passwords are encrypted.
+
+* `connection_password_kms_key_arn` - The ARN of the KMS key that encrypts connection passwords.
+
+* `encryption_mode` - The encryption mode of the Glue Data Catalog.
+
+* `encryption_kms_key_arn` - The ARN of the KMS key that encrypts the Glue Data Catalog.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
This PR adds new data sources for aws_glue_connection and aws_glue_data_catalog_encryption_settings.

Note: I was not able to test this due to odd behavior from `make fmt`. It modifies almost every file where it changes all instances of "%w" to "%s". I would appreciate it if someone else could test this for me.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
