### PR TITLE
linter: add rule to discourage data source referencing resource Read

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -151,6 +151,24 @@ rules:
         - pattern: '*aws.Time($VALUE)'
     severity: WARNING
 
+  - id: data-source-with-resource-read
+    languages: [go]
+    message: Calling a resource's Read method from within a data-source is discouraged
+    paths:
+      include:
+        - aws/data_source_aws_*.go
+    patterns:
+      - pattern-regex: '(resource.+Read|flatten.+Resource)'
+      - pattern-inside: func $FUNCNAME(...) error { ... }
+      - pattern-not-inside: |
+          d.Set(..., []interface{}{ ... })
+      - pattern-not-inside: |
+          d.Set($ATTRIBUTE, $FUNC($APIOBJECT))
+      - metavariable-regex:
+          metavariable: "$FUNCNAME"
+          regex: "dataSource.+Read"
+    severity: WARNING
+
   - id: helper-acctest-RandInt-compiled
     languages: [go]
     message: Using `acctest.RandInt()` in constant or variable declaration will execute during compilation and not randomize, pass into string generating function instead
@@ -210,7 +228,6 @@ rules:
             ...
             expandStringList($LIST)
     severity: WARNING
-
 
   - id: helper-schema-ResourceData-GetOk-with-extraneous-conditional
     languages: [go]

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -159,7 +159,7 @@ rules:
         - aws/data_source_aws_*.go
     patterns:
       - pattern-regex: '(resource.+Read|flatten.+Resource)'
-      - pattern-inside: func $FUNCNAME(...) error { ... }
+      - pattern-inside: func $FUNCNAME(...) $RETURNTYPE { ... }
       - pattern-not-inside: |
           d.Set(..., []interface{}{ ... })
       - pattern-not-inside: |


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Preceded by #18838, #18842, #18844,  #18846, and #18848
Closes #18819 

Output from running `semgrep` (currently):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
ran 19 rules on 2427 files: 0 findings

```


