### PR TITLE
tech-debt: refactor alb/lb data and resources to remove references to resource Read from data source

### DIFF
--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -2,11 +2,12 @@ package aws
 
 import (
 	"fmt"
-	"log"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsLbTargetGroup() *schema.Resource {
@@ -141,29 +142,122 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 }
 
 func dataSourceAwsLbTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
-	elbconn := meta.(*AWSClient).elbv2conn
-	tgArn := d.Get("arn").(string)
-	tgName := d.Get("name").(string)
+	conn := meta.(*AWSClient).elbv2conn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	describeTgOpts := &elbv2.DescribeTargetGroupsInput{}
-	switch {
-	case tgArn != "":
-		describeTgOpts.TargetGroupArns = []*string{aws.String(tgArn)}
-	case tgName != "":
-		describeTgOpts.Names = []*string{aws.String(tgName)}
+	input := &elbv2.DescribeTargetGroupsInput{}
+
+	if v, ok := d.GetOk("arn"); ok {
+		input.TargetGroupArns = aws.StringSlice([]string{v.(string)})
+	} else if v, ok := d.GetOk("name"); ok {
+		input.Names = aws.StringSlice([]string{v.(string)})
 	}
 
-	log.Printf("[DEBUG] Reading Load Balancer Target Group: %s", describeTgOpts)
-	describeResp, err := elbconn.DescribeTargetGroups(describeTgOpts)
+	var results []*elbv2.TargetGroup
+
+	err := conn.DescribeTargetGroupsPages(input, func(page *elbv2.DescribeTargetGroupsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		results = append(results, page.TargetGroups...)
+
+		return !lastPage
+	})
+
 	if err != nil {
-		return fmt.Errorf("Error retrieving LB Target Group: %w", err)
+		return fmt.Errorf("error retrieving LB Target Group: %w", err)
 	}
-	if len(describeResp.TargetGroups) != 1 {
-		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.TargetGroups))
+	if len(results) != 1 {
+		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(results))
 	}
 
-	targetGroup := describeResp.TargetGroups[0]
+	targetGroup := results[0]
 
 	d.SetId(aws.StringValue(targetGroup.TargetGroupArn))
-	return flattenAwsLbTargetGroupResource(d, meta, targetGroup)
+
+	d.Set("arn", targetGroup.TargetGroupArn)
+	d.Set("arn_suffix", lbTargetGroupSuffixFromARN(targetGroup.TargetGroupArn))
+	d.Set("name", targetGroup.TargetGroupName)
+	d.Set("target_type", targetGroup.TargetType)
+
+	if err := d.Set("health_check", flattenLbTargetGroupHealthCheck(targetGroup)); err != nil {
+		return fmt.Errorf("error setting health_check: %w", err)
+	}
+
+	if v, _ := d.Get("target_type").(string); v != elbv2.TargetTypeEnumLambda {
+		d.Set("vpc_id", targetGroup.VpcId)
+		d.Set("port", targetGroup.Port)
+		d.Set("protocol", targetGroup.Protocol)
+	}
+	switch d.Get("protocol").(string) {
+	case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
+		d.Set("protocol_version", targetGroup.ProtocolVersion)
+	}
+
+	attrResp, err := conn.DescribeTargetGroupAttributes(&elbv2.DescribeTargetGroupAttributesInput{
+		TargetGroupArn: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("error retrieving Target Group Attributes: %w", err)
+	}
+
+	for _, attr := range attrResp.Attributes {
+		switch aws.StringValue(attr.Key) {
+		case "deregistration_delay.timeout_seconds":
+			timeout, err := strconv.Atoi(aws.StringValue(attr.Value))
+			if err != nil {
+				return fmt.Errorf("error converting deregistration_delay.timeout_seconds to int: %s", aws.StringValue(attr.Value))
+			}
+			d.Set("deregistration_delay", timeout)
+		case "lambda.multi_value_headers.enabled":
+			enabled, err := strconv.ParseBool(aws.StringValue(attr.Value))
+			if err != nil {
+				return fmt.Errorf("error converting lambda.multi_value_headers.enabled to bool: %s", aws.StringValue(attr.Value))
+			}
+			d.Set("lambda_multi_value_headers_enabled", enabled)
+		case "proxy_protocol_v2.enabled":
+			enabled, err := strconv.ParseBool(aws.StringValue(attr.Value))
+			if err != nil {
+				return fmt.Errorf("error converting proxy_protocol_v2.enabled to bool: %s", aws.StringValue(attr.Value))
+			}
+			d.Set("proxy_protocol_v2", enabled)
+		case "slow_start.duration_seconds":
+			slowStart, err := strconv.Atoi(aws.StringValue(attr.Value))
+			if err != nil {
+				return fmt.Errorf("error converting slow_start.duration_seconds to int: %s", aws.StringValue(attr.Value))
+			}
+			d.Set("slow_start", slowStart)
+		case "load_balancing.algorithm.type":
+			loadBalancingAlgorithm := aws.StringValue(attr.Value)
+			d.Set("load_balancing_algorithm_type", loadBalancingAlgorithm)
+		case "preserve_client_ip.enabled":
+			_, err := strconv.ParseBool(aws.StringValue(attr.Value))
+			if err != nil {
+				return fmt.Errorf("error converting preserve_client_ip.enabled to bool: %s", aws.StringValue(attr.Value))
+			}
+			d.Set("preserve_client_ip", attr.Value)
+		}
+	}
+
+	stickinessAttr, err := flattenAwsLbTargetGroupStickiness(attrResp.Attributes)
+	if err != nil {
+		return fmt.Errorf("error flattening stickiness: %w", err)
+	}
+
+	if err := d.Set("stickiness", stickinessAttr); err != nil {
+		return fmt.Errorf("error setting stickiness: %w", err)
+	}
+
+	tags, err := keyvaluetags.Elbv2ListTags(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for LB Target Group (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
 }

--- a/aws/internal/service/elbv2/finder/finder.go
+++ b/aws/internal/service/elbv2/finder/finder.go
@@ -5,6 +5,64 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 )
 
+func ListenerByARN(conn *elbv2.ELBV2, arn string) (*elbv2.Listener, error) {
+	input := &elbv2.DescribeListenersInput{
+		ListenerArns: aws.StringSlice([]string{arn}),
+	}
+
+	var result *elbv2.Listener
+
+	err := conn.DescribeListenersPages(input, func(page *elbv2.DescribeListenersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, l := range page.Listeners {
+			if l == nil {
+				continue
+			}
+
+			if aws.StringValue(l.ListenerArn) == arn {
+				result = l
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}
+
+func LoadBalancerByARN(conn *elbv2.ELBV2, arn string) (*elbv2.LoadBalancer, error) {
+	input := &elbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: aws.StringSlice([]string{arn}),
+	}
+
+	var result *elbv2.LoadBalancer
+
+	err := conn.DescribeLoadBalancersPages(input, func(page *elbv2.DescribeLoadBalancersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, lb := range page.LoadBalancers {
+			if lb == nil {
+				continue
+			}
+
+			if aws.StringValue(lb.LoadBalancerArn) == arn {
+				result = lb
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}
+
 func TargetGroupByARN(conn *elbv2.ELBV2, arn string) (*elbv2.TargetGroup, error) {
 	input := &elbv2.DescribeTargetGroupsInput{
 		TargetGroupArns: aws.StringSlice([]string{arn}),

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -699,36 +699,19 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	d.Set("name", targetGroup.TargetGroupName)
 	d.Set("target_type", targetGroup.TargetType)
 
-	healthCheck := make(map[string]interface{})
-	healthCheck["enabled"] = aws.BoolValue(targetGroup.HealthCheckEnabled)
-	healthCheck["healthy_threshold"] = int(aws.Int64Value(targetGroup.HealthyThresholdCount))
-	healthCheck["interval"] = int(aws.Int64Value(targetGroup.HealthCheckIntervalSeconds))
-	healthCheck["port"] = aws.StringValue(targetGroup.HealthCheckPort)
-	healthCheck["protocol"] = aws.StringValue(targetGroup.HealthCheckProtocol)
-	healthCheck["timeout"] = int(aws.Int64Value(targetGroup.HealthCheckTimeoutSeconds))
-	healthCheck["unhealthy_threshold"] = int(aws.Int64Value(targetGroup.UnhealthyThresholdCount))
+	if err := d.Set("health_check", flattenLbTargetGroupHealthCheck(targetGroup)); err != nil {
+		return fmt.Errorf("error setting health_check: %w", err)
+	}
 
-	if targetGroup.HealthCheckPath != nil {
-		healthCheck["path"] = aws.StringValue(targetGroup.HealthCheckPath)
-	}
-	if targetGroup.Matcher != nil && targetGroup.Matcher.HttpCode != nil {
-		healthCheck["matcher"] = aws.StringValue(targetGroup.Matcher.HttpCode)
-	}
-	if targetGroup.Matcher != nil && targetGroup.Matcher.GrpcCode != nil {
-		healthCheck["matcher"] = aws.StringValue(targetGroup.Matcher.GrpcCode)
-	}
 	if v, _ := d.Get("target_type").(string); v != elbv2.TargetTypeEnumLambda {
 		d.Set("vpc_id", targetGroup.VpcId)
 		d.Set("port", targetGroup.Port)
 		d.Set("protocol", targetGroup.Protocol)
 	}
+
 	switch d.Get("protocol").(string) {
 	case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
 		d.Set("protocol_version", targetGroup.ProtocolVersion)
-	}
-
-	if err := d.Set("health_check", []interface{}{healthCheck}); err != nil {
-		return fmt.Errorf("error setting health_check: %w", err)
 	}
 
 	attrResp, err := conn.DescribeTargetGroupAttributes(&elbv2.DescribeTargetGroupAttributesInput{
@@ -740,6 +723,12 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 
 	for _, attr := range attrResp.Attributes {
 		switch aws.StringValue(attr.Key) {
+		case "deregistration_delay.timeout_seconds":
+			timeout, err := strconv.Atoi(aws.StringValue(attr.Value))
+			if err != nil {
+				return fmt.Errorf("error converting deregistration_delay.timeout_seconds to int: %s", aws.StringValue(attr.Value))
+			}
+			d.Set("deregistration_delay", timeout)
 		case "lambda.multi_value_headers.enabled":
 			enabled, err := strconv.ParseBool(aws.StringValue(attr.Value))
 			if err != nil {
@@ -770,8 +759,13 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 		}
 	}
 
-	if err = flattenAwsLbTargetGroupStickiness(d, attrResp.Attributes); err != nil {
-		return err
+	stickinessAttr, err := flattenAwsLbTargetGroupStickiness(attrResp.Attributes)
+	if err != nil {
+		return fmt.Errorf("error flattening stickiness: %w", err)
+	}
+
+	if err := d.Set("stickiness", stickinessAttr); err != nil {
+		return fmt.Errorf("error setting stickiness: %w", err)
 	}
 
 	tags, err := keyvaluetags.Elbv2ListTags(conn, d.Id())
@@ -787,41 +781,33 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	return nil
 }
 
-func flattenAwsLbTargetGroupStickiness(d *schema.ResourceData, attributes []*elbv2.TargetGroupAttribute) error {
-	stickinessMap := map[string]interface{}{}
+func flattenAwsLbTargetGroupStickiness(attributes []*elbv2.TargetGroupAttribute) ([]interface{}, error) {
+	if len(attributes) == 0 {
+		return []interface{}{}, nil
+	}
+
+	m := make(map[string]interface{})
+
 	for _, attr := range attributes {
 		switch aws.StringValue(attr.Key) {
 		case "stickiness.enabled":
 			enabled, err := strconv.ParseBool(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("error converting stickiness.enabled to bool: %s", aws.StringValue(attr.Value))
+				return nil, fmt.Errorf("error converting stickiness.enabled to bool: %s", aws.StringValue(attr.Value))
 			}
-			stickinessMap["enabled"] = enabled
+			m["enabled"] = enabled
 		case "stickiness.type":
-			stickinessMap["type"] = aws.StringValue(attr.Value)
+			m["type"] = aws.StringValue(attr.Value)
 		case "stickiness.lb_cookie.duration_seconds":
 			duration, err := strconv.Atoi(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("error converting stickiness.lb_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
+				return nil, fmt.Errorf("error converting stickiness.lb_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
 			}
-			stickinessMap["cookie_duration"] = duration
-		case "deregistration_delay.timeout_seconds":
-			timeout, err := strconv.Atoi(aws.StringValue(attr.Value))
-			if err != nil {
-				return fmt.Errorf("error converting deregistration_delay.timeout_seconds to int: %s", aws.StringValue(attr.Value))
-			}
-			d.Set("deregistration_delay", timeout)
+			m["cookie_duration"] = duration
 		}
 	}
 
-	setStickyMap := []interface{}{}
-	if len(stickinessMap) > 0 {
-		setStickyMap = []interface{}{stickinessMap}
-	}
-	if err := d.Set("stickiness", setStickyMap); err != nil {
-		return err
-	}
-	return nil
+	return []interface{}{m}, nil
 }
 
 func resourceAwsLbTargetGroupCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
@@ -891,4 +877,32 @@ func resourceAwsLbTargetGroupCustomizeDiff(_ context.Context, diff *schema.Resou
 		}
 	}
 	return nil
+}
+
+func flattenLbTargetGroupHealthCheck(targetGroup *elbv2.TargetGroup) []interface{} {
+	if targetGroup == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enabled":             aws.BoolValue(targetGroup.HealthCheckEnabled),
+		"healthy_threshold":   int(aws.Int64Value(targetGroup.HealthyThresholdCount)),
+		"interval":            int(aws.Int64Value(targetGroup.HealthCheckIntervalSeconds)),
+		"port":                aws.StringValue(targetGroup.HealthCheckPort),
+		"protocol":            aws.StringValue(targetGroup.HealthCheckProtocol),
+		"timeout":             int(aws.Int64Value(targetGroup.HealthCheckTimeoutSeconds)),
+		"unhealthy_threshold": int(aws.Int64Value(targetGroup.UnhealthyThresholdCount)),
+	}
+
+	if targetGroup.HealthCheckPath != nil {
+		m["path"] = aws.StringValue(targetGroup.HealthCheckPath)
+	}
+	if targetGroup.Matcher != nil && targetGroup.Matcher.HttpCode != nil {
+		m["matcher"] = aws.StringValue(targetGroup.Matcher.HttpCode)
+	}
+	if targetGroup.Matcher != nil && targetGroup.Matcher.GrpcCode != nil {
+		m["matcher"] = aws.StringValue(targetGroup.Matcher.GrpcCode)
+	}
+
+	return []interface{}{m}
 }

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -269,15 +269,11 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckInterval(&targetGroup1, 10),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "traffic-port"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&targetGroup1, 10),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
-					testAccCheckAWSLBTargetGroupHealthyThreshold(&targetGroup1, 3),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
-					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&targetGroup1, 3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
@@ -300,15 +296,11 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckInterval(&targetGroup2, 10),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "traffic-port"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&targetGroup2, 10),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "5"),
-					testAccCheckAWSLBTargetGroupHealthyThreshold(&targetGroup2, 5),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "5"),
-					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&targetGroup2, 5),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
@@ -522,16 +514,12 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "300"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
-					testAccCheckAWSLBTargetGroupHealthCheckInterval(&confBefore, 30),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/healthz"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&confBefore, 10),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "2"),
-					testAccCheckAWSLBTargetGroupHealthyThreshold(&confBefore, 2),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "2"),
-					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&confBefore, 2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
@@ -548,16 +536,12 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "300"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
-					testAccCheckAWSLBTargetGroupHealthCheckInterval(&confAfter, 30),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/healthz2"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&confAfter, 10),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
-					testAccCheckAWSLBTargetGroupHealthyThreshold(&confAfter, 4),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
-					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&confAfter, 4),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
@@ -835,7 +819,6 @@ func TestAccAWSLBTargetGroup_enableHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "false"),
-					testAccCheckAWSLBTargetGroupHealthCheckEnabled(&conf, false),
 				),
 			},
 			{
@@ -846,7 +829,6 @@ func TestAccAWSLBTargetGroup_enableHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
-					testAccCheckAWSLBTargetGroupHealthCheckEnabled(&conf, true),
 				),
 			},
 		},
@@ -882,14 +864,11 @@ func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "60"),
-					testAccCheckAWSLBTargetGroupHealthCheckInterval(&conf, 60),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8081"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
-					testAccCheckAWSLBTargetGroupHealthyThreshold(&conf, 3),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
-					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&conf, 3),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
 				),
 			},
@@ -908,17 +887,13 @@ func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
-					testAccCheckAWSLBTargetGroupHealthCheckEnabled(&conf, true),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
-					testAccCheckAWSLBTargetGroupHealthCheckInterval(&conf, 30),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8082"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "4"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
-					testAccCheckAWSLBTargetGroupHealthyThreshold(&conf, 4),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "4"),
-					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&conf, 4),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200"),
 				),
 			},
@@ -1418,76 +1393,6 @@ func testAccCheckAWSLBTargetGroupRecreated(i, j *elbv2.TargetGroup) resource.Tes
 			return fmt.Errorf("ELBv2 Target Group (%s) not recreated", aws.StringValue(i.TargetGroupArn))
 		}
 
-		return nil
-	}
-}
-
-func testAccCheckAWSLBTargetGroupHealthCheckEnabled(res *elbv2.TargetGroup, expected bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if res.HealthCheckEnabled == nil {
-			return fmt.Errorf("Expected HealthCheckEnabled to be %t, given %#v",
-				expected, res.HealthCheckEnabled)
-		}
-		if *res.HealthCheckEnabled != expected {
-			return fmt.Errorf("Expected HealthCheckEnabled to be %t, given %t",
-				expected, *res.HealthCheckEnabled)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSLBTargetGroupHealthCheckInterval(res *elbv2.TargetGroup, expected int64) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if res.HealthCheckIntervalSeconds == nil {
-			return fmt.Errorf("Expected HealthCheckIntervalSeconds to be %d, given: %#v",
-				expected, res.HealthCheckIntervalSeconds)
-		}
-		if *res.HealthCheckIntervalSeconds != expected {
-			return fmt.Errorf("Expected HealthCheckIntervalSeconds to be %d, given: %d",
-				expected, *res.HealthCheckIntervalSeconds)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSLBTargetGroupHealthCheckTimeout(res *elbv2.TargetGroup, expected int64) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if res.HealthCheckTimeoutSeconds == nil {
-			return fmt.Errorf("Expected HealthCheckTimeoutSeconds to be %d, given: %#v",
-				expected, res.HealthCheckTimeoutSeconds)
-		}
-		if *res.HealthCheckTimeoutSeconds != expected {
-			return fmt.Errorf("Expected HealthCheckTimeoutSeconds to be %d, given: %d",
-				expected, *res.HealthCheckTimeoutSeconds)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSLBTargetGroupHealthyThreshold(res *elbv2.TargetGroup, expected int64) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if res.HealthyThresholdCount == nil {
-			return fmt.Errorf("Expected HealthyThresholdCount to be %d, given: %#v",
-				expected, res.HealthyThresholdCount)
-		}
-		if *res.HealthyThresholdCount != expected {
-			return fmt.Errorf("Expected HealthyThresholdCount to be %d, given: %d",
-				expected, *res.HealthyThresholdCount)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSLBTargetGroupUnhealthyThreshold(res *elbv2.TargetGroup, expected int64) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if res.UnhealthyThresholdCount == nil {
-			return fmt.Errorf("Expected.UnhealthyThresholdCount to be %d, given: %#v",
-				expected, res.UnhealthyThresholdCount)
-		}
-		if *res.UnhealthyThresholdCount != expected {
-			return fmt.Errorf("Expected.UnhealthyThresholdCount to be %d, given: %d",
-				expected, *res.UnhealthyThresholdCount)
-		}
 		return nil
 	}
 }

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elbv2/finder"
 )
 
 func init() {
@@ -1192,21 +1195,18 @@ func testAccCheckAWSLBExists(n string, res *elbv2.LoadBalancer) resource.TestChe
 
 		conn := testAccProvider.Meta().(*AWSClient).elbv2conn
 
-		describe, err := conn.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
-			LoadBalancerArns: []*string{aws.String(rs.Primary.ID)},
-		})
+		lb, err := finder.LoadBalancerByARN(conn, rs.Primary.ID)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading LB (%s): %w", rs.Primary.ID, err)
 		}
 
-		if len(describe.LoadBalancers) != 1 ||
-			aws.StringValue(describe.LoadBalancers[0].LoadBalancerArn) != rs.Primary.ID {
-			return errors.New("LB not found")
+		if lb != nil {
+			*res = *lb
+			return nil
 		}
 
-		*res = *describe.LoadBalancers[0]
-		return nil
+		return fmt.Errorf("LB (%s) not found", rs.Primary.ID)
 	}
 }
 
@@ -1249,22 +1249,18 @@ func testAccCheckAWSLBDestroy(s *terraform.State) error {
 			continue
 		}
 
-		describe, err := conn.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
-			LoadBalancerArns: []*string{aws.String(rs.Primary.ID)},
-		})
+		lb, err := finder.LoadBalancerByARN(conn, rs.Primary.ID)
 
-		if err == nil {
-			if len(describe.LoadBalancers) != 0 &&
-				aws.StringValue(describe.LoadBalancers[0].LoadBalancerArn) == rs.Primary.ID {
-				return fmt.Errorf("LB %q still exists", rs.Primary.ID)
-			}
+		if tfawserr.ErrCodeContains(err, elb.ErrCodeAccessPointNotFoundException) {
+			continue
 		}
 
-		// Verify the error
-		if isLoadBalancerNotFound(err) {
-			return nil
-		} else {
-			return fmt.Errorf("Unexpected error checking LB destroyed: %s", err)
+		if err != nil {
+			return fmt.Errorf("Unexpected error checking LB (%s) destroyed: %w", rs.Primary.ID, err)
+		}
+
+		if lb != nil && aws.StringValue(lb.LoadBalancerArn) == rs.Primary.ID {
+			return fmt.Errorf("LB %q still exists", rs.Primary.ID)
 		}
 	}
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1026,6 +1026,15 @@ func expandFloat64Map(m map[string]interface{}) map[string]*float64 {
 	return float64Map
 }
 
+// Expands a map of string to interface to a map of string to *string
+func expandStringMap(m map[string]interface{}) map[string]*string {
+	stringMap := make(map[string]*string, len(m))
+	for k, v := range m {
+		stringMap[k] = aws.String(v.(string))
+	}
+	return stringMap
+}
+
 // Takes the result of schema.Set of strings and returns a []*string
 func expandStringSet(configured *schema.Set) []*string {
 	return expandStringList(configured.List()) // nosemgrep: helper-schema-Set-extraneous-expandStringList-with-List


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18819
Relates #7926

### Description

To enable provider-wide tags, we need to ensure data-sources do not reference resource Read functions to ensure the new attribute "tags_all" is not incorrectly set into a data-source state and the "tags" attribute is not filtered by the provider-level configuration.

Output from acceptance testing (commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestLBListenerARNFromRuleARN (0.00s)
--- SKIP: TestAccDataSourceAWSLB_outpost (1.10s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears_ELB (41.27s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears (41.93s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (53.61s)
--- PASS: TestAccDataSourceAWSLBListener_DefaultAction_Forward (165.92s)
--- PASS: TestAccDataSourceAWSLBListener_basic (175.74s)
--- PASS: TestAccDataSourceAWSLBListener_https (176.88s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_basic (177.77s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (178.37s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (7.86s)
--- PASS: TestAccAWSLBListenerRule_redirect (191.74s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (193.76s)
--- PASS: TestAccAWSLBListenerRule_basic (199.04s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (208.09s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (215.56s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (215.04s)
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (225.24s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (226.81s)
--- PASS: TestAccDataSourceAWSLB_basic (228.16s)
--- PASS: TestAccAWSLBListenerRule_oidc (187.51s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (55.86s)
--- PASS: TestAccAWSLBListenerRule_cognito (196.39s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (245.08s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (245.95s)
--- PASS: TestAccAWSLBListenerRule_priority (330.09s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (319.47s)
--- PASS: TestAccAWSLBListener_LoadBalancerArn_GatewayLoadBalancer (149.26s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (233.09s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (256.03s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (260.03s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (265.06s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (264.36s)
--- PASS: TestAccAWSLBListener_Protocol_Tls (225.81s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (295.78s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (30.99s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_disappears (29.63s)
--- PASS: TestAccAWSLBListener_basic (264.32s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (300.04s)
--- PASS: TestLBTargetGroupCloudwatchSuffixFromARN (0.00s)
--- PASS: TestAccAWSLBListener_redirect (261.18s)
--- PASS: TestAccAWSLBTargetGroup_basic (16.51s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (28.12s)
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (49.17s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion (31.75s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (329.52s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (81.93s)
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (337.73s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (95.70s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (107.70s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (100.90s)
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (42.51s)
--- PASS: TestAccAWSLBListener_basicUdp (350.93s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (180.19s)
--- PASS: TestAccAWSLBListener_cognito (206.27s)
--- PASS: TestAccAWSLBListener_fixedResponse (251.68s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (369.57s)
--- PASS: TestAccAWSLBListener_https (357.28s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (57.35s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (111.14s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (404.45s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (52.71s)
--- PASS: TestAccAWSLBListener_oidc (234.52s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (193.65s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck (63.65s)
--- PASS: TestAccAWSLBTargetGroup_generatedName (66.17s)
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (68.18s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (102.21s)
--- PASS: TestAccAWSLBListener_forwardWeighted (420.56s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (68.39s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update (106.51s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (117.74s)
--- PASS: TestLBCloudwatchSuffixFromARN (0.00s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (123.08s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (73.61s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (167.54s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (125.23s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (130.38s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (126.11s)
--- SKIP: TestAccAWSLB_ALB_outpost (1.50s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (125.34s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (72.47s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (120.17s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (96.38s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (80.89s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (124.35s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (99.16s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (105.98s)
--- PASS: TestAccAWSLBTargetGroup_tags (155.03s)
--- PASS: TestAccAWSLBTargetGroup_preserveClientIPValid (81.98s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (146.11s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (134.35s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (146.73s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (122.43s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (152.92s)
--- PASS: TestAccAWSLB_ALB_basic (195.15s)
--- PASS: TestAccAWSLB_generatedName (172.56s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (171.70s)
--- PASS: TestAccAWSLB_namePrefix (169.53s)
--- PASS: TestAccAWSLB_NLB_basic (226.37s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (206.16s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (222.02s)
--- PASS: TestAccAWSLB_noSecurityGroup (156.91s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (238.31s)
--- PASS: TestAccAWSLB_IPv6SubnetMapping (246.10s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (216.25s)
--- PASS: TestAccAWSLB_updatedSubnets (223.97s)
--- PASS: TestAccAWSLB_updatedIpAddressType (221.38s)
--- PASS: TestAccAWSLB_tags (272.09s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (276.02s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (278.23s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (288.13s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (307.50s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (239.65s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (300.44s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (227.47s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (319.43s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (343.84s)
```
