### PR TITLE
tech-debt: refactor curreportdefinition data and resources to use different Read methods

### DIFF
--- a/aws/internal/service/costandusagereportservice/finder/finder.go
+++ b/aws/internal/service/costandusagereportservice/finder/finder.go
@@ -1,0 +1,36 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/costandusagereportservice"
+)
+
+func ReportDefinitionByName(conn *costandusagereportservice.CostandUsageReportService, name string) (*costandusagereportservice.ReportDefinition, error) {
+	input := &costandusagereportservice.DescribeReportDefinitionsInput{}
+
+	var result *costandusagereportservice.ReportDefinition
+
+	err := conn.DescribeReportDefinitionsPages(input, func(page *costandusagereportservice.DescribeReportDefinitionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, reportDefinition := range page.ReportDefinitions {
+			if reportDefinition == nil {
+				continue
+			}
+
+			if aws.StringValue(reportDefinition.ReportName) == name {
+				result = reportDefinition
+				return false
+			}
+		}
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/aws/resource_aws_cur_report_definition_test.go
+++ b/aws/resource_aws_cur_report_definition_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/costandusagereportservice/finder"
 )
 
 func TestAccAwsCurReportDefinition_basic(t *testing.T) {
@@ -242,14 +243,17 @@ func testAccCheckAwsCurReportDefinitionDestroy(s *terraform.State) error {
 		if rs.Type != "aws_cur_report_definition" {
 			continue
 		}
-		reportName := rs.Primary.ID
-		matchingReportDefinition, err := describeCurReportDefinition(conn, reportName)
+
+		matchingReportDefinition, err := finder.ReportDefinitionByName(conn, rs.Primary.ID)
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading Report Definition (%s): %w", rs.Primary.ID, err)
 		}
-		if matchingReportDefinition != nil {
-			return fmt.Errorf("Report Definition still exists: %q", rs.Primary.ID)
+
+		if matchingReportDefinition == nil {
+			continue
 		}
+
+		return fmt.Errorf("Report Definition still exists: %q", rs.Primary.ID)
 	}
 	return nil
 
@@ -263,14 +267,16 @@ func testAccCheckAwsCurReportDefinitionExists(resourceName string) resource.Test
 		if !ok {
 			return fmt.Errorf("Resource not found: %s", resourceName)
 		}
-		reportName := rs.Primary.ID
-		matchingReportDefinition, err := describeCurReportDefinition(conn, reportName)
+
+		matchingReportDefinition, err := finder.ReportDefinitionByName(conn, rs.Primary.ID)
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading Report Definition (%s): %w", rs.Primary.ID, err)
 		}
+
 		if matchingReportDefinition == nil {
 			return fmt.Errorf("Report Definition does not exist: %q", rs.Primary.ID)
 		}
+
 		return nil
 	}
 }


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18819 
Relates #7926

Output from acceptance testing (Commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestCheckAwsCurReportDefinitionPropertyCombination (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestAthenaAndOverrideReport (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestAthenaValidCombination (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestAthenaAndEmptyPrefix (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestAthenaWithNonParquetFormat (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestParquetFormatWithoutParquetCompression (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestRedshiftWithZippedCreateNew (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestMultipleArtifacts (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestAthenaAndAdditionalArtifacts (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestRedshiftWithGzipedOverwrite (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestQuicksightWithGzipedOverwrite (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestQuicksightWithGzipedCreateNew (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestRedshiftWithGzipedCreateNew (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestQuicksightWithZippedOverwrite (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestQuicksightWithZippedCreateNew (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestCSVFormatWithParquetCompression (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestRedshiftWithParquetformat (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestQuicksightWithParquetformat (0.00s)
    --- PASS: TestCheckAwsCurReportDefinitionPropertyCombination/TestRedshiftWithZippedOverwrite (0.00s)
--- PASS: TestAccAwsCurReportDefinition_parquet (38.48s)
--- PASS: TestAccAwsCurReportDefinition_basic (39.40s)
--- PASS: TestAccAwsCurReportDefinition_refresh (40.00s)
--- PASS: TestAccAwsCurReportDefinition_textOrCsv (41.65s)
--- PASS: TestAccAwsCurReportDefinition_overwrite (41.78s)
--- PASS: TestAccAwsCurReportDefinition_athena (42.56s)
--- PASS: TestAccDataSourceAwsCurReportDefinition_additional (43.29s)
--- PASS: TestAccDataSourceAwsCurReportDefinition_basic (43.59s)
```
