### PR TITLE
r/codebuild_project - allow removing secondary fields + allow to fetch submodules for bitbucket projects

### DIFF
--- a/.changelog/18843.txt
+++ b/.changelog/18843.txt
@@ -1,3 +1,11 @@
 ```release-note:bug
 resource/aws_codebuild_project: Fix removing `secondary_sources` and `secondary_artifacts`
 ```
+
+```release-note:bug
+resource/aws_codebuild_project: Allow fetching submodules for bitbucket source types
+```
+
+```release-note:enhancement
+resource/aws_codebuild_project: Add plan time validation for `secondary_artifacts`, `secondary_sources`, `service_role`
+```

--- a/.changelog/18843.txt
+++ b/.changelog/18843.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_project: Fix removing `secondary_sources` and `secondary_artifacts`
+```

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -72,10 +72,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 								}
 								return false
 							},
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactNamespaceNone,
-								codebuild.ArtifactNamespaceBuildId,
-							}, false),
+							ValidateFunc: validation.StringInSlice(codebuild.ArtifactNamespace_Values(), false),
 						},
 						"packaging": {
 							Type:     schema.TypeString,
@@ -89,23 +86,16 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 								}
 								return false
 							},
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactPackagingNone,
-								codebuild.ArtifactPackagingZip,
-							}, false),
+							ValidateFunc: validation.StringInSlice(codebuild.ArtifactPackaging_Values(), false),
 						},
 						"path": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactsTypeCodepipeline,
-								codebuild.ArtifactsTypeS3,
-								codebuild.ArtifactsTypeNoArtifacts,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.ArtifactsType_Values(), false),
 						},
 						"override_artifact_name": {
 							Type:     schema.TypeBool,
@@ -172,14 +162,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  codebuild.CacheTypeNoCache,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.CacheTypeNoCache,
-								codebuild.CacheTypeS3,
-								codebuild.CacheTypeLocal,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      codebuild.CacheTypeNoCache,
+							ValidateFunc: validation.StringInSlice(codebuild.CacheType_Values(), false),
 						},
 						"location": {
 							Type:     schema.TypeString,
@@ -216,14 +202,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"compute_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ComputeTypeBuildGeneral1Small,
-								codebuild.ComputeTypeBuildGeneral1Medium,
-								codebuild.ComputeTypeBuildGeneral1Large,
-								codebuild.ComputeTypeBuildGeneral12xlarge,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.ComputeType_Values(), false),
 						},
 						"environment_variable": {
 							Type:     schema.TypeList,
@@ -239,14 +220,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										Required: true,
 									},
 									"type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.EnvironmentVariableTypePlaintext,
-											codebuild.EnvironmentVariableTypeParameterStore,
-											codebuild.EnvironmentVariableTypeSecretsManager,
-										}, false),
-										Default: codebuild.EnvironmentVariableTypePlaintext,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(codebuild.EnvironmentVariableType_Values(), false),
+										Default:      codebuild.EnvironmentVariableTypePlaintext,
 									},
 								},
 							},
@@ -256,24 +233,15 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Required: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.EnvironmentTypeLinuxContainer,
-								codebuild.EnvironmentTypeLinuxGpuContainer,
-								codebuild.EnvironmentTypeWindowsContainer,
-								codebuild.EnvironmentTypeWindowsServer2019Container,
-								codebuild.EnvironmentTypeArmContainer,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.EnvironmentType_Values(), false),
 						},
 						"image_pull_credentials_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  codebuild.ImagePullCredentialsTypeCodebuild,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ImagePullCredentialsTypeCodebuild,
-								codebuild.ImagePullCredentialsTypeServiceRole,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      codebuild.ImagePullCredentialsTypeCodebuild,
+							ValidateFunc: validation.StringInSlice(codebuild.ImagePullCredentialsType_Values(), false),
 						},
 						"privileged_mode": {
 							Type:     schema.TypeBool,
@@ -296,11 +264,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										Required: true,
 									},
 									"credential_provider": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.CredentialProviderTypeSecretsManager,
-										}, false),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(codebuild.CredentialProviderType_Values(), false),
 									},
 								},
 							},
@@ -321,13 +287,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"status": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  codebuild.LogsConfigStatusTypeEnabled,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.LogsConfigStatusTypeDisabled,
-											codebuild.LogsConfigStatusTypeEnabled,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      codebuild.LogsConfigStatusTypeEnabled,
+										ValidateFunc: validation.StringInSlice(codebuild.LogsConfigStatusType_Values(), false),
 									},
 									"group_name": {
 										Type:     schema.TypeString,
@@ -348,13 +311,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"status": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  codebuild.LogsConfigStatusTypeDisabled,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.LogsConfigStatusTypeDisabled,
-											codebuild.LogsConfigStatusTypeEnabled,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      codebuild.LogsConfigStatusTypeDisabled,
+										ValidateFunc: validation.StringInSlice(codebuild.LogsConfigStatusType_Values(), false),
 									},
 									"location": {
 										Type:         schema.TypeString,
@@ -383,6 +343,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 			"secondary_artifacts": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 12,
 				Set:      resourceAwsCodeBuildProjectArtifactsHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -400,13 +361,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Optional: true,
 						},
 						"namespace_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactNamespaceNone,
-								codebuild.ArtifactNamespaceBuildId,
-							}, false),
-							Default: codebuild.ArtifactNamespaceNone,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.ArtifactNamespace_Values(), false),
+							Default:      codebuild.ArtifactNamespaceNone,
 						},
 						"override_artifact_name": {
 							Type:     schema.TypeBool,
@@ -414,13 +372,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Default:  false,
 						},
 						"packaging": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactPackagingNone,
-								codebuild.ArtifactPackagingZip,
-							}, false),
-							Default: codebuild.ArtifactPackagingNone,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.ArtifactPackaging_Values(), false),
+							Default:      codebuild.ArtifactPackagingNone,
 						},
 						"path": {
 							Type:     schema.TypeString,
@@ -431,11 +386,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Required: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactsTypeS3,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.ArtifactsType_Values(), false),
 						},
 					},
 				},
@@ -443,6 +396,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 			"secondary_sources": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 12,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"auth": {
@@ -458,12 +412,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										Deprecated: "Use the aws_codebuild_source_credential resource instead",
 									},
 									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.SourceAuthTypeOauth,
-										}, false),
-										Deprecated: "Use the aws_codebuild_source_credential resource instead",
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(codebuild.SourceAuthType_Values(), false),
+										Deprecated:   "Use the aws_codebuild_source_credential resource instead",
 									},
 								},
 							},
@@ -478,16 +430,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Optional: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.SourceTypeCodecommit,
-								codebuild.SourceTypeCodepipeline,
-								codebuild.SourceTypeGithub,
-								codebuild.SourceTypeS3,
-								codebuild.SourceTypeBitbucket,
-								codebuild.SourceTypeGithubEnterprise,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.SourceType_Values(), false),
 						},
 						"git_clone_depth": {
 							Type:         schema.TypeInt,
@@ -540,8 +485,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				},
 			},
 			"service_role": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
 			},
 			"source": {
 				Type:     schema.TypeList,
@@ -562,12 +508,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										Deprecated: "Use the aws_codebuild_source_credential resource instead",
 									},
 									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.SourceAuthTypeOauth,
-										}, false),
-										Deprecated: "Use the aws_codebuild_source_credential resource instead",
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(codebuild.SourceAuthType_Values(), false),
+										Deprecated:   "Use the aws_codebuild_source_credential resource instead",
 									},
 								},
 							},
@@ -582,17 +526,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Optional: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.SourceTypeCodecommit,
-								codebuild.SourceTypeCodepipeline,
-								codebuild.SourceTypeGithub,
-								codebuild.SourceTypeS3,
-								codebuild.SourceTypeBitbucket,
-								codebuild.SourceTypeGithubEnterprise,
-								codebuild.SourceTypeNoSource,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(codebuild.SourceType_Values(), false),
 						},
 						"git_clone_depth": {
 							Type:         schema.TypeInt,
@@ -681,14 +617,12 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							// Set:      schema.HashString,
 							MaxItems: 16,
 						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							// Set:      schema.HashString,
 							MaxItems: 5,
 						},
 					},
@@ -1189,8 +1123,8 @@ func expandProjectSourceData(data map[string]interface{}) codebuild.ProjectSourc
 		}
 	}
 
-	// Only valid for CODECOMMIT, GITHUB, GITHUB_ENTERPRISE source types.
-	if sourceType == codebuild.SourceTypeCodecommit || sourceType == codebuild.SourceTypeGithub || sourceType == codebuild.SourceTypeGithubEnterprise {
+	// Only valid for CODECOMMIT, GITHUB, GITHUB_ENTERPRISE, BITBUCKET source types.
+	if sourceType == codebuild.SourceTypeCodecommit || sourceType == codebuild.SourceTypeGithub || sourceType == codebuild.SourceTypeGithubEnterprise || sourceType == codebuild.SourceTypeBitbucket {
 		if v, ok := data["git_submodules_config"]; ok && len(v.([]interface{})) > 0 {
 			config := v.([]interface{})[0].(map[string]interface{})
 

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -1341,13 +1341,25 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("secondary_sources") {
-		projectSecondarySources := expandProjectSecondarySources(d)
-		params.SecondarySources = projectSecondarySources
+		_, n := d.GetChange("secondary_sources")
+
+		if n.(*schema.Set).Len() > 0 {
+			projectSecondarySources := expandProjectSecondarySources(d)
+			params.SecondarySources = projectSecondarySources
+		} else {
+			params.SecondarySources = []*codebuild.ProjectSource{}
+		}
 	}
 
 	if d.HasChange("secondary_artifacts") {
-		projectSecondaryArtifacts := expandProjectSecondaryArtifacts(d)
-		params.SecondaryArtifacts = projectSecondaryArtifacts
+		_, n := d.GetChange("secondary_artifacts")
+
+		if n.(*schema.Set).Len() > 0 {
+			projectSecondaryArtifacts := expandProjectSecondaryArtifacts(d)
+			params.SecondaryArtifacts = projectSecondaryArtifacts
+		} else {
+			params.SecondaryArtifacts = []*codebuild.ProjectArtifacts{}
+		}
 	}
 
 	if d.HasChange("vpc_config") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18755
Closes #11525
Closes #18069
Closes #13588

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=-run=TestAccAWSCodeBuildProject_'
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (67.02s)
--- PASS: TestAccAWSCodeBuildProject_basic (77.12s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (101.11s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (109.02s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (119.76s)
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (58.31s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (163.06s)
--- PASS: TestAccAWSCodeBuildProject_WindowsServer2019Container (54.32s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (163.67s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (164.34s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (167.29s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (170.50s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (170.94s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (170.95s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (171.95s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (172.26s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (172.44s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (174.07s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (176.02s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (178.49s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (197.35s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (197.60s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (51.22s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (167.10s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (71.22s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (64.41s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (72.39s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (159.61s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (70.24s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (74.59s)
--- PASS: TestAccAWSCodeBuildProject_Tags (109.94s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (106.70s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (116.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (111.96s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (112.35s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (108.50s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (111.01s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (116.91s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (110.65s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (91.18s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (69.35s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (219.17s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (60.28s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (167.76s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (109.03s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (113.19s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (109.18s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (62.93s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (149.41s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (149.81s)
--- PASS: TestAccAWSCodeBuildProject_Description (107.22s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (150.10s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (201.84s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (167.78s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (125.83s)
--- PASS: TestAccAWSCodeBuildProject_Cache (245.65s)
```
