### PR TITLE
tech-debt: refactor dynamodb data and resources to use different Read methods

### DIFF
--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -216,48 +217,112 @@ func dataSourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).dynamodbconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
+	name := d.Get("name").(string)
+
 	result, err := conn.DescribeTable(&dynamodb.DescribeTableInput{
-		TableName: aws.String(d.Get("name").(string)),
+		TableName: aws.String(name),
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving DynamoDB table: %w", err)
+		return fmt.Errorf("error reading Dynamodb Table (%s): %w", name, err)
 	}
 
-	d.SetId(aws.StringValue(result.Table.TableName))
+	if result == nil || result.Table == nil {
+		return fmt.Errorf("error reading Dynamodb Table (%s): not found", name)
+	}
 
-	err = flattenDynamoDbTableResource(d, result.Table)
-	if err != nil {
-		return err
+	table := result.Table
+
+	d.SetId(aws.StringValue(table.TableName))
+
+	d.Set("arn", table.TableArn)
+	d.Set("name", table.TableName)
+
+	if table.BillingModeSummary != nil {
+		d.Set("billing_mode", table.BillingModeSummary.BillingMode)
+	} else {
+		d.Set("billing_mode", dynamodb.BillingModeProvisioned)
+	}
+
+	if table.ProvisionedThroughput != nil {
+		d.Set("write_capacity", table.ProvisionedThroughput.WriteCapacityUnits)
+		d.Set("read_capacity", table.ProvisionedThroughput.ReadCapacityUnits)
+	}
+
+	if err := d.Set("attribute", flattenDynamoDbTableAttributeDefinitions(table.AttributeDefinitions)); err != nil {
+		return fmt.Errorf("error setting attribute: %w", err)
+	}
+
+	for _, attribute := range table.KeySchema {
+		if aws.StringValue(attribute.KeyType) == dynamodb.KeyTypeHash {
+			d.Set("hash_key", attribute.AttributeName)
+		}
+
+		if aws.StringValue(attribute.KeyType) == dynamodb.KeyTypeRange {
+			d.Set("range_key", attribute.AttributeName)
+		}
+	}
+
+	if err := d.Set("local_secondary_index", flattenDynamoDbTableLocalSecondaryIndex(table.LocalSecondaryIndexes)); err != nil {
+		return fmt.Errorf("error setting local_secondary_index: %w", err)
+	}
+
+	if err := d.Set("global_secondary_index", flattenDynamoDbTableGlobalSecondaryIndex(table.GlobalSecondaryIndexes)); err != nil {
+		return fmt.Errorf("error setting global_secondary_index: %w", err)
+	}
+
+	if table.StreamSpecification != nil {
+		d.Set("stream_view_type", table.StreamSpecification.StreamViewType)
+		d.Set("stream_enabled", table.StreamSpecification.StreamEnabled)
+	} else {
+		d.Set("stream_view_type", "")
+		d.Set("stream_enabled", false)
+	}
+
+	d.Set("stream_arn", table.LatestStreamArn)
+	d.Set("stream_label", table.LatestStreamLabel)
+
+	if err := d.Set("server_side_encryption", flattenDynamodDbTableServerSideEncryption(table.SSEDescription)); err != nil {
+		return fmt.Errorf("error setting server_side_encryption: %w", err)
+	}
+
+	if err := d.Set("replica", flattenDynamoDbReplicaDescriptions(table.Replicas)); err != nil {
+		return fmt.Errorf("error setting replica: %w", err)
+	}
+
+	pitrOut, err := conn.DescribeContinuousBackups(&dynamodb.DescribeContinuousBackupsInput{
+		TableName: aws.String(d.Id()),
+	})
+
+	if err != nil && !tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
+		return fmt.Errorf("error describing DynamoDB Table (%s) Continuous Backups: %w", d.Id(), err)
+	}
+
+	if err := d.Set("point_in_time_recovery", flattenDynamoDbPitr(pitrOut)); err != nil {
+		return fmt.Errorf("error setting point_in_time_recovery: %w", err)
 	}
 
 	ttlOut, err := conn.DescribeTimeToLive(&dynamodb.DescribeTimeToLiveInput{
 		TableName: aws.String(d.Id()),
 	})
+
 	if err != nil {
 		return fmt.Errorf("error describing DynamoDB Table (%s) Time to Live: %w", d.Id(), err)
 	}
+
 	if err := d.Set("ttl", flattenDynamoDbTtl(ttlOut)); err != nil {
 		return fmt.Errorf("error setting ttl: %w", err)
 	}
 
 	tags, err := keyvaluetags.DynamodbListTags(conn, d.Get("arn").(string))
 
-	if err != nil && !isAWSErr(err, "UnknownOperationException", "Tagging is not currently supported in DynamoDB Local.") {
+	if err != nil && !tfawserr.ErrMessageContains(err, "UnknownOperationException", "Tagging is not currently supported in DynamoDB Local.") {
 		return fmt.Errorf("error listing tags for DynamoDB Table (%s): %w", d.Get("arn").(string), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
-
-	pitrOut, err := conn.DescribeContinuousBackups(&dynamodb.DescribeContinuousBackupsInput{
-		TableName: aws.String(d.Id()),
-	})
-	if err != nil && !isAWSErr(err, "UnknownOperationException", "") {
-		return err
-	}
-	d.Set("point_in_time_recovery", flattenDynamoDbPitr(pitrOut))
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18819 
Relates #7926

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestUpdateDynamoDbDiffGSI (0.00s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (13.84s)
--- PASS: TestAccAWSDynamoDbTableItem_basic (52.74s)
--- PASS: TestAccAWSDynamoDbTable_disappears (54.85s)
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (64.03s)
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (66.87s)
--- PASS: TestAccAWSDynamoDbTable_basic (69.95s)
--- PASS: TestAccDataSourceAwsDynamoDbTable_basic (73.17s)
--- PASS: TestAccAWSDynamoDbTable_lsiNonKeyAttributes (69.62s)
--- PASS: TestAccAWSDynamoDbTable_tags (85.45s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (100.30s)
--- PASS: TestAccAWSDynamoDbTableItem_updateWithRangeKey (100.66s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (16.16s)
--- PASS: TestAccAWSDynamoDbTableItem_update (103.11s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_payPerRequestToProvisioned (105.54s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_enabled (56.88s)
--- PASS: TestAccAWSDynamoDbTable_enablePitr (130.14s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_payPerRequestToProvisioned (133.41s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (134.03s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes_emptyPlan (82.44s)
--- PASS: TestAccAWSDynamoDbTable_disappears_payPerRequestWithGSI (138.69s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_disabled (72.64s)
--- PASS: TestAccAWSDynamoDbTable_lsiUpdate (79.40s)
--- PASS: TestAccAWSDynamoDbTable_encryption (157.01s)
--- PASS: TestAccAWSDynamoDbTable_Replica_singleWithCMK (192.84s)
--- PASS: TestAccAWSDynamoDbTable_extended (337.49s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (288.82s)
--- PASS: TestAccAWSDynamoDbTable_Replica_single (570.62s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (675.16s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (612.88s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_provisionedToPayPerRequest (1047.99s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_provisionedToPayPerRequest (1055.31s)
--- PASS: TestAccAWSDynamoDbTable_Replica_multiple (1055.56s)
```
