### PR TITLE
tech-debt: refactor iam data source and resource to use different Read methods

### DIFF
--- a/aws/data_source_aws_iam_policy.go
+++ b/aws/data_source_aws_iam_policy.go
@@ -1,7 +1,17 @@
 package aws
 
 import (
+	"fmt"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func dataSourceAwsIAMPolicy() *schema.Resource {
@@ -40,6 +50,105 @@ func dataSourceAwsIAMPolicy() *schema.Resource {
 }
 
 func dataSourceAwsIAMPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	d.SetId(d.Get("arn").(string))
-	return resourceAwsIamPolicyRead(d, meta)
+	conn := meta.(*AWSClient).iamconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	arn := d.Get("arn").(string)
+
+	input := &iam.GetPolicyInput{
+		PolicyArn: aws.String(arn),
+	}
+
+	// Handle IAM eventual consistency
+	var output *iam.GetPolicyOutput
+	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+		output, err = conn.GetPolicy(input)
+
+		if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.GetPolicy(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading IAM policy %s: %w", arn, err)
+	}
+
+	if output == nil || output.Policy == nil {
+		return fmt.Errorf("error reading IAM policy %s: empty output", arn)
+	}
+
+	policy := output.Policy
+
+	d.SetId(aws.StringValue(policy.Arn))
+
+	d.Set("arn", policy.Arn)
+	d.Set("description", policy.Description)
+	d.Set("name", policy.PolicyName)
+	d.Set("path", policy.Path)
+	d.Set("policy_id", policy.PolicyId)
+
+	if err := d.Set("tags", keyvaluetags.IamKeyValueTags(policy.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	// Retrieve policy
+
+	policyVersionInput := &iam.GetPolicyVersionInput{
+		PolicyArn: aws.String(arn),
+		VersionId: policy.DefaultVersionId,
+	}
+
+	// Handle IAM eventual consistency
+	var policyVersionOutput *iam.GetPolicyVersionOutput
+	err = resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+		policyVersionOutput, err = conn.GetPolicyVersion(policyVersionInput)
+
+		if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		policyVersionOutput, err = conn.GetPolicyVersion(policyVersionInput)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading IAM Policy (%s) version: %w", arn, err)
+	}
+
+	if policyVersionOutput == nil || policyVersionOutput.PolicyVersion == nil {
+		return fmt.Errorf("error reading IAM Policy (%s) version: empty output", arn)
+	}
+
+	policyVersion := policyVersionOutput.PolicyVersion
+
+	var policyDocument string
+	if policyVersion != nil {
+		policyDocument, err = url.QueryUnescape(aws.StringValue(policyVersion.Document))
+		if err != nil {
+			return fmt.Errorf("error parsing IAM Policy (%s) document: %w", arn, err)
+		}
+	}
+
+	d.Set("policy", policyDocument)
+
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18819 
Relates #7926

Output from acceptance testing (Commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov (0.73s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting (14.79s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_overrideList (58.13s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceList (58.70s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (58.95s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (59.20s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals (59.96s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (59.77s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice (61.46s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (61.80s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (62.00s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (65.73s)
--- PASS: TestAccAWSDataSourceIAMPolicy_basic (66.55s)
--- PASS: TestAccAWSIAMPolicy_basic (69.72s)
--- PASS: TestAccAWSIAMPolicy_description (61.42s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_version20081017 (81.87s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (84.87s)
--- PASS: TestAccAWSIAMPolicy_disappears (29.47s)
--- PASS: TestAccAWSIAMPolicyAttachment_Users_RenamedUser (93.55s)
--- PASS: TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup (93.73s)
--- PASS: TestAccAWSIAMPolicyAttachment_Roles_RenamedRole (96.69s)
--- PASS: TestAccAWSIAMPolicy_namePrefix (37.23s)
--- PASS: TestAccAWSIAMPolicy_path (37.11s)
--- PASS: TestAccAWSIAMPolicyAttachment_basic (100.54s)
--- PASS: TestAccAWSIAMPolicy_policy (49.30s)
--- PASS: TestAccAWSIAMPolicy_tags (60.08s)
--- PASS: TestAccAWSIAMPolicyAttachment_paginatedEntities (287.60s)
```
