### PR TITLE
structure/expandStringMap: migrate stringMapToPointers usage to expandStringMap

### DIFF
--- a/aws/data_source_aws_kms_ciphertext.go
+++ b/aws/data_source_aws_kms_ciphertext.go
@@ -48,7 +48,7 @@ func dataSourceAwsKmsCiphertextRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if ec := d.Get("context"); ec != nil {
-		req.EncryptionContext = stringMapToPointers(ec.(map[string]interface{}))
+		req.EncryptionContext = expandStringMap(ec.(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] KMS encrypt for key: %s", d.Get("key_id").(string))

--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -216,11 +216,11 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("request_parameters"); ok && len(v.(map[string]interface{})) > 0 {
-		input.RequestParameters = stringMapToPointers(v.(map[string]interface{}))
+		input.RequestParameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("request_templates"); ok && len(v.(map[string]interface{})) > 0 {
-		input.RequestTemplates = stringMapToPointers(v.(map[string]interface{}))
+		input.RequestTemplates = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("timeout_milliseconds"); ok {

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -201,7 +201,7 @@ func resourceAwsApiGatewayRestApiCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		if v, ok := d.GetOk("parameters"); ok && len(v.(map[string]interface{})) > 0 {
-			input.Parameters = stringMapToPointers(v.(map[string]interface{}))
+			input.Parameters = expandStringMap(v.(map[string]interface{}))
 		}
 
 		output, err := conn.PutRestApi(input)
@@ -560,7 +560,7 @@ func resourceAwsApiGatewayRestApiUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			if v, ok := d.GetOk("parameters"); ok && len(v.(map[string]interface{})) > 0 {
-				input.Parameters = stringMapToPointers(v.(map[string]interface{}))
+				input.Parameters = expandStringMap(v.(map[string]interface{}))
 			}
 
 			output, err := conn.PutRestApi(input)

--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -203,10 +203,10 @@ func resourceAwsApiGatewayV2IntegrationCreate(d *schema.ResourceData, meta inter
 		req.PayloadFormatVersion = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("request_parameters"); ok {
-		req.RequestParameters = stringMapToPointers(v.(map[string]interface{}))
+		req.RequestParameters = expandStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("request_templates"); ok {
-		req.RequestTemplates = stringMapToPointers(v.(map[string]interface{}))
+		req.RequestTemplates = expandStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("response_parameters"); ok && v.(*schema.Set).Len() > 0 {
 		req.ResponseParameters = expandApiGateway2IntegrationResponseParameters(v.(*schema.Set).List())
@@ -342,7 +342,7 @@ func resourceAwsApiGatewayV2IntegrationUpdate(d *schema.ResourceData, meta inter
 		req.RequestParameters = variables
 	}
 	if d.HasChange("request_templates") {
-		req.RequestTemplates = stringMapToPointers(d.Get("request_templates").(map[string]interface{}))
+		req.RequestTemplates = expandStringMap(d.Get("request_templates").(map[string]interface{}))
 	}
 	if d.HasChange("response_parameters") {
 		o, n := d.GetChange("response_parameters")
@@ -475,7 +475,7 @@ func expandApiGateway2IntegrationResponseParameters(tfList []interface{}) map[st
 
 		if vStatusCode, ok := tfMap["status_code"].(string); ok && vStatusCode != "" {
 			if v, ok := tfMap["mappings"].(map[string]interface{}); ok && len(v) > 0 {
-				responseParameters[vStatusCode] = stringMapToPointers(v)
+				responseParameters[vStatusCode] = expandStringMap(v)
 			}
 		}
 	}

--- a/aws/resource_aws_apigatewayv2_integration_response.go
+++ b/aws/resource_aws_apigatewayv2_integration_response.go
@@ -69,7 +69,7 @@ func resourceAwsApiGatewayV2IntegrationResponseCreate(d *schema.ResourceData, me
 		req.ContentHandlingStrategy = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("response_templates"); ok {
-		req.ResponseTemplates = stringMapToPointers(v.(map[string]interface{}))
+		req.ResponseTemplates = expandStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("template_selection_expression"); ok {
 		req.TemplateSelectionExpression = aws.String(v.(string))
@@ -129,7 +129,7 @@ func resourceAwsApiGatewayV2IntegrationResponseUpdate(d *schema.ResourceData, me
 		req.IntegrationResponseKey = aws.String(d.Get("integration_response_key").(string))
 	}
 	if d.HasChange("response_templates") {
-		req.ResponseTemplates = stringMapToPointers(d.Get("response_templates").(map[string]interface{}))
+		req.ResponseTemplates = expandStringMap(d.Get("response_templates").(map[string]interface{}))
 	}
 	if d.HasChange("template_selection_expression") {
 		req.TemplateSelectionExpression = aws.String(d.Get("template_selection_expression").(string))

--- a/aws/resource_aws_apigatewayv2_route.go
+++ b/aws/resource_aws_apigatewayv2_route.go
@@ -118,7 +118,7 @@ func resourceAwsApiGatewayV2RouteCreate(d *schema.ResourceData, meta interface{}
 		req.OperationName = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("request_models"); ok {
-		req.RequestModels = stringMapToPointers(v.(map[string]interface{}))
+		req.RequestModels = expandStringMap(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("request_parameter"); ok && v.(*schema.Set).Len() > 0 {
 		req.RequestParameters = expandApiGatewayV2RouteRequestParameters(v.(*schema.Set).List())
@@ -242,7 +242,7 @@ func resourceAwsApiGatewayV2RouteUpdate(d *schema.ResourceData, meta interface{}
 			req.OperationName = aws.String(d.Get("operation_name").(string))
 		}
 		if d.HasChange("request_models") {
-			req.RequestModels = stringMapToPointers(d.Get("request_models").(map[string]interface{}))
+			req.RequestModels = expandStringMap(d.Get("request_models").(map[string]interface{}))
 		}
 		if d.HasChange("request_parameter") {
 			req.RequestParameters = requestParameters

--- a/aws/resource_aws_apigatewayv2_route_response.go
+++ b/aws/resource_aws_apigatewayv2_route_response.go
@@ -60,7 +60,7 @@ func resourceAwsApiGatewayV2RouteResponseCreate(d *schema.ResourceData, meta int
 		req.ModelSelectionExpression = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("response_models"); ok {
-		req.ResponseModels = stringMapToPointers(v.(map[string]interface{}))
+		req.ResponseModels = expandStringMap(v.(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating API Gateway v2 route response: %s", req)
@@ -112,7 +112,7 @@ func resourceAwsApiGatewayV2RouteResponseUpdate(d *schema.ResourceData, meta int
 		req.ModelSelectionExpression = aws.String(d.Get("model_selection_expression").(string))
 	}
 	if d.HasChange("response_models") {
-		req.ResponseModels = stringMapToPointers(d.Get("response_models").(map[string]interface{}))
+		req.ResponseModels = expandStringMap(d.Get("response_models").(map[string]interface{}))
 	}
 	if d.HasChange("route_response_key") {
 		req.RouteResponseKey = aws.String(d.Get("route_response_key").(string))

--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -218,7 +218,7 @@ func resourceAwsApiGatewayV2StageCreate(d *schema.ResourceData, meta interface{}
 		req.RouteSettings = expandApiGatewayV2RouteSettings(v.(*schema.Set).List(), protocolType)
 	}
 	if v, ok := d.GetOk("stage_variables"); ok {
-		req.StageVariables = stringMapToPointers(v.(map[string]interface{}))
+		req.StageVariables = expandStringMap(v.(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating API Gateway v2 stage: %s", req)

--- a/aws/resource_aws_backup_global_settings.go
+++ b/aws/resource_aws_backup_global_settings.go
@@ -32,7 +32,7 @@ func resourceAwsBackupGlobalSettingsUpdate(d *schema.ResourceData, meta interfac
 	conn := meta.(*AWSClient).backupconn
 
 	input := &backup.UpdateGlobalSettingsInput{
-		GlobalSettings: stringMapToPointers(d.Get("global_settings").(map[string]interface{})),
+		GlobalSettings: expandStringMap(d.Get("global_settings").(map[string]interface{})),
 	}
 
 	_, err := conn.UpdateGlobalSettings(input)

--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -343,7 +343,7 @@ func expandBackupPlanAdvancedBackupSettings(vAdvancedBackupSettings *schema.Set)
 		mAdvancedBackupSetting := vAdvancedBackupSetting.(map[string]interface{})
 
 		if v, ok := mAdvancedBackupSetting["backup_options"].(map[string]interface{}); ok && v != nil {
-			advancedBackupSetting.BackupOptions = stringMapToPointers(v)
+			advancedBackupSetting.BackupOptions = expandStringMap(v)
 		}
 		if v, ok := mAdvancedBackupSetting["resource_type"].(string); ok && v != "" {
 			advancedBackupSetting.ResourceType = aws.String(v)

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -348,7 +348,7 @@ func expandAwsCodePipelineActions(a []interface{}) []*codepipeline.ActionDeclara
 	for _, config := range a {
 		data := config.(map[string]interface{})
 
-		conf := stringMapToPointers(data["configuration"].(map[string]interface{}))
+		conf := expandStringMap(data["configuration"].(map[string]interface{}))
 
 		action := codepipeline.ActionDeclaration{
 			ActionTypeId: &codepipeline.ActionTypeId{

--- a/aws/resource_aws_cognito_identity_provider.go
+++ b/aws/resource_aws_cognito_identity_provider.go
@@ -98,11 +98,11 @@ func resourceAwsCognitoIdentityProviderCreate(d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("attribute_mapping"); ok {
-		params.AttributeMapping = stringMapToPointers(v.(map[string]interface{}))
+		params.AttributeMapping = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("provider_details"); ok {
-		params.ProviderDetails = stringMapToPointers(v.(map[string]interface{}))
+		params.ProviderDetails = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("idp_identifiers"); ok {
@@ -183,11 +183,11 @@ func resourceAwsCognitoIdentityProviderUpdate(d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("attribute_mapping") {
-		params.AttributeMapping = stringMapToPointers(d.Get("attribute_mapping").(map[string]interface{}))
+		params.AttributeMapping = expandStringMap(d.Get("attribute_mapping").(map[string]interface{}))
 	}
 
 	if d.HasChange("provider_details") {
-		params.ProviderDetails = stringMapToPointers(d.Get("provider_details").(map[string]interface{}))
+		params.ProviderDetails = expandStringMap(d.Get("provider_details").(map[string]interface{}))
 	}
 
 	if d.HasChange("idp_identifiers") {

--- a/aws/resource_aws_eks_fargate_profile.go
+++ b/aws/resource_aws_eks_fargate_profile.go
@@ -277,7 +277,7 @@ func expandEksFargateProfileSelectors(l []interface{}) []*eks.FargateProfileSele
 		fargateProfileSelector := &eks.FargateProfileSelector{}
 
 		if v, ok := m["labels"].(map[string]interface{}); ok && len(v) > 0 {
-			fargateProfileSelector.Labels = stringMapToPointers(v)
+			fargateProfileSelector.Labels = expandStringMap(v)
 		}
 
 		if v, ok := m["namespace"].(string); ok && v != "" {

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -249,7 +249,7 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if v := d.Get("labels").(map[string]interface{}); len(v) > 0 {
-		input.Labels = stringMapToPointers(v)
+		input.Labels = expandStringMap(v)
 	}
 
 	if v := d.Get("launch_template").([]interface{}); len(v) > 0 {

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -468,7 +468,7 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("advanced_options"); ok {
-		input.AdvancedOptions = stringMapToPointers(v.(map[string]interface{}))
+		input.AdvancedOptions = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("advanced_security_options"); ok {
@@ -821,7 +821,7 @@ func resourceAwsElasticSearchDomainUpdate(d *schema.ResourceData, meta interface
 	}
 
 	if d.HasChange("advanced_options") {
-		input.AdvancedOptions = stringMapToPointers(d.Get("advanced_options").(map[string]interface{}))
+		input.AdvancedOptions = expandStringMap(d.Get("advanced_options").(map[string]interface{}))
 	}
 
 	if d.HasChange("advanced_security_options") {

--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -79,7 +79,7 @@ func resourceAwsGlueCatalogDatabaseCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
-		dbInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
+		dbInput.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	input := &glue.CreateDatabaseInput{
@@ -123,7 +123,7 @@ func resourceAwsGlueCatalogDatabaseUpdate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
-		dbInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
+		dbInput.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	dbUpdateInput.DatabaseInput = dbInput

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -507,7 +507,7 @@ func expandGlueTableInput(d *schema.ResourceData) *glue.TableInput {
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
-		tableInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
+		tableInput.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	return tableInput
@@ -581,7 +581,7 @@ func expandGlueStorageDescriptor(l []interface{}) *glue.StorageDescriptor {
 	}
 
 	if v, ok := s["parameters"]; ok {
-		storageDescriptor.Parameters = stringMapToPointers(v.(map[string]interface{}))
+		storageDescriptor.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := s["stored_as_sub_directories"]; ok {
@@ -613,7 +613,7 @@ func expandGlueColumns(columns []interface{}) []*glue.Column {
 		}
 
 		if v, ok := elementMap["parameters"]; ok {
-			column.Parameters = stringMapToPointers(v.(map[string]interface{}))
+			column.Parameters = expandStringMap(v.(map[string]interface{}))
 		}
 
 		columnSlice = append(columnSlice, column)
@@ -635,7 +635,7 @@ func expandGlueSerDeInfo(l []interface{}) *glue.SerDeInfo {
 	}
 
 	if v := s["parameters"]; len(v.(map[string]interface{})) > 0 {
-		serDeInfo.Parameters = stringMapToPointers(v.(map[string]interface{}))
+		serDeInfo.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v := s["serialization_library"]; len(v.(string)) > 0 {
@@ -678,7 +678,7 @@ func expandGlueSkewedInfo(l []interface{}) *glue.SkewedInfo {
 	}
 
 	if v, ok := s["skewed_column_value_location_maps"]; ok {
-		skewedInfo.SkewedColumnValueLocationMaps = stringMapToPointers(v.(map[string]interface{}))
+		skewedInfo.SkewedColumnValueLocationMaps = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := s["skewed_column_values"]; ok {

--- a/aws/resource_aws_glue_dev_endpoint.go
+++ b/aws/resource_aws_glue_dev_endpoint.go
@@ -168,7 +168,7 @@ func resourceAwsGlueDevEndpointCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if v, ok := d.GetOk("arguments"); ok {
-		input.Arguments = stringMapToPointers(v.(map[string]interface{}))
+		input.Arguments = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("extra_jars_s3_path"); ok {

--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -177,11 +177,11 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if kv, ok := d.GetOk("default_arguments"); ok {
-		input.DefaultArguments = stringMapToPointers(kv.(map[string]interface{}))
+		input.DefaultArguments = expandStringMap(kv.(map[string]interface{}))
 	}
 
 	if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-		input.NonOverridableArguments = stringMapToPointers(kv.(map[string]interface{}))
+		input.NonOverridableArguments = expandStringMap(kv.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -335,11 +335,11 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if kv, ok := d.GetOk("default_arguments"); ok {
-			jobUpdate.DefaultArguments = stringMapToPointers(kv.(map[string]interface{}))
+			jobUpdate.DefaultArguments = expandStringMap(kv.(map[string]interface{}))
 		}
 
 		if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-			jobUpdate.NonOverridableArguments = stringMapToPointers(kv.(map[string]interface{}))
+			jobUpdate.NonOverridableArguments = expandStringMap(kv.(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_glue_partition.go
+++ b/aws/resource_aws_glue_partition.go
@@ -317,7 +317,7 @@ func expandGluePartitionInput(d *schema.ResourceData) *glue.PartitionInput {
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
-		tableInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
+		tableInput.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("partition_values"); ok && len(v.([]interface{})) > 0 {

--- a/aws/resource_aws_glue_workflow.go
+++ b/aws/resource_aws_glue_workflow.go
@@ -61,7 +61,7 @@ func resourceAwsGlueWorkflowCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if kv, ok := d.GetOk("default_run_properties"); ok {
-		input.DefaultRunProperties = stringMapToPointers(kv.(map[string]interface{}))
+		input.DefaultRunProperties = expandStringMap(kv.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -146,7 +146,7 @@ func resourceAwsGlueWorkflowUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if kv, ok := d.GetOk("default_run_properties"); ok {
-			input.DefaultRunProperties = stringMapToPointers(kv.(map[string]interface{}))
+			input.DefaultRunProperties = expandStringMap(kv.(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_imagebuilder_distribution_configuration.go
+++ b/aws/resource_aws_imagebuilder_distribution_configuration.go
@@ -274,7 +274,7 @@ func expandImageBuilderAmiDistributionConfiguration(tfMap map[string]interface{}
 	apiObject := &imagebuilder.AmiDistributionConfiguration{}
 
 	if v, ok := tfMap["ami_tags"].(map[string]interface{}); ok && len(v) > 0 {
-		apiObject.AmiTags = stringMapToPointers(v)
+		apiObject.AmiTags = expandStringMap(v)
 	}
 
 	if v, ok := tfMap["description"].(string); ok && v != "" {

--- a/aws/resource_aws_iot_thing.go
+++ b/aws/resource_aws_iot_thing.go
@@ -65,7 +65,7 @@ func resourceAwsIotThingCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOk("attributes"); ok {
 		params.AttributePayload = &iot.AttributePayload{
-			Attributes: stringMapToPointers(v.(map[string]interface{})),
+			Attributes: expandStringMap(v.(map[string]interface{})),
 		}
 	}
 
@@ -127,7 +127,7 @@ func resourceAwsIotThingUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if v, ok := d.GetOk("attributes"); ok {
 			if m, ok := v.(map[string]interface{}); ok {
-				attributes = stringMapToPointers(m)
+				attributes = expandStringMap(m)
 			}
 		}
 		params.AttributePayload = &iot.AttributePayload{

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1798,7 +1798,7 @@ func expandFirehoseOpenXJsonSerDe(l []interface{}) *firehose.OpenXJsonSerDe {
 
 	return &firehose.OpenXJsonSerDe{
 		CaseInsensitive:                    aws.Bool(m["case_insensitive"].(bool)),
-		ColumnToJsonKeyMappings:            stringMapToPointers(m["column_to_json_key_mappings"].(map[string]interface{})),
+		ColumnToJsonKeyMappings:            expandStringMap(m["column_to_json_key_mappings"].(map[string]interface{})),
 		ConvertDotsInJsonKeysToUnderscores: aws.Bool(m["convert_dots_in_json_keys_to_underscores"].(bool)),
 	}
 }

--- a/aws/resource_aws_kinesisanalyticsv2_application.go
+++ b/aws/resource_aws_kinesisanalyticsv2_application.go
@@ -2243,7 +2243,7 @@ func expandKinesisAnalyticsV2PropertyGroups(vPropertyGroups []interface{}) []*ki
 		}
 
 		if vPropertyMap, ok := mPropertyGroup["property_map"].(map[string]interface{}); ok && len(vPropertyMap) > 0 {
-			propertyGroup.PropertyMap = stringMapToPointers(vPropertyMap)
+			propertyGroup.PropertyMap = expandStringMap(vPropertyMap)
 		}
 
 		propertyGroups = append(propertyGroups, propertyGroup)

--- a/aws/resource_aws_kms_ciphertext.go
+++ b/aws/resource_aws_kms_ciphertext.go
@@ -58,7 +58,7 @@ func resourceAwsKmsCiphertextCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if ec := d.Get("context"); ec != nil {
-		req.EncryptionContext = stringMapToPointers(ec.(map[string]interface{}))
+		req.EncryptionContext = expandStringMap(ec.(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] KMS encrypt for key: %s", d.Get("key_id").(string))

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -437,10 +437,10 @@ func expandKmsGrantConstraints(configured *schema.Set) *kms.GrantConstraints {
 	for _, raw := range configured.List() {
 		data := raw.(map[string]interface{})
 		if contextEq, ok := data["encryption_context_equals"]; ok {
-			constraint.SetEncryptionContextEquals(stringMapToPointers(contextEq.(map[string]interface{})))
+			constraint.SetEncryptionContextEquals(expandStringMap(contextEq.(map[string]interface{})))
 		}
 		if contextSub, ok := data["encryption_context_subset"]; ok {
-			constraint.SetEncryptionContextSubset(stringMapToPointers(contextSub.(map[string]interface{})))
+			constraint.SetEncryptionContextSubset(expandStringMap(contextSub.(map[string]interface{})))
 		}
 	}
 
@@ -480,12 +480,12 @@ func resourceKmsGrantConstraintsHash(v interface{}) int {
 
 	if v, ok := m["encryption_context_equals"]; ok {
 		if len(v.(map[string]interface{})) > 0 {
-			buf.WriteString(fmt.Sprintf("encryption_context_equals-%s-", sortedConcatStringMap(stringMapToPointers(v.(map[string]interface{})))))
+			buf.WriteString(fmt.Sprintf("encryption_context_equals-%s-", sortedConcatStringMap(expandStringMap(v.(map[string]interface{})))))
 		}
 	}
 	if v, ok := m["encryption_context_subset"]; ok {
 		if len(v.(map[string]interface{})) > 0 {
-			buf.WriteString(fmt.Sprintf("encryption_context_subset-%s-", sortedConcatStringMap(stringMapToPointers(v.(map[string]interface{})))))
+			buf.WriteString(fmt.Sprintf("encryption_context_subset-%s-", sortedConcatStringMap(expandStringMap(v.(map[string]interface{})))))
 		}
 	}
 

--- a/aws/resource_aws_mwaa_environment.go
+++ b/aws/resource_aws_mwaa_environment.go
@@ -241,7 +241,7 @@ func resourceAwsMwaaEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if v, ok := d.GetOk("airflow_configuration_options"); ok {
-		input.AirflowConfigurationOptions = stringMapToPointers(v.(map[string]interface{}))
+		input.AirflowConfigurationOptions = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("airflow_version"); ok {
@@ -385,7 +385,7 @@ func resourceAwsMwaaEnvironmentUpdate(d *schema.ResourceData, meta interface{}) 
 				options = map[string]interface{}{}
 			}
 
-			input.AirflowConfigurationOptions = stringMapToPointers(options.(map[string]interface{}))
+			input.AirflowConfigurationOptions = expandStringMap(options.(map[string]interface{}))
 		}
 
 		if d.HasChange("airflow_version") {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -250,7 +250,7 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
-		putInput.Metadata = stringMapToPointers(v.(map[string]interface{}))
+		putInput.Metadata = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("content_encoding"); ok {

--- a/aws/resource_aws_s3_object_copy.go
+++ b/aws/resource_aws_s3_object_copy.go
@@ -545,7 +545,7 @@ func resourceAwsS3ObjectCopyDoCopy(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
-		input.Metadata = stringMapToPointers(v.(map[string]interface{}))
+		input.Metadata = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("metadata_directive"); ok {

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -384,7 +384,7 @@ func expandContainer(m map[string]interface{}) *sagemaker.ContainerDefinition {
 		container.ModelDataUrl = aws.String(v.(string))
 	}
 	if v, ok := m["environment"]; ok {
-		container.Environment = stringMapToPointers(v.(map[string]interface{}))
+		container.Environment = expandStringMap(v.(map[string]interface{}))
 	}
 
 	if v, ok := m["image_config"]; ok {

--- a/aws/resource_aws_xray_sampling_rule.go
+++ b/aws/resource_aws_xray_sampling_rule.go
@@ -112,7 +112,7 @@ func resourceAwsXraySamplingRuleCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("attributes"); ok {
-		samplingRule.Attributes = stringMapToPointers(v.(map[string]interface{}))
+		samplingRule.Attributes = expandStringMap(v.(map[string]interface{}))
 	}
 
 	params := &xray.CreateSamplingRuleInput{
@@ -202,7 +202,7 @@ func resourceAwsXraySamplingRuleUpdate(d *schema.ResourceData, meta interface{})
 			attributes := map[string]*string{}
 			if v, ok := d.GetOk("attributes"); ok {
 				if m, ok := v.(map[string]interface{}); ok {
-					attributes = stringMapToPointers(m)
+					attributes = expandStringMap(m)
 				}
 			}
 			samplingRuleUpdate.Attributes = attributes

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -138,11 +138,11 @@ func expandEcsVolumes(configured []interface{}) []*ecs.Volume {
 			}
 
 			if v, ok := config["driver_opts"].(map[string]interface{}); ok && len(v) > 0 {
-				l.DockerVolumeConfiguration.DriverOpts = stringMapToPointers(v)
+				l.DockerVolumeConfiguration.DriverOpts = expandStringMap(v)
 			}
 
 			if v, ok := config["labels"].(map[string]interface{}); ok && len(v) > 0 {
-				l.DockerVolumeConfiguration.Labels = stringMapToPointers(v)
+				l.DockerVolumeConfiguration.Labels = expandStringMap(v)
 			}
 		}
 
@@ -1589,14 +1589,6 @@ func pointersMapToStringList(pointers map[string]*string) map[string]interface{}
 	list := make(map[string]interface{}, len(pointers))
 	for i, v := range pointers {
 		list[i] = *v
-	}
-	return list
-}
-
-func stringMapToPointers(m map[string]interface{}) map[string]*string {
-	list := make(map[string]*string, len(m))
-	for i, v := range m {
-		list[i] = aws.String(v.(string))
 	}
 	return list
 }

--- a/docs/contributing/data-handling-and-conversion.md
+++ b/docs/contributing/data-handling-and-conversion.md
@@ -365,7 +365,7 @@ To read:
 input := service.ExampleOperationInput{}
 
 if v, ok := d.GetOk("attribute_name"); ok && len(v.(map[string]interface{})) > 0 {
-    input.AttributeName = stringMapToPointers(v.(map[string]interface{}))
+    input.AttributeName = expandStringMap(v.(map[string]interface{}))
 }
 ```
 
@@ -667,7 +667,7 @@ To read:
 input := service.ExampleOperationInput{}
 
 if v, ok := tfMap["nested_attribute_name"].(map[string]interface{}); ok && len(v) > 0 {
-    apiObject.NestedAttributeName = stringMapToPointers(v)
+    apiObject.NestedAttributeName = expandStringMap(v)
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18838 (`expandStringMap` method added but duplicates `stringMapToPointers`)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
...
```
