### PR TITLE
Add aws_kms_public_key data source

### DIFF
--- a/.changelog/18873.txt
+++ b/.changelog/18873.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_kms_public_key
+```

--- a/aws/data_source_aws_kms_public_key.go
+++ b/aws/data_source_aws_kms_public_key.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsKmsPublicKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsKmsPublicKeyRead,
+		Schema: map[string]*schema.Schema{
+			"key_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateKmsKey,
+			},
+			"grant_tokens": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"customer_master_key_spec": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"encryption_algorithms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"key_usage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"signing_algorithms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"public_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsKmsPublicKeyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+	keyId := d.Get("key_id")
+	var grantTokens []*string
+	if v, ok := d.GetOk("grant_tokens"); ok {
+		grantTokens = aws.StringSlice(v.([]string))
+	}
+	input := &kms.GetPublicKeyInput{
+		KeyId:       aws.String(keyId.(string)),
+		GrantTokens: grantTokens,
+	}
+	output, err := conn.GetPublicKey(input)
+	if err != nil {
+		return fmt.Errorf("error while describing key [%s]: %w", keyId, err)
+	}
+	d.SetId(aws.StringValue(output.KeyId))
+	d.Set("customer_master_key_spec", output.CustomerMasterKeySpec)
+	d.Set("encryption_algorithms", output.EncryptionAlgorithms)
+	d.Set("id", output.KeyId)
+	d.Set("key_usage", output.KeyUsage)
+	d.Set("public_key", string(output.PublicKey))
+	d.Set("signing_algorithms", output.SigningAlgorithms)
+
+	return nil
+}

--- a/aws/data_source_aws_kms_public_key_test.go
+++ b/aws/data_source_aws_kms_public_key_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccDataSourceAwsKmsPublicKey_basic(t *testing.T) {
 	resourceName := "aws_kms_key.test"
 	datasourceName := "data.aws_kms_public_key.test"
-	rName := fmt.Sprintf("tf-testacc-kms-public-key-%s", acctest.RandString(13))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -24,7 +24,36 @@ func TestAccDataSourceAwsKmsPublicKey_basic(t *testing.T) {
 				Config: testAccDataSourceAwsKmsPublicKeyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsKmsPublicKeyCheck(datasourceName),
-					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckResourceAttrPair(datasourceName, "key_id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrSet(datasourceName, "public_key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsKmsPublicKey_encrypt(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	datasourceName := "data.aws_kms_public_key.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, kms.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsKmsPublicKeyEncryptConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsKmsPublicKeyCheck(datasourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "key_id", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckResourceAttrPair(datasourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrSet(datasourceName, "public_key"),
 				),
 			},
 		},
@@ -49,6 +78,21 @@ resource "aws_kms_key" "test" {
   deletion_window_in_days  = 7
   customer_master_key_spec = "RSA_2048"
   key_usage                = "SIGN_VERIFY"
+}
+
+data "aws_kms_public_key" "test" {
+  key_id = aws_kms_key.test.arn
+}
+`, rName)
+}
+
+func testAccDataSourceAwsKmsPublicKeyEncryptConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description              = %[1]q
+  deletion_window_in_days  = 7
+  customer_master_key_spec = "RSA_2048"
+  key_usage                = "ENCRYPT_DECRYPT"
 }
 
 data "aws_kms_public_key" "test" {

--- a/aws/data_source_aws_kms_public_key_test.go
+++ b/aws/data_source_aws_kms_public_key_test.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceAwsKmsPublicKey_basic(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	datasourceName := "data.aws_kms_public_key.test"
+	rName := fmt.Sprintf("tf-testacc-kms-public-key-%s", acctest.RandString(13))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, kms.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsKmsPublicKeyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsKmsPublicKeyCheck(datasourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsKmsPublicKeyCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsKmsPublicKeyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description              = %[1]q
+  deletion_window_in_days  = 7
+  customer_master_key_spec = "RSA_2048"
+  key_usage                = "SIGN_VERIFY"
+}
+
+data "aws_kms_public_key" "test" {
+  key_id = aws_kms_key.test.arn
+}
+`, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -314,6 +314,7 @@ func Provider() *schema.Provider {
 			"aws_kms_alias":                                  dataSourceAwsKmsAlias(),
 			"aws_kms_ciphertext":                             dataSourceAwsKmsCiphertext(),
 			"aws_kms_key":                                    dataSourceAwsKmsKey(),
+			"aws_kms_public_key":                             dataSourceAwsKmsPublicKey(),
 			"aws_kms_secret":                                 dataSourceAwsKmsSecret(),
 			"aws_kms_secrets":                                dataSourceAwsKmsSecrets(),
 			"aws_lakeformation_data_lake_settings":           dataSourceAwsLakeFormationDataLakeSettings(),

--- a/website/docs/d/kms_public_key.html.markdown
+++ b/website/docs/d/kms_public_key.html.markdown
@@ -3,15 +3,12 @@ subcategory: "KMS"
 layout: "aws"
 page_title: "AWS: aws_kms_public_key"
 description: |-
-  Get public key on a AWS Key Management Service (KMS) Key
+  Get information on a KMS public key
 ---
 
 # aws_kms_public_key
 
-Use this data source to get the public key about
-the specified KMS Key with flexible key id input.
-This can be useful to reference key alias
-without having to hard code the ARN as input.
+Use this data source to get the public key about the specified KMS Key with flexible key id input. This can be useful to reference key alias without having to hard code the ARN as input.
 
 ## Example Usage
 
@@ -35,18 +32,23 @@ data "aws_kms_public_key" "by_key_arn" {
 
 ## Argument Reference
 
+The following arguments are supported:
+
 * `key_id` - (Required) Key identifier which can be one of the following format:
-    * Key ID. E.g: `1234abcd-12ab-34cd-56ef-1234567890ab`
-    * Key ARN. E.g.: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
-    * Alias name. E.g.: `alias/my-key`
-    * Alias ARN: E.g.: `arn:aws:kms:us-east-1:111122223333:alias/my-key`
+    * Key ID. E.g - `1234abcd-12ab-34cd-56ef-1234567890ab`
+    * Key ARN. E.g. - `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
+    * Alias name. E.g. - `alias/my-key`
+    * Alias ARN - E.g. - `arn:aws:kms:us-east-1:111122223333:alias/my-key`
 * `grant_tokens` - (Optional) List of grant tokens
 
 ## Attributes Reference
 
-* `id`: The globally unique identifier for the key
-* `customer_master_key_spec`: The type of the public key that was downloaded
-* `encryption_algorithms`: The encryption algorithms that AWS KMS supports for this key
-* `key_usage`: The permitted use of the public key. Valid values are `ENCRYPT_DECRYPT` or `SIGN_VERIFY`
-* `signing_algorithms`: The signing algorithms that AWS KMS supports for this key
-* `public_key`: The exported public key in a DER-encoded X.509 string format
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Key ARN of the asymmetric CMK from which the public key was downloaded.
+* `customer_master_key_spec` - Type of the public key that was downloaded.
+* `encryption_algorithms` - Encryption algorithms that AWS KMS supports for this key. Only set when the `key_usage` of the public key is `ENCRYPT_DECRYPT`.
+* `id` - Key ARN of the asymmetric CMK from which the public key was downloaded.
+* `key_usage` - Permitted use of the public key. Valid values are `ENCRYPT_DECRYPT` or `SIGN_VERIFY`
+* `public_key` - Exported public key. The value is a DER-encoded X.509 public key, also known as SubjectPublicKeyInfo (SPKI), as defined in [RFC 5280](https://tools.ietf.org/html/rfc5280). The value is Base64-encoded.
+* `signing_algorithms` - Signing algorithms that AWS KMS supports for this key. Only set when the `key_usage` of the public key is `SIGN_VERIFY`.

--- a/website/docs/d/kms_public_key.html.markdown
+++ b/website/docs/d/kms_public_key.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "KMS"
+layout: "aws"
+page_title: "AWS: aws_kms_public_key"
+description: |-
+  Get public key on a AWS Key Management Service (KMS) Key
+---
+
+# aws_kms_public_key
+
+Use this data source to get the public key about
+the specified KMS Key with flexible key id input.
+This can be useful to reference key alias
+without having to hard code the ARN as input.
+
+## Example Usage
+
+```terraform
+data "aws_kms_public_key" "by_alias" {
+  key_id = "alias/my-key"
+}
+
+data "aws_kms_public_key" "by_id" {
+  key_id = "1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+
+data "aws_kms_public_key" "by_alias_arn" {
+  key_id = "arn:aws:kms:us-east-1:111122223333:alias/my-key"
+}
+
+data "aws_kms_public_key" "by_key_arn" {
+  key_id = "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+```
+
+## Argument Reference
+
+* `key_id` - (Required) Key identifier which can be one of the following format:
+    * Key ID. E.g: `1234abcd-12ab-34cd-56ef-1234567890ab`
+    * Key ARN. E.g.: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
+    * Alias name. E.g.: `alias/my-key`
+    * Alias ARN: E.g.: `arn:aws:kms:us-east-1:111122223333:alias/my-key`
+* `grant_tokens` - (Optional) List of grant tokens
+
+## Attributes Reference
+
+* `id`: The globally unique identifier for the key
+* `customer_master_key_spec`: The type of the public key that was downloaded
+* `encryption_algorithms`: The encryption algorithms that AWS KMS supports for this key
+* `key_usage`: The permitted use of the public key. Valid values are `ENCRYPT_DECRYPT` or `SIGN_VERIFY`
+* `signing_algorithms`: The signing algorithms that AWS KMS supports for this key
+* `public_key`: The exported public key in a DER-encoded X.509 string format


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsKmsPublicKey_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsKmsPublicKey_basic -timeout 180m
=== RUN   TestAccDataSourceAwsKmsPublicKey_basic
=== PAUSE TestAccDataSourceAwsKmsPublicKey_basic
=== CONT  TestAccDataSourceAwsKmsPublicKey_basic
--- PASS: TestAccDataSourceAwsKmsPublicKey_basic (32.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       32.248s

```
