### PR TITLE
r/ecr_replication - delete rules on resource delete

### DIFF
--- a/.changelog/18882.txt
+++ b/.changelog/18882.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecr_replication_configuration: Remove relication rules on resource deletion
+```

--- a/aws/resource_aws_ecr_replication_configuration.go
+++ b/aws/resource_aws_ecr_replication_configuration.go
@@ -14,7 +14,7 @@ func resourceAwsEcrReplicationConfiguration() *schema.Resource {
 		Create: resourceAwsEcrReplicationConfigurationPut,
 		Read:   resourceAwsEcrReplicationConfigurationRead,
 		Update: resourceAwsEcrReplicationConfigurationPut,
-		Delete: schema.Noop,
+		Delete: resourceAwsEcrReplicationConfigurationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -93,6 +93,23 @@ func resourceAwsEcrReplicationConfigurationRead(d *schema.ResourceData, meta int
 
 	if err := d.Set("replication_configuration", flattenEcrReplicationConfigurationReplicationConfiguration(out.ReplicationConfiguration)); err != nil {
 		return fmt.Errorf("error setting replication_configuration for ECR Replication Configuration: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsEcrReplicationConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	input := ecr.PutReplicationConfigurationInput{
+		ReplicationConfiguration: &ecr.ReplicationConfiguration{
+			Rules: []*ecr.ReplicationRule{},
+		},
+	}
+
+	_, err := conn.PutReplicationConfiguration(&input)
+	if err != nil {
+		return fmt.Errorf("error deleting ECR Replication Configuration: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18708

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcrReplicationConfiguration_basic'
--- PASS: TestAccAWSEcrReplicationConfiguration_basic (40.75s)
```
