### PR TITLE
r/aws_route53_resolver_firewall_rule_group: Fix `prefer-pagination-bool-var-last-page` semgrep error

### DIFF
--- a/aws/resource_aws_route53_resolver_firewall_rule_group_test.go
+++ b/aws/resource_aws_route53_resolver_firewall_rule_group_test.go
@@ -32,9 +32,9 @@ func testSweepRoute53ResolverFirewallRuleGroups(region string) error {
 	conn := client.(*AWSClient).route53resolverconn
 	var sweeperErrs *multierror.Error
 
-	err = conn.ListFirewallRuleGroupsPages(&route53resolver.ListFirewallRuleGroupsInput{}, func(page *route53resolver.ListFirewallRuleGroupsOutput, isLast bool) bool {
+	err = conn.ListFirewallRuleGroupsPages(&route53resolver.ListFirewallRuleGroupsInput{}, func(page *route53resolver.ListFirewallRuleGroupsOutput, lastPage bool) bool {
 		if page == nil {
-			return !isLast
+			return !lastPage
 		}
 
 		for _, firewallRuleGroup := range page.FirewallRuleGroups {
@@ -53,7 +53,7 @@ func testSweepRoute53ResolverFirewallRuleGroups(region string) error {
 			}
 		}
 
-		return !isLast
+		return !lastPage
 	})
 	if testSweepSkipSweepError(err) {
 		log.Printf("[WARN] Skipping Route53 Resolver DNS Firewall rule groups sweep for %s: %s", region, err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #18554.
Relates: #18651.

Fixes current `main` _semgrep_ error:

```
prefer-pagination-bool-var-last-page
     > aws/resource_aws_route53_resolver_firewall_rule_group_test.go:35
     ╷
=== exiting with failing status
   35│   err = conn.ListFirewallRuleGroupsPages(&route53resolver.ListFirewallRuleGroupsInput{}, func(page *route53resolver.ListFirewallRuleGroupsOutput, isLast bool) bool {
   36│   	if page == nil {
   37│   		return !isLast
   38│   	}
   39│   
   40│   	for _, firewallRuleGroup := range page.FirewallRuleGroups {
   41│   		id := aws.StringValue(firewallRuleGroup.Id)
   42│   
   43│   		log.Printf("[INFO] Deleting Route53 Resolver DNS Firewall rule group: %s", id)
   44│   		r := resourceAwsRoute53ResolverFirewallRuleGroup()
   45│   		d := r.Data(nil)
   46│   		d.SetId(id)
   47│   		err := r.Delete(d, client)
   48│   
   49│   		if err != nil {
Error:   			log.Printf("[ERROR] %s", err)
   51│   			sweeperErrs = multierror.Append(sweeperErrs, err)
   52│   			continue
   53│   		}
   54│   	}
   55│   
   56│   	return !isLast
   57│   })
     ╵
     = Use lastPage for bool variable in pagination functions
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```