### PR TITLE
Only reject tags for standard EIPs on EC2 Classic

### DIFF
--- a/.changelog/18909.txt
+++ b/.changelog/18909.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eip: Tags are created for EIPs which default to vpc domain
+```

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -148,7 +148,7 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
 		supportedPlatforms := meta.(*AWSClient).supportedplatforms
 		if domainOpt != ec2.DomainTypeVpc && len(supportedPlatforms) > 0 && hasEc2Classic(supportedPlatforms) {
-			return fmt.Errorf("tags can not be set for an EIP in EC2 Classic")
+			return fmt.Errorf("tags cannot be set for a standard-domain EIP - must be a VPC-domain EIP")
 		}
 		allocOpts.TagSpecifications = ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeElasticIp)
 	}
@@ -400,7 +400,7 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("tags") && !d.IsNewResource() {
 		if d.Get("domain").(string) == ec2.DomainTypeStandard {
-			return fmt.Errorf("tags can not be set for an EIP in EC2 Classic")
+			return fmt.Errorf("tags cannot be set for a standard-domain EIP - must be a VPC-domain EIP")
 		}
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.Ec2UpdateTags(ec2conn, d.Id(), o, n); err != nil {

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -145,7 +145,11 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 		Domain: aws.String(domainOpt),
 	}
 
-	if domainOpt == ec2.DomainTypeVpc {
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		supportedPlatforms := meta.(*AWSClient).supportedplatforms
+		if domainOpt != ec2.DomainTypeVpc && len(supportedPlatforms) > 0 && hasEc2Classic(supportedPlatforms) {
+			return fmt.Errorf("tags can not be set for an EIP in EC2 Classic")
+		}
 		allocOpts.TagSpecifications = ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeElasticIp)
 	}
 
@@ -182,10 +186,6 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[INFO] EIP ID: %s (domain: %v)", d.Id(), *allocResp.Domain)
-
-	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 && d.Get("domain").(string) == ec2.DomainTypeStandard {
-		return fmt.Errorf("tags can not be set for an EIP in EC2 Classic")
-	}
 
 	return resourceAwsEipUpdate(d, meta)
 }

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -24,7 +24,7 @@ func TestAccAWSEIPAssociation_instance(t *testing.T) {
 			{
 				Config: testAccAWSEIPAssociationConfig_instance(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.test", &a),
+					testAccCheckAWSEIPExists("aws_eip.test", false, &a),
 					testAccCheckAWSEIPAssociationExists(resourceName, &a),
 				),
 			},
@@ -50,7 +50,7 @@ func TestAccAWSEIPAssociation_networkInterface(t *testing.T) {
 			{
 				Config: testAccAWSEIPAssociationConfig_networkInterface,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.test", &a),
+					testAccCheckAWSEIPExists("aws_eip.test", false, &a),
 					testAccCheckAWSEIPAssociationExists(resourceName, &a),
 				),
 			},
@@ -76,11 +76,11 @@ func TestAccAWSEIPAssociation_basic(t *testing.T) {
 			{
 				Config: testAccAWSEIPAssociationConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.test.0", &a),
+					testAccCheckAWSEIPExists("aws_eip.test.0", false, &a),
 					testAccCheckAWSEIPAssociationExists("aws_eip_association.by_allocation_id", &a),
-					testAccCheckAWSEIPExists("aws_eip.test.1", &a),
+					testAccCheckAWSEIPExists("aws_eip.test.1", false, &a),
 					testAccCheckAWSEIPAssociationExists("aws_eip_association.by_public_ip", &a),
-					testAccCheckAWSEIPExists("aws_eip.test.2", &a),
+					testAccCheckAWSEIPExists("aws_eip.test.2", false, &a),
 					testAccCheckAWSEIPAssociationExists("aws_eip_association.to_eni", &a),
 				),
 			},
@@ -106,7 +106,7 @@ func TestAccAWSEIPAssociation_ec2Classic(t *testing.T) {
 			{
 				Config: testAccAWSEIPAssociationConfig_ec2Classic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPEc2ClassicExists("aws_eip.test", &a),
+					testAccCheckAWSEIPExists("aws_eip.test", true, &a),
 					testAccCheckAWSEIPAssociationEc2ClassicExists(resourceName, &a),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
@@ -136,7 +136,7 @@ func TestAccAWSEIPAssociation_spotInstance(t *testing.T) {
 			{
 				Config: testAccAWSEIPAssociationConfig_spotInstance(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.test", &a),
+					testAccCheckAWSEIPExists("aws_eip.test", false, &a),
 					testAccCheckAWSEIPAssociationExists(resourceName, &a),
 					resource.TestCheckResourceAttrSet(resourceName, "allocation_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
@@ -165,7 +165,7 @@ func TestAccAWSEIPAssociation_disappears(t *testing.T) {
 			{
 				Config: testAccAWSEIPAssociationConfigDisappears(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.test", &a),
+					testAccCheckAWSEIPExists("aws_eip.test", false, &a),
 					testAccCheckAWSEIPAssociationExists(resourceName, &a),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsEipAssociation(), resourceName),
 				),

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -7,13 +7,17 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 // This will currently skip EIPs with associations,
@@ -25,15 +29,17 @@ func init() {
 		Dependencies: []string{
 			"aws_vpc",
 		},
-		F: testSweepEc2Eips,
+		F: testSweepEC2Eips,
 	})
 }
 
-func testSweepEc2Eips(region string) error {
+func testSweepEC2Eips(region string) error {
 	client, err := sharedClientForRegion(region)
+
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
+
 	conn := client.(*AWSClient).ec2conn
 
 	// There is currently no paginator or Marker/NextToken
@@ -55,6 +61,9 @@ func testSweepEc2Eips(region string) error {
 		return nil
 	}
 
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
 	for _, address := range output.Addresses {
 		publicIP := aws.StringValue(address.PublicIp)
 
@@ -63,54 +72,27 @@ func testSweepEc2Eips(region string) error {
 			continue
 		}
 
-		input := &ec2.ReleaseAddressInput{}
-
-		// The EC2 API is particular that you only specify one or the other
-		// InvalidParameterCombination: You may specify public IP or allocation id, but not both in the same call
+		r := resourceAwsEip()
+		d := r.Data(nil)
 		if address.AllocationId != nil {
-			input.AllocationId = address.AllocationId
+			d.SetId(aws.StringValue(address.AllocationId))
 		} else {
-			input.PublicIp = address.PublicIp
+			d.SetId(aws.StringValue(address.PublicIp))
 		}
 
-		log.Printf("[INFO] Releasing EC2 EIP: %s", publicIP)
-
-		_, err := conn.ReleaseAddress(input)
-
-		if err != nil {
-			return fmt.Errorf("error releasing EC2 EIP (%s): %s", publicIP, err)
-		}
+		sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 	}
 
-	return nil
-}
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 EIPs for %s: %w", region, err))
+	}
 
-func TestAccAWSEIP_Ec2Classic(t *testing.T) {
-	resourceName := "aws_eip.test"
-	var conf ec2.Address
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping EC2 EIP sweep for %s: %s", region, errs)
+		return nil
+	}
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPInstanceEc2Classic(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPEc2ClassicExists(resourceName, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
-					testAccCheckAWSEIPPublicDNSEc2Classic(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeStandard),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
+	return errs.ErrorOrNil()
 }
 
 func TestAccAWSEIP_basic(t *testing.T) {
@@ -125,9 +107,9 @@ func TestAccAWSEIP_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPConfig,
+				Config: testAccEIPConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					testAccCheckAWSEIPPublicDNS(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
@@ -137,170 +119,6 @@ func TestAccAWSEIP_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEIP_instance(t *testing.T) {
-	var conf ec2.Address
-	resourceName := "aws_eip.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPInstanceConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEIP_networkInterface(t *testing.T) {
-	var conf ec2.Address
-	resourceName := "aws_eip.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPNetworkInterfaceConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
-					testAccCheckAWSEIPAssociated(&conf),
-					testAccCheckAWSEIPPrivateDNS(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEIP_twoEIPsOneNetworkInterface(t *testing.T) {
-	var one, two ec2.Address
-	resourceName := "aws_eip.test"
-	resourceName2 := "aws_eip.test2"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPMultiNetworkInterfaceConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &one),
-					testAccCheckAWSEIPAttributes(&one),
-					testAccCheckAWSEIPAssociated(&one),
-					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
-
-					testAccCheckAWSEIPExists(resourceName2, &two),
-					testAccCheckAWSEIPAttributes(&two),
-					testAccCheckAWSEIPAssociated(&two),
-					resource.TestCheckResourceAttr(resourceName2, "domain", ec2.DomainTypeVpc),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
-			},
-		},
-	})
-}
-
-// This test is an expansion of TestAccAWSEIP_instance, by testing the
-// associated Private EIPs of two instances
-func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
-	var one ec2.Address
-	resourceName := "aws_eip.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPInstanceConfig_associated(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &one),
-					testAccCheckAWSEIPAttributes(&one),
-					testAccCheckAWSEIPAssociated(&one),
-					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
-			},
-			{
-				Config: testAccAWSEIPInstanceConfig_associated_switch(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &one),
-					testAccCheckAWSEIPAttributes(&one),
-					testAccCheckAWSEIPAssociated(&one),
-					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
-				),
-			},
-		},
-	})
-}
-
-// Regression test for https://github.com/hashicorp/terraform/issues/3429 (now
-// https://github.com/hashicorp/terraform-provider-aws/issues/42)
-func TestAccAWSEIP_Instance_Reassociate(t *testing.T) {
-	instanceResourceName := "aws_instance.test"
-	resourceName := "aws_eip.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIP_Instance(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
-				),
-			},
-			{
-				Config: testAccAWSEIP_Instance(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
-				),
-				Taint: []string{resourceName},
 			},
 		},
 	})
@@ -317,9 +135,9 @@ func TestAccAWSEIP_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPConfig,
+				Config: testAccEIPConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsEip(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -328,7 +146,7 @@ func TestAccAWSEIP_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEIP_notAssociated(t *testing.T) {
+func TestAccAWSEIP_Instance(t *testing.T) {
 	var conf ec2.Address
 	resourceName := "aws_eip.test"
 
@@ -340,9 +158,9 @@ func TestAccAWSEIP_notAssociated(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPAssociate_not_associated(),
+				Config: testAccEIPInstanceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 				),
 			},
@@ -351,23 +169,16 @@ func TestAccAWSEIP_notAssociated(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccAWSEIPAssociate_associated(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
-					testAccCheckAWSEIPAssociated(&conf),
-				),
-			},
 		},
 	})
 }
 
-func TestAccAWSEIP_tags_Vpc(t *testing.T) {
-	var conf ec2.Address
+// Regression test for https://github.com/hashicorp/terraform/issues/3429 (now
+// https://github.com/hashicorp/terraform-provider-aws/issues/42)
+func TestAccAWSEIP_Instance_reassociate(t *testing.T) {
+	instanceResourceName := "aws_instance.test"
 	resourceName := "aws_eip.test"
-	rName1 := fmt.Sprintf("%s-%d", t.Name(), acctest.RandInt())
-	rName2 := fmt.Sprintf("%s-%d", t.Name(), acctest.RandInt())
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -376,14 +187,79 @@ func TestAccAWSEIP_tags_Vpc(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPConfig_tags(rName1, t.Name()),
+				Config: testAccEIPInstanceReassociateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccEIPInstanceReassociateConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
+				),
+				Taint: []string{resourceName},
+			},
+		},
+	})
+}
+
+// This test is an expansion of TestAccAWSEIP_instance, by testing the
+// associated Private EIPs of two instances
+func TestAccAWSEIP_Instance_associatedUserPrivateIP(t *testing.T) {
+	var one ec2.Address
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPInstanceAssociatedConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &one),
+					testAccCheckAWSEIPAttributes(&one),
+					testAccCheckAWSEIPAssociated(&one),
 					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName1),
-					resource.TestCheckResourceAttr(resourceName, "tags.TestName", t.Name()),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
+			},
+			{
+				Config: testAccEIPInstanceAssociatedSwitchConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &one),
+					testAccCheckAWSEIPAttributes(&one),
+					testAccCheckAWSEIPAssociated(&one),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_Instance_notAssociated(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPInstanceAssociateNotAssociatedConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
 				),
 			},
 			{
@@ -392,21 +268,86 @@ func TestAccAWSEIP_tags_Vpc(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEIPConfig_tags(rName2, t.Name()),
+				Config: testAccEIPInstanceAssociateAssociatedConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName2),
-					resource.TestCheckResourceAttr(resourceName, "tags.TestName", t.Name()),
+					testAccCheckAWSEIPAssociated(&conf),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSEIP_tags_Ec2Classic(t *testing.T) {
-	rName1 := fmt.Sprintf("%s-%d", t.Name(), acctest.RandInt())
+func TestAccAWSEIP_NetworkInterface(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPNetworkInterfaceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					testAccCheckAWSEIPAssociated(&conf),
+					testAccCheckAWSEIPPrivateDNS(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_NetworkInterface_twoEIPsOneInterface(t *testing.T) {
+	var one, two ec2.Address
+	resourceName := "aws_eip.test"
+	resourceName2 := "aws_eip.test2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPMultiNetworkInterfaceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &one),
+					testAccCheckAWSEIPAttributes(&one),
+					testAccCheckAWSEIPAssociated(&one),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
+
+					testAccCheckAWSEIPExists(resourceName2, false, &two),
+					testAccCheckAWSEIPAttributes(&two),
+					testAccCheckAWSEIPAssociated(&two),
+					resource.TestCheckResourceAttr(resourceName2, "domain", ec2.DomainTypeVpc),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_Instance_ec2Classic(t *testing.T) {
+	resourceName := "aws_eip.test"
+	var conf ec2.Address
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
@@ -415,14 +356,173 @@ func TestAccAWSEIP_tags_Ec2Classic(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSEIPConfig_tags_Ec2Classic(rName1, t.Name()),
-				ExpectError: regexp.MustCompile(`tags can not be set for an EIP in EC2 Classic`),
+				Config: testAccEIPInstanceEC2ClassicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, true, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					testAccCheckAWSEIPPublicDNSEC2Classic(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeStandard),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSEIP_PublicIpv4Pool_default(t *testing.T) {
+func TestAccAWSEIP_Tags_EC2VPC_withVPCTrue(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	// exclude ec2classic
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2VPCOnlyPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPTagsEC2VPCConfig(rName, "vpc = true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEIPTagsEC2VPCConfig(rName2, "vpc = true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName2),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_Tags_EC2VPC_withoutVPCTrue(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	// exclude ec2classic
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2VPCOnlyPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPTagsEC2VPCConfig(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEIPTagsEC2VPCConfig(rName2, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName2),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_Tags_EC2Classic_withVPCTrue(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	// exclude ec2classic
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPTagsEC2ClassicConfig(rName, "vpc = true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, true, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEIPTagsEC2ClassicConfig(rName2, "vpc = true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, true, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName2),
+					resource.TestCheckResourceAttr(resourceName, "tags.TestName", rName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_Tags_EC2Classic_withoutVPCTrue(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccEIPTagsEC2ClassicConfig(rName, ""),
+				ExpectError: regexp.MustCompile(`tags cannot be set for a standard-domain EIP - must be a VPC-domain EIP`),
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_PublicIPv4Pool_default(t *testing.T) {
 	var conf ec2.Address
 	resourceName := "aws_eip.test"
 
@@ -434,9 +534,9 @@ func TestAccAWSEIP_PublicIpv4Pool_default(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPConfig_PublicIpv4Pool_default,
+				Config: testAccEIPPublicIPv4PoolDefaultConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", "amazon"),
 					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeVpc),
@@ -451,66 +551,7 @@ func TestAccAWSEIP_PublicIpv4Pool_default(t *testing.T) {
 	})
 }
 
-func TestAccAWSEIP_NetworkBorderGroup(t *testing.T) {
-	var conf ec2.Address
-	resourceName := "aws_eip.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPConfigNetworkBorderGroup,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
-					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", "amazon"),
-					resource.TestCheckResourceAttr(resourceName, "network_border_group", testAccGetRegion()),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEIP_CarrierIP(t *testing.T) {
-	var conf ec2.Address
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_eip.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPConfigCarrierIP(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, "carrier_ip"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_border_group"),
-					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEIP_PublicIpv4Pool_custom(t *testing.T) {
+func TestAccAWSEIP_PublicIPv4Pool_custom(t *testing.T) {
 	if os.Getenv("AWS_EC2_EIP_PUBLIC_IPV4_POOL") == "" {
 		t.Skip("Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set")
 	}
@@ -528,12 +569,99 @@ func TestAccAWSEIP_PublicIpv4Pool_custom(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPConfig_PublicIpv4Pool_custom(poolName),
+				Config: testAccEIPPublicIPv4PoolCustomConfig(poolName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", poolName),
 					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeStandard),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_CustomerOwnedIPv4Pool(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPCustomerOwnedIPv4PoolConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					resource.TestMatchResourceAttr(resourceName, "customer_owned_ipv4_pool", regexp.MustCompile(`^ipv4pool-coip-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "customer_owned_ip", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_networkBorderGroup(t *testing.T) {
+	var conf ec2.Address
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPNetworkBorderGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", "amazon"),
+					resource.TestCheckResourceAttr(resourceName, "network_border_group", testAccGetRegion()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEIP_carrierIP(t *testing.T) {
+	var conf ec2.Address
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSWavelengthZoneAvailable(t) },
+		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPCarrierIPConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, false, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "carrier_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_border_group"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
 				),
 			},
 			{
@@ -591,34 +719,6 @@ func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 	return nil
 }
 
-func TestAccAWSEIP_CustomerOwnedIpv4Pool(t *testing.T) {
-	var conf ec2.Address
-	resourceName := "aws_eip.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPConfigCustomerOwnedIpv4Pool(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, &conf),
-					resource.TestMatchResourceAttr(resourceName, "customer_owned_ipv4_pool", regexp.MustCompile(`^ipv4pool-coip-.+$`)),
-					resource.TestMatchResourceAttr(resourceName, "customer_owned_ip", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccCheckAWSEIPAttributes(conf *ec2.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *conf.PublicIp == "" {
@@ -639,7 +739,7 @@ func testAccCheckAWSEIPAssociated(conf *ec2.Address) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc {
+func testAccCheckAWSEIPExists(n string, ec2classic bool, res *ec2.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -652,69 +752,57 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
+		if ec2classic {
+			conn = testAccProviderEc2Classic.Meta().(*AWSClient).ec2conn
+		}
+
+		input := &ec2.DescribeAddressesInput{}
+
 		if strings.Contains(rs.Primary.ID, "eipalloc") {
-			req := &ec2.DescribeAddressesInput{
-				AllocationIds: []*string{aws.String(rs.Primary.ID)},
-			}
-			describe, err := conn.DescribeAddresses(req)
-			if err != nil {
-				return err
-			}
-
-			if len(describe.Addresses) != 1 ||
-				*describe.Addresses[0].AllocationId != rs.Primary.ID {
-				return fmt.Errorf("EIP not found")
-			}
-			*res = *describe.Addresses[0]
-
+			input.AllocationIds = aws.StringSlice([]string{rs.Primary.ID})
 		} else {
-			req := &ec2.DescribeAddressesInput{
-				PublicIps: []*string{aws.String(rs.Primary.ID)},
+			input.PublicIps = aws.StringSlice([]string{rs.Primary.ID})
+		}
+
+		var output *ec2.DescribeAddressesOutput
+
+		err := resource.Retry(15*time.Minute, func() *resource.RetryError {
+			var err error
+
+			output, err = conn.DescribeAddresses(input)
+
+			if tfawserr.ErrCodeEquals(err, "InvalidAllocationID.NotFound") {
+				return resource.RetryableError(err)
 			}
-			describe, err := conn.DescribeAddresses(req)
+
+			if tfawserr.ErrCodeEquals(err, "InvalidAddress.NotFound") {
+				return resource.RetryableError(err)
+			}
+
 			if err != nil {
-				return err
+				return resource.NonRetryableError(err)
 			}
 
-			if len(describe.Addresses) != 1 ||
-				*describe.Addresses[0].PublicIp != rs.Primary.ID {
-				return fmt.Errorf("EIP not found")
-			}
-			*res = *describe.Addresses[0]
+			return nil
+		})
+
+		if tfresource.TimedOut(err) {
+			output, err = conn.DescribeAddresses(input)
 		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSEIPEc2ClassicExists(n string, res *ec2.Address) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No EIP ID is set")
-		}
-
-		conn := testAccProviderEc2Classic.Meta().(*AWSClient).ec2conn
-
-		input := &ec2.DescribeAddressesInput{
-			PublicIps: []*string{aws.String(rs.Primary.ID)},
-		}
-
-		describe, err := conn.DescribeAddresses(input)
 
 		if err != nil {
-			return fmt.Errorf("error describing EC2 Address (%s): %w", rs.Primary.ID, err)
+			return fmt.Errorf("while describing addresses (%s): %w", rs.Primary.ID, err)
 		}
 
-		if len(describe.Addresses) != 1 || aws.StringValue(describe.Addresses[0].PublicIp) != rs.Primary.ID {
-			return fmt.Errorf("EC2 Address (%s) not found", rs.Primary.ID)
+		if len(output.Addresses) != 1 {
+			return fmt.Errorf("wrong number of EIP found for (%s): %d", rs.Primary.ID, len(output.Addresses))
 		}
 
-		*res = *describe.Addresses[0]
+		if aws.StringValue(output.Addresses[0].AllocationId) != rs.Primary.ID && aws.StringValue(output.Addresses[0].PublicIp) != rs.Primary.ID {
+			return fmt.Errorf("EIP (%s) not found", rs.Primary.ID)
+		}
+
+		*res = *output.Addresses[0]
 
 		return nil
 	}
@@ -765,7 +853,7 @@ func testAccCheckAWSEIPPublicDNS(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAWSEIPPublicDNSEc2Classic(resourceName string) resource.TestCheckFunc {
+func testAccCheckAWSEIPPublicDNSEC2Classic(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -788,45 +876,47 @@ func testAccCheckAWSEIPPublicDNSEc2Classic(resourceName string) resource.TestChe
 	}
 }
 
-const testAccAWSEIPConfig = `
+const testAccEIPConfig = `
 resource "aws_eip" "test" {
   vpc = true
 }
 `
 
-func testAccAWSEIPConfig_tags(rName, testName string) string {
+func testAccEIPTagsEC2VPCConfig(rName, vpcConfig string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
-  vpc = true
+  %[1]s
 
   tags = {
-    RandomName = "%[1]s"
-    TestName   = "%[2]s"
+    RandomName = %[2]q
+    TestName   = %[2]q
   }
 }
-`, rName, testName)
+`, vpcConfig, rName)
 }
 
-func testAccAWSEIPConfig_tags_Ec2Classic(rName, testName string) string {
+func testAccEIPTagsEC2ClassicConfig(rName, vpcConfig string) string {
 	return composeConfig(
 		testAccEc2ClassicRegionProviderConfig(),
 		fmt.Sprintf(`
 resource "aws_eip" "test" {
+  %[1]s
+
   tags = {
-    RandomName = "%[1]s"
-    TestName   = "%[2]s"
+    RandomName = %[2]q
+    TestName   = %[2]q
   }
 }
-`, rName, testName))
+`, vpcConfig, rName))
 }
 
-const testAccAWSEIPConfig_PublicIpv4Pool_default = `
+const testAccEIPPublicIPv4PoolDefaultConfig = `
 resource "aws_eip" "test" {
   vpc = true
 }
 `
 
-func testAccAWSEIPConfig_PublicIpv4Pool_custom(poolName string) string {
+func testAccEIPPublicIPv4PoolCustomConfig(poolName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "test" {
   vpc              = true
@@ -835,7 +925,7 @@ resource "aws_eip" "test" {
 `, poolName)
 }
 
-func testAccAWSEIPInstanceEc2Classic() string {
+func testAccEIPInstanceEC2ClassicConfig() string {
 	return composeConfig(
 		testAccEc2ClassicRegionProviderConfig(),
 		testAccLatestAmazonLinuxPvEbsAmiConfig(),
@@ -852,7 +942,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccAWSEIPInstanceConfig() string {
+func testAccEIPInstanceConfig() string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
@@ -885,7 +975,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccAWSEIPInstanceConfig_associated() string {
+func testAccEIPInstanceAssociatedConfig() string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"), `
@@ -961,7 +1051,7 @@ data "aws_availability_zones" "available" {
 `)
 }
 
-func testAccAWSEIPInstanceConfig_associated_switch() string {
+func testAccEIPInstanceAssociatedSwitchConfig() string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(), `
 resource "aws_vpc" "default" {
@@ -1027,7 +1117,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-const testAccAWSEIPNetworkInterfaceConfig = `
+const testAccEIPNetworkInterfaceConfig = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -1070,7 +1160,7 @@ resource "aws_eip" "test" {
 }
 `
 
-const testAccAWSEIPMultiNetworkInterfaceConfig = `
+const testAccEIPMultiNetworkInterfaceConfig = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -1121,7 +1211,7 @@ resource "aws_eip" "test2" {
 }
 `
 
-func testAccAWSEIP_Instance(rName string) string {
+func testAccEIPInstanceReassociateConfig(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
@@ -1195,7 +1285,7 @@ resource "aws_route_table_association" "test" {
 `, rName))
 }
 
-func testAccAWSEIPAssociate_not_associated() string {
+func testAccEIPInstanceAssociateNotAssociatedConfig() string {
 	return composeConfig(
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		testAccAvailableAZsNoOptInConfig(),
@@ -1225,7 +1315,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccAWSEIPAssociate_associated() string {
+func testAccEIPInstanceAssociateAssociatedConfig() string {
 	return composeConfig(
 		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
 		testAccAvailableAZsNoOptInConfig(),
@@ -1257,7 +1347,7 @@ resource "aws_eip" "test" {
 `)
 }
 
-func testAccAWSEIPConfigCustomerOwnedIpv4Pool() string {
+func testAccEIPCustomerOwnedIPv4PoolConfig() string {
 	return `
 data "aws_ec2_coip_pools" "test" {}
 
@@ -1268,7 +1358,7 @@ resource "aws_eip" "test" {
 `
 }
 
-const testAccAWSEIPConfigNetworkBorderGroup = `
+const testAccEIPNetworkBorderGroupConfig = `
 data "aws_region" current {}
 
 resource "aws_eip" "test" {
@@ -1277,7 +1367,7 @@ resource "aws_eip" "test" {
 }
 `
 
-func testAccAWSEIPConfigCarrierIP(rName string) string {
+func testAccEIPCarrierIPConfig(rName string) string {
 	return composeConfig(
 		testAccAvailableAZsWavelengthZonesDefaultExcludeConfig(),
 		fmt.Sprintf(`

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -279,6 +279,34 @@ func TestAccAWSEIP_Instance_notAssociated(t *testing.T) {
 	})
 }
 
+func TestAccAWSEIP_Instance_ec2Classic(t *testing.T) {
+	resourceName := "aws_eip.test"
+	var conf ec2.Address
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPInstanceEC2ClassicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, true, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					testAccCheckAWSEIPPublicDNSEC2Classic(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeStandard),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSEIP_NetworkInterface(t *testing.T) {
 	var conf ec2.Address
 	resourceName := "aws_eip.test"
@@ -345,41 +373,11 @@ func TestAccAWSEIP_NetworkInterface_twoEIPsOneInterface(t *testing.T) {
 	})
 }
 
-func TestAccAWSEIP_Instance_ec2Classic(t *testing.T) {
-	resourceName := "aws_eip.test"
-	var conf ec2.Address
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEIPInstanceEC2ClassicConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists(resourceName, true, &conf),
-					testAccCheckAWSEIPAttributes(&conf),
-					testAccCheckAWSEIPPublicDNSEC2Classic(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "domain", ec2.DomainTypeStandard),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSEIP_Tags_EC2VPC_withVPCTrue(t *testing.T) {
 	var conf ec2.Address
 	resourceName := "aws_eip.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
-
-	// exclude ec2classic
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccEC2VPCOnlyPreCheck(t) },
@@ -417,13 +415,12 @@ func TestAccAWSEIP_Tags_EC2VPC_withVPCTrue(t *testing.T) {
 	})
 }
 
+// Regression test for https://github.com/hashicorp/terraform-provider-aws/issues/18756
 func TestAccAWSEIP_Tags_EC2VPC_withoutVPCTrue(t *testing.T) {
 	var conf ec2.Address
 	resourceName := "aws_eip.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
-
-	// exclude ec2classic
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccEC2VPCOnlyPreCheck(t) },
@@ -466,8 +463,6 @@ func TestAccAWSEIP_Tags_EC2Classic_withVPCTrue(t *testing.T) {
 	resourceName := "aws_eip.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
-
-	// exclude ec2classic
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

Only reject tags for standard EIPs for EC2 Classic platforms.

Fixes a regression introduced here:
https://github.com/hashicorp/terraform-provider-aws/pull/17612/files#diff-5cc53a93a886b4b2474bd02b135f8aabd7f4aeb82d77e8ac0378386eaa01ae84L186

The code above did not take account of the fact that  accounts without EC2 Classic support will automatically default to type "vpc" for EIPs and so tags are ok.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18756 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Pending...