### PR TITLE
adds client_config_options to aws_ec2_client_vpn_endpoint #16056

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -275,6 +275,9 @@ func resourceAwsEc2ClientVpnEndpointRead(d *schema.ResourceData, meta interface{
 	}
 
 	err = d.Set("client_connect_options", flattenClientConnectOptions(result.ClientVpnEndpoints[0].ClientConnectOptions))
+	if err != nil {
+		return fmt.Errorf("error setting client_connect_options: %w", err)
+	}
 
 	err = d.Set("connection_log_options", flattenConnLoggingConfig(result.ClientVpnEndpoints[0].ConnectionLogOptions))
 	if err != nil {

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -89,6 +89,7 @@ func TestAccAwsEc2ClientVpn_serial(t *testing.T) {
 			"msAD":              testAccAwsEc2ClientVpnEndpoint_msAD,
 			"mutualAuthAndMsAD": testAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD,
 			"federated":         testAccAwsEc2ClientVpnEndpoint_federated,
+			"withClientConnect": testAccAwsEc2ClientVpnEndpoint_withClientConnectOptions,
 			"withLogGroup":      testAccAwsEc2ClientVpnEndpoint_withLogGroup,
 			"withDNSServers":    testAccAwsEc2ClientVpnEndpoint_withDNSServers,
 			"tags":              testAccAwsEc2ClientVpnEndpoint_tags,

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -588,8 +588,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
   }
 
   client_connect_options {
-    enabled              = true
-    lambda_function_arn  = aws_lambda_function.test.arn
+    enabled             = true
+    lambda_function_arn = aws_lambda_function.test.arn
   }
 }
 `, rName, rName)

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -272,7 +272,7 @@ func testAccAwsEc2ClientVpnEndpoint_withClientConnectOptions(t *testing.T) {
 	var v1, v2 ec2.ClientVpnEndpoint
 	rStr := acctest.RandString(5)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	lambdaFunctionArn := "aws_lambda_function.lg"
+	lambdaFunctionArn := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckClientVPNSyncronize(t); testAccPreCheck(t) },
@@ -589,7 +589,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 
   client_connect_options {
     enabled              = true
-    lambda_function_arn  = aws_lambda_function_test.arn
+    lambda_function_arn  = aws_lambda_function.test.arn
   }
 }
 `, rName, rName)

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -290,9 +290,9 @@ func testAccAwsEc2ClientVpnEndpoint_withClientConnectOptions(t *testing.T) {
 				Config: testAccEc2ClientVpnEndpointConfigWithClientConfig(rStr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEc2ClientVpnEndpointExists(resourceName, &v2),
-					resource.TestCheckResourceAttr(resourceName, "client_config_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "client_config_options.0.enabled", "true"),
-					resource.TestCheckResourceAttrPair(resourceName, "client_config_options.0.lambda_function_arn", lambdaFunctionArn, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "client_connect_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_connect_options.0.enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "client_connect_options.0.lambda_function_arn", lambdaFunctionArn, "arn"),
 				),
 			},
 			{
@@ -570,7 +570,7 @@ func testAccEc2ClientVpnEndpointConfigWithClientConfig(rName string) string {
 	return testAccEc2ClientVpnEndpointConfigAcmCertificateBase() + fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = "AWSClientVPN-client_config_handler_%s"
+  function_name = "AWSClientVPN-client_connect_handler_%s"
   publish       = false
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
@@ -587,7 +587,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
     root_certificate_chain_arn = aws_acm_certificate.test.arn
   }
 
-  client_config_options {
+  client_connect_options {
     enabled              = true
     lambda_function_arn  = aws_lambda_function_test.arn
   }

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -29,12 +29,11 @@ resource "aws_ec2_client_vpn_endpoint" "example" {
     cloudwatch_log_group  = aws_cloudwatch_log_group.lg.name
     cloudwatch_log_stream = aws_cloudwatch_log_stream.ls.name
   }
-  
+
   client_connect_options {
-    enabled = true
+    enabled             = true
     lambda_function_arn = aws_lambda_function.example.arn
   }
-}
 }
 ```
 

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -29,6 +29,12 @@ resource "aws_ec2_client_vpn_endpoint" "example" {
     cloudwatch_log_group  = aws_cloudwatch_log_group.lg.name
     cloudwatch_log_stream = aws_cloudwatch_log_stream.ls.name
   }
+  
+  client_connect_options {
+    enabled = true
+    lambda_function_arn = aws_lambda_function.example.arn
+  }
+}
 }
 ```
 
@@ -39,6 +45,7 @@ The following arguments are supported:
 * `authentication_options` - (Required) Information about the authentication method to be used to authenticate clients.
 * `client_cidr_block` - (Required) The IPv4 address range, in CIDR notation, from which to assign client IP addresses. The address range cannot overlap with the local CIDR of the VPC in which the associated subnet is located, or the routes that you add manually. The address range cannot be changed after the Client VPN endpoint has been created. The CIDR block should be /22 or greater.
 * `connection_log_options` - (Required) Information about the client connection logging options.
+* `client_connect_options` - (Optional) Information about a client connect handler.
 * `description` - (Optional) Name of the repository.
 * `dns_servers` - (Optional) Information about the DNS servers to be used for DNS resolution. A Client VPN endpoint can have up to two DNS servers. If no DNS server is specified, the DNS address of the VPC that is to be associated with Client VPN endpoint is used as the DNS server.
 * `server_certificate_arn` - (Required) The ARN of the ACM server certificate.
@@ -58,11 +65,17 @@ One of the following arguments must be supplied:
 
 ### `connection_log_options` Argument Reference
 
-One of the following arguments must be supplied:
+one of the following arguments must be supplied:
 
-* `enabled` - (Required) Indicates whether connection logging is enabled.
-* `cloudwatch_log_group` - (Optional) The name of the CloudWatch Logs log group.
+* `enabled` - (required) indicates whether connection logging is enabled.
+* `cloudwatch_log_group` - (optional) the name of the cloudwatch logs log group.
 * `cloudwatch_log_stream` - (Optional) The name of the CloudWatch Logs log stream to which the connection data is published.
+
+### `client_connect_options` Argument reference
+
+* `enabled` - (required) indicates whether a client connect handler is enabled.
+* `lambda_function_arn` - (required) the arn of the lambda function that implements a client connect handler.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
This implements client connection handlers for AWS Client VPN endpoints to fix #16056