### PR TITLE
ds/efs_mount_target: Add access_point_id, file_system_id args

### DIFF
--- a/.changelog/18918.txt
+++ b/.changelog/18918.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_efs_mount_target: Add `access_point_id`, `file_system_id` arguments
+```

--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -79,15 +79,15 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 
 	input := &efs.DescribeMountTargetsInput{}
 
-	if v, ok := d.GetOk("access_point_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("access_point_id"); ok {
 		input.AccessPointId = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("file_system_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("file_system_id"); ok {
 		input.FileSystemId = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("mount_target_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("mount_target_id"); ok {
 		input.MountTargetId = aws.String(v.(string))
 	}
 

--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -15,9 +15,21 @@ func dataSourceAwsEfsMountTarget() *schema.Resource {
 		Read: dataSourceAwsEfsMountTargetRead,
 
 		Schema: map[string]*schema.Schema{
-			"mount_target_id": {
+			"access_point_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+			},
+			"availability_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"file_system_arn": {
 				Type:     schema.TypeString,
@@ -25,9 +37,27 @@ func dataSourceAwsEfsMountTarget() *schema.Resource {
 			},
 			"file_system_id": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mount_target_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"mount_target_dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -40,30 +70,6 @@ func dataSourceAwsEfsMountTarget() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"network_interface_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"dns_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"mount_target_dns_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"availability_zone_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"availability_zone_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -71,20 +77,32 @@ func dataSourceAwsEfsMountTarget() *schema.Resource {
 func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).efsconn
 
-	describeEfsOpts := &efs.DescribeMountTargetsInput{
-		MountTargetId: aws.String(d.Get("mount_target_id").(string)),
+	input := &efs.DescribeMountTargetsInput{}
+
+	if v, ok := d.GetOk("access_point_id"); ok && v.(string) != "" {
+		input.AccessPointId = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Reading EFS Mount Target: %s", describeEfsOpts)
-	resp, err := conn.DescribeMountTargets(describeEfsOpts)
+	if v, ok := d.GetOk("file_system_id"); ok && v.(string) != "" {
+		input.FileSystemId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("mount_target_id"); ok && v.(string) != "" {
+		input.MountTargetId = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Reading EFS Mount Target: %s", input)
+	output, err := conn.DescribeMountTargets(input)
+
 	if err != nil {
 		return fmt.Errorf("Error retrieving EFS Mount Target: %w", err)
 	}
-	if len(resp.MountTargets) != 1 {
-		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.MountTargets))
+
+	if len(output.MountTargets) != 1 {
+		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(output.MountTargets))
 	}
 
-	mt := resp.MountTargets[0]
+	mt := output.MountTargets[0]
 
 	log.Printf("[DEBUG] Found EFS mount target: %#v", mt)
 
@@ -98,14 +116,17 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 		Service:   "elasticfilesystem",
 	}.String()
 
+	d.Set("availability_zone_id", mt.AvailabilityZoneId)
+	d.Set("availability_zone_name", mt.AvailabilityZoneName)
+	d.Set("dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.efs", aws.StringValue(mt.FileSystemId))))
 	d.Set("file_system_arn", fsARN)
 	d.Set("file_system_id", mt.FileSystemId)
 	d.Set("ip_address", mt.IpAddress)
-	d.Set("subnet_id", mt.SubnetId)
+	d.Set("mount_target_dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.%s.efs", aws.StringValue(mt.AvailabilityZoneName), aws.StringValue(mt.FileSystemId))))
+	d.Set("mount_target_id", mt.MountTargetId)
 	d.Set("network_interface_id", mt.NetworkInterfaceId)
-	d.Set("availability_zone_name", mt.AvailabilityZoneName)
-	d.Set("availability_zone_id", mt.AvailabilityZoneId)
 	d.Set("owner_id", mt.OwnerId)
+	d.Set("subnet_id", mt.SubnetId)
 
 	sgResp, err := conn.DescribeMountTargetSecurityGroups(&efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String(d.Id()),
@@ -117,9 +138,6 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-
-	d.Set("dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.efs", aws.StringValue(mt.FileSystemId))))
-	d.Set("mount_target_dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.%s.efs", aws.StringValue(mt.AvailabilityZoneName), aws.StringValue(mt.FileSystemId))))
 
 	return nil
 }

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 func TestAccDataSourceAwsEfsMountTarget_basic(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_efs_mount_target.test"
 	resourceName := "aws_efs_mount_target.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
 		ErrorCheck: testAccErrorCheck(t, efs.EndpointsID),
@@ -38,13 +39,73 @@ func TestAccDataSourceAwsEfsMountTarget_basic(t *testing.T) {
 	})
 }
 
-func testAccAwsEfsMountTargetConfigByMountTargetId(ct string) string {
-	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+func TestAccDataSourceAwsEfsMountTarget_byAccessPointID(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_efs_mount_target.test"
+	resourceName := "aws_efs_mount_target.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, efs.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSMountTargetConfigByAccessPointId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_id", resourceName, "file_system_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ip_address", resourceName, "ip_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_id", resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interface_id", resourceName, "network_interface_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mount_target_dns_name", resourceName, "mount_target_dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_name", resourceName, "availability_zone_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_id", resourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups", resourceName, "security_groups"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsEfsMountTarget_byFileSystemID(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_efs_mount_target.test"
+	resourceName := "aws_efs_mount_target.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, efs.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSMountTargetConfigByFileSystemId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_id", resourceName, "file_system_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ip_address", resourceName, "ip_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_id", resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interface_id", resourceName, "network_interface_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mount_target_dns_name", resourceName, "mount_target_dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_name", resourceName, "availability_zone_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_id", resourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups", resourceName, "security_groups"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsEfsMountTargetDataSourceBaseConfig(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
-  creation_token = "%s"
+  creation_token = %[1]q
 
   tags = {
-    Name = "tf-acc-efs-mount-target-test"
+    Name = %[1]q
   }
 }
 
@@ -57,7 +118,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-acc-efs-mount-target-test"
+    Name = %[1]q
   }
 }
 
@@ -67,12 +128,36 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.1.0/24"
 
   tags = {
-    Name = "tf-acc-efs-mount-target-test"
+    Name = %[1]q
   }
 }
+`, rName))
+}
 
+func testAccAwsEfsMountTargetConfigByMountTargetId(rName string) string {
+	return composeConfig(testAccAwsEfsMountTargetDataSourceBaseConfig(rName), `
 data "aws_efs_mount_target" "test" {
   mount_target_id = aws_efs_mount_target.test.id
 }
-`, ct)
+`)
+}
+
+func testAccAWSEFSMountTargetConfigByAccessPointId(rName string) string {
+	return composeConfig(testAccAwsEfsMountTargetDataSourceBaseConfig(rName), `
+resource "aws_efs_access_point" "test" {
+  file_system_id = aws_efs_file_system.test.id
+}
+
+data "aws_efs_mount_target" "test" {
+  access_point_id = aws_efs_access_point.test.id
+}
+`)
+}
+
+func testAccAWSEFSMountTargetConfigByFileSystemId(rName string) string {
+	return composeConfig(testAccAwsEfsMountTargetDataSourceBaseConfig(rName), `
+data "aws_efs_mount_target" "test" {
+  file_system_id = aws_efs_file_system.test.id
+}
+`)
 }

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -158,6 +158,8 @@ func testAccAWSEFSMountTargetConfigByFileSystemId(rName string) string {
 	return composeConfig(testAccAwsEfsMountTargetDataSourceBaseConfig(rName), `
 data "aws_efs_mount_target" "test" {
   file_system_id = aws_efs_file_system.test.id
+
+  depends_on = [aws_efs_mount_target.test]
 }
 `)
 }

--- a/website/docs/d/efs_mount_target.html.markdown
+++ b/website/docs/d/efs_mount_target.html.markdown
@@ -27,14 +27,15 @@ data "aws_efs_mount_target" "by_id" {
 
 The following arguments are supported:
 
-* `mount_target_id` - (Required) ID of the mount target that you want to have described
+* `access_point_id` - (Optional) ID or ARN of the access point whose mount target that you want to find. It must be included if a `file_system_id` and `mount_target_id` are not included.
+* `file_system_id` - (Optional) ID or ARN of the file system whose mount target that you want to find. It must be included if an `access_point_id` and `mount_target_id` are not included.
+* `mount_target_id` - (Optional) ID or ARN of the mount target that you want to find. It must be included in your request if an `access_point_id` and `file_system_id` are not included.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `file_system_arn` - Amazon Resource Name of the file system for which the mount target is intended.
-* `file_system_id` - ID of the file system for which the mount target is intended.
 * `subnet_id` - ID of the mount target's subnet.
 * `ip_address` - Address at which the file system may be mounted via the mount target.
 * `security_groups` - List of VPC security group IDs attached to the mount target.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18859

Output from acceptance testing (Commercial):
```
--- PASS: TestAccDataSourceAwsEfsMountTarget_byAccessPointID (135.41s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_byFileSystemID (137.30s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_basic (137.43s)
```

Output from acceptance testing (GovCloud):
```
--- PASS: TestAccDataSourceAwsEfsMountTarget_basic (129.79s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_byAccessPointID (137.91s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_byFileSystemID (140.12s)
```
