### PR TITLE
tests/resource/sns_topic: Make FIFO topic tests GovCloud compatible

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1067,8 +1067,9 @@ func testAccErrorCheckSkipMessagesContaining(t *testing.T, messages ...string) r
 		}
 
 		for _, message := range messages {
-			if strings.Contains(err.Error(), message) {
-				t.Skipf("skipping test for %s/%s: %s", testAccGetPartition(), testAccGetRegion(), err.Error())
+			errorMessage := err.Error()
+			if strings.Contains(errorMessage, message) {
+				t.Skipf("skipping test for %s/%s: %s", testAccGetPartition(), testAccGetRegion(), errorMessage)
 			}
 		}
 

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -414,7 +414,7 @@ func TestAccAWSSNSTopicSubscription_firehose(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheckSkipSNS(t),
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{
@@ -480,13 +480,6 @@ func TestAccAWSSNSTopicSubscription_disappears_topic(t *testing.T) {
 			},
 		},
 	})
-}
-
-// testAccErrorCheckSkipSNS skips SNS tests that have error messages indicating unsupported features
-func testAccErrorCheckSkipSNS(t *testing.T) resource.ErrorCheckFunc {
-	return testAccErrorCheckSkipMessagesContaining(t,
-		"Invalid protocol type: firehose",
-	)
 }
 
 func testAccCheckAWSSNSTopicSubscriptionDestroy(s *terraform.State) error {

--- a/aws/resource_aws_sns_topic_test.go
+++ b/aws/resource_aws_sns_topic_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(sns.EndpointsID, testAccErrorCheckSkipSNS)
+
 	resource.AddTestSweepers("aws_sns_topic", &resource.Sweeper{
 		Name: "aws_sns_topic",
 		F:    testSweepSnsTopics,
@@ -86,6 +88,13 @@ func testSweepSnsTopics(region string) error {
 	}
 
 	return sweeperErrs.ErrorOrNil()
+}
+
+func testAccErrorCheckSkipSNS(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"Invalid protocol type: firehose",
+		"Unknown attribute FifoTopic",
+	)
 }
 
 func TestAccAWSSNSTopic_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18885.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

##### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopic_\|TestAccAWSSNSTopicSubscription_' ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSSNSTopic_\|TestAccAWSSNSTopicSubscription_ -timeout 180m
=== RUN   TestAccAWSSNSTopicSubscription_basic
=== PAUSE TestAccAWSSNSTopicSubscription_basic
=== RUN   TestAccAWSSNSTopicSubscription_filterPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_filterPolicy
=== RUN   TestAccAWSSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccAWSSNSTopicSubscription_redrivePolicy
=== PAUSE TestAccAWSSNSTopicSubscription_redrivePolicy
=== RUN   TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_email
=== PAUSE TestAccAWSSNSTopicSubscription_email
=== RUN   TestAccAWSSNSTopicSubscription_firehose
=== PAUSE TestAccAWSSNSTopicSubscription_firehose
=== RUN   TestAccAWSSNSTopicSubscription_disappears
=== PAUSE TestAccAWSSNSTopicSubscription_disappears
=== RUN   TestAccAWSSNSTopicSubscription_disappears_topic
=== PAUSE TestAccAWSSNSTopicSubscription_disappears_topic
=== RUN   TestAccAWSSNSTopic_basic
=== PAUSE TestAccAWSSNSTopic_basic
=== RUN   TestAccAWSSNSTopic_Name
=== PAUSE TestAccAWSSNSTopic_Name
=== RUN   TestAccAWSSNSTopic_NamePrefix
=== PAUSE TestAccAWSSNSTopic_NamePrefix
=== RUN   TestAccAWSSNSTopic_policy
=== PAUSE TestAccAWSSNSTopic_policy
=== RUN   TestAccAWSSNSTopic_withIAMRole
=== PAUSE TestAccAWSSNSTopic_withIAMRole
=== RUN   TestAccAWSSNSTopic_withFakeIAMRole
=== PAUSE TestAccAWSSNSTopic_withFakeIAMRole
=== RUN   TestAccAWSSNSTopic_withDeliveryPolicy
=== PAUSE TestAccAWSSNSTopic_withDeliveryPolicy
=== RUN   TestAccAWSSNSTopic_deliveryStatus
=== PAUSE TestAccAWSSNSTopic_deliveryStatus
=== RUN   TestAccAWSSNSTopic_Name_Generated_FIFOTopic
=== PAUSE TestAccAWSSNSTopic_Name_Generated_FIFOTopic
=== RUN   TestAccAWSSNSTopic_Name_FIFOTopic
=== PAUSE TestAccAWSSNSTopic_Name_FIFOTopic
=== RUN   TestAccAWSSNSTopic_NamePrefix_FIFOTopic
=== PAUSE TestAccAWSSNSTopic_NamePrefix_FIFOTopic
=== RUN   TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication
=== PAUSE TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication
=== RUN   TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError
=== PAUSE TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError
=== RUN   TestAccAWSSNSTopic_encryption
=== PAUSE TestAccAWSSNSTopic_encryption
=== RUN   TestAccAWSSNSTopic_tags
=== PAUSE TestAccAWSSNSTopic_tags
=== CONT  TestAccAWSSNSTopicSubscription_basic
=== CONT  TestAccAWSSNSTopic_policy
=== CONT  TestAccAWSSNSTopicSubscription_email
=== CONT  TestAccAWSSNSTopic_basic
--- PASS: TestAccAWSSNSTopicSubscription_email (15.65s)
=== CONT  TestAccAWSSNSTopic_tags
--- PASS: TestAccAWSSNSTopic_basic (18.62s)
=== CONT  TestAccAWSSNSTopic_encryption
--- PASS: TestAccAWSSNSTopic_policy (19.84s)
=== CONT  TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError
--- PASS: TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError (1.62s)
=== CONT  TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication
--- PASS: TestAccAWSSNSTopic_encryption (24.96s)
=== CONT  TestAccAWSSNSTopic_NamePrefix_FIFOTopic
--- PASS: TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication (25.99s)
=== CONT  TestAccAWSSNSTopic_Name_FIFOTopic
--- PASS: TestAccAWSSNSTopic_tags (37.00s)
=== CONT  TestAccAWSSNSTopic_Name_Generated_FIFOTopic
--- PASS: TestAccAWSSNSTopic_NamePrefix_FIFOTopic (13.83s)
=== CONT  TestAccAWSSNSTopic_deliveryStatus
--- PASS: TestAccAWSSNSTopic_Name_FIFOTopic (13.95s)
=== CONT  TestAccAWSSNSTopic_withDeliveryPolicy
--- PASS: TestAccAWSSNSTopicSubscription_basic (65.31s)
=== CONT  TestAccAWSSNSTopic_withFakeIAMRole
--- PASS: TestAccAWSSNSTopic_Name_Generated_FIFOTopic (13.43s)
=== CONT  TestAccAWSSNSTopic_withIAMRole
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (14.58s)
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
--- PASS: TestAccAWSSNSTopic_deliveryStatus (30.36s)
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
--- PASS: TestAccAWSSNSTopic_withIAMRole (32.59s)
=== CONT  TestAccAWSSNSTopicSubscription_deliveryPolicy
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (69.23s)
=== CONT  TestAccAWSSNSTopicSubscription_redrivePolicy
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (102.35s)
=== CONT  TestAccAWSSNSTopicSubscription_filterPolicy
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (125.52s)
=== CONT  TestAccAWSSNSTopic_NamePrefix
--- PASS: TestAccAWSSNSTopic_NamePrefix (16.01s)
=== CONT  TestAccAWSSNSTopicSubscription_rawMessageDelivery
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (127.42s)
=== CONT  TestAccAWSSNSTopicSubscription_disappears
--- PASS: TestAccAWSSNSTopicSubscription_redrivePolicy (64.37s)
=== CONT  TestAccAWSSNSTopicSubscription_disappears_topic
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (61.43s)
=== CONT  TestAccAWSSNSTopic_Name
--- PASS: TestAccAWSSNSTopic_Name (13.32s)
=== CONT  TestAccAWSSNSTopicSubscription_firehose
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (67.97s)
--- PASS: TestAccAWSSNSTopicSubscription_disappears (69.49s)
--- PASS: TestAccAWSSNSTopicSubscription_disappears_topic (69.51s)
--- PASS: TestAccAWSSNSTopicSubscription_firehose (149.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	405.098s
```

##### GovCloud

```console
% AWS_DEFAULT_REGION=us-gov-west-1 make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopic_\|TestAccAWSSNSTopicSubscription_' ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSSNSTopic_\|TestAccAWSSNSTopicSubscription_ -timeout 180m
=== RUN   TestAccAWSSNSTopicSubscription_basic
=== PAUSE TestAccAWSSNSTopicSubscription_basic
=== RUN   TestAccAWSSNSTopicSubscription_filterPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_filterPolicy
=== RUN   TestAccAWSSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccAWSSNSTopicSubscription_redrivePolicy
=== PAUSE TestAccAWSSNSTopicSubscription_redrivePolicy
=== RUN   TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_email
=== PAUSE TestAccAWSSNSTopicSubscription_email
=== RUN   TestAccAWSSNSTopicSubscription_firehose
=== PAUSE TestAccAWSSNSTopicSubscription_firehose
=== RUN   TestAccAWSSNSTopicSubscription_disappears
=== PAUSE TestAccAWSSNSTopicSubscription_disappears
=== RUN   TestAccAWSSNSTopicSubscription_disappears_topic
=== PAUSE TestAccAWSSNSTopicSubscription_disappears_topic
=== RUN   TestAccAWSSNSTopic_basic
=== PAUSE TestAccAWSSNSTopic_basic
=== RUN   TestAccAWSSNSTopic_Name
=== PAUSE TestAccAWSSNSTopic_Name
=== RUN   TestAccAWSSNSTopic_NamePrefix
=== PAUSE TestAccAWSSNSTopic_NamePrefix
=== RUN   TestAccAWSSNSTopic_policy
=== PAUSE TestAccAWSSNSTopic_policy
=== RUN   TestAccAWSSNSTopic_withIAMRole
=== PAUSE TestAccAWSSNSTopic_withIAMRole
=== RUN   TestAccAWSSNSTopic_withFakeIAMRole
=== PAUSE TestAccAWSSNSTopic_withFakeIAMRole
=== RUN   TestAccAWSSNSTopic_withDeliveryPolicy
=== PAUSE TestAccAWSSNSTopic_withDeliveryPolicy
=== RUN   TestAccAWSSNSTopic_deliveryStatus
=== PAUSE TestAccAWSSNSTopic_deliveryStatus
=== RUN   TestAccAWSSNSTopic_Name_Generated_FIFOTopic
=== PAUSE TestAccAWSSNSTopic_Name_Generated_FIFOTopic
=== RUN   TestAccAWSSNSTopic_Name_FIFOTopic
=== PAUSE TestAccAWSSNSTopic_Name_FIFOTopic
=== RUN   TestAccAWSSNSTopic_NamePrefix_FIFOTopic
=== PAUSE TestAccAWSSNSTopic_NamePrefix_FIFOTopic
=== RUN   TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication
=== PAUSE TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication
=== RUN   TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError
=== PAUSE TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError
=== RUN   TestAccAWSSNSTopic_encryption
=== PAUSE TestAccAWSSNSTopic_encryption
=== RUN   TestAccAWSSNSTopic_tags
=== PAUSE TestAccAWSSNSTopic_tags
=== CONT  TestAccAWSSNSTopicSubscription_basic
=== CONT  TestAccAWSSNSTopic_policy
=== CONT  TestAccAWSSNSTopic_tags
=== CONT  TestAccAWSSNSTopic_encryption
--- PASS: TestAccAWSSNSTopic_policy (22.18s)
=== CONT  TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError
--- PASS: TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError (2.14s)
=== CONT  TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication
    provider_test.go:1072: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/04/16 12:41:43 [DEBUG] Using modified User-Agent: Terraform/0.12.30 HashiCorp-terraform-exec/0.13.0
        
        Error: error creating SNS Topic (terraform-test-topic-n24ddljqyr.fifo): InvalidParameter: Invalid parameter: Attributes Reason: Unknown attribute FifoTopic
        	status code: 400, request id: cc256230-6d8e-592c-8dbf-3ac3ad07bc41
        
          on terraform_plugin_test.tf line 2, in resource "aws_sns_topic" "test":
           2: resource "aws_sns_topic" "test" {
        
        
--- SKIP: TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication (4.07s)
=== CONT  TestAccAWSSNSTopic_NamePrefix_FIFOTopic
    provider_test.go:1072: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/04/16 12:41:48 [DEBUG] Using modified User-Agent: Terraform/0.12.30 HashiCorp-terraform-exec/0.13.0
        
        Error: error creating SNS Topic (tf-acc-test-prefix-20210416164149505600000003.fifo): InvalidParameter: Invalid parameter: Attributes Reason: Unknown attribute FifoTopic
        	status code: 400, request id: 2d9cb6cc-6618-5805-bb6a-ee3fa6955d70
        
          on terraform_plugin_test.tf line 2, in resource "aws_sns_topic" "test":
           2: resource "aws_sns_topic" "test" {
        
        
--- SKIP: TestAccAWSSNSTopic_NamePrefix_FIFOTopic (4.27s)
=== CONT  TestAccAWSSNSTopicSubscription_email
--- PASS: TestAccAWSSNSTopic_encryption (35.96s)
=== CONT  TestAccAWSSNSTopic_NamePrefix
--- PASS: TestAccAWSSNSTopicSubscription_email (16.49s)
=== CONT  TestAccAWSSNSTopic_Name
--- PASS: TestAccAWSSNSTopic_tags (52.27s)
=== CONT  TestAccAWSSNSTopic_basic
--- PASS: TestAccAWSSNSTopic_NamePrefix (19.52s)
=== CONT  TestAccAWSSNSTopic_Name_FIFOTopic
    provider_test.go:1072: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/04/16 12:42:15 [DEBUG] Using modified User-Agent: Terraform/0.12.30 HashiCorp-terraform-exec/0.13.0
        
        Error: error creating SNS Topic (tf-acc-test-1307469381805298597.fifo): InvalidParameter: Invalid parameter: Attributes Reason: Unknown attribute FifoTopic
        	status code: 400, request id: 52253a73-1125-5122-a9c0-6280d18d18a9
        
          on terraform_plugin_test.tf line 2, in resource "aws_sns_topic" "test":
           2: resource "aws_sns_topic" "test" {
        
        
--- SKIP: TestAccAWSSNSTopic_Name_FIFOTopic (4.15s)
=== CONT  TestAccAWSSNSTopicSubscription_disappears_topic
--- PASS: TestAccAWSSNSTopicSubscription_basic (67.34s)
=== CONT  TestAccAWSSNSTopic_Name_Generated_FIFOTopic
--- PASS: TestAccAWSSNSTopic_Name (18.30s)
=== CONT  TestAccAWSSNSTopicSubscription_disappears
--- PASS: TestAccAWSSNSTopic_basic (18.31s)
=== CONT  TestAccAWSSNSTopic_deliveryStatus
=== CONT  TestAccAWSSNSTopic_Name_Generated_FIFOTopic
    provider_test.go:1072: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/04/16 12:42:27 [DEBUG] Using modified User-Agent: Terraform/0.12.30 HashiCorp-terraform-exec/0.13.0
        
        Error: error creating SNS Topic (terraform-2021041616422837920000000c.fifo): InvalidParameter: Invalid parameter: Attributes Reason: Unknown attribute FifoTopic
        	status code: 400, request id: 532aa48d-59b2-5c41-99f0-fc7e99068f2f
        
          on terraform_plugin_test.tf line 2, in resource "aws_sns_topic" "test":
           2: resource "aws_sns_topic" "test" {
        
        
--- SKIP: TestAccAWSSNSTopic_Name_Generated_FIFOTopic (4.06s)
=== CONT  TestAccAWSSNSTopicSubscription_firehose
--- PASS: TestAccAWSSNSTopic_deliveryStatus (34.82s)
=== CONT  TestAccAWSSNSTopic_withDeliveryPolicy
=== CONT  TestAccAWSSNSTopicSubscription_firehose
    provider_test.go:1072: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/04/16 12:42:32 [DEBUG] Using modified User-Agent: Terraform/0.12.30 HashiCorp-terraform-exec/0.13.0
        
        Error: error creating SNS topic subscription: InvalidParameter: Invalid parameter: Invalid protocol type: firehose
        	status code: 400, request id: faebfb2b-226b-5d3b-8ddd-a3d8e2b4824b
        
          on terraform_plugin_test.tf line 6, in resource "aws_sns_topic_subscription" "test":
           6: resource "aws_sns_topic_subscription" "test" {
        
        
--- PASS: TestAccAWSSNSTopicSubscription_disappears_topic (62.55s)
=== CONT  TestAccAWSSNSTopic_withFakeIAMRole
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (19.33s)
=== CONT  TestAccAWSSNSTopic_withIAMRole
--- SKIP: TestAccAWSSNSTopicSubscription_firehose (59.73s)
=== CONT  TestAccAWSSNSTopicSubscription_rawMessageDelivery
--- PASS: TestAccAWSSNSTopicSubscription_disappears (72.58s)
=== CONT  TestAccAWSSNSTopicSubscription_deliveryPolicy
--- PASS: TestAccAWSSNSTopic_withIAMRole (30.59s)
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
    resource_aws_api_gateway_rest_api_test.go:1326: skipping test; Endpoint Configuration type EDGE is not supported in this partition (aws-us-gov)
--- SKIP: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (0.00s)
=== CONT  TestAccAWSSNSTopicSubscription_redrivePolicy
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (60.82s)
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
    resource_aws_api_gateway_rest_api_test.go:1326: skipping test; Endpoint Configuration type EDGE is not supported in this partition (aws-us-gov)
--- SKIP: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (0.00s)
=== CONT  TestAccAWSSNSTopicSubscription_filterPolicy
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (61.31s)
--- PASS: TestAccAWSSNSTopicSubscription_redrivePolicy (53.45s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (127.56s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (60.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	255.630s
```