### PR TITLE
elasticache: Adds Redis 6.x support

### DIFF
--- a/.changelog/18920.txt
+++ b/.changelog/18920.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_elasticache_cluster: Allows specifying Redis 6.x
+```
+
+```release-note:bug
+resource/aws_elasticache_replication_group: Allows specifying Redis 6.x
+```
+
+```release-note:enhancement
+resource/aws_elasticache_global_replication_group: Adds parameter `engine_version_actual` to match other ElastiCache resources
+```

--- a/aws/elasticache_validation.go
+++ b/aws/elasticache_validation.go
@@ -1,10 +1,12 @@
-package elasticache
+package aws
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
 	gversion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const (
@@ -34,7 +36,7 @@ func ValidateElastiCacheRedisVersionString(v interface{}, k string) (ws []string
 	return
 }
 
-// normalizeElastiCacheEngineVersion returns a github.com/hashicorp/go-version Version
+// NormalizeElastiCacheEngineVersion returns a github.com/hashicorp/go-version Version
 // that can handle a regular 1.2.3 version number or a 6.x version number used for
 // ElastiCache Redis version 6 and higher
 func NormalizeElastiCacheEngineVersion(version string) (*gversion.Version, error) {
@@ -42,4 +44,27 @@ func NormalizeElastiCacheEngineVersion(version string) (*gversion.Version, error
 		version = matches[1]
 	}
 	return gversion.NewVersion(version)
+}
+
+// CustomizeDiffElastiCacheEngineVersion causes re-creation of the resource if the version is being downgraded
+func CustomizeDiffElastiCacheEngineVersion(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if diff.Id() == "" || !diff.HasChange("engine_version") {
+		return nil
+	}
+
+	o, n := diff.GetChange("engine_version")
+	oVersion, err := NormalizeElastiCacheEngineVersion(o.(string))
+	if err != nil {
+		return fmt.Errorf("error parsing old engine_version: %w", err)
+	}
+	nVersion, err := NormalizeElastiCacheEngineVersion(n.(string))
+	if err != nil {
+		return fmt.Errorf("error parsing new engine_version: %w", err)
+	}
+
+	if nVersion.GreaterThan(oVersion) {
+		return nil
+	}
+
+	return diff.ForceNew("engine_version")
 }

--- a/aws/elasticache_validation.go
+++ b/aws/elasticache_validation.go
@@ -2,11 +2,15 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	multierror "github.com/hashicorp/go-multierror"
 	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfelasticache "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache"
 )
 
 const (
@@ -67,4 +71,86 @@ func CustomizeDiffElastiCacheEngineVersion(_ context.Context, diff *schema.Resou
 	}
 
 	return diff.ForceNew("engine_version")
+}
+
+// CustomizeDiffValidateClusterAZMode validates that `num_cache_nodes` is greater than 1 when `az_mode` is "cross-az"
+func CustomizeDiffValidateClusterAZMode(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if v, ok := diff.GetOk("az_mode"); !ok || v.(string) != elasticache.AZModeCrossAz {
+		return nil
+	}
+	if v, ok := diff.GetOk("num_cache_nodes"); !ok || v.(int) != 1 {
+		return nil
+	}
+
+	return errors.New(`az_mode "cross-az" is not supported with num_cache_nodes = 1`)
+}
+
+// CustomizeDiffValidateClusterEngineVersion validates the correct format for `engine_version`, based on `engine`
+func CustomizeDiffValidateClusterEngineVersion(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	// Memcached: Versions in format <major>.<minor>.<bug fix>
+	// Redis: Starting with version 6, must match <major>.x, prior to version 6, <major>.<minor>.<bug fix>
+	engineVersion, ok := diff.GetOk("engine_version")
+	if !ok {
+		return nil
+	}
+
+	var validator schema.SchemaValidateFunc
+	if v, ok := diff.GetOk("engine"); !ok || v.(string) == tfelasticache.EngineMemcached {
+		validator = validateVersionString
+	} else {
+		validator = ValidateElastiCacheRedisVersionString
+	}
+
+	_, errs := validator(engineVersion, "engine_version")
+
+	var err *multierror.Error
+	err = multierror.Append(err, errs...)
+	return err.ErrorOrNil()
+}
+
+// CustomizeDiffValidateClusterNumCacheNodes validates that `num_cache_nodes` is 1 when `engine` is "redis"
+func CustomizeDiffValidateClusterNumCacheNodes(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if v, ok := diff.GetOk("engine"); !ok || v.(string) == tfelasticache.EngineMemcached {
+		return nil
+	}
+
+	if v, ok := diff.GetOk("num_cache_nodes"); !ok || v.(int) == 1 {
+		return nil
+	}
+	return errors.New(`engine "redis" does not support num_cache_nodes > 1`)
+}
+
+// CustomizeDiffClusterMemcachedNodeType causes re-creation when `node_type` is changed and `engine` is "memcached"
+func CustomizeDiffClusterMemcachedNodeType(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	// Engine memcached does not currently support vertical scaling
+	// https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/Scaling.html#Scaling.Memcached.Vertically
+	if diff.Id() == "" || !diff.HasChange("node_type") {
+		return nil
+	}
+	if v, ok := diff.GetOk("engine"); !ok || v.(string) == tfelasticache.EngineRedis {
+		return nil
+	}
+	return diff.ForceNew("node_type")
+}
+
+// CustomizeDiffValidateClusterMemcachedSnapshotIdentifier validates that `final_snapshot_identifier` is not set when `engine` is "memcached"
+func CustomizeDiffValidateClusterMemcachedSnapshotIdentifier(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if v, ok := diff.GetOk("engine"); !ok || v.(string) == tfelasticache.EngineRedis {
+		return nil
+	}
+	if _, ok := diff.GetOk("final_snapshot_identifier"); !ok {
+		return nil
+	}
+	return errors.New(`engine "memcached" does not support final_snapshot_identifier`)
+}
+
+// CustomizeDiffValidateReplicationGroupAutomaticFailover validates that `automatic_failover_enabled` is set when `multi_az_enabled` is true
+func CustomizeDiffValidateReplicationGroupAutomaticFailover(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if v := diff.Get("multi_az_enabled").(bool); !v {
+		return nil
+	}
+	if v := diff.Get("automatic_failover_enabled").(bool); !v {
+		return errors.New(`automatic_failover_enabled must be true if multi_az_enabled is true`)
+	}
+	return nil
 }

--- a/aws/internal/service/elasticache/engine_version.go
+++ b/aws/internal/service/elasticache/engine_version.go
@@ -1,0 +1,45 @@
+package elasticache
+
+import (
+	"fmt"
+	"regexp"
+
+	gversion "github.com/hashicorp/go-version"
+)
+
+const (
+	redisVersionPreV6RegexpRaw  = `[1-5](\.[[:digit:]]+){2}`
+	redisVersionPostV6RegexpRaw = `([6-9]|[[:digit:]]{2})\.x`
+
+	redisVersionRegexpRaw = redisVersionPreV6RegexpRaw + "|" + redisVersionPostV6RegexpRaw
+)
+
+const (
+	redisVersionRegexpPattern       = "^" + redisVersionRegexpRaw + "$"
+	redisVersionPostV6RegexpPattern = "^" + redisVersionPostV6RegexpRaw + "$"
+)
+
+var (
+	redisVersionRegexp       = regexp.MustCompile(redisVersionRegexpPattern)
+	redisVersionPostV6Regexp = regexp.MustCompile(redisVersionPostV6RegexpPattern)
+)
+
+func ValidateElastiCacheRedisVersionString(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !redisVersionRegexp.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s: Redis versions must match <major>.x when using version 6 or higher, or <major>.<minor>.<bug-fix>", k))
+	}
+
+	return
+}
+
+// normalizeElastiCacheEngineVersion returns a github.com/hashicorp/go-version Version
+// that can handle a regular 1.2.3 version number or a 6.x version number used for
+// ElastiCache Redis version 6 and higher
+func NormalizeElastiCacheEngineVersion(version string) (*gversion.Version, error) {
+	if matches := redisVersionPostV6Regexp.FindStringSubmatch(version); matches != nil {
+		version = matches[1]
+	}
+	return gversion.NewVersion(version)
+}

--- a/aws/internal/service/elasticache/service.go
+++ b/aws/internal/service/elasticache/service.go
@@ -1,0 +1,14 @@
+package elasticache
+
+const (
+	EngineMemcached = "memcached"
+	EngineRedis     = "redis"
+)
+
+// Engine_Values returns all elements of the Engine enum
+func Engine_Values() []string {
+	return []string{
+		EngineMemcached,
+		EngineRedis,
+	}
+}

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -128,7 +128,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"actual_engine_version": {
+			"engine_version_actual": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -468,7 +468,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	} else {
 		d.Set("engine_version", fmt.Sprintf("%d.x", engineVersion.Segments()[0]))
 	}
-	d.Set("actual_engine_version", engineVersion.String())
+	d.Set("engine_version_actual", engineVersion.String())
 
 	if c.ConfigurationEndpoint != nil {
 		d.Set("port", c.ConfigurationEndpoint.Port)

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -179,6 +179,7 @@ func TestAccAWSElasticacheCluster_ParameterGroupName_Default(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "engine", "memcached"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.34"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.34"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.memcached1.4"),
 				),
 			},
@@ -500,6 +501,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.33"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.33"),
 				),
 			},
 			{
@@ -508,6 +510,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &mid),
 					testAccCheckAWSElasticacheClusterRecreated(&pre, &mid),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.24"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.24"),
 				),
 			},
 			{
@@ -516,6 +519,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.34"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.34"),
 				),
 			},
 		},
@@ -538,6 +542,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.6"),
 				),
 			},
 			{
@@ -546,6 +551,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &mid),
 					testAccCheckAWSElasticacheClusterRecreated(&pre, &mid),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.4"),
 				),
 			},
 			{
@@ -554,6 +560,25 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.10"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "6.x"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
+					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
+					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "5.0.6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
+					testAccCheckAWSElasticacheClusterRecreated(&mid, &post),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "5.0.6"),
 				),
 			},
 		},

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -527,7 +527,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 }
 
 func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
-	var pre, mid, post elasticache.CacheCluster
+	var v1, v2, v3, v4, v5 elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
@@ -540,7 +540,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "3.2.6"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
 					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.6"),
 				),
@@ -548,8 +548,8 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "3.2.4"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheClusterExists(resourceName, &mid),
-					testAccCheckAWSElasticacheClusterRecreated(&pre, &mid),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &v2),
+					testAccCheckAWSElasticacheClusterRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
 					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.4"),
 				),
@@ -557,8 +557,8 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "3.2.10"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
-					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &v3),
+					testAccCheckAWSElasticacheClusterNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
 					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.10"),
 				),
@@ -566,8 +566,8 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "6.x"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
-					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &v4),
+					testAccCheckAWSElasticacheClusterNotRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
@@ -575,8 +575,8 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "5.0.6"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
-					testAccCheckAWSElasticacheClusterRecreated(&mid, &post),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &v5),
+					testAccCheckAWSElasticacheClusterRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
 					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "5.0.6"),
 				),

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -179,7 +179,7 @@ func TestAccAWSElasticacheCluster_ParameterGroupName_Default(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "engine", "memcached"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.34"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.34"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.34"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.memcached1.4"),
 				),
 			},
@@ -501,7 +501,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.33"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.33"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.33"),
 				),
 			},
 			{
@@ -510,7 +510,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &mid),
 					testAccCheckAWSElasticacheClusterRecreated(&pre, &mid),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.24"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.24"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.24"),
 				),
 			},
 			{
@@ -519,7 +519,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.34"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "1.4.34"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.34"),
 				),
 			},
 		},
@@ -542,7 +542,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.6"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.6"),
 				),
 			},
 			{
@@ -551,7 +551,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &v2),
 					testAccCheckAWSElasticacheClusterRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.4"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.4"),
 				),
 			},
 			{
@@ -560,7 +560,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &v3),
 					testAccCheckAWSElasticacheClusterNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.10"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.10"),
 				),
 			},
 			{
@@ -569,7 +569,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &v4),
 					testAccCheckAWSElasticacheClusterNotRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
-					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -578,7 +578,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists(resourceName, &v5),
 					testAccCheckAWSElasticacheClusterRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "5.0.6"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
 			},
 		},

--- a/aws/resource_aws_elasticache_global_replication_group.go
+++ b/aws/resource_aws_elasticache_global_replication_group.go
@@ -70,12 +70,17 @@ func resourceAwsElasticacheGlobalReplicationGroup() *schema.Resource {
 			},
 			// Leaving space for `engine_version` for creation and updating.
 			// `engine_version` cannot be used for returning the version because, starting with Redis 6,
-			// version configuration is major-version-only: `engine_version = "6.x"`, while `actual_engine_version`
+			// version configuration is major-version-only: `engine_version = "6.x"`, while `engine_version_actual`
 			// will be e.g. `6.0.5`
 			// See also https://github.com/hashicorp/terraform-provider-aws/issues/15625
-			"actual_engine_version": {
+			"engine_version_actual": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"actual_engine_version": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use engine_version_actual instead",
 			},
 			"global_replication_group_id": {
 				Type:     schema.TypeString,
@@ -194,6 +199,7 @@ func resourceAwsElasticacheGlobalReplicationGroupRead(d *schema.ResourceData, me
 	d.Set("cache_node_type", globalReplicationGroup.CacheNodeType)
 	d.Set("cluster_enabled", globalReplicationGroup.ClusterEnabled)
 	d.Set("engine", globalReplicationGroup.Engine)
+	d.Set("engine_version_actual", globalReplicationGroup.EngineVersion)
 	d.Set("actual_engine_version", globalReplicationGroup.EngineVersion)
 	d.Set("global_replication_group_description", globalReplicationGroup.GlobalReplicationGroupDescription)
 	d.Set("global_replication_group_id", globalReplicationGroup.GlobalReplicationGroupId)

--- a/aws/resource_aws_elasticache_global_replication_group_test.go
+++ b/aws/resource_aws_elasticache_global_replication_group_test.go
@@ -96,6 +96,7 @@ func TestAccAWSElasticacheGlobalReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "cache_node_type", primaryReplicationGroupResourceName, "node_type"),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_enabled", primaryReplicationGroupResourceName, "cluster_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "engine", primaryReplicationGroupResourceName, "engine"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "actual_engine_version", primaryReplicationGroupResourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_id_suffix", rName),
 					resource.TestMatchResourceAttr(resourceName, "global_replication_group_id", regexp.MustCompile(elasticacheGlobalReplicationGroupRegionPrefixFormat+rName)),

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfelasticache "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
@@ -106,8 +107,8 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				Default:      "redis",
-				ValidateFunc: validation.StringInSlice([]string{"redis"}, true),
+				Default:      tfelasticache.EngineRedis,
+				ValidateFunc: validation.StringInSlice([]string{tfelasticache.EngineRedis}, true),
 			},
 			"engine_version": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -117,7 +117,7 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: ValidateElastiCacheRedisVersionString,
 			},
-			"actual_engine_version": {
+			"engine_version_actual": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -542,7 +542,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		} else {
 			d.Set("engine_version", fmt.Sprintf("%d.x", engineVersion.Segments()[0]))
 		}
-		d.Set("actual_engine_version", engineVersion.String())
+		d.Set("engine_version_actual", engineVersion.String())
 
 		d.Set("subnet_group_name", c.CacheSubnetGroupName)
 		d.Set("security_group_names", flattenElastiCacheSecurityGroupNames(c.CacheSecurityGroups))

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -109,6 +109,8 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
+					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -145,6 +147,71 @@ func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheReplicationGroup_EngineVersion_Update(t *testing.T) {
+	var v1, v2, v3, v4, v5 elasticache.ReplicationGroup
+	var c1, c2, c3, c4, c5 map[string]*elasticache.CacheCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_EngineVersion(rName, "3.2.6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &v1),
+					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c1),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.6"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_EngineVersion(rName, "3.2.4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &v2),
+					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c2),
+					testAccCheckAWSElastiCacheReplicationGroupRecreated(&c1, &c2),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.4"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_EngineVersion(rName, "3.2.10"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &v3),
+					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c3),
+					testAccCheckAWSElastiCacheReplicationGroupNotRecreated(&c2, &c3),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.10"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_EngineVersion(rName, "6.x"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &v4),
+					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c4),
+					testAccCheckAWSElastiCacheReplicationGroupNotRecreated(&c3, &c4),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
+					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_EngineVersion(rName, "5.0.6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &v5),
+					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c5),
+					testAccCheckAWSElastiCacheReplicationGroupRecreated(&c4, &c5),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
+					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "5.0.6"),
+				),
 			},
 		},
 	})
@@ -1624,6 +1691,67 @@ func testAccCheckAWSElasticacheReplicationDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckAWSElastiCacheReplicationGroupMemberClusters(n string, v *map[string]*elasticache.CacheCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var rg elasticache.ReplicationGroup
+
+		err := testAccCheckAWSElasticacheReplicationGroupExists(n, &rg)(s)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+
+		clusters := make(map[string]*elasticache.CacheCluster, len(rg.MemberClusters))
+		for _, clusterID := range rg.MemberClusters {
+			c, err := finder.CacheClusterWithNodeInfoByID(conn, aws.StringValue(clusterID))
+			if err != nil {
+				return fmt.Errorf("could not read ElastiCache replication group (%s) member cluster (%s): %w", n, aws.StringValue(clusterID), err)
+			}
+
+			clusters[aws.StringValue(c.CacheClusterId)] = c
+		}
+
+		*v = clusters
+
+		return nil
+	}
+}
+
+func testAccCheckAWSElastiCacheReplicationGroupRecreated(i, j *map[string]*elasticache.CacheCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for key, iv := range *i {
+			jv, ok := (*j)[key]
+			if !ok {
+				continue
+			}
+
+			if aws.TimeValue(iv.CacheClusterCreateTime).Equal(aws.TimeValue(jv.CacheClusterCreateTime)) {
+				return fmt.Errorf("ElastiCache replication group not recreated: member cluster (%s) not recreated", key)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSElastiCacheReplicationGroupNotRecreated(i, j *map[string]*elasticache.CacheCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for key, iv := range *i {
+			jv, ok := (*j)[key]
+			if !ok {
+				continue
+			}
+
+			if !aws.TimeValue(iv.CacheClusterCreateTime).Equal(aws.TimeValue(jv.CacheClusterCreateTime)) {
+				return fmt.Errorf("ElastiCache replication group recreated: member cluster (%s) recreated", key)
+			}
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSElasticacheReplicationGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
@@ -1685,6 +1813,23 @@ resource "aws_elasticache_replication_group" "test" {
   subnet_group_name             = aws_elasticache_subnet_group.test.name
 }
 `, rName)
+}
+
+func testAccAWSElasticacheReplicationGroupConfig_EngineVersion(rName, engineVersion string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[1]q
+  replication_group_description = "test description"
+
+  node_type                     = "cache.t3.small"
+  number_cache_clusters         = 2
+
+  engine_version = %[2]q
+  apply_immediately             = true
+  maintenance_window            = "tue:06:30-tue:07:30"
+  snapshot_window               = "01:00-02:00"
+}
+`, rName, engineVersion)
 }
 
 func testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName string) string {

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1821,13 +1821,13 @@ resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
 
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 2
+  node_type             = "cache.t3.small"
+  number_cache_clusters = 2
 
-  engine_version = %[2]q
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
+  engine_version     = %[2]q
+  apply_immediately  = true
+  maintenance_window = "tue:06:30-tue:07:30"
+  snapshot_window    = "01:00-02:00"
 }
 `, rName, engineVersion)
 }

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -110,7 +110,7 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
-					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -170,7 +170,7 @@ func TestAccAWSElasticacheReplicationGroup_EngineVersion_Update(t *testing.T) {
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &v1),
 					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c1),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.6"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.6"),
 				),
 			},
 			{
@@ -180,7 +180,7 @@ func TestAccAWSElasticacheReplicationGroup_EngineVersion_Update(t *testing.T) {
 					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c2),
 					testAccCheckAWSElastiCacheReplicationGroupRecreated(&c1, &c2),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.4"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.4"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.4"),
 				),
 			},
 			{
@@ -190,7 +190,7 @@ func TestAccAWSElasticacheReplicationGroup_EngineVersion_Update(t *testing.T) {
 					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c3),
 					testAccCheckAWSElastiCacheReplicationGroupNotRecreated(&c2, &c3),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.10"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "3.2.10"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "3.2.10"),
 				),
 			},
 			{
@@ -200,7 +200,7 @@ func TestAccAWSElasticacheReplicationGroup_EngineVersion_Update(t *testing.T) {
 					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c4),
 					testAccCheckAWSElastiCacheReplicationGroupNotRecreated(&c3, &c4),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "6.x"),
-					resource.TestMatchResourceAttr(resourceName, "actual_engine_version", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexp.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -210,7 +210,7 @@ func TestAccAWSElasticacheReplicationGroup_EngineVersion_Update(t *testing.T) {
 					testAccCheckAWSElastiCacheReplicationGroupMemberClusters(resourceName, &c5),
 					testAccCheckAWSElastiCacheReplicationGroupRecreated(&c4, &c5),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.0.6"),
-					resource.TestCheckResourceAttr(resourceName, "actual_engine_version", "5.0.6"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
 			},
 		},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -26,17 +26,23 @@ const (
 	awsAccountIDRegexpInternalPattern = `(aws|\d{12})`
 	awsPartitionRegexpInternalPattern = `aws(-[a-z]+)*`
 	awsRegionRegexpInternalPattern    = `[a-z]{2}(-[a-z]+)+-\d`
+
+	versionStringRegexpInternalPattern = `[[:digit:]]+(\.[[:digit:]]+){2}`
 )
 
 const (
 	awsAccountIDRegexpPattern = "^" + awsAccountIDRegexpInternalPattern + "$"
 	awsPartitionRegexpPattern = "^" + awsPartitionRegexpInternalPattern + "$"
 	awsRegionRegexpPattern    = "^" + awsRegionRegexpInternalPattern + "$"
+
+	versionStringRegexpPattern = "^" + versionStringRegexpInternalPattern + "$"
 )
 
 var awsAccountIDRegexp = regexp.MustCompile(awsAccountIDRegexpPattern)
 var awsPartitionRegexp = regexp.MustCompile(awsPartitionRegexpPattern)
 var awsRegionRegexp = regexp.MustCompile(awsRegionRegexpPattern)
+
+var versionStringRegexp = regexp.MustCompile(versionStringRegexpPattern)
 
 // validateTypeStringNullableBoolean provides custom error messaging for TypeString booleans
 // Some arguments require three values: true, false, and "" (unspecified).
@@ -2426,3 +2432,13 @@ var validateTypeStringIsDateOrPositiveInt = validation.Any(
 	validation.IsRFC3339Time,
 	validation.StringMatch(regexp.MustCompile(`^\d+$`), "must be a positive integer value"),
 )
+
+func validateVersionString(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !versionStringRegexp.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s: must be a version string matching x.y.z", k))
+	}
+
+	return
+}

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -85,7 +85,7 @@ The following arguments are optional:
 * `az_mode` - (Optional, Memcached only) Whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are `single-az` or `cross-az`, default is `single-az`. If you want to choose `cross-az`, `num_cache_nodes` must be greater than `1`.
 * `engine_version` – (Optional) Version number of the cache engine to be used.
 See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html)
-in the AWS Documentation center for supported versions. When `engine` is `redis` and the version is 6 or higher, only the major version can be set, e.g. `6.x`, otherwise, specify the full version desired, e.g. `5.0.6`. The actual engine version used is returned in the attribute `actual_engine_version`, [defined below](#actual_engine_version).
+in the AWS Documentation for supported versions. When `engine` is `redis` and the version is 6 or higher, only the major version can be set, e.g. `6.x`, otherwise, specify the full version desired, e.g. `5.0.6`. The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 * `final_snapshot_identifier` - (Optional, Redis only) Name of your final cluster snapshot. If omitted, no final snapshot will be made.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
 on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).
@@ -108,7 +108,7 @@ The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the created ElastiCache Cluster.
-* `actual_engine_version` - The running version of the cache engine.
+* `engine_version_actual` - The running version of the cache engine.
 * `cache_nodes` - List of node objects including `id`, `address`, `port` and `availability_zone`.
 * `cluster_address` - (Memcached only) DNS name of the cache cluster without the port appended.
 * `configuration_endpoint` - (Memcached only) Configuration endpoint to allow host discovery.

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -74,18 +74,22 @@ The following arguments are required:
 
 * `cluster_id` – (Required) Group identifier. ElastiCache converts this name to lowercase. Changing this value will re-create the resource.
 * `engine` – (Required unless `replication_group_id` is provided) Name of the cache engine to be used for this cache cluster. Valid values are `memcached` or `redis`.
-* `node_type` – (Required unless `replication_group_id` is provided) Instance class used. See AWS documentation for information on [supported node types for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html). See AWS documentation for information on [supported node types for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/nodes-select-size.html). For Memcached, changing this value will re-create the resource.
-* `num_cache_nodes` – (Required unless `replication_group_id` is provided) Initial number of cache nodes that the cache cluster will have. For Redis, this value must be 1. For Memcached, this value must be between 1 and 20. If this number is reduced on subsequent runs, the highest numbered nodes will be removed.
-* `parameter_group_name` – (Required unless `replication_group_id` is provided) Name of the parameter group to associate with this cache cluster
+* `node_type` – (Required unless `replication_group_id` is provided) The instance class used. See AWS documentation for information on [supported node types for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html). See AWS documentation for information on [supported node types for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/nodes-select-size.html). For Memcached, changing this value will re-create the resource.
+* `num_cache_nodes` – (Required unless `replication_group_id` is provided) The initial number of cache nodes that the cache cluster will have. For Redis, this value must be 1. For Memcached, this value must be between 1 and 20. If this number is reduced on subsequent runs, the highest numbered nodes will be removed.
+* `parameter_group_name` – (Required unless `replication_group_id` is provided) The name of the parameter group to associate with this cache cluster.
 
 The following arguments are optional:
 
-* `apply_immediately` - (Optional) Whether any database modifications are applied immediately, or during the next maintenance window. Default is `false`. See [Amazon ElastiCache Documentation for more information.](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html)
+* `apply_immediately` - (Optional) Whether any database modifications are applied immediately, or during the next maintenance window. Default is `false`. See [Amazon ElastiCache Documentation for more information.](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyCacheCluster.html).
 * `availability_zone` - (Optional) Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone. Changing this value will re-create the resource.
-* `az_mode` - (Optional, Memcached only) Whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are `single-az` or `cross-az`, default is `single-az`. If you want to choose `cross-az`, `num_cache_nodes` must be greater than `1`
-* `engine_version` – (Optional) Version number of the cache engine to be used. See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html) in the AWS Documentation center for supported versions
+* `az_mode` - (Optional, Memcached only) Whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are `single-az` or `cross-az`, default is `single-az`. If you want to choose `cross-az`, `num_cache_nodes` must be greater than `1`.
+* `engine_version` – (Optional) Version number of the cache engine to be used.
+See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html)
+in the AWS Documentation center for supported versions. When `engine` is `redis` and the version is 6 or higher, only the major version can be set, e.g. `6.x`, otherwise, specify the full version desired, e.g. `5.0.6`. The actual engine version used is returned in the attribute `actual_engine_version`, [defined below](#actual_engine_version).
 * `final_snapshot_identifier` - (Optional, Redis only) Name of your final cluster snapshot. If omitted, no final snapshot will be made.
-* `maintenance_window` – (Optional) Weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
+* `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
+on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).
+The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`.
 * `notification_topic_arn` – (Optional) ARN of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic`.
 * `port` – (Optional) The port number on which each of the cache nodes will accept connections. For Memcached the default is 11211, and for Redis the default port is 6379. Cannot be provided with `replication_group_id`. Changing this value will re-create the resource.
 * `preferred_availability_zones` - (Optional, Memcached only) List of the Availability Zones in which cache nodes are created. If you are creating your cluster in an Amazon VPC you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group. The number of Availability Zones listed must equal the value of `num_cache_nodes`. If you want all the nodes in the same Availability Zone, use `availability_zone` instead, or repeat the Availability Zone multiple times in the list. Default: System chosen Availability Zones. Detecting drift of existing node availability zone is not currently supported. Updating this argument by itself to migrate existing node availability zones is not currently supported and will show a perpetual difference.
@@ -103,7 +107,8 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the created ElastiCache Cluster.
+* `arn` - The ARN of the created ElastiCache Cluster.
+* `actual_engine_version` - The running version of the cache engine.
 * `cache_nodes` - List of node objects including `id`, `address`, `port` and `availability_zone`.
 * `cluster_address` - (Memcached only) DNS name of the cache cluster without the port appended.
 * `configuration_endpoint` - (Memcached only) Configuration endpoint to allow host discovery.

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -58,7 +58,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the ElastiCache Global Replication Group.
 * `arn` - The ARN of the ElastiCache Global Replication Group.
-* `actual_engine_version` - The full version number of the cache engine running on the members of this global replication group.
+* `actual_engine_version` - (**DEPRECATED** use `engine_version_actual` instead) The full version number of the cache engine running on the members of this global replication group.
+* `engine_version_actual` - The full version number of the cache engine running on the members of this global replication group.
 * `at_rest_encryption_enabled` - A flag that indicate whether the encryption at rest is enabled.
 * `auth_token_enabled` - A flag that indicate whether AuthToken (password) is enabled.
 * `cache_node_type` - The instance class used. See AWS documentation for information on [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html).

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -153,8 +153,8 @@ The following arguments are optional:
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `number_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
 * `availability_zones` - (Optional) A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.
 * `cluster_mode` - (Optional) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. One of `number_cache_clusters` or `cluster_mode` is required. Note that configuring this block does not enable cluster mode, i.e. data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
-* `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group.
 * `engine` - (Optional) The name of the cache engine to be used for the clusters in this replication group. The only valid value is `redis`.
+* `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group. If the version is 6 or higher, only the major version can be set, e.g. `6.x`, otherwise, specify the full version desired, e.g. `5.0.6`. The actual engine version used is returned in the attribute `actual_engine_version`, [defined below](#actual_engine_version).
 * `final_snapshot_identifier` - (Optional) The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made.
 * `global_replication_group_id` - (Optional) The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group.
 * `kms_key_id` - (Optional) The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true`.
@@ -185,13 +185,14 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the created ElastiCache Replication Group.
-* `cluster_enabled` - Whether cluster mode is enabled.
-* `configuration_endpoint_address` - Address of the replication group configuration endpoint when cluster mode is enabled.
-* `id` - ID of the ElastiCache Replication Group.
-* `member_clusters` - Identifiers of all the nodes that are part of this replication group.
-* `primary_endpoint_address` - (Redis only) Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
-* `reader_endpoint_address` - (Redis only) Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled.
+* `actual_engine_version` - The running version of the cache engine.
+* `arn` - The Amazon Resource Name (ARN) of the created ElastiCache Replication Group.
+* `cluster_enabled` - Indicates if cluster mode is enabled.
+* `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
+* `id` - The ID of the ElastiCache Replication Group.
+* `member_clusters` - The identifiers of all the nodes that are part of this replication group.
+* `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
+* `reader_endpoint_address` - (Redis only) The address of the endpoint for the reader node in the replication group, if the cluster mode is disabled.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Timeouts

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -154,7 +154,7 @@ The following arguments are optional:
 * `availability_zones` - (Optional) A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.
 * `cluster_mode` - (Optional) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. One of `number_cache_clusters` or `cluster_mode` is required. Note that configuring this block does not enable cluster mode, i.e. data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
 * `engine` - (Optional) The name of the cache engine to be used for the clusters in this replication group. The only valid value is `redis`.
-* `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group. If the version is 6 or higher, only the major version can be set, e.g. `6.x`, otherwise, specify the full version desired, e.g. `5.0.6`. The actual engine version used is returned in the attribute `actual_engine_version`, [defined below](#actual_engine_version).
+* `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group. If the version is 6 or higher, only the major version can be set, e.g. `6.x`, otherwise, specify the full version desired, e.g. `5.0.6`. The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 * `final_snapshot_identifier` - (Optional) The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made.
 * `global_replication_group_id` - (Optional) The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group.
 * `kms_key_id` - (Optional) The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true`.
@@ -185,8 +185,8 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `actual_engine_version` - The running version of the cache engine.
 * `arn` - The Amazon Resource Name (ARN) of the created ElastiCache Replication Group.
+* `engine_version_actual` - The running version of the cache engine.
 * `cluster_enabled` - Indicates if cluster mode is enabled.
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `id` - The ID of the ElastiCache Replication Group.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds support for specifying Redis version 6.x. This was due to a change in how AWS specifies Redis versions: prior to version 6, the full version was specified, e.g. 5.0.6. Staring with version 6, only the major version is specified followed by `.x`. The AWS API, however, returns the full deployed version in the corresponding parameter, leading to perpetual `plan` differences.

This PR adds validation and handling to the `engine_version` parameter to specify it as needed by the API. It also adds the parameter `engine_version_actual` to output the actual in-use version. Additionally, in `aws_elasticache_global_replication_group`, it deprecates `actual_engine_version` in favour of `engine_version_actual`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15625
Closes #18539

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheCluster\|TestAccAWSElasticacheGlobalReplicationGroup\|TestAccAWSElasticacheReplicationGroup'

--- SKIP: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (2.23s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (13.80s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (495.39s)
--- PASS: TestAccAWSElasticacheCluster_Memcached_FinalSnapshot (2.79s)
--- PASS: TestAccAWSElasticacheCluster_Port (617.02s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (617.69s)
--- PASS: TestAccAWSElasticacheCluster_vpc (632.82s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (639.96s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (640.42s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (654.64s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (673.72s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (676.60s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (679.57s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (929.33s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1029.14s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1087.77s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1242.96s)
--- PASS: TestAccAWSElasticacheCluster_Redis_FinalSnapshot (826.97s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1326.44s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1384.06s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1381.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Validation_multiAz_NoAutomaticFailover (2.50s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1394.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (801.42s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (1493.73s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_disappears (960.43s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_basic (1023.89s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (967.71s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_Description (1044.01s)
--- PASS: TestAccAWSElasticacheReplicationGroup_disappears (1150.50s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (832.55s)
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (1.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1022.65s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (2106.49s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (958.07s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1114.17s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_SingleNode (891.48s)
--- FAIL: TestAccAWSElasticacheGlobalReplicationGroup_ReplaceSecondary_DifferentRegion (2107.14s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1562.71s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1137.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1106.66s)
--- PASS: TestAccAWSElasticacheReplicationGroup_useCmkKmsKeyId (993.98s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (2516.41s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzNotInVpc (2279.69s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroups_ScaleUp (2176.34s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateReplicasPerNodeGroup (2068.33s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Validation_NoNodeType (4.62s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (2479.59s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (2012.62s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NonClusteredParameterGroup (2445.77s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Basic (1792.71s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (2943.24s)
--- PASS: TestAccAWSElasticacheReplicationGroup_EngineVersion_Update (3655.68s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_NoChange (1305.79s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Validation_GlobalReplicationGroupIdAndNodeType (851.30s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroupsAndReplicasPerNodeGroup_ScaleUp (2954.68s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (1923.84s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_AddMemberCluster (1475.98s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_RemoveMemberCluster_AtTargetSize (1408.32s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroups_ScaleDown (3166.17s)
--- PASS: TestAccAWSElasticacheReplicationGroup_tags (1183.78s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MemberClusterDisappears_RemoveMemberCluster_ScaleDown (1335.60s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_MultiAZEnabled (2020.69s)
--- PASS: TestAccAWSElasticacheReplicationGroup_FinalSnapshot (1302.19s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_MultipleSecondaries (4419.23s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (2444.80s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_UpdateNumNodeGroupsAndReplicasPerNodeGroup_ScaleDown (3578.48s)
--- PASS: TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_Basic (2221.57s)
--- PASS: TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_Full (2405.63s)
--- PASS: TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_disappears (2448.18s)
```

`TestAccAWSElasticacheGlobalReplicationGroup_ReplaceSecondary_DifferentRegion` failed with an unrelated error: `Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.`