### PR TITLE
aws_iam_user_login_profile - added password string parameter

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"log"
 	"math/big"
-
-	// "regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -98,7 +98,7 @@ func TestAccAWSUserLoginProfile_basic(t *testing.T) {
 	})
 }
 
-func TestACCAWSUserLoginProfile_password_provided(t *testing.T) {
+func TestAccAWSUserLoginProfile_passwordProvided(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 	username := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	password := acctest.RandomWithPrefix("Pa5s!")
@@ -122,6 +122,7 @@ func TestACCAWSUserLoginProfile_password_provided(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"password",
 					"encrypted_password",
 					"key_fingerprint",
 					"password_length",
@@ -427,9 +428,9 @@ func testAccAWSUserLoginProfileConfig_PasswordProvided(rName, path, password str
 resource "aws_iam_user_login_profile" "user" {
   user = aws_iam_user.user.name
 
-  pgp_key = %s
+  password = "%s"
 }
-`, testAccAWSUserLoginProfileConfig_base(rName, path), pgpKey)
+`, testAccAWSUserLoginProfileConfig_base(rName, path), password)
 }
 
 const testPubKey1 = `mQENBFXbjPUBCADjNjCUQwfxKL+RR2GA6pv/1K+zJZ8UWIF9S0lk7cVIEfJiprzzwiMwBS5cD0da

--- a/website/docs/r/iam_user_login_profile.html.markdown
+++ b/website/docs/r/iam_user_login_profile.html.markdown
@@ -31,13 +31,29 @@ output "password" {
 }
 ```
 
+```terraform
+resource "aws_iam_user" "example" {
+  name          = "example"
+  path          = "/"
+  force_destroy = true
+}
+
+resource "aws_iam_user_login_profile" "example" {
+  user                    = aws_iam_user.example.name
+  password                = "TestPassword!"
+  password_reset_required = false
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `user` - (Required) The IAM user's name.
-* `pgp_key` - (Required) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Only applies on resource creation. Drift detection is not possible with this argument.
-* `password_length` - (Optional, default 20) The length of the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument.
+* `password` (Optional) A string value to use as the password. Must be a minimum of 8 characters in length, contain one uppercase, one lowercase, a special character and a number.
+Using this field **does not** use any encryption and is not recommended for production use. Cannot be used with `pgp_key`.
+* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Only applies on resource creation. Drift detection is not possible with this argument.
+* `password_length` - (Optional, default 20) The length of the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument. Value is ignored if provided with `password` field.
 * `password_reset_required` - (Optional, default "true") Whether the user should be forced to reset the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18749 

Ive added a `password` parameter to `aws_iam_user_login_profile` and made the `pgp_key` optional. This will allow for login profiles to be created (insecurely) without the overhead of PGP.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Added new test `TestAccAWSUserLoginProfile_passwordProvided`. The new functionality dosent break the existing tests.
```
─ make testacc TESTARGS='-run=TestAccAWSUserLoginProfile_ -parallel 2' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSUserLoginProfile_ -parallel 2 -timeout 180m
=== RUN   TestAccAWSUserLoginProfile_basic
=== PAUSE TestAccAWSUserLoginProfile_basic
=== RUN   TestAccAWSUserLoginProfile_passwordProvided
=== PAUSE TestAccAWSUserLoginProfile_passwordProvided
=== RUN   TestAccAWSUserLoginProfile_keybase
=== PAUSE TestAccAWSUserLoginProfile_keybase
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
=== PAUSE TestAccAWSUserLoginProfile_keybaseDoesntExist
=== RUN   TestAccAWSUserLoginProfile_notAKey
=== PAUSE TestAccAWSUserLoginProfile_notAKey
=== RUN   TestAccAWSUserLoginProfile_PasswordLength
=== PAUSE TestAccAWSUserLoginProfile_PasswordLength
=== CONT  TestAccAWSUserLoginProfile_basic
=== CONT  TestAccAWSUserLoginProfile_notAKey
--- PASS: TestAccAWSUserLoginProfile_notAKey (15.69s)
=== CONT  TestAccAWSUserLoginProfile_keybase
--- PASS: TestAccAWSUserLoginProfile_keybase (24.41s)
=== CONT  TestAccAWSUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccAWSUserLoginProfile_basic (41.70s)
=== CONT  TestAccAWSUserLoginProfile_passwordProvided
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (14.07s)
=== CONT  TestAccAWSUserLoginProfile_PasswordLength
--- PASS: TestAccAWSUserLoginProfile_passwordProvided (62.14s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (64.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       118.817s
```
