### PR TITLE
f/resource_aws_datasync_task: Add support for log_level

### DIFF
--- a/aws/datasync.go
+++ b/aws/datasync.go
@@ -71,6 +71,7 @@ func expandDataSyncOptions(l []interface{}) *datasync.Options {
 	options := &datasync.Options{
 		Atime:                aws.String(m["atime"].(string)),
 		Gid:                  aws.String(m["gid"].(string)),
+		LogLevel:             aws.String(m["log_level"].(string)),
 		Mtime:                aws.String(m["mtime"].(string)),
 		PreserveDeletedFiles: aws.String(m["preserve_deleted_files"].(string)),
 		PreserveDevices:      aws.String(m["preserve_devices"].(string)),
@@ -146,6 +147,7 @@ func flattenDataSyncOptions(options *datasync.Options) []interface{} {
 		"atime":                  aws.StringValue(options.Atime),
 		"bytes_per_second":       aws.Int64Value(options.BytesPerSecond),
 		"gid":                    aws.StringValue(options.Gid),
+		"log_level":              aws.StringValue(options.LogLevel),
 		"mtime":                  aws.StringValue(options.Mtime),
 		"posix_permissions":      aws.StringValue(options.PosixPermissions),
 		"preserve_deleted_files": aws.StringValue(options.PreserveDeletedFiles),

--- a/aws/resource_aws_datasync_task.go
+++ b/aws/resource_aws_datasync_task.go
@@ -85,6 +85,16 @@ func resourceAwsDataSyncTask() *schema.Resource {
 								datasync.GidNone,
 							}, false),
 						},
+						"log_level": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  datasync.LogLevelOff,
+							ValidateFunc: validation.StringInSlice([]string{
+								datasync.LogLevelOff,
+								datasync.LogLevelBasic,
+								datasync.LogLevelTransfer,
+							}, false),
+						},
 						"mtime": {
 							Type:     schema.TypeString,
 							Optional: true,

--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported inside the `options` configuration block:
 * `atime` - (Optional) A file metadata that shows the last time a file was accessed (that is when the file was read or written to). If set to `BEST_EFFORT`, the DataSync Task attempts to preserve the original (that is, the version before sync `PREPARING` phase) `atime` attribute on all source files. Valid values: `BEST_EFFORT`, `NONE`. Default: `BEST_EFFORT`.
 * `bytes_per_second` - (Optional) Limits the bandwidth utilized. For example, to set a maximum of 1 MB, set this value to `1048576`. Value values: `-1` or greater. Default: `-1` (unlimited).
 * `gid` - (Optional) Group identifier of the file's owners. Valid values: `BOTH`, `INT_VALUE`, `NAME`, `NONE`. Default: `INT_VALUE` (preserve integer value of the ID).
+* `log_level` - (Optional) Type of logs to be published to a log stream. Valid values: `OFF`, `BASIC`, `TRANSFER`. Default: `OFF`.
 * `mtime` - (Optional) A file metadata that indicates the last time a file was modified (written to) before the sync `PREPARING` phase. Value values: `NONE`, `PRESERVE`. Default: `PRESERVE`.
 * `posix_permissions` - (Optional) Determines which users or groups can access a file for a specific purpose such as reading, writing, or execution of the file. Valid values: `NONE`, `PRESERVE`. Default: `PRESERVE`.
 * `preserve_deleted_files` - (Optional) Whether files deleted in the source should be removed or preserved in the destination file system. Valid values: `PRESERVE`, `REMOVE`. Default: `PRESERVE`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #18933

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDataSyncTask_DefaultSyncOptions_LogLevel'
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_LogLevel
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_LogLevel
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_LogLevel
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_LogLevel (371.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	374.766s
...
```
