### PR TITLE
provider: update SetTagsDiff when setting the computed tags_all attribute

### DIFF
--- a/.changelog/18958.txt
+++ b/.changelog/18958.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Prevent `Provider produced inconsistent final plan` errors when resource `tags` are not known until apply
+```

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -521,6 +521,47 @@ func TestAccAWSSubnet_defaultAndIgnoreTags(t *testing.T) {
 	})
 }
 
+// TestAccAWSSubnet_updateTagsKnownAtApply ensures computed "tags_all"
+// attributes are correctly determined when the provider-level default_tags block
+// is left unused and resource tags are only known at apply time, thereby
+// eliminating "Inconsistent final plan" errors
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18366
+func TestAccAWSSubnet_updateTagsKnownAtApply(t *testing.T) {
+	var providers []*schema.Provider
+	var subnet ec2.Subnet
+	resourceName := "aws_subnet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      testAccCheckSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubnetConfig_tagsComputedFromVpcDataSource1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists(resourceName, &subnet),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+				),
+			},
+			{
+				Config: testAccSubnetConfig_tagsComputedFromVpcDataSource2("key1", "value1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists(resourceName, &subnet),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSSubnet_ignoreTags(t *testing.T) {
 	var providers []*schema.Provider
 	var subnet ec2.Subnet
@@ -967,6 +1008,48 @@ resource "aws_subnet" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+const testAccSubnetComputedTagsBaseConfig = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = local.tags
+}
+
+data "aws_vpc" "test" {
+  id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  vpc_id     = aws_vpc.test.id
+  tags       = data.aws_vpc.test.tags
+}
+`
+
+func testAccSubnetConfig_tagsComputedFromVpcDataSource1(tagKey1, tagValue1 string) string {
+	return composeConfig(
+		testAccSubnetComputedTagsBaseConfig,
+		fmt.Sprintf(`
+locals {
+  tags = {
+    %q = %q
+  }
+}
+`, tagKey1, tagValue1))
+}
+
+func testAccSubnetConfig_tagsComputedFromVpcDataSource2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return composeConfig(
+		testAccSubnetComputedTagsBaseConfig,
+		fmt.Sprintf(`
+locals {
+  tags = {
+    %q = %q
+    %q = %q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 const testAccSubnetConfigPreIpv6 = `

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -121,7 +121,7 @@ func SetTagsDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{})
 		}
 	} else {
 		if err := diff.SetNewComputed("tags_all"); err != nil {
-			return fmt.Errorf("error setting new tags_all diff: %w", err)
+			return fmt.Errorf("error setting tags_all to computed: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18366 

Output from acceptance testing before code change in `aws/tags.go`:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Error: Provider produced inconsistent final plan

        When expanding the plan for aws_subnet.test to include new values learned so
        far during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "key1" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.


        Error: Provider produced inconsistent final plan

        When expanding the plan for aws_subnet.test to include new values learned so
        far during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "key2" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```

Output from acceptance testing after code change in `aws/tags.go`:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSubnet_updateTagsKnownAtApply (27.48s)
```
