### PR TITLE
provider: add additional logic to SetTagsDiff to prevent `tags_all` perpetual diff when no `tags` configured

### DIFF
--- a/aws/tags.go
+++ b/aws/tags.go
@@ -111,15 +111,16 @@ func SetTagsDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{})
 
 	allTags := defaultTagsConfig.MergeTags(resourceTags).IgnoreConfig(ignoreTagsConfig)
 
-	// To ensure "tags_all" is correctly computed with the value held in allTags,
-	// we explicitly set the attribute diff when values are known,
-	// otherwise mark the attribute only as "Computed"
+	// To ensure "tags_all" is correctly computed, we explicitly set the attribute
+	// diff when the merger of resource-level tags onto provider-level tags results in n > 0 tags,
+	// otherwise we mark the attribute as "Computed" only when their is a known diff for "tags_all"
 	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/18366
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19005
 	if len(allTags) > 0 {
 		if err := diff.SetNew("tags_all", allTags.Map()); err != nil {
 			return fmt.Errorf("error setting new tags_all diff: %w", err)
 		}
-	} else {
+	} else if len(diff.Get("tags_all").(map[string]interface{})) > 0 {
 		if err := diff.SetNewComputed("tags_all"); err != nil {
 			return fmt.Errorf("error setting tags_all to computed: %w", err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19005 

Output from acceptance testing before change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== CONT  TestAccAWSSubnet_basic
    resource_aws_subnet_test.go:117: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_subnet.test will be updated in-place
          ~ resource "aws_subnet" "test" {
                id                              = "subnet-0fe05d105c277af1e"
              ~ tags_all                        = {} -> (known after apply)
                # (9 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAWSSubnet_basic (16.08s)
--- PASS: TestAccAWSSubnet_updateTagsKnownAtApply (54.32s)
```
```
------- Stdout: -------
=== RUN   TestAccAWSALBTargetGroup_generatedName
=== PAUSE TestAccAWSALBTargetGroup_generatedName
=== CONT  TestAccAWSALBTargetGroup_generatedName
    resource_aws_alb_target_group_test.go:120: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_alb_target_group.test will be updated in-place
          ~ resource "aws_alb_target_group" "test" {
                id                                 = "arn:aws:elasticloadbalancing:us-west-2:*******:targetgroup/tf-20210420043346757400000001/98413905f615c1e8"
                name                               = "tf-20210420043346757400000001"
              ~ tags_all                           = {} -> (known after apply)
                # (12 unchanged attributes hidden)
        
        
                # (2 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAWSALBTargetGroup_generatedName (33.92s)
```

Output from acceptance testing after change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSALBTargetGroup_generatedName (25.91s)
--- PASS: TestAccAWSSubnet_basic (27.10s)
--- PASS: TestAccAWSSubnet_tags (67.01s)
--- PASS: TestAccAWSSubnet_updateTagsKnownAtApply (54.32s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_duplicateTag (2.25s)
--- PASS: TestAccAWSSubnet_defaultTags_updateToProviderOnly (37.14s)
--- PASS: TestAccAWSSubnet_defaultTags_updateToResourceOnly (40.15s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_nonOverlappingTag (49.27s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_overlappingTag (53.70s)
--- PASS: TestAccAWSSubnet_defaultTags_providerOnly (53.71s)
```
