### PR TITLE
f/resource_aws_dms_endpoint: support for secrets id for oracle and postgres

### DIFF
--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -504,6 +504,192 @@ func TestAccDMSEndpoint_MongoDB_update(t *testing.T) {
 	})
 }
 
+func TestAccDMSEndpoint_Oracle(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := sdkacctest.RandString(8) + "-oracledb"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointOracleConfig(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Oracle_secretId(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := sdkacctest.RandString(8) + "-oracledb"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointOracleConfigSecretId(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Oracle_update(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := sdkacctest.RandString(8) + "-oracledb"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointOracleConfig(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				Config: dmsEndpointOracleConfigUpdate(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest-new-server_name"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27018"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest-new-username"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Postgres(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := sdkacctest.RandString(8) + "-oracledb"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointPostgresConfig(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TTestAccDMSEndpoint_Postgres_secretId(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := sdkacctest.RandString(8) + "-oracledb"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointPostgresConfigSecretId(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Postgres_update(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := sdkacctest.RandString(8) + "-oracledb"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointPostgresConfig(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				Config: dmsEndpointPostgresConfigUpdate(randId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest-new-server_name"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27018"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest-new-username"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "require"),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
 func TestAccDMSEndpoint_docDB(t *testing.T) {
 	resourceName := "aws_dms_endpoint.dms_endpoint"
 	randId := sdkacctest.RandString(8) + "-docdb"
@@ -1392,6 +1578,235 @@ resource "aws_dms_endpoint" "dms_endpoint" {
     nesting_level       = "one"
     extract_doc_id      = "true"
     docs_to_investigate = "1001"
+  }
+}
+`, randId)
+}
+
+func dmsEndpointOracleConfig(randId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "source"
+  engine_name                 = "oracle"
+  server_name                 = "tftest"
+  port                        = 27017
+  username                    = "tftest"
+  password                    = "tftest"
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+}
+`, randId)
+}
+
+func dmsEndpointOracleConfigUpdate(randId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "source"
+  engine_name                 = "oracle"
+  server_name                 = "tftest-new-server_name"
+  port                        = 27018
+  username                    = "tftest-new-username"
+  password                    = "tftest-new-password"
+  database_name               = "tftest-new-database_name"
+  ssl_mode                    = "none"
+  extra_connection_attributes = "key=value;"
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "updated"
+    Add    = "added"
+  }
+}
+`, randId)
+}
+
+func dmsEndpointOracleConfigSecretId(randId string) string {
+	return fmt.Sprintf(`
+data "aws_kms_alias" "dms" {
+  name = "alias/aws/dms"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_secretsmanager_secret" "test" {
+  name                    = %[1]q
+  recovery_window_in_days = 0
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dms.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Action": "secretsmanager:*",
+        "Effect": "Allow",
+        "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                     = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type                   = "source"
+  engine_name                     = "oracle"
+  secrets_manager_access_role_arn = aws_iam_role.test.arn
+  secrets_manager_arn             = aws_secretsmanager_secret.test.id
+
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+}
+`, randId)
+}
+
+func dmsEndpointPostgresConfig(randId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "source"
+  engine_name                 = "postgres"
+  server_name                 = "tftest"
+  port                        = 27017
+  username                    = "tftest"
+  password                    = "tftest"
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+}
+`, randId)
+}
+
+func dmsEndpointPostgresConfigUpdate(randId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "source"
+  engine_name                 = "postgres"
+  server_name                 = "tftest-new-server_name"
+  port                        = 27018
+  username                    = "tftest-new-username"
+  password                    = "tftest-new-password"
+  database_name               = "tftest-new-database_name"
+  ssl_mode                    = "require"
+  extra_connection_attributes = "key=value;"
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "updated"
+    Add    = "added"
+  }
+}
+`, randId)
+}
+
+func dmsEndpointPostgresConfigSecretId(randId string) string {
+	return fmt.Sprintf(`
+data "aws_kms_alias" "dms" {
+  name = "alias/aws/dms"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_secretsmanager_secret" "test" {
+  name                    = %[1]q
+  recovery_window_in_days = 0
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dms.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Action": "secretsmanager:*",
+        "Effect": "Allow",
+        "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                     = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type                   = "source"
+  engine_name                     = "postgres"
+  secrets_manager_access_role_arn = aws_iam_role.test.arn
+  secrets_manager_arn             = aws_secretsmanager_secret.test.id
+
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "to-update"
+    Remove = "to-remove"
   }
 }
 `, randId)

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -624,7 +624,7 @@ func TestAccDMSEndpoint_Postgres(t *testing.T) {
 	})
 }
 
-func TTestAccDMSEndpoint_Postgres_secretId(t *testing.T) {
+func TestAccDMSEndpoint_Postgres_secretId(t *testing.T) {
 	resourceName := "aws_dms_endpoint.dms_endpoint"
 	randId := sdkacctest.RandString(8) + "-oracledb"
 
@@ -1635,6 +1635,7 @@ data "aws_kms_alias" "dms" {
   name = "alias/aws/dms"
 }
 
+data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_secretsmanager_secret" "test" {
@@ -1651,7 +1652,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "dms.${data.aws_partition.current.dns_suffix}"
+        "Service": "dms.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -1750,6 +1751,7 @@ data "aws_kms_alias" "dms" {
   name = "alias/aws/dms"
 }
 
+data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_secretsmanager_secret" "test" {
@@ -1766,7 +1768,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "dms.${data.aws_partition.current.dns_suffix}"
+        "Service": "dms.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1643,7 +1643,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_iam_role" "test" {
-  name = %[1]q
+  name               = %[1]q
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1662,8 +1662,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = %[1]q
-  role = aws_iam_role.test.id
+  name   = %[1]q
+  role   = aws_iam_role.test.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1758,7 +1758,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_iam_role" "test" {
-  name = %[1]q
+  name               = %[1]q
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1777,8 +1777,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = %[1]q
-  role = aws_iam_role.test.id
+  name   = %[1]q
+  role   = aws_iam_role.test.id
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1635,7 +1635,7 @@ data "aws_kms_alias" "dms" {
   name = "alias/aws/dms"
 }
 
-data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_secretsmanager_secret" "test" {
   name                    = %[1]q
@@ -1750,7 +1750,7 @@ data "aws_kms_alias" "dms" {
   name = "alias/aws/dms"
 }
 
-data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_secretsmanager_secret" "test" {
   name                    = %[1]q

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 * `password` - (Optional) The password to be used to login to the endpoint database.
 * `port` - (Optional) The port used by the endpoint database.
 * `s3_settings` - (Optional) Configuration block with S3 settings. Detailed below.
+* `secrets_manager_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM role that specifies AWS DMS as the trusted entity and has the required permissions to access the value in SecretsManagerSecret.
+* `secrets_manager_arn` - (Optional) The full ARN, partial ARN, or friendly name of the SecretsManagerSecret that contains the endpoint connection details. Supported only for `engine_name` as `oracle` and `postgres`.
 * `server_name` - (Optional) The host name of the server.
 * `service_access_role` - (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
 * `ssl_mode` - (Optional, Default: none) The SSL mode to use for the connection. Can be one of `none | require | verify-ca | verify-full`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18123

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsDmsEndpoint_OracleDb'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsDmsEndpoint_OracleDb -timeout 180m
=== RUN   TestAccAwsDmsEndpoint_OracleDb
=== PAUSE TestAccAwsDmsEndpoint_OracleDb
=== RUN   TestAccAwsDmsEndpoint_OracleDb_SecretId
=== PAUSE TestAccAwsDmsEndpoint_OracleDb_SecretId
=== RUN   TestAccAwsDmsEndpoint_OracleDb_Update
=== PAUSE TestAccAwsDmsEndpoint_OracleDb_Update
=== CONT  TestAccAwsDmsEndpoint_OracleDb
=== CONT  TestAccAwsDmsEndpoint_OracleDb_Update
=== CONT  TestAccAwsDmsEndpoint_OracleDb_SecretId
--- PASS: TestAccAwsDmsEndpoint_OracleDb (51.35s)
--- PASS: TestAccAwsDmsEndpoint_OracleDb_SecretId (73.63s)
--- PASS: TestAccAwsDmsEndpoint_OracleDb_Update (96.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	99.303s

make testacc TESTARGS='-run=TestAccAwsDmsEndpoint_Postgres'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsDmsEndpoint_Postgres -timeout 180m
=== RUN   TestAccAwsDmsEndpoint_Postgres
=== PAUSE TestAccAwsDmsEndpoint_Postgres
=== RUN   TestAccAwsDmsEndpoint_Postgres_SecretId
=== PAUSE TestAccAwsDmsEndpoint_Postgres_SecretId
=== RUN   TestAccAwsDmsEndpoint_Postgres_Update
=== PAUSE TestAccAwsDmsEndpoint_Postgres_Update
=== CONT  TestAccAwsDmsEndpoint_Postgres
=== CONT  TestAccAwsDmsEndpoint_Postgres_Update
=== CONT  TestAccAwsDmsEndpoint_Postgres_SecretId
--- PASS: TestAccAwsDmsEndpoint_Postgres (47.97s)
--- PASS: TestAccAwsDmsEndpoint_Postgres_SecretId (65.65s)
--- PASS: TestAccAwsDmsEndpoint_Postgres_Update (88.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	90.243s
...
```
