### PR TITLE
Add kms_key_arn to dynamodb_table data source

### DIFF
--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -169,10 +169,8 @@ func dataSourceAwsDynamoDbTable() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"kms_key_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validateArn,
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"region_name": {
 							Type:     schema.TypeString,

--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -168,6 +168,12 @@ func dataSourceAwsDynamoDbTable() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"kms_key_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateArn,
+						},
 						"region_name": {
 							Type:     schema.TypeString,
 							Computed: true,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18922

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Before:
```
[wedge@terraform ~/development/terraform-providers/terraform-provider-aws]$ gmake testacc TESTARGS='-run=TestAccAWSDynamoDbTable_Replica_singleWithCMK'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDynamoDbTable_Replica_singleWithCMK -timeout 180m
=== RUN   TestAccAWSDynamoDbTable_Replica_singleWithCMK
=== PAUSE TestAccAWSDynamoDbTable_Replica_singleWithCMK
=== CONT  TestAccAWSDynamoDbTable_Replica_singleWithCMK
panic: Invalid address to set: []string{"replica", "0", "kms_key_arn"}

goroutine 1075 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc007428200, 0x7d42022, 0x7, 0x660dc20, 0xc0062e5ce0, 0x1, 0x0)
	/home/wedge/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.5.0/helper/schema/resource_data.go:230 +0x371
github.com/terraform-providers/terraform-provider-aws/aws.dataSourceAwsDynamoDbTableRead(0xc007428200, 0x6fa44e0, 0xc00397c000, 0xc8f4780, 0xc0001f3800)
	/home/wedge/development/terraform-providers/terraform-provider-aws/aws/data_source_aws_dynamodb_table.go:289 +0x98f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc002055960, 0x8d55248, 0xc008639e40, 0xc007428200, 0x6fa44e0, 0xc00397c000, 0x0, 0x0, 0x0)
	/home/wedge/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.5.0/helper/schema/resource.go:335 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc002055960, 0x8d55248, 0xc008639e40, 0xc0061c4780, 0x6fa44e0, 0xc00397c000, 0xc00397c000, 0xc0061c4780, 0x0, 0x0)
	/home/wedge/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.5.0/helper/schema/resource.go:558 +0xfd
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc002b82048, 0x8d55248, 0xc008639e40, 0xc0061c44c0, 0xc008639e40, 0x40d945, 0x7886ac0)
	/home/wedge/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.5.0/helper/schema/grpc_provider.go:1105 +0x4d6
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadDataSource(0xc0073f6140, 0x8d552f0, 0xc008639e40, 0xc006194f00, 0xc0073f6140, 0xc0061cc4e0, 0xc0005faba0)
	/home/wedge/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/server/server.go:247 +0xe5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler(0x7b3ffc0, 0xc0073f6140, 0x8d552f0, 0xc0061cc4e0, 0xc0061d2000, 0x0, 0x8d552f0, 0xc0061cc4e0, 0xc005755600, 0x14c)
	/home/wedge/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc005508000, 0x8d7db38, 0xc00551d980, 0xc0061a4500, 0xc004639b30, 0xc894ad0, 0x0, 0x0, 0x0)
	/home/wedge/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc005508000, 0x8d7db38, 0xc00551d980, 0xc0061a4500, 0x0)
	/home/wedge/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0069cb760, 0xc005508000, 0x8d7db38, 0xc00551d980, 0xc0061a4500)
	/home/wedge/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/home/wedge/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	110.519s
FAIL
gmake: *** [GNUmakefile:28: testacc] Error 1
```

Note that in order to reproduce the bug (and verify that it went away) I modified the test above by adding a data source like so (did not commit this change):

```
diff --git a/aws/resource_aws_dynamodb_table_test.go b/aws/resource_aws_dynamodb_table_test.go
index 7a9c3277d..49f2e52e1 100644
--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -2457,6 +2457,10 @@ resource "aws_dynamodb_table" "test" {
     delete = "20m"
   }
 }
+
+data "aws_dynamodb_table" "test" {
+  name = aws_dynamodb_table.test.name
+}
 `, rName))
 }
```

After:

```
[wedge@terraform ~/development/terraform-providers/terraform-provider-aws]$ gmake testacc TESTARGS='-run=TestAccAWSDynamoDbTable_Replica_singleWithCMK'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDynamoDbTable_Replica_singleWithCMK -timeout 180m
=== RUN   TestAccAWSDynamoDbTable_Replica_singleWithCMK
=== PAUSE TestAccAWSDynamoDbTable_Replica_singleWithCMK
=== CONT  TestAccAWSDynamoDbTable_Replica_singleWithCMK
--- PASS: TestAccAWSDynamoDbTable_Replica_singleWithCMK (246.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	246.594s
[wedge@terraform ~/development/terraform-providers/terraform-provider-aws]$ gmake testacc TESTARGS='-run=TestAccDataSourceAwsDynamoDbTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsDynamoDbTable -timeout 180m
=== RUN   TestAccDataSourceAwsDynamoDbTable_basic
=== PAUSE TestAccDataSourceAwsDynamoDbTable_basic
=== CONT  TestAccDataSourceAwsDynamoDbTable_basic
--- PASS: TestAccDataSourceAwsDynamoDbTable_basic (32.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.528s
```

Note that the tests for the data source passed before the fix - the tests do not catch this bug. Adding the data source to the tests for the resource as I did above is simple but I'm assuming that is not preferred since it mixes up the testing of the resource with testing of the data source. I spent a few hours digging into the test framework to see if I could improve the tests but ran into two problems.

1. I modified the existing test to add a replica and related config and ended up with a test configuration for the data provider that looks like this https://gist.github.com/wedge-jarrad/68839317d13075b1e97c4b25e4e3327d. But in running that outside of the test framework I ran into #671 and was unable to figure out how to work around it. I'm guessing that probably doesn't matter for the purposes of the test, though, so maybe this isn't a show stopper.

2. I'm not sure how to test that the value for `kms_key_arn` that the data source returns is correct. When trying to reference the value, I run into the error `This value does not have any indices.` I read you can work around this with for_each but I'm not clever enough to figure out how to incorporate that into one of the Checks in the test. To verify it manually I set an output with a value of `data.aws_dynamodb_table.test.replica`. That results in this output (account id redacted) which can be manually verified as correct.

```
replica_kms = toset([
  {
    "kms_key_arn" = "arn:aws:kms:us-east-1:xxxxxxxxxxxx:key/3d979a62-78c4-40bd-b640-5d3c3be347e7"
    "region_name" = "us-east-1"
  },
])
```

If anyone can provide some pointers on how to deal with the test issues above I'd be happy to spend some more time on it.