### PR TITLE
Cleans up acceptance test `terrafmt` GitHub actions

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -31,6 +31,11 @@ jobs:
       - run: cd tools && go install github.com/katbyte/terrafmt
       # - run: terrafmt diff ./aws --check --pattern '*_test.go' --fmtcompat
       - run: |
+          # resource_aws_ecs_capacity_provider_test.go: two format verbs on one line (%[2]q = %[3]q). https://github.com/katbyte/terrafmt/issues/46
+          # resource_aws_efs_file_system_test.go: argument name is format verb and replaced with quoted string. https://github.com/katbyte/terrafmt/issues/47
+          # resource_aws_kms_grant_test.go: argument name is format verb and replaced with quoted string. https://github.com/katbyte/terrafmt/issues/47
+          # resource_aws_quicksight_user_test.go: format verb as resource name (%[1]q). https://github.com/katbyte/terrafmt/issues/48
+          # resource_aws_sns_platform_application_test.go: argument name is format verb and replaced with quoted string. https://github.com/katbyte/terrafmt/issues/47
           find ./aws -type f -name '*_test.go' \
             | sort -u \
             | grep -v resource_aws_ecs_capacity_provider_test.go \
@@ -59,6 +64,12 @@ jobs:
       - run: cd tools && go install github.com/katbyte/terrafmt
       - run: cd tools && go install github.com/terraform-linters/tflint
       - run: |
+          # resource_aws_ecs_capacity_provider_test.go: two format verbs on one line (%[2]q = %[3]q). https://github.com/katbyte/terrafmt/issues/46
+          # resource_aws_efs_file_system_test.go: argument name is format verb and replaced with quoted string. https://github.com/katbyte/terrafmt/issues/47
+          # resource_aws_kms_grant_test.go: argument name is format verb and replaced with quoted string. https://github.com/katbyte/terrafmt/issues/47
+          # resource_aws_lambda_permission_test.go: format verb as resource name ("%s"). https://github.com/katbyte/terrafmt/issues/48
+          # resource_aws_quicksight_user_test.go: format verb as resource name (%[1]q). https://github.com/katbyte/terrafmt/issues/48
+          # resource_aws_sns_platform_application_test.go: argument name is format verb and replaced with quoted string. https://github.com/katbyte/terrafmt/issues/47
           find ./aws -type f -name '*_test.go' \
             | sort -u \
             | grep -v resource_aws_ecs_capacity_provider_test.go \

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -61,11 +61,8 @@ jobs:
       - run: |
           find ./aws -type f -name '*_test.go' \
             | sort -u \
-            | grep -v resource_aws_apigatewayv2_domain_name_test.go \
             | grep -v resource_aws_ecs_capacity_provider_test.go \
             | grep -v resource_aws_efs_file_system_test.go \
-            | grep -v resource_aws_elasticache_cluster_test.go \
-            | grep -v resource_aws_kinesis_stream_test.go \
             | grep -v resource_aws_kms_grant_test.go \
             | grep -v resource_aws_lambda_permission_test.go \
             | grep -v resource_aws_quicksight_user_test.go \

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -33,10 +33,8 @@ jobs:
       - run: |
           find ./aws -type f -name '*_test.go' \
             | sort -u \
-            | grep -v resource_aws_apigatewayv2_domain_name_test.go \
             | grep -v resource_aws_ecs_capacity_provider_test.go \
             | grep -v resource_aws_efs_file_system_test.go \
-            | grep -v resource_aws_kinesis_stream_test.go \
             | grep -v resource_aws_kms_grant_test.go \
             | grep -v resource_aws_quicksight_user_test.go \
             | grep -v resource_aws_s3_bucket_object_test.go \

--- a/aws/resource_aws_apigatewayv2_domain_name_test.go
+++ b/aws/resource_aws_apigatewayv2_domain_name_test.go
@@ -437,25 +437,25 @@ resource "aws_acm_certificate" "test" {
   validation_method = "DNS"
 }
 
- #
- # for_each acceptance testing requires:
- # https://github.com/hashicorp/terraform-plugin-sdk/issues/536
- #
- # resource "aws_route53_record" "test" {
- #   for_each = {
- #     for dvo in aws_acm_certificate.test.domain_validation_options: dvo.domain_name => {
- #       name   = dvo.resource_record_name
- #       record = dvo.resource_record_value
- #       type   = dvo.resource_record_type
- #     }
- #   }
- #   allow_overwrite = true
- #   name            = each.value.name
- #   records         = [each.value.record]
- #   ttl             = 60
- #   type            = each.value.type
- #   zone_id         = data.aws_route53_zone.test.zone_id
- # }
+#
+# for_each acceptance testing requires:
+# https://github.com/hashicorp/terraform-plugin-sdk/issues/536
+#
+# resource "aws_route53_record" "test" {
+#   for_each = {
+#     for dvo in aws_acm_certificate.test.domain_validation_options: dvo.domain_name => {
+#       name   = dvo.resource_record_name
+#       record = dvo.resource_record_value
+#       type   = dvo.resource_record_type
+#     }
+#   }
+#   allow_overwrite = true
+#   name            = each.value.name
+#   records         = [each.value.record]
+#   ttl             = 60
+#   type            = each.value.type
+#   zone_id         = data.aws_route53_zone.test.zone_id
+# }
 
 resource "aws_route53_record" "test" {
   allow_overwrite = true

--- a/aws/resource_aws_kinesis_stream_test.go
+++ b/aws/resource_aws_kinesis_stream_test.go
@@ -778,7 +778,7 @@ func testAccKinesisStreamUpdateKmsKeyId(rInt int, key int) string {
 resource "aws_kms_key" "key" {
   count = 2
 
-  description             = "KMS key ${count.index+1}"
+  description             = "KMS key ${count.index + 1}"
   deletion_window_in_days = 10
 }
 

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -1910,8 +1910,8 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_objectBucketKeyEnabled(randInt int, content string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-    description             = "Encrypts test bucket objects"
-    deletion_window_in_days = 7
+  description             = "Encrypts test bucket objects"
+  deletion_window_in_days = 7
 }
 
 resource "aws_s3_bucket" "object_bucket" {
@@ -1931,8 +1931,8 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectConfig_bucketBucketKeyEnabled(randInt int, content string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-    description             = "Encrypts test bucket objects"
-    deletion_window_in_days = 7
+  description             = "Encrypts test bucket objects"
+  deletion_window_in_days = 7
 }
 
 resource "aws_s3_bucket" "object_bucket" {
@@ -1950,9 +1950,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket             = aws_s3_bucket.object_bucket.bucket
-  key                = "test-key"
-  content            = %q
+  bucket  = aws_s3_bucket.object_bucket.bucket
+  key     = "test-key"
+  content = %q
 }
 `, randInt, content)
 }

--- a/scripts/validate-terraform.sh
+++ b/scripts/validate-terraform.sh
@@ -20,11 +20,9 @@ rules=(
     "--only=terraform_comment_syntax"
     # Ensure valid instance types
     "--only=aws_db_instance_invalid_type"
-    "--only=aws_elasticache_cluster_invalid_type"
     # Ensure modern instance types
     "--only=aws_instance_previous_type"
     "--only=aws_db_instance_previous_type"
-    "--only=aws_elasticache_cluster_previous_type"
     # Ensure engine types are valid
     "--only=aws_db_instance_invalid_engine"
     "--only=aws_mq_broker_invalid_engine_type"


### PR DESCRIPTION
Removes a number of unneeded exclusions for acceptance test `terrafmt` validations and cleans up some findings.

Adds references to GitHub issues for the exclusions still needed

Output from acceptance testing:

N/A