### PR TITLE
Fix aws_vpc_endpoint auto_accept failing on pending status

### DIFF
--- a/.changelog/19059.txt
+++ b/.changelog/19059.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint: Fix auto_accept failing while waiting for the VPC Endpoint Connection acceptance
+```

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -405,7 +405,7 @@ func vpcEndpointAccept(conn *ec2.EC2, vpceId, svcName string, timeout time.Durat
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"pendingAcceptance"},
+		Pending:    []string{"pendingAcceptance", "pending"},
 		Target:     []string{"available"},
 		Refresh:    vpcEndpointStateRefresh(conn, vpceId),
 		Timeout:    timeout,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14604

Release note for CHANGELOG:
```release-note:bug
resource/aws_vpc_endpoint: Fix auto_accept failing while waiting for the VPC Endpoint Connection acceptance
```

`aws_vpc_endpoint` waits for the accept of the connection to the VPC Endpoint Service. Before connection is accepted status is `pendingAcceptance`. However, after it is accepted it changes to the `pending` which is not accounted for in the `stateConf`. This PR fixes this issue by adding the `pending` state as expected Pending value.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
