### PR TITLE
resource/aws_mq_broker: Adds nullable bool for `audit`

### DIFF
--- a/aws/internal/experimental/nullable/bool.go
+++ b/aws/internal/experimental/nullable/bool.go
@@ -1,0 +1,54 @@
+package nullable
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	TypeNullableBool = schema.TypeString
+)
+
+type Bool string
+
+func (b Bool) IsNull() bool {
+	return b == ""
+}
+
+func (b Bool) Value() (bool, bool, error) {
+	if b.IsNull() {
+		return false, true, nil
+	}
+
+	value, err := strconv.ParseBool(string(b))
+	if err != nil {
+		return false, false, err
+	}
+	return value, false, nil
+}
+
+func NewBool(v bool) Bool {
+	return Bool(strconv.FormatBool(v))
+}
+
+// ValidateTypeStringNullableInt provides custom error messaging for TypeString ints
+// Some arguments require an int value or unspecified, empty field.
+func ValidateTypeStringNullableBool(v interface{}, k string) (ws []string, es []error) {
+	value, ok := v.(string)
+	if !ok {
+		es = append(es, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if value == "" {
+		return
+	}
+
+	if _, err := strconv.ParseBool(value); err != nil {
+		es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean: %w", k, value, err))
+	}
+
+	return
+}

--- a/aws/internal/experimental/nullable/bool_test.go
+++ b/aws/internal/experimental/nullable/bool_test.go
@@ -7,33 +7,38 @@ import (
 	"testing"
 )
 
-func TestNullableInt(t *testing.T) {
+func TestNullableBool(t *testing.T) {
 	cases := []struct {
 		val           string
 		expectNull    bool
-		expectedValue int64
+		expectedValue bool
 		expectedErr   error
 	}{
 		{
-			val:           "1",
+			val:           "true",
 			expectNull:    false,
-			expectedValue: 1,
+			expectedValue: true,
+		},
+		{
+			val:           "false",
+			expectNull:    false,
+			expectedValue: false,
 		},
 		{
 			val:           "",
 			expectNull:    true,
-			expectedValue: 0,
+			expectedValue: false,
 		},
 		{
 			val:           "A",
 			expectNull:    false,
-			expectedValue: 0,
+			expectedValue: false,
 			expectedErr:   strconv.ErrSyntax,
 		},
 	}
 
 	for i, tc := range cases {
-		v := Int(tc.val)
+		v := Bool(tc.val)
 
 		if null := v.IsNull(); null != tc.expectNull {
 			t.Fatalf("expected test case %d IsNull to return %t, got %t", i, null, tc.expectNull)
@@ -41,7 +46,7 @@ func TestNullableInt(t *testing.T) {
 
 		value, null, err := v.Value()
 		if value != tc.expectedValue {
-			t.Fatalf("expected test case %d Value to be %d, got %d", i, tc.expectedValue, value)
+			t.Fatalf("expected test case %d Value to be %t, got %t", i, tc.expectedValue, value)
 		}
 		if null != tc.expectNull {
 			t.Fatalf("expected test case %d Value null flag to be %t, got %t", i, tc.expectNull, null)
@@ -57,43 +62,20 @@ func TestNullableInt(t *testing.T) {
 	}
 }
 
-func TestValidationInt(t *testing.T) {
+func TestValidationBool(t *testing.T) {
 	runTestCases(t, []testCase{
 		{
-			val: "1",
-			f:   ValidateTypeStringNullableInt,
+			val: "true",
+			f:   ValidateTypeStringNullableBool,
 		},
 		{
 			val:         "A",
-			f:           ValidateTypeStringNullableInt,
-			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as int: .*`),
+			f:           ValidateTypeStringNullableBool,
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as boolean: .*`),
 		},
 		{
 			val:         1,
-			f:           ValidateTypeStringNullableInt,
-			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
-		},
-	})
-}
-
-func TestValidationIntAtLeast(t *testing.T) {
-	runTestCases(t, []testCase{
-		{
-			val: "1",
-			f:   ValidateTypeStringNullableIntAtLeast(1),
-		},
-		{
-			val: "1",
-			f:   ValidateTypeStringNullableIntAtLeast(0),
-		},
-		{
-			val:         "1",
-			f:           ValidateTypeStringNullableIntAtLeast(2),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\), got 1`),
-		},
-		{
-			val:         1,
-			f:           ValidateTypeStringNullableIntAtLeast(2),
+			f:           ValidateTypeStringNullableBool,
 			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
 		},
 	})

--- a/aws/internal/experimental/nullable/testing.go
+++ b/aws/internal/experimental/nullable/testing.go
@@ -2,9 +2,9 @@ package nullable
 
 import (
 	"regexp"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
 type testCase struct {
@@ -13,7 +13,7 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
-func runTestCases(t testing.T, cases []testCase) {
+func runTestCases(t *testing.T, cases []testCase) {
 	t.Helper()
 
 	matchErr := func(errs []error, r *regexp.Regexp) bool {

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -2,18 +2,23 @@ package aws
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/copystructure"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/experimental/nullable"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/mq/waiter"
@@ -217,8 +222,17 @@ func resourceAwsMqBroker() *schema.Resource {
 							Optional: true,
 						},
 						"audit": {
-							Type:     schema.TypeBool,
-							Optional: true,
+							Type:         nullable.TypeNullableBool,
+							Optional:     true,
+							ValidateFunc: nullable.ValidateTypeStringNullableBool,
+							DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
+								ov, onull, _ := nullable.Bool(o).Value()
+								nv, nnull, _ := nullable.Bool(n).Value()
+								if !ov && nnull || onull && !nv {
+									return true
+								}
+								return false
+							},
 						},
 					},
 				},
@@ -319,7 +333,20 @@ func resourceAwsMqBroker() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: SetTagsDiff,
+		CustomizeDiff: customdiff.All(
+			SetTagsDiff,
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				if strings.EqualFold(diff.Get("engine_type").(string), mq.EngineTypeRabbitmq) {
+					if v, ok := diff.GetOk("logs.0.audit"); ok {
+						if v, _, _ := nullable.Bool(v.(string)).Value(); v {
+							return errors.New("logs.audit: Can not be configured when engine is RabbitMQ")
+						}
+					}
+				}
+
+				return nil
+			},
+		),
 	}
 }
 
@@ -329,12 +356,13 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("broker_name").(string)
+	engineType := d.Get("engine_type").(string)
 	requestId := resource.PrefixedUniqueId(fmt.Sprintf("tf-%s", name))
 	input := mq.CreateBrokerRequest{
 		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 		BrokerName:              aws.String(name),
 		CreatorRequestId:        aws.String(requestId),
-		EngineType:              aws.String(d.Get("engine_type").(string)),
+		EngineType:              aws.String(engineType),
 		EngineVersion:           aws.String(d.Get("engine_version").(string)),
 		HostInstanceType:        aws.String(d.Get("host_instance_type").(string)),
 		PubliclyAccessible:      aws.Bool(d.Get("publicly_accessible").(bool)),
@@ -354,7 +382,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		input.EncryptionOptions = expandMqEncryptionOptions(d.Get("encryption_options").([]interface{}))
 	}
 	if v, ok := d.GetOk("logs"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Logs = expandMqLogs(v.([]interface{}))
+		input.Logs = expandMqLogs(engineType, v.([]interface{}))
 	}
 	if v, ok := d.GetOk("ldap_server_metadata"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.LdapServerMetadata = expandMQLDAPServerMetadata(v.([]interface{}))
@@ -493,10 +521,11 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChanges("configuration", "logs", "engine_version") {
+		engineType := d.Get("engine_type").(string)
 		_, err := conn.UpdateBroker(&mq.UpdateBrokerRequest{
 			BrokerId:      aws.String(d.Id()),
 			Configuration: expandMqConfigurationId(d.Get("configuration").([]interface{})),
-			Logs:          expandMqLogs(d.Get("logs").([]interface{})),
+			Logs:          expandMqLogs(engineType, d.Get("logs").([]interface{})),
 			EngineVersion: aws.String(d.Get("engine_version").(string)),
 		})
 		if err != nil {
@@ -925,13 +954,13 @@ func flattenMqLogs(logs *mq.LogsSummary) []interface{} {
 	}
 
 	if logs.Audit != nil {
-		m["audit"] = aws.BoolValue(logs.Audit)
+		m["audit"] = strconv.FormatBool(aws.BoolValue(logs.Audit))
 	}
 
 	return []interface{}{m}
 }
 
-func expandMqLogs(l []interface{}) *mq.Logs {
+func expandMqLogs(engineType string, l []interface{}) *mq.Logs {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -944,8 +973,13 @@ func expandMqLogs(l []interface{}) *mq.Logs {
 		logs.General = aws.Bool(v.(bool))
 	}
 
+	// When the engine type is "RabbitMQ", the parameter audit cannot be set at all.
 	if v, ok := m["audit"]; ok {
-		logs.Audit = aws.Bool(v.(bool))
+		if v, null, _ := nullable.Bool(v.(string)).Value(); !null {
+			if !strings.EqualFold(engineType, mq.EngineTypeRabbitmq) {
+				logs.Audit = aws.Bool(v)
+			}
+		}
 	}
 
 	return logs

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1008,6 +1008,9 @@ func TestAccAWSMqBroker_rabbitmq(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.0", regexp.MustCompile(`^amqps://[a-z0-9-\.]+:5671$`)),
+					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "false"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", ""),
 				),
 			},
 			{
@@ -1015,6 +1018,81 @@ func TestAccAWSMqBroker_rabbitmq(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccAWSMqBroker_rabbitmq_Logs(t *testing.T) {
+	var broker mq.DescribeBrokerResponse
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_mq_broker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMqBrokerConfigRabbitLogs(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists(resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "RabbitMQ"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.8.6"),
+					resource.TestCheckResourceAttr(resourceName, "host_instance_type", "mq.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "instances.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instances.0.endpoints.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "instances.0.endpoints.0", regexp.MustCompile(`^amqps://[a-z0-9-\.]+:5671$`)),
+					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "true"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccAWSMqBroker_rabbitmq_Validation_AuditLog(t *testing.T) {
+	var broker mq.DescribeBrokerResponse
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_mq_broker.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(mq.EndpointsID, t)
+			testAccPreCheckAWSMq(t)
+		},
+		ErrorCheck:   testAccErrorCheck(t, mq.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMqBrokerConfigRabbitAuditLog(rName, true),
+				ExpectError: regexp.MustCompile(`logs.audit: Can not be configured when engine is RabbitMQ`),
+			},
+			{
+				// Special case: allow explicitly setting logs.0.audit to false,
+				// though the AWS API does not accept the parameter.
+				Config: testAccMqBrokerConfigRabbitAuditLog(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists(resourceName, &broker),
+					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "true"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", ""),
+				),
 			},
 		},
 	})
@@ -1052,6 +1130,7 @@ func TestAccAWSMqBroker_clusterRabbitMQ(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.time_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logs.0.general", "false"),
+					resource.TestCheckResourceAttr(resourceName, "logs.0.audit", ""),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window_start_time.0.time_zone", "UTC"),
 					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
@@ -1730,6 +1809,57 @@ resource "aws_mq_broker" "test" {
   }
 }
 `, rName)
+}
+
+func testAccMqBrokerConfigRabbitLogs(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_mq_broker" "test" {
+  broker_name        = %[1]q
+  engine_type        = "RabbitMQ"
+  engine_version     = "3.8.6"
+  host_instance_type = "mq.t3.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccMqBrokerConfigRabbitAuditLog(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_mq_broker" "test" {
+  broker_name        = %[1]q
+  engine_type        = "RabbitMQ"
+  engine_version     = "3.8.6"
+  host_instance_type = "mq.t3.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  logs {
+    general = true
+    audit   = %[2]t
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+`, rName, enabled)
 }
 
 func testAccRabbitMqClusterBrokerConfig(rName string) string {

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -68,7 +68,6 @@ resource "aws_mq_broker" "example" {
     password = "MindTheGap"
   }
 }
-
 ```
 
 ## Argument Reference


### PR DESCRIPTION
When the `engine_type` is `RABBITMQ`, no value for `logs.audit` is allowed, not even `false`.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18067
Closes #18350

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMqBroker_'

--- PASS: TestAccAWSMqBroker_rabbitmq_Logs (626.20s)
--- PASS: TestAccAWSMqBroker_throughputOptimized (664.12s)
--- PASS: TestAccAWSMqBroker_rabbitmq_Validation_AuditLog (756.43s)
--- PASS: TestAccAWSMqBroker_clusterRabbitMQ (768.65s)
--- PASS: TestAccAWSMqBroker_rabbitmq (771.58s)
--- PASS: TestAccAWSMqBroker_disappears (1105.31s)
--- PASS: TestAccAWSMqBroker_ldap (1122.57s)
--- PASS: TestAccAWSMqBroker_basic (1141.67s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_KmsKeyId (1153.39s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled (1156.94s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled (1176.22s)
--- PASS: TestAccAWSMqBroker_tags (1195.02s)
--- PASS: TestAccAWSMqBroker_updateEngineVersion (1373.76s)
--- PASS: TestAccAWSMqBroker_updateSecurityGroup (1409.84s)
--- PASS: TestAccAWSMqBroker_updateUsers (1595.92s)
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (1771.77s)
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (1850.80s)
```
