### PR TITLE
added eks cluster_name validation

### DIFF
--- a/.changelog/19042.txt
+++ b/.changelog/19042.txt
@@ -1,7 +1,0 @@
-```release-note:enhancement
-data-source/aws_dynamodb_table: Add `replica` `kms_key_arn` attribute
-```
-
-```release-note:bug
-data-source/aws_dynamodb_table: Prevent panic for replicas with KMS Key ARN configured
-```

--- a/.changelog/19042.txt
+++ b/.changelog/19042.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_dynamodb_table: Add `replica` `kms_key_arn` attribute
+```
+
+```release-note:bug
+data-source/aws_dynamodb_table: Prevent panic for replicas with KMS Key ARN configured
+```

--- a/.changelog/19078.txt
+++ b/.changelog/19078.txt
@@ -1,0 +1,8 @@
+```release-note:enhancement
+data/source_aws_eks_addon: added validation for `cluster_name`
+data/source_aws_eks_cluster: added validation for `cluster_name`
+resource/aws_eks_addon: added validation for `cluster_name`
+resource/aws_eks_cluster: added validation for `name`
+resource/aws_eks_fargate_profile: added validation for `cluster_name`
+resource/aws_eks_node_group: added validation for `cluster_name`
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* data-source/aws_dynamodb_table: Add `replica` `kms_key_arn` attribute ([#19042](https://github.com/hashicorp/terraform-provider-aws/issues/19042))
 * data-source/aws_iam_policy: Add support for lookup by `arn`, `name`, and/or `path_prefix` ([#6084](https://github.com/hashicorp/terraform-provider-aws/issues/6084))
-* resource/aws_batch_compute_environment: Additional supported value `FARGATE` and `FARGATE_SPOT` for the `type` argument in the `compute_resources` configuration block ([#16819](https://github.com/hashicorp/terraform-provider-aws/issues/16819))
-* resource/aws_batch_compute_environment: The `instance_role`, `instance_type` and `min_vcpus` arguments in the `compute_resources` configuration block are now optional ([#16819](https://github.com/hashicorp/terraform-provider-aws/issues/16819))
-* resource/aws_batch_compute_environment: The `security_group_ids` and `subnets` arguments in the `compute_resources` configuration block can now be updated in-place for Fargate compute resources ([#16819](https://github.com/hashicorp/terraform-provider-aws/issues/16819))
 * resource/aws_batch_job_definition: Add `propagate_tags` argument ([#18336](https://github.com/hashicorp/terraform-provider-aws/issues/18336))
 * resource/aws_instance: Make `instance_initiated_shutdown_behavior` also computed, allowing value to be read ([#18880](https://github.com/hashicorp/terraform-provider-aws/issues/18880))
 * resource/aws_organizations_organizational_unit: Add `tags` argument ([#18861](https://github.com/hashicorp/terraform-provider-aws/issues/18861))
@@ -21,7 +17,6 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-* data-source/aws_dynamodb_table: Prevent panic for replicas with KMS Key ARN configured ([#19042](https://github.com/hashicorp/terraform-provider-aws/issues/19042))
 * provider: Prevent `Provider produced inconsistent final plan` errors when resource `tags` are not known until apply ([#18958](https://github.com/hashicorp/terraform-provider-aws/issues/18958))
 * resource/aws_batch_job_definition: Treat empty `container_properties.logConfiguration.secretOptions` array as `null` to prevent continual diffs ([#16120](https://github.com/hashicorp/terraform-provider-aws/issues/16120))
 * resource/aws_vpc_endpoint: Fix auto_accept failing while waiting for the VPC Endpoint Connection acceptance ([#19059](https://github.com/hashicorp/terraform-provider-aws/issues/19059))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ FEATURES:
 
 ENHANCEMENTS:
 
+* data-source/aws_dynamodb_table: Add `replica` `kms_key_arn` attribute ([#19042](https://github.com/hashicorp/terraform-provider-aws/issues/19042))
 * data-source/aws_iam_policy: Add support for lookup by `arn`, `name`, and/or `path_prefix` ([#6084](https://github.com/hashicorp/terraform-provider-aws/issues/6084))
+* resource/aws_batch_compute_environment: Additional supported value `FARGATE` and `FARGATE_SPOT` for the `type` argument in the `compute_resources` configuration block ([#16819](https://github.com/hashicorp/terraform-provider-aws/issues/16819))
+* resource/aws_batch_compute_environment: The `instance_role`, `instance_type` and `min_vcpus` arguments in the `compute_resources` configuration block are now optional ([#16819](https://github.com/hashicorp/terraform-provider-aws/issues/16819))
+* resource/aws_batch_compute_environment: The `security_group_ids` and `subnets` arguments in the `compute_resources` configuration block can now be updated in-place for Fargate compute resources ([#16819](https://github.com/hashicorp/terraform-provider-aws/issues/16819))
 * resource/aws_batch_job_definition: Add `propagate_tags` argument ([#18336](https://github.com/hashicorp/terraform-provider-aws/issues/18336))
 * resource/aws_instance: Make `instance_initiated_shutdown_behavior` also computed, allowing value to be read ([#18880](https://github.com/hashicorp/terraform-provider-aws/issues/18880))
 * resource/aws_organizations_organizational_unit: Add `tags` argument ([#18861](https://github.com/hashicorp/terraform-provider-aws/issues/18861))
@@ -17,6 +21,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* data-source/aws_dynamodb_table: Prevent panic for replicas with KMS Key ARN configured ([#19042](https://github.com/hashicorp/terraform-provider-aws/issues/19042))
 * provider: Prevent `Provider produced inconsistent final plan` errors when resource `tags` are not known until apply ([#18958](https://github.com/hashicorp/terraform-provider-aws/issues/18958))
 * resource/aws_batch_job_definition: Treat empty `container_properties.logConfiguration.secretOptions` array as `null` to prevent continual diffs ([#16120](https://github.com/hashicorp/terraform-provider-aws/issues/16120))
 * resource/aws_vpc_endpoint: Fix auto_accept failing while waiting for the VPC Endpoint Connection acceptance ([#19059](https://github.com/hashicorp/terraform-provider-aws/issues/19059))

--- a/aws/data_source_aws_eks_addon.go
+++ b/aws/data_source_aws_eks_addon.go
@@ -25,7 +25,7 @@ func dataSourceAwsEksAddon() *schema.Resource {
 			"cluster_name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validateEKSClusterName,
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_eks_cluster.go
+++ b/aws/data_source_aws_eks_cluster.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -81,7 +80,7 @@ func dataSourceAwsEksCluster() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validateEKSClusterName,
 			},
 			"platform_version": {
 				Type:     schema.TypeString,

--- a/aws/internal/vault/helper/pgpkeys/keybase_test.go
+++ b/aws/internal/vault/helper/pgpkeys/keybase_test.go
@@ -33,7 +33,7 @@ func TestFetchKeybasePubkeys(t *testing.T) {
 
 	exp := []string{
 		"0f801f518ec853daff611e836528efcac6caa3db",
-		"91a6e7f85d05c65630bef18951852d87348ffc4c",
+		"c874011f0ab405110d02105534365d9472d7468f",
 	}
 
 	if !reflect.DeepEqual(fingerprints, exp) {

--- a/aws/resource_aws_eks_addon.go
+++ b/aws/resource_aws_eks_addon.go
@@ -40,7 +40,7 @@ func resourceAwsEksAddon() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validateEKSClusterName,
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -143,7 +143,7 @@ func resourceAwsEksCluster() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validateEKSClusterName,
 			},
 			"platform_version": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_eks_fargate_profile.go
+++ b/aws/resource_aws_eks_fargate_profile.go
@@ -42,7 +42,7 @@ func resourceAwsEksFargateProfile() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validateEKSClusterName,
 			},
 			"fargate_profile_name": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -60,7 +60,7 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validateEKSClusterName,
 			},
 			"disk_size": {
 				Type:     schema.TypeInt,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2345,6 +2345,24 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 	return
 }
 
+func validateEKSClusterName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) < 1 || len(value) > 100 {
+		errors = append(errors, fmt.Errorf(
+			"%q length must be between 1-100 characters: %q", k, value))
+	}
+
+	// https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html#API_CreateCluster_RequestSyntax
+	pattern := `^[0-9A-Za-z][A-Za-z0-9\-_]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
 var validateCloudWatchEventCustomEventBusName = validation.All(
 	validation.StringLenBetween(1, 256),
 	validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`), ""),

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3246,3 +3246,55 @@ func TestValidateTypeStringIsDateOrInt(t *testing.T) {
 		}
 	}
 }
+
+func TestResourceAWSEKSClusterNameValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "my-valid-eks-cluster_1_dev",
+			ErrCount: 0,
+		},
+		{
+			Value:    `_invalid`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `-invalid`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `invalid@`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `invalid*`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `invalid:`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `invalid$`,
+			ErrCount: 1,
+		},
+		{
+			Value:    ``,
+			ErrCount: 2,
+		},
+		{
+			Value:    acctest.RandStringFromCharSet(101, acctest.CharSetAlpha),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateEKSClusterName(tc.Value, "cluster_name")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the EKS Cluster Name to trigger a validation error: %s, expected %d, got %d errors", tc.Value, tc.ErrCount, len(errors))
+		}
+	}
+}

--- a/website/docs/d/eks_addon.html.markdown
+++ b/website/docs/d/eks_addon.html.markdown
@@ -27,7 +27,7 @@ output "eks_addon_outputs" {
 
 * `addon_name` – (Required) Name of the EKS add-on. The name must match one of
   the names returned by [list-addon](https://docs.aws.amazon.com/cli/latest/reference/eks/list-addons.html).
-* `cluster_name` – (Required) Name of the EKS Cluster.
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 
 ## Attributes Reference
 

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -33,7 +33,7 @@ output "identity-oidc-issuer" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the cluster
+* `name` - (Required) The name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 
 ## Attributes Reference
 

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -76,7 +76,7 @@ The following arguments are required:
 
 * `addon_name` – (Required) Name of the EKS add-on. The name must match one of
   the names returned by [list-addon](https://docs.aws.amazon.com/cli/latest/reference/eks/list-addons.html).
-* `cluster_name` – (Required) Name of the EKS Cluster.
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 
 The following arguments are optional:
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -155,7 +155,7 @@ After adding inline IAM Policies (e.g. [`aws_iam_role_policy` resource](/docs/pr
 
 The following arguments are required:
 
-* `name` – (Required) Name of the cluster.
+* `name` – (Required) Name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `role_arn` - (Required) ARN of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf. Ensure the resource configuration includes explicit dependencies on the IAM Role permissions by adding [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html) if using the [`aws_iam_role_policy` resource](/docs/providers/aws/r/iam_role_policy.html) or [`aws_iam_role_policy_attachment` resource](/docs/providers/aws/r/iam_role_policy_attachment.html), otherwise EKS cannot delete EKS managed EC2 infrastructure such as Security Groups on EKS Cluster deletion.
 * `vpc_config` - (Required) Configuration block for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Detailed below. Also contains attributes detailed in the Attributes section.
 

--- a/website/docs/r/eks_fargate_profile.html.markdown
+++ b/website/docs/r/eks_fargate_profile.html.markdown
@@ -53,7 +53,7 @@ resource "aws_iam_role_policy_attachment" "example-AmazonEKSFargatePodExecutionR
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster.
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `fargate_profile_name` – (Required) Name of the EKS Fargate Profile.
 * `pod_execution_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Fargate Profile.
 * `selector` - (Required) Configuration block(s) for selecting Kubernetes Pods to execute with this EKS Fargate Profile. Detailed below.

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -115,7 +115,7 @@ resource "aws_subnet" "example" {
 
 The following arguments are required:
 
-* `cluster_name` – (Required) Name of the EKS Cluster.
+* `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `node_group_name` – (Required) Name of the EKS Node Group.
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
 * `scaling_config` - (Required) Configuration block with scaling settings. Detailed below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18806

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -run=TestResourceAWSEKSClusterNameValidation
=== RUN   TestResourceAWSEKSClusterNameValidation
--- PASS: TestResourceAWSEKSClusterNameValidation (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.690s
```
Thanks in advance for your review!

The regex listed in the documentation is actually incorrect, I've left feedback on that page so hopefully it gets corrected
https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html
Listed as `^[0-9A-Za-z][A-Za-z0-9\-_]*` but should be `^[0-9A-Za-z][A-Za-z0-9\-_]+$`.

Wasn't sure if I had to run acc tests for the resources themselves so please let me know if I do, I just skipped them since it will be expensive and long, but can run them if required 😄 
