### PR TITLE
service/opsworks: add default tags support to opsworks_*_layer resources

### DIFF
--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -213,7 +213,8 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"tags": tagsSchema(),
+		"tags":     tagsSchema(),
+		"tags_all": tagsSchemaComputed(),
 	}
 
 	if lt.CustomShortName {
@@ -247,34 +248,31 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 
 	return &schema.Resource{
 		Read: func(d *schema.ResourceData, meta interface{}) error {
-			client := meta.(*AWSClient).opsworksconn
-			ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
-
-			return lt.Read(d, client, ignoreTagsConfig)
+			return lt.Read(d, meta)
 		},
 		Create: func(d *schema.ResourceData, meta interface{}) error {
-			client := meta.(*AWSClient).opsworksconn
-			return lt.Create(d, client, meta)
+			return lt.Create(d, meta)
 		},
 		Update: func(d *schema.ResourceData, meta interface{}) error {
-			client := meta.(*AWSClient).opsworksconn
-			ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
-
-			return lt.Update(d, client, ignoreTagsConfig)
+			return lt.Update(d, meta)
 		},
 		Delete: func(d *schema.ResourceData, meta interface{}) error {
-			client := meta.(*AWSClient).opsworksconn
-			return lt.Delete(d, client)
+			return lt.Delete(d, meta)
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: resourceSchema,
+
+		CustomizeDiff: SetTagsDiff,
 	}
 }
 
-func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWorks, ignoreTagsConfig *keyvaluetags.IgnoreConfig) error {
+func (lt *opsworksLayerType) Read(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).opsworksconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	req := &opsworks.DescribeLayersInput{
 		LayerIds: []*string{
@@ -284,7 +282,7 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 
 	log.Printf("[DEBUG] Reading OpsWorks layer: %s", d.Id())
 
-	resp, err := client.DescribeLayers(req)
+	resp, err := conn.DescribeLayers(req)
 	if err != nil {
 		if isAWSErr(err, opsworks.ErrCodeResourceNotFoundException, "") {
 			d.SetId("")
@@ -334,7 +332,7 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 			aws.String(d.Id()),
 		},
 	}
-	loadBalancers, err := client.DescribeElasticLoadBalancers(ebsRequest)
+	loadBalancers, err := conn.DescribeElasticLoadBalancers(ebsRequest)
 	if err != nil {
 		return err
 	}
@@ -350,21 +348,30 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 
 	arn := aws.StringValue(layer.Arn)
 	d.Set("arn", arn)
-	tags, err := keyvaluetags.OpsworksListTags(client, arn)
+	tags, err := keyvaluetags.OpsworksListTags(conn, arn)
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for Opsworks Layer (%s): %s", arn, err)
 	}
 
-	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
 	return nil
 }
 
-func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.OpsWorks, meta interface{}) error {
-	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+func (lt *opsworksLayerType) Create(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).opsworksconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
 	attributes, err := lt.AttributeMap(d)
 	if err != nil {
@@ -398,7 +405,7 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 
 	log.Printf("[DEBUG] Creating OpsWorks layer: %s", d.Id())
 
-	resp, err := client.CreateLayer(req)
+	resp, err := conn.CreateLayer(req)
 	if err != nil {
 		return err
 	}
@@ -409,7 +416,7 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 	loadBalancer := aws.String(d.Get("elastic_load_balancer").(string))
 	if loadBalancer != nil && *loadBalancer != "" {
 		log.Printf("[DEBUG] Attaching load balancer: %s", *loadBalancer)
-		_, err := client.AttachElasticLoadBalancer(&opsworks.AttachElasticLoadBalancerInput{
+		_, err := conn.AttachElasticLoadBalancer(&opsworks.AttachElasticLoadBalancerInput{
 			ElasticLoadBalancerName: loadBalancer,
 			LayerId:                 &layerId,
 		})
@@ -426,16 +433,18 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 		Resource:  fmt.Sprintf("layer/%s", d.Id()),
 	}.String()
 
-	if v, ok := d.GetOk("tags"); ok {
-		if err := keyvaluetags.OpsworksUpdateTags(client, arn, nil, v.(map[string]interface{})); err != nil {
+	if len(tags) > 0 {
+		if err := keyvaluetags.OpsworksUpdateTags(conn, arn, nil, tags); err != nil {
 			return fmt.Errorf("error updating Opsworks stack (%s) tags: %s", arn, err)
 		}
 	}
 
-	return lt.Read(d, client, ignoreTagsConfig)
+	return lt.Read(d, meta)
 }
 
-func (lt *opsworksLayerType) Update(d *schema.ResourceData, client *opsworks.OpsWorks, ignoreTagsConfig *keyvaluetags.IgnoreConfig) error {
+func (lt *opsworksLayerType) Update(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).opsworksconn
+
 	attributes, err := lt.AttributeMap(d)
 	if err != nil {
 		return err
@@ -475,7 +484,7 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, client *opsworks.Ops
 
 		if loadBalancerOld != nil && *loadBalancerOld != "" {
 			log.Printf("[DEBUG] Dettaching load balancer: %s", *loadBalancerOld)
-			_, err := client.DetachElasticLoadBalancer(&opsworks.DetachElasticLoadBalancerInput{
+			_, err := conn.DetachElasticLoadBalancer(&opsworks.DetachElasticLoadBalancerInput{
 				ElasticLoadBalancerName: loadBalancerOld,
 				LayerId:                 aws.String(d.Id()),
 			})
@@ -486,7 +495,7 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, client *opsworks.Ops
 
 		if loadBalancerNew != nil && *loadBalancerNew != "" {
 			log.Printf("[DEBUG] Attaching load balancer: %s", *loadBalancerNew)
-			_, err := client.AttachElasticLoadBalancer(&opsworks.AttachElasticLoadBalancerInput{
+			_, err := conn.AttachElasticLoadBalancer(&opsworks.AttachElasticLoadBalancerInput{
 				ElasticLoadBalancerName: loadBalancerNew,
 				LayerId:                 aws.String(d.Id()),
 			})
@@ -496,31 +505,33 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, client *opsworks.Ops
 		}
 	}
 
-	_, err = client.UpdateLayer(req)
+	_, err = conn.UpdateLayer(req)
 	if err != nil {
 		return err
 	}
 
-	if d.HasChange("tags") {
-		o, n := d.GetChange("tags")
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
 
 		arn := d.Get("arn").(string)
-		if err := keyvaluetags.OpsworksUpdateTags(client, arn, o, n); err != nil {
+		if err := keyvaluetags.OpsworksUpdateTags(conn, arn, o, n); err != nil {
 			return fmt.Errorf("error updating Opsworks Layer (%s) tags: %s", arn, err)
 		}
 	}
 
-	return lt.Read(d, client, ignoreTagsConfig)
+	return lt.Read(d, meta)
 }
 
-func (lt *opsworksLayerType) Delete(d *schema.ResourceData, client *opsworks.OpsWorks) error {
+func (lt *opsworksLayerType) Delete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).opsworksconn
+
 	req := &opsworks.DeleteLayerInput{
 		LayerId: aws.String(d.Id()),
 	}
 
 	log.Printf("[DEBUG] Deleting OpsWorks layer: %s", d.Id())
 
-	_, err := client.DeleteLayer(req)
+	_, err := conn.DeleteLayer(req)
 	return err
 }
 

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -68,6 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/opsworks_ganglia_layer.html.markdown
+++ b/website/docs/r/opsworks_ganglia_layer.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -68,3 +68,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_haproxy_layer.html.markdown
+++ b/website/docs/r/opsworks_haproxy_layer.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -71,3 +71,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_java_app_layer.html.markdown
+++ b/website/docs/r/opsworks_java_app_layer.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -69,3 +69,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_memcached_layer.html.markdown
+++ b/website/docs/r/opsworks_memcached_layer.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -65,3 +65,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_mysql_layer.html.markdown
+++ b/website/docs/r/opsworks_mysql_layer.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -69,3 +69,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_nodejs_app_layer.html.markdown
+++ b/website/docs/r/opsworks_nodejs_app_layer.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -65,3 +65,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_php_app_layer.html.markdown
+++ b/website/docs/r/opsworks_php_app_layer.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -64,6 +64,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/opsworks_rails_app_layer.html.markdown
+++ b/website/docs/r/opsworks_rails_app_layer.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -70,3 +70,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/opsworks_static_web_layer.html.markdown
+++ b/website/docs/r/opsworks_static_web_layer.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `system_packages` - (Optional) Names of a set of system packages to install on the layer's instances.
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
-* `tags` - (Optional) A map of tags to assign to the resource.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -63,6 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
 * `arn` - The Amazon Resource Name(ARN) of the layer.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7926

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Will be managed by CI nightly tests
```
