### PR TITLE
aws/resource_aws_db_proxy_target.go: Fixing InvalidDBInstanceState

### DIFF
--- a/.changelog/19096.txt
+++ b/.changelog/19096.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_proxy_target: Fixed InvalidDBInstanceState: DB Instance is in an unsupported state - CREATING, needs to be in [AVAILABLE, MODIFYING, BACKING_UP]
+```

--- a/aws/resource_aws_db_proxy_target.go
+++ b/aws/resource_aws_db_proxy_target.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/finder"
 )
@@ -101,13 +103,24 @@ func resourceAwsDbProxyTargetCreate(d *schema.ResourceData, meta interface{}) er
 		params.DBClusterIdentifiers = []*string{aws.String(v.(string))}
 	}
 
-	resp, err := conn.RegisterDBProxyTargets(&params)
+	var err error
+	var registerDBProxyTargetsOutput *rds.RegisterDBProxyTargetsOutput
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		registerDBProxyTargetsOutput, err = conn.RegisterDBProxyTargets(&params)
+		if err != nil {
+			if isAWSErr(err, "InvalidDBInstanceState", "CREATING") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 
 	if err != nil {
 		return fmt.Errorf("error registering RDS DB Proxy (%s/%s) Target: %w", dbProxyName, targetGroupName, err)
 	}
 
-	dbProxyTarget := resp.DBProxyTargets[0]
+	dbProxyTarget := registerDBProxyTargetsOutput.DBProxyTargets[0]
 
 	d.SetId(strings.Join([]string{dbProxyName, targetGroupName, aws.StringValue(dbProxyTarget.Type), aws.StringValue(dbProxyTarget.RdsResourceId)}, "/"))
 


### PR DESCRIPTION
When creating resources aws_db_proxy_target, aws_rds_cluster, aws_db_proxy and aws_db_proxy_default_target_group as part of a single module, we observe the following error:

```
module.testdb.aws_rds_cluster_instance.aurora[0]: Still creating... [6m30s elapsed]
module.testdb.aws_rds_cluster_instance.aurora[0]: Creation complete after 6m31s [id=refactor-testdb01-01]

│ Error: error registering RDS DB Proxy (refactor-testdb01/default) Target: InvalidDBInstanceState: DB Instance refactor-testdb01-01 is in an unsupported state - CREATING, needs to be in [AVAILABLE, MODIFYING, BACKING_UP]
│       status code: 400, request id: c288d6f0-84f4-408f-81ec-f735085fb736
│
│   on .terraform/modules/testdb/main.tf line 284, in resource "aws_db_proxy_target" "default":
│  284: resource "aws_db_proxy_target" "default" {
```

This PR resolves that problem by leveraging resource.Retry.
```
module.testdb.aws_db_proxy_target.default[0]: Still creating... [4m0s elapsed]
module.testdb.aws_rds_cluster_instance.aurora[0]: Still creating... [5m30s elapsed]
module.testdb.aws_rds_cluster_instance.aurora[0]: Creation complete after 5m38s [id=refactor-testdb01-01]
module.testdb.aws_db_proxy_target.default[0]: Still creating... [4m10s elapsed]
module.testdb.aws_db_proxy_target.default[0]: Creation complete after 4m15s [id=refactor-testdb01/default/TRACKED_CLUSTER/refactor-testdb01]
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #18358

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDBProxyTarget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBProxyTarget -timeout 180m

=== RUN   TestAccAWSDBProxyTarget_Instance
=== PAUSE TestAccAWSDBProxyTarget_Instance
=== RUN   TestAccAWSDBProxyTarget_Cluster
=== PAUSE TestAccAWSDBProxyTarget_Cluster
=== RUN   TestAccAWSDBProxyTarget_disappears
=== PAUSE TestAccAWSDBProxyTarget_disappears
=== CONT  TestAccAWSDBProxyTarget_Instance
=== CONT  TestAccAWSDBProxyTarget_disappears
=== CONT  TestAccAWSDBProxyTarget_Cluster
--- PASS: TestAccAWSDBProxyTarget_Cluster (1200.50s)
--- PASS: TestAccAWSDBProxyTarget_Instance (1200.74s)
--- PASS: TestAccAWSDBProxyTarget_disappears (1203.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1203.431s
```
