### PR TITLE
Add SecurityHub Organization Configuration Resource

### DIFF
--- a/.changelog/19108.txt
+++ b/.changelog/19108.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_securityhub_organization_configuration
+```

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -992,6 +992,7 @@ func Provider() *schema.Provider {
 			"aws_securityhub_invite_accepter":                         resourceAwsSecurityHubInviteAccepter(),
 			"aws_securityhub_member":                                  resourceAwsSecurityHubMember(),
 			"aws_securityhub_organization_admin_account":              resourceAwsSecurityHubOrganizationAdminAccount(),
+			"aws_securityhub_organization_configuration":              resourceAwsSecurityHubOrganizationConfiguration(),
 			"aws_securityhub_product_subscription":                    resourceAwsSecurityHubProductSubscription(),
 			"aws_securityhub_standards_subscription":                  resourceAwsSecurityHubStandardsSubscription(),
 			"aws_servicecatalog_portfolio":                            resourceAwsServiceCatalogPortfolio(),

--- a/aws/resource_aws_securityhub_organization_configuration.go
+++ b/aws/resource_aws_securityhub_organization_configuration.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsSecurityHubOrganizationConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSecurityHubOrganizationConfigurationUpdate,
+		Read:   resourceAwsSecurityHubOrganizationConfigurationRead,
+		Update: resourceAwsSecurityHubOrganizationConfigurationUpdate,
+		Delete: schema.Noop,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"auto_enable": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSecurityHubOrganizationConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+
+	input := &securityhub.UpdateOrganizationConfigurationInput{
+		AutoEnable: aws.Bool(d.Get("auto_enable").(bool)),
+	}
+
+	_, err := conn.UpdateOrganizationConfiguration(input)
+
+	if err != nil {
+		return fmt.Errorf("error updating Security Hub Organization Configuration (%s): %w", d.Id(), err)
+	}
+
+	d.SetId(meta.(*AWSClient).accountid)
+
+	return resourceAwsSecurityHubOrganizationConfigurationRead(d, meta)
+}
+
+func resourceAwsSecurityHubOrganizationConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+
+	output, err := conn.DescribeOrganizationConfiguration(&securityhub.DescribeOrganizationConfigurationInput{})
+
+	if err != nil {
+		return fmt.Errorf("error reading Security Hub Organization Configuration: %w", err)
+	}
+
+	d.Set("auto_enable", output.AutoEnable)
+
+	return nil
+}

--- a/aws/resource_aws_securityhub_organization_configuration_test.go
+++ b/aws/resource_aws_securityhub_organization_configuration_test.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccAwsSecurityHubOrganizationConfiguration_basic(t *testing.T) {
+	resourceName := "aws_securityhub_organization_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, securityhub.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil, //lintignore:AT001
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSecurityHubOrganizationConfigurationConfig(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAwsSecurityHubOrganizationConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsSecurityHubOrganizationConfigurationConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAwsSecurityHubOrganizationConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsSecurityHubOrganizationConfigurationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).securityhubconn
+
+		_, err := conn.DescribeOrganizationConfiguration(&securityhub.DescribeOrganizationConfigurationInput{})
+
+		return err
+	}
+}
+
+func testAccAwsSecurityHubOrganizationConfigurationConfig(autoEnable bool) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["securityhub.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_securityhub_account" "test" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_securityhub_organization_admin_account" "test" {
+  admin_account_id = data.aws_caller_identity.current.account_id
+
+  depends_on = [aws_organizations_organization.test, aws_securityhub_account.test]
+}
+
+resource "aws_securityhub_organization_configuration" "test" {
+  auto_enable = %[1]t
+
+  depends_on = [aws_securityhub_organization_admin_account.test]
+}
+`, autoEnable)
+}

--- a/aws/resource_aws_securityhub_test.go
+++ b/aws/resource_aws_securityhub_test.go
@@ -40,6 +40,9 @@ func TestAccAWSSecurityHub_serial(t *testing.T) {
 			"disappears":  testAccAwsSecurityHubOrganizationAdminAccount_disappears,
 			"MultiRegion": testAccAwsSecurityHubOrganizationAdminAccount_MultiRegion,
 		},
+		"OrganizationConfiguration": {
+			"basic": testAccAwsSecurityHubOrganizationConfiguration_basic,
+		},
 		"ProductSubscription": {
 			"basic": testAccAWSSecurityHubProductSubscription_basic,
 		},

--- a/website/docs/r/securityhub_organization_admin_account.html.markdown
+++ b/website/docs/r/securityhub_organization_admin_account.html.markdown
@@ -25,6 +25,9 @@ resource "aws_securityhub_organization_admin_account" "example" {
 
   admin_account_id = "123456789012"
 }
+
+// Auto enable security hub in organization member accounts
+resource "aws_securityhub_organization_configuration" "example" {}
 ```
 
 ## Argument Reference

--- a/website/docs/r/securityhub_organization_configuration.markdown
+++ b/website/docs/r/securityhub_organization_configuration.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Security Hub"
+layout: "aws"
+page_title: "AWS: aws_securityhub_organization_configuration"
+description: |-
+  Manages the Security Hub Organization Configuration
+---
+
+# Resource: aws_securityhub_organization_configuration
+
+Manages the Security Hub Organization Configuration.
+
+~> **NOTE:** This resource requires an [`aws_securityhub_organization_admin_account`](/docs/providers/aws/r/securityhub_organization_admin_account.html) to be configured (not necessarily with Terraform). More information about managing Security Hub in an organization can be found in the [Managing administrator and member accounts](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-accounts.html) documentation
+
+~> **NOTE:** This is an advanced Terraform resource. Terraform will automatically assume management of the Security Hub Organization Configuration without import and perform no actions on removal from the Terraform configuration.
+
+## Example Usage
+
+```terraform
+resource "aws_organizations_organization" "example" {
+  aws_service_access_principals = ["securityhub.amazonaws.com"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_securityhub_organization_admin_account" "example" {
+  depends_on = [aws_organizations_organization.example]
+
+  admin_account_id = "123456789012"
+}
+
+resource "aws_securityhub_organization_configuration" "example" {
+  auto_enable = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auto_enable` - (Required) Whether to automatically enable Security Hub for new accounts in the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - AWS Account ID.
+
+## Import
+
+An existing Security Hub enabled account can be imported using the AWS account ID, e.g.
+
+```
+$ terraform import aws_securityhub_organization_configuration.example 123456789012
+```


### PR DESCRIPTION
Resource to enable security hub's auto-enroll feature when apart of an
organization and a security hub admin account has been configured.

By default the **Auto-Enable** feature is disabled. See: [Automatically enabling new organization accounts](https://docs.aws.amazon.com/securityhub/latest/userguide/accounts-orgs-auto-enable.html)

[method]: https://docs.aws.amazon.com/sdk-for-go/api/service/securityhub/#SecurityHub.UpdateOrganizationConfiguration
[input]: https://docs.aws.amazon.com/sdk-for-go/api/service/securityhub/#UpdateOrganizationConfigurationInput



<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/17287

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
