### PR TITLE
Replace or remove calls to `fmt.Print` (and variants)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -415,3 +415,21 @@ rules:
           metavariable: '$Z'
           regex: '.*Pages$'
     severity: WARNING
+
+  - id: calling-fmt.Print-and-variants
+    languages: [go]
+    message: Do not call `fmt.Print` and variant
+    paths:
+      exclude:
+        - awsproviderlint/vendor/
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+        - pattern: |
+            fmt.Print(...)
+        - pattern: |
+            fmt.Printf(...)
+        - pattern: |
+            fmt.Println(...)
+    severity: WARNING

--- a/aws/internal/vault/sdk/helper/jsonutil/json_test.go
+++ b/aws/internal/vault/sdk/helper/jsonutil/json_test.go
@@ -2,7 +2,6 @@ package jsonutil
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -14,7 +13,7 @@ func TestJSONUtil_DecodeJSONFromReader(t *testing.T) {
 
 	err := DecodeJSONFromReader(bytes.NewReader([]byte(input)), &actual)
 	if err != nil {
-		fmt.Printf("decoding err: %v\n", err)
+		t.Errorf("decoding err: %v", err)
 	}
 
 	expected := map[string]interface{}{

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -372,7 +372,7 @@ func resourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) 
 	// I'm not sure why it needs to be wrapped with double quotes first, but it does
 	normalized_policy, err := structure.NormalizeJsonString(`"` + aws.StringValue(api.Policy) + `"`)
 	if err != nil {
-		fmt.Printf("error normalizing policy JSON: %s\n", err)
+		return fmt.Errorf("error normalizing policy JSON: %w", err)
 	}
 	policy, err := strconv.Unquote(normalized_policy)
 	if err != nil {

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -674,8 +674,6 @@ func testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName string) resou
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		fmt.Printf("%#v", rs.Primary.Attributes)
-
 		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["event_bus_name"], rs.Primary.Attributes["rule"], rs.Primary.Attributes["target_id"]), nil
 	}
 }

--- a/aws/resource_aws_lakeformation_permissions_test.go
+++ b/aws/resource_aws_lakeformation_permissions_test.go
@@ -256,9 +256,8 @@ func testAccCheckAWSLakeFormationPermissionsDestroy(s *terraform.State) error {
 			},
 		}
 
-		out, err := conn.ListPermissions(input)
+		_, err := conn.ListPermissions(input)
 		if err == nil {
-			fmt.Print(out)
 			return fmt.Errorf("Resource still registered: %s %s", catalogId, principal)
 		}
 	}

--- a/aws/resource_aws_lb_ssl_negotiation_policy_test.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -145,7 +146,7 @@ func testAccCheckLBSSLNegotiationPolicy(elbResource string, policyResource strin
 		})
 
 		if err != nil {
-			fmt.Printf("[ERROR] Problem describing load balancer policy '%s': %s", policyName, err)
+			log.Printf("[ERROR] Problem describing load balancer policy '%s': %s", policyName, err)
 			return err
 		}
 

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -582,10 +582,10 @@ func testAccCheckAWSSNSTopicSubscriptionRedrivePolicyAttribute(attributes map[st
 const awsSNSPasswordObfuscationPattern = "****"
 
 // returns the endpoint with obfuscated password, if any
-func obfuscateEndpoint(endpoint string) string {
+func obfuscateEndpoint(t *testing.T, endpoint string) string {
 	res, err := url.Parse(endpoint)
 	if err != nil {
-		fmt.Println(err)
+		t.Errorf("error parsing URL: %s", err)
 	}
 
 	var obfuscatedEndpoint = res.String()
@@ -607,7 +607,7 @@ func TestObfuscateEndpointPassword(t *testing.T) {
 		"https://username:password@example.com/myroute": "https://username:****@example.com/myroute",
 	}
 	for endpoint, expected := range checks {
-		out := obfuscateEndpoint(endpoint)
+		out := obfuscateEndpoint(t, endpoint)
 
 		if expected != out {
 			t.Fatalf("Expected %v, got %v", expected, out)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18489.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Ran `aws_api_gateway_rest_api` resource acceptance tests as this was the only non-test code modified.

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayRestApi_'                                                                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayRestApi_ -timeout 180m
=== RUN   TestAccAWSAPIGatewayRestApi_basic
=== PAUSE TestAccAWSAPIGatewayRestApi_basic
=== RUN   TestAccAWSAPIGatewayRestApi_tags
=== PAUSE TestAccAWSAPIGatewayRestApi_tags
=== RUN   TestAccAWSAPIGatewayRestApi_disappears
=== PAUSE TestAccAWSAPIGatewayRestApi_disappears
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== RUN   TestAccAWSAPIGatewayRestApi_ApiKeySource
=== PAUSE TestAccAWSAPIGatewayRestApi_ApiKeySource
=== RUN   TestAccAWSAPIGatewayRestApi_ApiKeySource_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_ApiKeySource_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_ApiKeySource_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_ApiKeySource_SetByBody
=== RUN   TestAccAWSAPIGatewayRestApi_BinaryMediaTypes
=== PAUSE TestAccAWSAPIGatewayRestApi_BinaryMediaTypes
=== RUN   TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_SetByBody
=== RUN   TestAccAWSAPIGatewayRestApi_Body
=== PAUSE TestAccAWSAPIGatewayRestApi_Body
=== RUN   TestAccAWSAPIGatewayRestApi_Description
=== PAUSE TestAccAWSAPIGatewayRestApi_Description
=== RUN   TestAccAWSAPIGatewayRestApi_Description_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_Description_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_Description_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_Description_SetByBody
=== RUN   TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint
=== PAUSE TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint
=== RUN   TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_SetByBody
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_SetByBody
=== RUN   TestAccAWSAPIGatewayRestApi_MinimumCompressionSize
=== PAUSE TestAccAWSAPIGatewayRestApi_MinimumCompressionSize
=== RUN   TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_SetByBody
=== RUN   TestAccAWSAPIGatewayRestApi_Name_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_Name_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_Parameters
=== PAUSE TestAccAWSAPIGatewayRestApi_Parameters
=== RUN   TestAccAWSAPIGatewayRestApi_Policy
=== PAUSE TestAccAWSAPIGatewayRestApi_Policy
=== RUN   TestAccAWSAPIGatewayRestApi_Policy_OverrideBody
=== PAUSE TestAccAWSAPIGatewayRestApi_Policy_OverrideBody
=== RUN   TestAccAWSAPIGatewayRestApi_Policy_SetByBody
=== PAUSE TestAccAWSAPIGatewayRestApi_Policy_SetByBody
=== CONT  TestAccAWSAPIGatewayRestApi_basic
=== CONT  TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint
=== CONT  TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_SetByBody
=== CONT  TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_OverrideBody
=== CONT  TestAccAWSAPIGatewayRestApi_Description_SetByBody
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== CONT  TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_OverrideBody
=== CONT  TestAccAWSAPIGatewayRestApi_MinimumCompressionSize
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_SetByBody
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_OverrideBody
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds
=== CONT  TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_SetByBody
=== CONT  TestAccAWSAPIGatewayRestApi_BinaryMediaTypes
=== CONT  TestAccAWSAPIGatewayRestApi_Policy_SetByBody
=== CONT  TestAccAWSAPIGatewayRestApi_Policy_OverrideBody
=== CONT  TestAccAWSAPIGatewayRestApi_Policy
=== CONT  TestAccAWSAPIGatewayRestApi_Parameters
=== CONT  TestAccAWSAPIGatewayRestApi_Name_OverrideBody
=== CONT  TestAccAWSAPIGatewayRestApi_tags
=== CONT  TestAccAWSAPIGatewayRestApi_ApiKeySource_OverrideBody
--- PASS: TestAccAWSAPIGatewayRestApi_Description_SetByBody (22.49s)
=== CONT  TestAccAWSAPIGatewayRestApi_Body
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (48.12s)
=== CONT  TestAccAWSAPIGatewayRestApi_Description_OverrideBody
--- PASS: TestAccAWSAPIGatewayRestApi_BinaryMediaTypes (55.37s)
=== CONT  TestAccAWSAPIGatewayRestApi_Description
--- PASS: TestAccAWSAPIGatewayRestApi_MinimumCompressionSize (89.16s)
=== CONT  TestAccAWSAPIGatewayRestApi_ApiKeySource
--- PASS: TestAccAWSAPIGatewayRestApi_ApiKeySource (29.48s)
=== CONT  TestAccAWSAPIGatewayRestApi_ApiKeySource_SetByBody
--- PASS: TestAccAWSAPIGatewayRestApi_Policy_OverrideBody (145.86s)
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration
--- PASS: TestAccAWSAPIGatewayRestApi_ApiKeySource_OverrideBody (176.93s)
=== CONT  TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_SetByBody
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_SetByBody (189.35s)
=== CONT  TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_OverrideBody
--- PASS: TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_OverrideBody (211.66s)
=== CONT  TestAccAWSAPIGatewayRestApi_disappears
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_OverrideBody (218.42s)
--- PASS: TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_SetByBody (241.05s)
--- PASS: TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_OverrideBody (77.43s)
--- PASS: TestAccAWSAPIGatewayRestApi_tags (297.70s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds (341.49s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (224.77s)
--- PASS: TestAccAWSAPIGatewayRestApi_Name_OverrideBody (408.60s)
--- PASS: TestAccAWSAPIGatewayRestApi_Policy_SetByBody (437.08s)
--- PASS: TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_SetByBody (463.04s)
--- PASS: TestAccAWSAPIGatewayRestApi_Description (459.46s)
--- PASS: TestAccAWSAPIGatewayRestApi_Description_OverrideBody (504.69s)
--- PASS: TestAccAWSAPIGatewayRestApi_disappears (344.99s)
--- PASS: TestAccAWSAPIGatewayRestApi_Policy (596.52s)
--- PASS: TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_SetByBody (438.44s)
--- PASS: TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_OverrideBody (664.02s)
--- PASS: TestAccAWSAPIGatewayRestApi_Parameters (703.76s)
--- PASS: TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint (724.61s)
--- PASS: TestAccAWSAPIGatewayRestApi_ApiKeySource_SetByBody (800.44s)
--- PASS: TestAccAWSAPIGatewayRestApi_Body (1102.30s)
--- PASS: TestAccAWSAPIGatewayRestApi_basic (1388.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1391.882s
```
