### PR TITLE
Adds handling for new error message seen in `us-east-2`

### DIFF
--- a/.changelog/19116.txt
+++ b/.changelog/19116.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_gateway: Correctly handle additional error message returned in some regions
+```


### PR DESCRIPTION
Correctly handles new error message returned by the AWS API in `us-east-2`: `This operation is not valid for the specified gateway` instead of `The specified operation is not supported`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19111

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_DEFAULT_REGION=us-east-2  make testacc TESTARGS='-run=TestAccAWSStorageGatewayGateway_GatewayType_FileS3'

--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (245.33s)
```
