### PR TITLE
Removes `IDRefreshName` from acceptance tests for resources I-N

### DIFF
--- a/aws/resource_aws_iam_group_policy_test.go
+++ b/aws/resource_aws_iam_group_policy_test.go
@@ -86,11 +86,10 @@ func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
 	var groupPolicy1, groupPolicy2 iam.GetGroupPolicyOutput
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName: "aws_iam_group_policy.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMGroupPolicyConfig_namePrefix(rInt, "*"),
@@ -127,11 +126,10 @@ func TestAccAWSIAMGroupPolicy_generatedName(t *testing.T) {
 	var groupPolicy1, groupPolicy2 iam.GetGroupPolicyOutput
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName: "aws_iam_group_policy.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMGroupPolicyConfig_generatedName(rInt, "*"),

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -169,12 +169,10 @@ func TestAccAWSIAMInstanceProfile_namePrefix(t *testing.T) {
 	resourceName := "aws_iam_instance_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"name_prefix"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSInstanceProfileDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSInstanceProfilePrefixNameConfig(rName),

--- a/aws/resource_aws_iam_role_policy_test.go
+++ b/aws/resource_aws_iam_role_policy_test.go
@@ -100,11 +100,10 @@ func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 	roleName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckIAMRolePolicyDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMRolePolicyConfig_namePrefix(role, "*"),
@@ -146,11 +145,10 @@ func TestAccAWSIAMRolePolicy_generatedName(t *testing.T) {
 	roleName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckIAMRolePolicyDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMRolePolicyConfig_generatedName(role, "*"),

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -220,12 +220,10 @@ func TestAccAWSIAMRole_namePrefix(t *testing.T) {
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"name_prefix"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSRoleDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSIAMRolePrefixNameConfig(rName),

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -94,11 +94,10 @@ func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
 	userName := fmt.Sprintf("test_user_%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName: policyResourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMUserPolicyConfig_namePrefix(rInt, strconv.Quote(policy1)),
@@ -137,11 +136,10 @@ func TestAccAWSIAMUserPolicy_generatedName(t *testing.T) {
 	userName := fmt.Sprintf("test_user_%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, iam.EndpointsID),
-		IDRefreshName: policyResourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, iam.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMUserPolicyConfig_generatedName(rInt, strconv.Quote(policy1)),

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -245,10 +245,9 @@ func TestAccAWSInstance_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t)
 		},
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigBasic(),
@@ -275,11 +274,10 @@ func TestAccAWSInstance_atLeastOneOtherEbsVolume(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigAtLeastOneOtherEbsVolume(rName),
@@ -405,11 +403,10 @@ func TestAccAWSInstance_userDataBase64(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigWithUserDataBase64(rName),
@@ -450,12 +447,10 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"ephemeral_block_device", "user_data"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGP2IopsDevice(),
@@ -542,12 +537,10 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 	rootVolumeSize := "11"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"ephemeral_block_device"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEc2InstanceConfigBlockDevices(rootVolumeSize),
@@ -619,11 +612,10 @@ func TestAccAWSInstance_rootInstanceStore(t *testing.T) {
 	resourceName := "aws_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigRootInstanceStore(),
@@ -674,12 +666,10 @@ func TestAccAWSInstance_noAMIEphemeralDevices(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"ephemeral_block_device"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigNoAMIEphemeralDevices(),
@@ -731,11 +721,10 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigSourceDestDisable(rName),
@@ -791,11 +780,10 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigDisableAPITermination(rName, true),
@@ -826,12 +814,10 @@ func TestAccAWSInstance_dedicatedInstance(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"associate_public_ip_address"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEc2InstanceConfigDedicatedInstance(rName),
@@ -857,12 +843,10 @@ func TestAccAWSInstance_outpost(t *testing.T) {
 	resourceName := "aws_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"associate_public_ip_address"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigOutpost(),
@@ -886,12 +870,10 @@ func TestAccAWSInstance_placementGroup(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"associate_public_ip_address"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigPlacementGroup(rName),
@@ -986,12 +968,10 @@ func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"associate_public_ip_address"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceNetworkInstanceSecurityGroups(rName),
@@ -1014,11 +994,10 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
@@ -1052,11 +1031,10 @@ func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
@@ -1284,11 +1262,10 @@ func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigWithoutInstanceProfile(rName),
@@ -1341,11 +1318,10 @@ func TestAccAWSInstance_withIamInstanceProfile(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigWithInstanceProfile(rName),
@@ -1406,11 +1382,10 @@ func TestAccAWSInstance_privateIP(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigPrivateIP(rName),
@@ -1444,12 +1419,10 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"associate_public_ip_address"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigAssociatePublicIPAndPrivateIP(rName),
@@ -1485,11 +1458,10 @@ func TestAccAWSInstance_Empty_PrivateIP(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigEmptyPrivateIP(rName),
@@ -1528,12 +1500,10 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"source_dest_check"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigKeyPair(rName),
@@ -1589,11 +1559,10 @@ func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandString(12))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigForceNewAndTagsDrift(rName),
@@ -3353,11 +3322,10 @@ func TestAccAWSInstance_metadataOptions(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigMetadataOptions(rName),
@@ -3951,12 +3919,10 @@ func TestAccAWSInstance_GP3RootBlockDevice(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"ephemeral_block_device", "user_data"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceConfigGP3RootBlockDevice(),

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -141,11 +141,10 @@ func TestAccAWSInternetGateway_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInternetGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInternetGatewayConfig,
@@ -188,11 +187,10 @@ func TestAccAWSInternetGateway_delete(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInternetGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInternetGatewayConfig,
@@ -213,11 +211,10 @@ func TestAccAWSInternetGateway_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckInternetGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSInternetGatewayConfigTags1(rName, "key1", "value1"),

--- a/aws/resource_aws_key_pair_test.go
+++ b/aws/resource_aws_key_pair_test.go
@@ -168,12 +168,10 @@ func TestAccAWSKeyPair_namePrefix(t *testing.T) {
 	resourceName := "aws_key_pair.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"key_name_prefix"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSKeyPairDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAWSKeyPairPrefixNameConfig,

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -21,11 +21,10 @@ func TestAccAWSLBListener_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_basic(rName),
@@ -59,11 +58,10 @@ func TestAccAWSLBListener_forwardWeighted(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_forwardWeighted(rName, rName2),
@@ -139,11 +137,10 @@ func TestAccAWSLBListener_basicUdp(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_basicUdp(rName),
@@ -176,11 +173,10 @@ func TestAccAWSLBListener_BackwardsCompatibility(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfigBackwardsCompatibility(rName),
@@ -215,11 +211,10 @@ func TestAccAWSLBListener_https(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_https(rName, key, certificate),
@@ -309,11 +304,10 @@ func TestAccAWSLBListener_redirect(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_redirect(rName),
@@ -352,11 +346,10 @@ func TestAccAWSLBListener_fixedResponse(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_fixedResponse(rName),
@@ -394,11 +387,10 @@ func TestAccAWSLBListener_cognito(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheckSkipELBV2(t),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheckSkipELBV2(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_cognito(rName, key, certificate),
@@ -439,11 +431,10 @@ func TestAccAWSLBListener_oidc(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBListenerConfig_oidc(rName, key, certificate),

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -99,11 +99,10 @@ func TestAccAWSLBTargetGroup_basic(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basic(rName),
@@ -145,11 +144,10 @@ func TestAccAWSLBTargetGroup_basicUdp(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basicUdp(rName),
@@ -177,11 +175,10 @@ func TestAccAWSLBTargetGroup_ProtocolVersion(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_ProtocolVersion(rName),
@@ -223,11 +220,10 @@ func TestAccAWSLBTargetGroup_withoutHealthcheck(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_withoutHealthcheck(rName),
@@ -249,11 +245,10 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_typeTCP(rName),
@@ -355,11 +350,10 @@ func TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(rName),
@@ -410,11 +404,10 @@ func TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_GRPC_ProtocolVersion(rName),
@@ -466,11 +459,10 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_typeTCP(rName),
@@ -496,11 +488,10 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(rName, "/healthz", 2),
@@ -556,11 +547,10 @@ func TestAccAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 	resourceName := "aws_alb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfigBackwardsCompatibility(rName),
@@ -600,11 +590,10 @@ func TestAccAWSLBTargetGroup_namePrefix(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_namePrefix(rName),
@@ -623,11 +612,10 @@ func TestAccAWSLBTargetGroup_generatedName(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_generatedName(rName),
@@ -646,11 +634,10 @@ func TestAccAWSLBTargetGroup_changeNameForceNew(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basic(rNameBefore),
@@ -676,11 +663,10 @@ func TestAccAWSLBTargetGroup_changeProtocolForceNew(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basic(rName),
@@ -706,11 +692,10 @@ func TestAccAWSLBTargetGroup_changePortForceNew(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basic(rName),
@@ -736,11 +721,10 @@ func TestAccAWSLBTargetGroup_changeVpcForceNew(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basic(rName),
@@ -764,11 +748,10 @@ func TestAccAWSLBTargetGroup_tags(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfigTags1(rName, "key1", "value1"),
@@ -805,11 +788,10 @@ func TestAccAWSLBTargetGroup_enableHealthCheck(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_withoutHealthcheck(rName),
@@ -841,11 +823,10 @@ func TestAccAWSLBTargetGroup_updateHealthCheck(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_basic(rName),
@@ -907,11 +888,10 @@ func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_stickiness(rName, false, false),
@@ -994,11 +974,10 @@ func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccALB_defaults(rName),
@@ -1056,11 +1035,10 @@ protocol = "TCP"
     `
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNLB_defaults(rName, healthCheckInvalid1),
@@ -1106,11 +1084,10 @@ func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_stickinessDefault(rName, "TCP"),
@@ -1149,11 +1126,10 @@ func TestAccAWSLBTargetGroup_stickinessDefaultALB(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_stickinessDefault(rName, "HTTP"),
@@ -1174,11 +1150,10 @@ func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "TCP", "source_ip", false),
@@ -1235,11 +1210,10 @@ func TestAccAWSLBTargetGroup_stickinessValidALB(t *testing.T) {
 	resourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupConfig_stickinessValidity(rName, "HTTP", "lb_cookie", true),

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -109,11 +109,10 @@ func TestAccAWSLB_ALB_basic(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_basic(lbName),
@@ -147,11 +146,10 @@ func TestAccAWSLB_NLB_basic(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_networkLoadbalancer(lbName, false),
@@ -291,11 +289,10 @@ func TestAccAWSLB_ALB_outpost(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_outpost(lbName),
@@ -361,11 +358,10 @@ func TestAccAWSLB_NLB_privateipv4address(t *testing.T) {
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_networkLoadBalancerPrivateIPV4Address(lbName),
@@ -391,11 +387,10 @@ func TestAccAWSLB_BackwardsCompatibility(t *testing.T) {
 	resourceName := "aws_alb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfigBackwardsCompatibility(lbName),
@@ -426,11 +421,10 @@ func TestAccAWSLB_generatedName(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_generatedName(),
@@ -448,11 +442,10 @@ func TestAccAWSLB_generatesNameForZeroValue(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_zeroValueName(),
@@ -470,11 +463,10 @@ func TestAccAWSLB_namePrefix(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_namePrefix(),
@@ -495,11 +487,10 @@ func TestAccAWSLB_tags(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_basic(lbName),
@@ -536,11 +527,10 @@ func TestAccAWSLB_networkLoadbalancer_updateCrossZone(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_networkLoadbalancer(lbName, true),
@@ -578,11 +568,10 @@ func TestAccAWSLB_applicationLoadBalancer_updateHttp2(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_enableHttp2(lbName, false),
@@ -619,11 +608,10 @@ func TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields(t *testi
 	lbName := fmt.Sprintf("testaccawsalb-headers-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: "aws_lb.lb_test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_enableDropInvalidHeaderFields(lbName, false),
@@ -661,11 +649,10 @@ func TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection(t *testing.T)
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_enableDeletionProtection(lbName, false),
@@ -703,11 +690,10 @@ func TestAccAWSLB_updatedSecurityGroups(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_basic(lbName),
@@ -734,11 +720,10 @@ func TestAccAWSLB_updatedSubnets(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_basic(lbName),
@@ -765,11 +750,10 @@ func TestAccAWSLB_updatedIpAddressType(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfigWithIpAddressType(lbName),
@@ -798,11 +782,10 @@ func TestAccAWSLB_noSecurityGroup(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_nosg(lbName),
@@ -832,11 +815,10 @@ func TestAccAWSLB_ALB_AccessLogs(t *testing.T) {
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfigALBAccessLogs(true, lbName, bucketName, ""),
@@ -921,11 +903,10 @@ func TestAccAWSLB_ALB_AccessLogs_Prefix(t *testing.T) {
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfigALBAccessLogs(true, lbName, bucketName, "prefix1"),
@@ -992,11 +973,10 @@ func TestAccAWSLB_NLB_AccessLogs(t *testing.T) {
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfigNLBAccessLogs(true, lbName, bucketName, ""),
@@ -1081,11 +1061,10 @@ func TestAccAWSLB_NLB_AccessLogs_Prefix(t *testing.T) {
 	resourceName := "aws_lb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfigNLBAccessLogs(true, lbName, bucketName, "prefix1"),
@@ -1151,11 +1130,10 @@ func TestAccAWSLB_networkLoadbalancer_subnet_change(t *testing.T) {
 	resourceName := "aws_lb.lb_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, elbv2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBConfig_networkLoadbalancer_subnets(lbName),

--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -82,10 +82,9 @@ func TestAccAWSLightsailInstance_basic(t *testing.T) {
 			testAccPartitionHasServicePreCheck(lightsail.EndpointsID, t)
 			testAccPreCheckAWSLightsail(t)
 		},
-		ErrorCheck:    testAccErrorCheck(t, lightsail.EndpointsID),
-		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
+		ErrorCheck:   testAccErrorCheck(t, lightsail.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLightsailInstanceConfig_basic(lightsailName),
@@ -118,10 +117,9 @@ func TestAccAWSLightsailInstance_Name(t *testing.T) {
 			testAccPartitionHasServicePreCheck(lightsail.EndpointsID, t)
 			testAccPreCheckAWSLightsail(t)
 		},
-		ErrorCheck:    testAccErrorCheck(t, lightsail.EndpointsID),
-		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
+		ErrorCheck:   testAccErrorCheck(t, lightsail.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithSpaces),
@@ -165,10 +163,9 @@ func TestAccAWSLightsailInstance_Tags(t *testing.T) {
 			testAccPartitionHasServicePreCheck(lightsail.EndpointsID, t)
 			testAccPreCheckAWSLightsail(t)
 		},
-		ErrorCheck:    testAccErrorCheck(t, lightsail.EndpointsID),
-		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
+		ErrorCheck:   testAccErrorCheck(t, lightsail.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLightsailInstanceConfig_tags1(lightsailName),

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -61,11 +61,10 @@ func TestAccAWSNatGateway_basic(t *testing.T) {
 	resourceName := "aws_nat_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckNatGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNatGatewayConfig,

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -308,11 +308,10 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEgressNIngressConfig,
@@ -351,11 +350,10 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIngressConfig,
@@ -386,11 +384,10 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIngressConfig,
@@ -442,11 +439,10 @@ func TestAccAWSNetworkAcl_CaseSensitivityNoChanges(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclCaseSensitiveConfig,
@@ -468,11 +464,10 @@ func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEgressConfig,
@@ -497,11 +492,10 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclSubnetConfig,
@@ -543,11 +537,10 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIds,
@@ -592,11 +585,10 @@ func TestAccAWSNetworkAcl_SubnetsDelete(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIds,
@@ -629,11 +621,10 @@ func TestAccAWSNetworkAcl_ipv6Rules(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIpv6Config,
@@ -686,11 +677,10 @@ func TestAccAWSNetworkAcl_ipv6VpcRules(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIpv6VpcConfig,
@@ -717,11 +707,10 @@ func TestAccAWSNetworkAcl_espProtocol(t *testing.T) {
 	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEsp,

--- a/aws/resource_aws_network_interface_attachment_test.go
+++ b/aws/resource_aws_network_interface_attachment_test.go
@@ -14,11 +14,10 @@ func TestAccAWSNetworkInterfaceAttachment_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: "aws_network_interface.bar",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkInterfaceAttachmentConfig_basic(rInt),

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -72,11 +72,10 @@ func TestAccAWSENI_basic(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIConfig(),
@@ -107,11 +106,10 @@ func TestAccAWSENI_ipv6(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIIPV6Config(rName),
@@ -155,11 +153,10 @@ func TestAccAWSENI_tags(t *testing.T) {
 	var conf ec2.NetworkInterface
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENITagsConfig1(rName, "key1", "value1"),
@@ -201,11 +198,10 @@ func TestAccAWSENI_ipv6_count(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIIPV6CountConfig(1, rName),
@@ -271,11 +267,10 @@ func TestAccAWSENI_updatedDescription(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIConfig(),
@@ -305,11 +300,10 @@ func TestAccAWSENI_attached(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIConfigWithAttachment(),
@@ -334,11 +328,10 @@ func TestAccAWSENI_ignoreExternalAttachment(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIConfigExternalAttachment(),
@@ -363,11 +356,10 @@ func TestAccAWSENI_sourceDestCheck(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIConfigWithSourceDestCheck(false),
@@ -404,11 +396,10 @@ func TestAccAWSENI_computedIPs(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSENIDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSENIConfigWithNoPrivateIPs(),


### PR DESCRIPTION
ID-only refresh tests are no longer needed now that import testing is available. Remove from the following resources:

* aws_iam_group_policy
* aws_iam_instance_profile
* aws_iam_role_policy
* aws_iam_role
* aws_iam_user_policy
* aws_instance
* aws_internet_gateway
* aws_key_pair
* aws_lb_listener
* aws_lb_target_group
* aws_lb
* aws_lightsail_instance
* aws_nat_gateway
* aws_network_acl
* aws_network_interface_attachment
* aws_network_interface

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18354

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIAMUserPolicy\|TestAccAWSLB\|TestAccAWSENI\|TestAccAWSIAMGroupPolicy\|TestAccAWSInstance\|TestAccAWSLBListener\|TestAccAWSNatGateway\|TestAccAWSIAMRole\|TestAccAWSInternetGateway\|TestAccAWSIAMInstanceProfile\|TestAccAWSNetworkInterfaceAttachment\|TestAccAWSLightsailInstance\|TestAccAWSKeyPair\|TestAccAWSNetworkAcl\|TestAccAWSLBTargetGroup\|TestAccAWSIAMRolePolicy'

--- PASS: TestAccAWSInstanceDataSource_AzUserData (95.50s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (100.62s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (102.39s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (103.23s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (103.81s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (108.42s)
--- PASS: TestAccAWSInstanceDataSource_gp3ThroughputDevice (113.38s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (113.54s)
--- PASS: TestAccAWSInstanceDataSource_basic (125.58s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (127.33s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (135.29s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (141.52s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (142.05s)
--- PASS: TestAccAWSInstanceDataSource_tags (149.56s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (150.18s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (154.76s)
--- PASS: TestAccAWSIAMGroupPolicy_disappears (33.40s)
--- PASS: TestAccAWSIAMGroupPolicyAttachment_basic (51.30s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (71.30s)
--- PASS: TestAccAWSIAMInstanceProfile_withoutRole (38.25s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (46.40s)
--- PASS: TestAccAWSIAMGroupPolicy_basic (68.62s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (42.17s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (198.61s)
--- PASS: TestAccAWSIAMInstanceProfile_disappears (37.82s)
--- PASS: TestAccAWSIAMInstanceProfile_disappears_role (34.49s)
--- PASS: TestAccAWSInstanceDataSource_blockDeviceTags (99.16s)
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (5.67s)
--- PASS: TestAccAWSIAMGroupPolicy_namePrefix (68.68s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (104.97s)
--- PASS: TestAccAWSIAMGroupPolicy_generatedName (65.99s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (207.95s)
--- PASS: TestAccAWSInstancesDataSource_tags (105.11s)
--- PASS: TestAccAWSIAMRole_badJSON (10.31s)
--- PASS: TestAccAWSInstancesDataSource_instanceStateNames (106.58s)
--- PASS: TestAccAWSInstanceDataSource_enclaveOptions (121.10s)
--- PASS: TestAccAWSIAMRolePolicy_Policy_InvalidResource (25.78s)
--- PASS: TestAccAWSInstancesDataSource_basic (124.49s)
--- PASS: TestAccAWSIAMRolePolicy_disappears (42.52s)
--- PASS: TestAccAWSInstanceDataSource_VPC (232.48s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (241.55s)
--- PASS: TestAccAWSIAMRolePolicy_basic (87.52s)
--- PASS: TestAccAWSIAMRole_disappears (53.29s)
--- PASS: TestAccAWSIAMRole_basic (63.12s)
--- PASS: TestAccAWSIAMRole_namePrefix (64.46s)
--- PASS: TestAccAWSIAMInstanceProfile_tags (131.37s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (73.98s)
--- PASS: TestAccAWSIAMRole_policyBasicInlineEmpty (62.80s)
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (108.75s)
--- PASS: TestAccAWSIAMRolePolicy_generatedName (110.86s)
--- PASS: TestAccAWSIAMRole_testNameChange (128.59s)
--- PASS: TestFetchRootDevice (0.00s)
    --- PASS: TestFetchRootDevice/device_name_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/device_name_not_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/no_images (0.00s)
--- PASS: TestAccAWSIAMRole_tags (122.70s)
--- PASS: TestAccAWSIAMUserPolicy_disappears (64.43s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_managedNonEmpty (121.32s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (141.78s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_inlineNonEmpty (119.26s)
--- SKIP: TestAccAWSInstance_inEc2Classic (2.45s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedNonEmpty (122.79s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineNonEmpty (118.04s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (168.22s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_managedNonExistent (115.58s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineEmpty (115.49s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedEmpty (114.36s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (34.90s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidThroughputForVolumeType (31.54s)
--- PASS: TestAccAWSIAMRole_policyBasicInline (174.91s)
--- PASS: TestAccAWSIAMRole_policyBasicManaged (178.02s)
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (116.22s)
--- PASS: TestAccAWSIAMUserPolicy_basic (121.94s)
--- SKIP: TestAccAWSInstance_outpost (1.08s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (26.59s)
--- PASS: TestAccAWSIAMUserPolicy_generatedName (111.50s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_inlineNonExistent (158.47s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (21.45s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (226.01s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (111.21s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (116.75s)
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (151.11s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (92.28s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (120.24s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (83.29s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (118.69s)
--- PASS: TestAccAWSInstance_basic (135.37s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (89.01s)
--- PASS: TestAccAWSInstance_userDataBase64 (131.42s)
--- PASS: TestAccAWSInstance_rootInstanceStore (119.34s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (92.52s)
--- PASS: TestAccAWSInstance_placementGroup (106.42s)
--- PASS: TestAccAWSInstance_dedicatedInstance (118.53s)
--- PASS: TestAccAWSInstance_blockDevices (141.71s)
--- PASS: TestAccAWSInstance_disableApiTermination (123.67s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (94.53s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (90.72s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (103.54s)
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (202.15s)
--- PASS: TestAccAWSInstance_sourceDestCheck (159.34s)
--- PASS: TestAccAWSInstance_keyPairCheck (76.19s)
--- PASS: TestAccAWSInstance_privateIP (89.55s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (92.51s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (100.70s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (94.83s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (98.94s)
--- PASS: TestAccAWSInstance_blockDeviceTags_volumeTags (170.92s)
--- PASS: TestAccAWSInstance_withIamInstanceProfilePath (146.00s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (154.39s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (138.92s)
--- PASS: TestAccAWSInstance_tags (221.80s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (133.73s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (136.95s)
--- PASS: TestAccAWSInstance_blockDeviceTags_withAttachedVolume (216.38s)
--- PASS: TestAccAWSInstance_changeInstanceType (166.37s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (137.51s)
--- PASS: TestAccAWSInstance_blockDeviceTags_ebsAndRoot (224.83s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyThroughput_Gp3 (143.43s)
--- PASS: TestAccAWSInstance_instanceProfileChange (234.98s)
--- FAIL: TestAccAWSInstance_addSecondaryInterface (97.14s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (107.12s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (151.68s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (136.93s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (78.03s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (183.16s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (80.06s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (250.15s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (142.11s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (94.30s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (107.67s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (82.81s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (191.71s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (94.53s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (120.04s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (199.29s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (75.03s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (91.48s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (215.58s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (72.19s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (72.00s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (183.97s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (176.63s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (73.86s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (95.51s)
--- PASS: TestInstanceHostIDSchema (0.00s)
--- PASS: TestInstanceCpuCoreCountSchema (0.00s)
--- PASS: TestInstanceCpuThreadsPerCoreSchema (0.00s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (96.37s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (127.39s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (201.76s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (167.17s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (110.14s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (112.31s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (118.38s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (133.80s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (120.99s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (121.85s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (100.18s)
--- PASS: TestAccAWSInternetGateway_delete (65.35s)
--- PASS: TestAccAWSInternetGateway_basic (76.06s)
--- PASS: TestAccAWSKeyPair_basic (46.05s)
--- PASS: TestAccAWSKeyPair_generatedName (44.56s)
--- PASS: TestAccAWSInternetGateway_disappears (52.30s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (110.90s)
--- PASS: TestAccAWSKeyPair_disappears (36.93s)
--- PASS: TestAccAWSKeyPair_namePrefix (45.87s)
--- PASS: TestAccAWSInstance_GP3RootBlockDevice (99.48s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears_ELB (35.36s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_disappears (37.91s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (58.90s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (176.79s)
--- PASS: TestAccAWSKeyPair_tags (84.96s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (176.34s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (263.14s)
--- PASS: TestAccAWSInternetGateway_tags (100.43s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (23.17s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (1.72s)
--- PASS: TestAccAWSInstance_metadataOptions (189.93s)
--- PASS: TestAccAWSInstance_hibernation (217.75s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (162.35s)
--- PASS: TestAccAWSLBListenerRule_redirect (174.44s)
--- PASS: TestAccAWSLBListenerRule_cognito (178.73s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (172.66s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (200.07s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (179.20s)
--- PASS: TestAccAWSLBListenerRule_oidc (181.71s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (203.36s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (213.08s)
--- PASS: TestAccAWSInstance_disappears (332.81s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (222.84s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (176.45s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (176.44s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (217.05s)
--- PASS: TestAccAWSLBListenerRule_basic (248.70s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (175.98s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (174.25s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (165.71s)
--- PASS: TestAccAWSLBListenerRule_priority (268.79s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (29.51s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (156.71s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_disappears (28.66s)
--- PASS: TestAccAWSLBListener_LoadBalancerArn_GatewayLoadBalancer (107.16s)
--- PASS: TestAccAWSInstance_enclaveOptions (433.39s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (180.41s)
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (148.26s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (55.22s)
--- PASS: TestLBTargetGroupCloudwatchSuffixFromARN (0.00s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (164.06s)
--- PASS: TestAccAWSLBListener_basic (167.61s)
--- PASS: TestAccAWSLBListener_https (174.62s)
--- PASS: TestAccAWSLBListener_redirect (172.85s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (73.20s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (77.98s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (81.07s)
--- PASS: TestAccAWSLBListener_oidc (168.80s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (49.45s)
--- PASS: TestAccAWSLBTargetGroup_basic (49.94s)
--- PASS: TestAccAWSLBListener_fixedResponse (194.18s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion (50.66s)
--- PASS: TestAccAWSLBListener_cognito (193.84s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (86.47s)
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (47.13s)
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (72.83s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (187.44s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (173.47s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (230.37s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (54.34s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (67.32s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck (55.75s)
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (59.05s)
--- PASS: TestAccAWSLBTargetGroup_namePrefix (56.85s)
--- PASS: TestAccAWSLBTargetGroup_generatedName (56.69s)
--- PASS: TestAccAWSLBListener_forwardWeighted (267.96s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (102.85s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update (107.55s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (103.89s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (104.01s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (59.82s)
--- PASS: TestLBCloudwatchSuffixFromARN (0.00s)
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (106.83s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (106.55s)
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (106.66s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (107.17s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (59.40s)
--- SKIP: TestAccAWSLB_ALB_outpost (1.10s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (103.11s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (157.54s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (107.85s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (85.18s)
--- PASS: TestAccAWSLBListener_basicUdp (362.21s)
--- PASS: TestAccAWSLBTargetGroup_tags (141.08s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (61.43s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (87.08s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (127.60s)
--- PASS: TestAccAWSLBTargetGroup_preserveClientIPValid (73.06s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (75.23s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (118.33s)
--- PASS: TestAccAWSLBListener_Protocol_Tls (378.37s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (139.08s)
--- PASS: TestAccAWSLB_ALB_basic (178.93s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (164.80s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (179.09s)
--- FAIL: TestAccAWSLB_IPv6SubnetMapping (205.24s)
--- PASS: TestAccAWSLB_generatedName (184.63s)
--- PASS: TestAccAWSLB_namePrefix (175.90s)
--- PASS: TestAccAWSLB_NLB_basic (222.77s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (219.92s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway (233.54s)
--- PASS: TestAccAWSLB_noSecurityGroup (172.82s)
--- PASS: TestAccAWSLB_updatedSubnets (205.82s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (258.76s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (216.96s)
--- PASS: TestAccAWSLB_LoadBalancerType_Gateway_EnableCrossZoneLoadBalancing (272.09s)
--- PASS: TestAccAWSLightsailInstancePublicPorts_multiple (61.27s)
--- PASS: TestAccAWSLB_updatedIpAddressType (224.50s)
--- PASS: TestAccAWSLightsailInstancePublicPorts_cidrs (59.25s)
--- PASS: TestAccAWSLightsailInstance_basic (56.25s)
--- PASS: TestAccAWSLightsailInstancePublicPorts_basic (71.30s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (240.41s)
--- PASS: TestAccAWSNetworkAclRule_missingParam (16.55s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (253.13s)
--- PASS: TestAccAWSNetworkAclRule_disappears (28.31s)
--- PASS: TestAccAWSNetworkAclRule_disappears_IngressEgressSameNumber (29.56s)
--- PASS: TestAccAWSNetworkAclRule_basic (36.83s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (262.29s)
--- PASS: TestAccAWSNetworkAclRule_disappears_NetworkAcl (33.48s)
--- PASS: TestAccAWSLB_tags (279.15s)
--- PASS: TestAccAWSNetworkAclRule_ipv6 (43.92s)
--- PASS: TestAccAWSLightsailInstance_disapear (71.49s)
--- PASS: TestAccAWSNetworkAclRule_ipv6ICMP (45.43s)
--- PASS: TestAccAWSLightsailInstance_Tags (103.45s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (328.88s)
--- PASS: TestAccAWSNetworkAcl_disappears (51.23s)
--- PASS: TestAccAWSNetworkAcl_basic (54.77s)
--- PASS: TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate (75.85s)
--- PASS: TestAccAWSNetworkAclRule_allProtocol (73.72s)
--- PASS: TestAccAWSNetworkAclRule_tcpProtocol (77.20s)
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (56.03s)
--- PASS: TestAccAWSLightsailInstance_Name (144.33s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (69.60s)
--- PASS: TestAccAWSNetworkAcl_tags (124.42s)
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (77.01s)
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (76.63s)
--- PASS: TestAccAWSNetworkAcl_ipv6ICMPRules (60.51s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (254.60s)
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (142.86s)
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (68.64s)
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (77.17s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (145.62s)
--- PASS: TestAccAWSNetworkAcl_espProtocol (60.53s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (116.75s)
--- PASS: TestAccAWSNetworkAcl_SubnetChange (118.36s)
--- PASS: TestAccAWSNetworkAcl_Subnets (109.41s)
--- PASS: TestAccAWSNetworkAcl_SubnetsDelete (104.96s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (327.58s)
--- PASS: TestAccAWSENI_basic (73.23s)
--- PASS: TestAccAWSNatGateway_basic (250.52s)
--- PASS: TestAccAWSENI_disappears (78.82s)
--- PASS: TestAccAWSNetworkInterfaceAttachment_basic (116.31s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (395.98s)
--- PASS: TestAccAWSENI_computedIPs (79.48s)
--- PASS: TestAccAWSENI_ipv6 (119.64s)
--- PASS: TestAccAWSENI_tags (118.49s)
--- PASS: TestAccAWSENI_updatedDescription (104.64s)
--- PASS: TestAccAWSNatGateway_tags (306.18s)
--- PASS: TestAccAWSENI_sourceDestCheck (111.41s)
--- PASS: TestAccAWSENI_ipv6_count (134.03s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (392.66s)
--- PASS: TestAccAWSENI_PrivateIpsCount (116.39s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (128.86s)
--- PASS: TestAccAWSENI_attached (139.93s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (431.66s)
```

The two test failures are intermittent and unrelated to this change