### PR TITLE
Removes `IDRefreshName` from acceptance tests for resources P-V

### DIFF
--- a/aws/resource_aws_pinpoint_adm_channel_test.go
+++ b/aws/resource_aws_pinpoint_adm_channel_test.go
@@ -47,11 +47,10 @@ func TestAccAWSPinpointADMChannel_basic(t *testing.T) {
 	config := testAccAwsPinpointADMChannelConfigurationFromEnv(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointADMChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointADMChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointADMChannelConfig_basic(config),

--- a/aws/resource_aws_pinpoint_apns_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_channel_test.go
@@ -94,11 +94,10 @@ func TestAccAWSPinpointAPNSChannel_basicCertificate(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSChannelConfig_basicCertificate(configuration),
@@ -129,11 +128,10 @@ func TestAccAWSPinpointAPNSChannel_basicToken(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSChannelConfig_basicToken(configuration),

--- a/aws/resource_aws_pinpoint_apns_sandbox_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_sandbox_channel_test.go
@@ -94,11 +94,10 @@ func TestAccAWSPinpointAPNSSandboxChannel_basicCertificate(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSSandboxChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSSandboxChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSSandboxChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSSandboxChannelConfig_basicCertificate(configuration),
@@ -129,11 +128,10 @@ func TestAccAWSPinpointAPNSSandboxChannel_basicToken(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSSandboxChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSSandboxChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSSandboxChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSSandboxChannelConfig_basicToken(configuration),

--- a/aws/resource_aws_pinpoint_apns_voip_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_voip_channel_test.go
@@ -94,11 +94,10 @@ func TestAccAWSPinpointAPNSVoipChannel_basicCertificate(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSVoipChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSVoipChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSVoipChannelConfig_basicCertificate(configuration),
@@ -129,11 +128,10 @@ func TestAccAWSPinpointAPNSVoipChannel_basicToken(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSVoipChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSVoipChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSVoipChannelConfig_basicToken(configuration),

--- a/aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go
@@ -94,11 +94,10 @@ func TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSVoipSandboxChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicCertificate(configuration),
@@ -129,11 +128,10 @@ func TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken(t *testing.T) {
 	configuration := testAccAwsPinpointAPNSVoipSandboxChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicToken(configuration),

--- a/aws/resource_aws_pinpoint_app_test.go
+++ b/aws/resource_aws_pinpoint_app_test.go
@@ -69,11 +69,10 @@ func TestAccAWSPinpointApp_basic(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAppDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAppConfig_withGeneratedName,
@@ -96,11 +95,10 @@ func TestAccAWSPinpointApp_CampaignHookLambda(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAppDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAppConfig_CampaignHookLambda(rName),
@@ -125,11 +123,10 @@ func TestAccAWSPinpointApp_Limits(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAppDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAppConfig_Limits(rName),
@@ -154,11 +151,10 @@ func TestAccAWSPinpointApp_QuietTime(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointAppDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointAppConfig_QuietTime(rName),

--- a/aws/resource_aws_pinpoint_baidu_channel_test.go
+++ b/aws/resource_aws_pinpoint_baidu_channel_test.go
@@ -19,11 +19,10 @@ func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
 	secretKey := "456"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointBaiduChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointBaiduChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointBaiduChannelConfig_basic(apiKey, secretKey),

--- a/aws/resource_aws_pinpoint_email_channel_test.go
+++ b/aws/resource_aws_pinpoint_email_channel_test.go
@@ -16,11 +16,10 @@ func TestAccAWSPinpointEmailChannel_basic(t *testing.T) {
 	resourceName := "aws_pinpoint_email_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointEmailChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointEmailChannelConfig_FromAddress("user@example.com"),
@@ -55,11 +54,10 @@ func TestAccAWSPinpointEmailChannel_configurationSet(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointEmailChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointEmailChannelConfigConfigurationSet("user@example.com", rName),
@@ -81,11 +79,10 @@ func TestAccAWSPinpointEmailChannel_disappears(t *testing.T) {
 	resourceName := "aws_pinpoint_email_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointEmailChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointEmailChannelConfig_FromAddress("user@example.com"),

--- a/aws/resource_aws_pinpoint_event_stream_test.go
+++ b/aws/resource_aws_pinpoint_event_stream_test.go
@@ -18,11 +18,10 @@ func TestAccAWSPinpointEventStream_basic(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointEventStreamDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointEventStreamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointEventStreamConfig_basic(rName, rName),
@@ -57,11 +56,10 @@ func TestAccAWSPinpointEventStream_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointEventStreamDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointEventStreamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointEventStreamConfig_basic(rName, rName),

--- a/aws/resource_aws_pinpoint_gcm_channel_test.go
+++ b/aws/resource_aws_pinpoint_gcm_channel_test.go
@@ -28,11 +28,10 @@ func TestAccAWSPinpointGCMChannel_basic(t *testing.T) {
 	apiKey := os.Getenv("GCM_API_KEY")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointGCMChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointGCMChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointGCMChannelConfig_basic(apiKey),

--- a/aws/resource_aws_pinpoint_sms_channel_test.go
+++ b/aws/resource_aws_pinpoint_sms_channel_test.go
@@ -15,11 +15,10 @@ func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
 	resourceName := "aws_pinpoint_sms_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointSMSChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointSMSChannelConfig_basic,
@@ -61,11 +60,10 @@ func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 	newShortCode := "7890"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointSMSChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointSMSChannelConfig_full(senderId, shortCode),
@@ -112,11 +110,10 @@ func TestAccAWSPinpointSMSChannel_disappears(t *testing.T) {
 	resourceName := "aws_pinpoint_sms_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
-		ErrorCheck:    testAccErrorCheck(t, pinpoint.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
+		ErrorCheck:   testAccErrorCheck(t, pinpoint.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPinpointSMSChannelDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSPinpointSMSChannelConfig_basic,

--- a/aws/resource_aws_route53_delegation_set_test.go
+++ b/aws/resource_aws_route53_delegation_set_test.go
@@ -18,12 +18,10 @@ func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
 	resourceName := "aws_route53_delegation_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"reference_name"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckRoute53DelegationSetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53DelegationSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53DelegationSetConfig(refName),
@@ -51,12 +49,10 @@ func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 	zoneName2 := fmt.Sprintf("%s-secondary.terraformtest.com", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"reference_name"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckRoute53DelegationSetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53DelegationSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53DelegationSetWithZonesConfig(refName, zoneName1, zoneName2),

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -16,11 +16,10 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53HealthCheckConfig,
@@ -53,11 +52,10 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53HealthCheckConfigTags1("key1", "value1"),
@@ -97,11 +95,10 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53HealthCheckConfigWithSearchString,
@@ -260,11 +257,10 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53HealthCheckConfigWithoutSNI,

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -113,11 +113,10 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfig,
@@ -217,11 +216,10 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfig_fqdn,
@@ -259,11 +257,10 @@ func TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfig_nameWithTrailingPeriod,
@@ -286,12 +283,10 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		ErrorCheck:      testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"zone_id"}, // just for this test
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigTXT,
@@ -314,11 +309,10 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigSPF,
@@ -342,11 +336,10 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigCAA,
@@ -370,11 +363,10 @@ func TestAccAWSRoute53Record_dsSupport(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigDS,
@@ -396,11 +388,10 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigSuffix,
@@ -423,11 +414,10 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 	resourceName := "aws_route53_record.wildcard"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53WildCardRecordConfig,
@@ -458,11 +448,10 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 	resourceName := "aws_route53_record.www-primary"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53FailoverCNAMERecord,
@@ -486,11 +475,10 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 	resourceName := "aws_route53_record.www-live"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: "aws_route53_record.www-live",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53WeightedCNAMERecord,
@@ -549,11 +537,10 @@ func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -636,11 +623,10 @@ func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -663,11 +649,10 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 	resourceName := "aws_route53_record.elb_weighted_alias_live"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53WeightedElbAliasRecord,
@@ -730,11 +715,10 @@ func TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange(t *testing.T) {
 	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigHealthCheckIdSetIdentifier("test1"),
@@ -763,11 +747,10 @@ func TestAccAWSRoute53Record_HealthCheckId_TypeChange(t *testing.T) {
 	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigHealthCheckIdTypeCname(),
@@ -824,11 +807,10 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 	resourceName := "aws_route53_record.sample"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordTypeChangePre,
@@ -859,11 +841,10 @@ func TestAccAWSRoute53Record_NameChange(t *testing.T) {
 	resourceName := "aws_route53_record.sample"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordNameChangePre,
@@ -895,11 +876,10 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 	resourceName := "aws_route53_record.basic_to_weighted"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordSetIdentifierChangePre,
@@ -930,11 +910,10 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 	resourceName := "aws_route53_record.elb_alias_change"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordAliasChangePre,
@@ -965,11 +944,10 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 	resourceName := "aws_route53_record.empty"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigEmptyName,
@@ -987,11 +965,10 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 	resourceName := "aws_route53_record.long_txt"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, route53.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigLongTxtRecord,

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -230,11 +230,10 @@ func TestAccAWSRouteTable_IPv4_To_InternetGateway(t *testing.T) {
 	destinationCidr3 := "10.4.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigIpv4InternetGateway(rName, destinationCidr1, destinationCidr2),
@@ -283,11 +282,10 @@ func TestAccAWSRouteTable_IPv4_To_Instance(t *testing.T) {
 	destinationCidr := "10.2.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigIpv4Instance(rName, destinationCidr),
@@ -320,11 +318,10 @@ func TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 	destinationCidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigIpv6EgressOnlyInternetGateway(rName, destinationCidr),
@@ -360,11 +357,10 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigTags1(rName, "key1", "value1"),
@@ -401,15 +397,13 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 }
 
 func TestAccAWSRouteTable_RequireRouteDestination(t *testing.T) {
-	resourceName := "aws_route_table.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRouteTableConfigNoDestination(rName),
@@ -420,15 +414,13 @@ func TestAccAWSRouteTable_RequireRouteDestination(t *testing.T) {
 }
 
 func TestAccAWSRouteTable_RequireRouteTarget(t *testing.T) {
-	resourceName := "aws_route_table.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRouteTableConfigNoTarget(rName),
@@ -789,11 +781,10 @@ func TestAccAWSRouteTable_IPv4_To_NatGateway(t *testing.T) {
 	destinationCidr := "10.2.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigIpv4NatGateway(rName, destinationCidr),
@@ -826,11 +817,10 @@ func TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached(t *testing.T) {
 	destinationCidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigIpv6NetworkInterfaceUnattached(rName, destinationCidr),
@@ -974,11 +964,10 @@ func TestAccAWSRouteTable_MultipleRoutes(t *testing.T) {
 	destinationCidr4 := "2001:db8::/122"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigMultipleRoutes(rName,
@@ -1054,11 +1043,10 @@ func TestAccAWSRouteTable_PrefixList_To_InternetGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRouteTableDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckEc2ManagedPrefixList(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRouteTableConfigPrefixListInternetGateway(rName),

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -684,11 +684,10 @@ func TestAccAWSSecurityGroup_basic(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfig,
@@ -1057,11 +1056,10 @@ func TestAccAWSSecurityGroup_ipv6(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigIpv6,
@@ -1238,11 +1236,10 @@ func TestAccAWSSecurityGroup_self(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigSelf,
@@ -1274,11 +1271,10 @@ func TestAccAWSSecurityGroup_vpc(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigVpc,
@@ -1319,11 +1315,10 @@ func TestAccAWSSecurityGroup_vpcNegOneIngress(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigVpcNegOneIngress,
@@ -1357,11 +1352,10 @@ func TestAccAWSSecurityGroup_vpcProtoNumIngress(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigVpcProtoNumIngress,
@@ -1394,11 +1388,10 @@ func TestAccAWSSecurityGroup_multiIngress(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigMultiIngress,
@@ -1421,11 +1414,10 @@ func TestAccAWSSecurityGroup_change(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfig,
@@ -1455,11 +1447,10 @@ func TestAccAWSSecurityGroup_ruleDescription(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigRuleDescription("Egress description", "Ingress description"),
@@ -1568,11 +1559,10 @@ func TestAccAWSSecurityGroup_defaultEgressVPC(t *testing.T) {
 
 	// VPC
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfigDefaultEgress,

--- a/aws/resource_aws_sns_topic_test.go
+++ b/aws/resource_aws_sns_topic_test.go
@@ -102,11 +102,10 @@ func TestAccAWSSNSTopic_basic(t *testing.T) {
 	resourceName := "aws_sns_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigNameGenerated,
@@ -132,11 +131,10 @@ func TestAccAWSSNSTopic_Name(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigName(rName),
@@ -161,11 +159,10 @@ func TestAccAWSSNSTopic_NamePrefix(t *testing.T) {
 	rName := "tf-acc-test-prefix-"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigNamePrefix(rName),
@@ -192,11 +189,10 @@ func TestAccAWSSNSTopic_policy(t *testing.T) {
 	expectedPolicy := fmt.Sprintf(`{"Statement":[{"Sid":"Stmt1445931846145","Effect":"Allow","Principal":{"AWS":"*"},"Action":"sns:Publish","Resource":"arn:%s:sns:%s::example"}],"Version":"2012-10-17","Id":"Policy1445931846145"}`, testAccGetPartition(), testAccGetRegion())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicWithPolicy(rName),
@@ -220,11 +216,10 @@ func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfig_withIAMRole(rName),
@@ -239,11 +234,10 @@ func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
 func TestAccAWSSNSTopic_withFakeIAMRole(t *testing.T) {
 	rName := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: "aws_sns_topic.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSNSTopicConfig_withFakeIAMRole(rName),
@@ -260,11 +254,10 @@ func TestAccAWSSNSTopic_withDeliveryPolicy(t *testing.T) {
 	expectedPolicy := `{"http":{"defaultHealthyRetryPolicy": {"minDelayTarget": 20,"maxDelayTarget": 20,"numMaxDelayRetries": 0,"numRetries": 3,"numNoDelayRetries": 0,"numMinDelayRetries": 0,"backoffFunction": "linear"},"disableSubscriptionOverrides": false}}`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfig_withDeliveryPolicy(rName),
@@ -290,11 +283,10 @@ func TestAccAWSSNSTopic_deliveryStatus(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfig_deliveryStatus(rName),
@@ -323,11 +315,10 @@ func TestAccAWSSNSTopic_Name_Generated_FIFOTopic(t *testing.T) {
 	resourceName := "aws_sns_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigNameGeneratedFIFOTopic,
@@ -353,11 +344,10 @@ func TestAccAWSSNSTopic_Name_FIFOTopic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test") + tfsns.FifoTopicNameSuffix
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigNameFIFOTopic(rName),
@@ -382,11 +372,10 @@ func TestAccAWSSNSTopic_NamePrefix_FIFOTopic(t *testing.T) {
 	rName := "tf-acc-test-prefix-"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigNamePrefixFIFOTopic(rName),
@@ -412,11 +401,10 @@ func TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigWithFIFOContentBasedDeduplication(rName, true),
@@ -446,11 +434,10 @@ func TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication(t *testing.T) {
 func TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError(t *testing.T) {
 	rName := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: "aws_sns_topic.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSNSTopicExpectContentBasedDeduplicationError(rName),
@@ -466,11 +453,10 @@ func TestAccAWSSNSTopic_encryption(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfig_withEncryption(rName),
@@ -501,11 +487,10 @@ func TestAccAWSSNSTopic_tags(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, sns.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sns.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSNSTopicConfigTags1(rName, "key1", "value1"),

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -115,11 +115,10 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 	resourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSubnetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetConfig,
@@ -153,11 +152,10 @@ func TestAccAWSSubnet_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSubnetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetTagsConfig1(rName, "key1", "value1"),
@@ -598,11 +596,10 @@ func TestAccAWSSubnet_ipv6(t *testing.T) {
 	resourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSubnetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetConfigIpv6,
@@ -639,11 +636,10 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 	resourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSubnetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetConfigPreIpv6,
@@ -683,11 +679,10 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 	resourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSubnetDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetConfigAvailabilityZoneId(),
@@ -827,11 +822,10 @@ func TestAccAWSSubnet_outpost(t *testing.T) {
 	resourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckSubnetDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetConfigOutpost(),

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -70,11 +70,10 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_basic,
@@ -117,11 +116,10 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 	resourceName := "aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_Vpc,
@@ -161,11 +159,10 @@ func TestAccAWSTransferServer_apigateway(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_apigateway(rName),
@@ -215,11 +212,10 @@ func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_forcedestroy(rName),
@@ -249,11 +245,10 @@ func TestAccAWSTransferServer_vpcEndpointId(t *testing.T) {
 	resourceName := "aws_transfer_server.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_VpcEndPoint,
@@ -279,11 +274,10 @@ func TestAccAWSTransferServer_hostKey(t *testing.T) {
 	hostKey := "test-fixtures/transfer-ssh-rsa-key"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_hostKey(hostKey),

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -18,11 +18,10 @@ func TestAccAWSTransferUser_basic(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferUserConfig_basic(rName),
@@ -51,11 +50,10 @@ func TestAccAWSTransferUser_modifyWithOptions(t *testing.T) {
 	rName2 := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferUserConfig_options(rName),
@@ -172,11 +170,10 @@ func TestAccAWSTransferUser_homeDirectoryMappings(t *testing.T) {
 	resourceName := "aws_transfer_user.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		ErrorCheck:    testAccErrorCheck(t, transfer.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferUserConfig_homeDirectoryMappings(rName),

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -17,11 +17,10 @@ func TestAccAWSVpcEndpointConnectionNotification_basic(t *testing.T) {
 	resourceName := "aws_vpc_endpoint_connection_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckVpcEndpointConnectionNotificationDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointConnectionNotificationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcEndpointConnectionNotificationBasicConfig(lbName),

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -479,11 +479,10 @@ func TestAccAWSVpcEndpoint_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckVpcEndpointDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcEndpointConfigTags1(rName, "key1", "value1"),

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -99,11 +99,10 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 	var vpn ec2.VpnConnection
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsVpnConnectionConfig(rBgpAsn),
@@ -293,11 +292,10 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
 			// Checking CIDR blocks
 			{
@@ -406,11 +404,10 @@ func TestAccAWSVpnConnection_withoutStaticRoutes(t *testing.T) {
 	var vpn ec2.VpnConnection
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsVpnConnectionConfigUpdate(rInt, rBgpAsn),
@@ -435,11 +432,10 @@ func TestAccAWSVpnConnection_withEnableAcceleration(t *testing.T) {
 	var vpn ec2.VpnConnection
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsVpnConnectionConfigEnableAcceleration(rBgpAsn),
@@ -463,11 +459,10 @@ func TestAccAWSVpnConnection_withIpv6(t *testing.T) {
 	var vpn ec2.VpnConnection
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsVpnConnectionConfigIpv6(rBgpAsn, "fd00:2001:db8:2:2d1:81ff:fe41:d201/128", "fd00:2001:db8:2:2d1:81ff:fe41:d202/128", "fd00:2001:db8:2:2d1:81ff:fe41:d200/126", "fd00:2001:db8:2:2d1:81ff:fe41:d204/126"),
@@ -490,11 +485,10 @@ func TestAccAWSVpnConnection_tags(t *testing.T) {
 	var vpn ec2.VpnConnection
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccAwsVpnConnectionDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsVpnConnectionConfigTags1(rBgpAsn, "key1", "value1"),

--- a/aws/resource_aws_vpn_gateway_route_propagation_test.go
+++ b/aws/resource_aws_vpn_gateway_route_propagation_test.go
@@ -15,10 +15,9 @@ func TestAccAWSVPNGatewayRoutePropagation_basic(t *testing.T) {
 	var rtID, gwID string
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: "aws_vpn_gateway_route_propagation.foo",
-		Providers:     testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSVPNGatewayRoutePropagation_basic,

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -108,11 +108,10 @@ func TestAccAWSVpnGateway_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckVpnGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpnGatewayConfig,
@@ -256,11 +255,10 @@ func TestAccAWSVpnGateway_reattach(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckVpnGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckVpnGatewayConfigReattach,
@@ -321,11 +319,10 @@ func TestAccAWSVpnGateway_delete(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckVpnGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpnGatewayConfig,
@@ -350,11 +347,10 @@ func TestAccAWSVpnGateway_tags(t *testing.T) {
 	resourceName := "aws_vpn_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		ErrorCheck:    testAccErrorCheck(t, ec2.EndpointsID),
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckVpnGatewayDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckVpnGatewayConfigTags1("key1", "value1"),


### PR DESCRIPTION
ID-only refresh tests are no longer needed now that import testing is available. Remove from the following resources:

* aws_pinpoint_adm_channel
* aws_pinpoint_apns_channel
* aws_pinpoint_apns_sandbox_channel
* aws_pinpoint_apns_voip_channel
* aws_pinpoint_apns_voip_sandbox_channel
* aws_pinpoint_app
* aws_pinpoint_baidu_channel
* aws_pinpoint_email_channel
* aws_pinpoint_event_stream
* aws_pinpoint_gcm_channel
* aws_pinpoint_sms_channel
* aws_route53_delegation_set
* aws_route53_health_check
* aws_route53_record
* aws_route_table
* aws_security_group
* aws_sns_topic
* aws_subnet
* aws_transfer_server
* aws_transfer_user
* aws_vpc_endpoint_connection_notification
* aws_vpc_endpoint
* aws_vpn_connection
* aws_vpn_gateway_route_propagation
* aws_vpn_gateway

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18354

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSTransferServer\|TestAccAWSPinpointAPNSChannel\|TestAccAWSPinpointBaiduChannel\|TestAccAWSVpnGateway\|TestAccAWSPinpointEventStream\|TestAccAWSSNSTopic\|TestAccAWSPinpointApp\|TestAccAWSPinpointEmailChannel\|TestAccAWSPinpointSMSChannel\|TestAccAWSRoute53HealthCheck\|TestAccAWSPinpointAPNSVoipChannel\|TestAccAWSSubnet\|TestAccAWSPinpointAPNSVoipSandboxChannel\|TestAccAWSVPNGatewayRoutePropagation\|TestAccAWSVpnConnection\|TestAccAWSRoute53DelegationSet\|TestAccAWSPinpointADMChannel\|TestAccAWSRoute53Record\|TestAccAWSPinpointAPNSSandboxChannel\|TestAccAWSSecurityGroup\|TestAccAWSPinpointGCMChannel\|TestAccAWSVpcEndpointConnectionNotification\|TestAccAWSTransferUser\|TestAccAWSVpcEndpoint\|TestAccAWSRouteTable'

--- SKIP: TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken (0.00s)
--- SKIP: TestAccAWSPinpointAPNSSandboxChannel_basicToken (0.00s)
--- SKIP: TestAccAWSPinpointAPNSVoipChannel_basicToken (0.00s)
--- SKIP: TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate (0.00s)
--- SKIP: TestAccAWSPinpointAPNSChannel_basicCertificate (0.00s)
--- SKIP: TestAccAWSPinpointADMChannel_basic (0.00s)
--- SKIP: TestAccAWSPinpointAPNSVoipChannel_basicCertificate (0.00s)
--- SKIP: TestAccAWSPinpointAPNSChannel_basicToken (0.00s)
--- SKIP: TestAccAWSPinpointAPNSSandboxChannel_basicCertificate (0.00s)
--- SKIP: TestAccAWSPinpointGCMChannel_basic (0.00s)
--- PASS: TestAccAWSPinpointSMSChannel_disappears (52.90s)
--- PASS: TestAccAWSPinpointEmailChannel_disappears (59.25s)
--- PASS: TestAccAWSPinpointApp_Limits (60.24s)
--- PASS: TestAccAWSPinpointApp_basic (64.79s)
--- PASS: TestAccAWSPinpointApp_QuietTime (65.20s)
--- PASS: TestAccAWSRoute53DelegationSet_basic (64.84s)
--- PASS: TestAccAWSPinpointEmailChannel_configurationSet (70.87s)
--- PASS: TestAccAWSPinpointApp_CampaignHookLambda (94.90s)
--- PASS: TestAccAWSRoute53DelegationSetDataSource_basic (97.90s)
--- PASS: TestCleanRecordName (0.00s)
--- PASS: TestExpandRecordName (0.00s)
--- PASS: TestNormalizeAwsAliasName (0.00s)
--- PASS: TestParseRecordId (0.00s)
--- PASS: TestAccAWSPinpointSMSChannel_basic (109.77s)
--- PASS: TestAccAWSPinpointBaiduChannel_basic (111.21s)
--- PASS: TestAccAWSRoute53DelegationSet_withZones (111.91s)
--- PASS: TestAccAWSPinpointEventStream_disappears (115.99s)
--- PASS: TestAccAWSPinpointSMSChannel_full (118.01s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (120.22s)
--- PASS: TestAccAWSPinpointEmailChannel_basic (121.44s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (120.92s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (76.85s)
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (77.01s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (76.27s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (75.89s)
--- PASS: TestAccAWSRoute53HealthCheck_disappears (50.06s)
--- PASS: TestAccAWSPinpointApp_Tags (148.67s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (154.40s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (89.38s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (104.28s)
--- PASS: TestAccAWSRoute53HealthCheck_Disabled (100.09s)
--- PASS: TestAccAWSPinpointEventStream_basic (194.74s)
--- PASS: TestAccAWSRoute53Record_disappears (134.45s)
--- PASS: TestAccAWSRoute53Record_basic_trailingPeriodAndZoneID (135.59s)
--- PASS: TestAccAWSRoute53Record_underscored (147.22s)
--- PASS: TestAccAWSRoute53Record_spfSupport (136.39s)
--- PASS: TestAccAWSRoute53Record_caaSupport (136.84s)
--- PASS: TestAccAWSRoute53Record_txtSupport (138.24s)
--- PASS: TestAccAWSRoute53Record_basic (163.41s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (134.86s)
--- PASS: TestAccAWSRoute53Record_failover (134.17s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (173.60s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (170.11s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (132.23s)
--- PASS: TestAccAWSRoute53Record_dsSupport (159.10s)
--- PASS: TestAccAWSRoute53Record_Alias_Elb (141.48s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (151.89s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (126.77s)
--- PASS: TestAccAWSRoute53Record_wildcard (179.23s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_basic (27.44s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (181.82s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable (38.45s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeSubnet (38.23s)
--- PASS: TestAccAWSRouteTable_basic (29.00s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (122.57s)
--- PASS: TestAccAWSRouteTableAssociation_disappears (37.75s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_basic (70.12s)
--- PASS: TestAccAWSRouteTable_disappears (21.69s)
--- PASS: TestAccAWSRoute53Record_latency_basic (134.38s)
--- PASS: TestAccAWSRoute53Record_doNotAllowOverwrite (109.92s)
--- PASS: TestAccAWSRoute53Record_empty (120.95s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable (79.63s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (125.41s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (125.66s)
--- PASS: TestAccAWSRouteTable_RequireRouteTarget (19.49s)
--- SKIP: TestAccAWSRouteTable_IPv4_To_CarrierGateway (0.96s)
--- SKIP: TestAccAWSRouteTable_IPv4_To_LocalGateway (1.42s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_SetIdentifierChange (170.19s)
--- PASS: TestAccAWSRouteTable_IPv6_To_EgressOnlyInternetGateway (45.46s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeGateway (103.88s)
--- PASS: TestAccAWSRouteTable_IPv4_To_InternetGateway (60.27s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (243.87s)
--- PASS: TestAccAWSRoute53Record_TypeChange (181.61s)
--- PASS: TestAccAWSRoute53Record_HealthCheckId_TypeChange (186.63s)
--- PASS: TestAccAWSRouteTable_IPv4_To_VpcPeeringConnection (30.38s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (163.53s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (190.11s)
--- PASS: TestAccAWSRoute53Record_AliasChange (186.45s)
--- PASS: TestAccAWSRouteTable_tags (76.21s)
--- PASS: TestAccAWSRouteTable_VpcClassicLink (34.35s)
--- PASS: TestAccAWSRoute53Record_NameChange (221.83s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (36.11s)
--- PASS: TestAccAWSRouteTable_GatewayVpcEndpoint (47.81s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id (35.60s)
--- PASS: TestAccAWSRouteTable_VpcMultipleCidrs (59.80s)
--- PASS: TestAccAWSRouteTable_ConditionalCidrBlock (65.83s)
--- PASS: TestAccAWSRouteTable_PrefixList_To_InternetGateway (48.99s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (99.76s)
--- PASS: TestAccAWSRouteTable_IPv6_To_NetworkInterface_Unattached (69.22s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (5.85s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (10.48s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (41.16s)
--- PASS: TestAccAWSRouteTable_IPv4_To_Instance (129.30s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (42.83s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (98.19s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (45.53s)
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (46.29s)
--- PASS: TestAccAWSSecurityGroupRule_Egress (45.84s)
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (49.00s)
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (51.97s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (57.58s)
--- PASS: TestProtocolStateFunc (0.00s)
--- PASS: TestProtocolForValue (0.00s)
--- PASS: TestResourceAwsSecurityGroupExpandCollapseRules (0.00s)
--- PASS: TestResourceAwsSecurityGroupIPPermGather (0.01s)
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (53.55s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (51.02s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (53.26s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (69.77s)
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (65.69s)
--- PASS: TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash (47.33s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (92.69s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (93.10s)
--- PASS: TestAccAWSSecurityGroup_allowAll (62.59s)
--- PASS: TestAccAWSSecurityGroup_sourceSecurityGroup (62.57s)
--- PASS: TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules (62.02s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts (93.52s)
--- PASS: TestAccAWSSecurityGroup_IPRangesWithSameRules (60.47s)
--- PASS: TestAccAWSSecurityGroup_basic (58.93s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts (95.59s)
--- PASS: TestAccAWSSecurityGroupRule_Race (149.85s)
--- PASS: TestAccAWSRouteTable_IPv4_To_NatGateway (234.79s)
--- PASS: TestAccAWSSecurityGroup_Name_Generated (48.47s)
--- PASS: TestAccAWSSecurityGroup_ipv6 (51.13s)
--- PASS: TestAccAWSSecurityGroup_ruleGathering (63.06s)
--- PASS: TestAccAWSSecurityGroup_Name_TerraformPrefix (48.55s)
--- PASS: TestAccAWSSecurityGroup_NamePrefix (48.29s)
--- PASS: TestAccAWSSecurityGroup_NamePrefix_TerraformPrefix (48.98s)
--- PASS: TestAccAWSSecurityGroup_self (50.75s)
--- SKIP: TestAccAWSSecurityGroup_defaultEgressClassic (2.05s)
--- PASS: TestAccAWSRouteTable_MultipleRoutes (237.34s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (522.85s)
--- PASS: TestAccAWSRouteTable_IPv4_To_VpcEndpoint (283.91s)
--- PASS: TestAccAWSSecurityGroup_egressConfigMode (124.05s)
--- PASS: TestAccAWSRouteTable_RequireRouteDestination (305.35s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (145.86s)
--- SKIP: TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic (2.13s)
--- PASS: TestAccAWSSecurityGroup_vpc (51.50s)
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (20.80s)
--- PASS: TestAccAWSSecurityGroup_ingressConfigMode (126.89s)
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (55.39s)
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (56.97s)
--- PASS: TestAccAWSSecurityGroup_defaultEgressVPC (55.80s)
--- PASS: TestAccAWSSecurityGroup_multiIngress (58.86s)
--- PASS: TestAccAWSSecurityGroup_drift (55.07s)
--- PASS: TestAccAWSSecurityGroup_driftComplex (57.91s)
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (62.48s)
--- PASS: TestAccAWSRouteTable_disappears_SubnetAssociation (391.14s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC (64.11s)
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (61.67s)
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (60.12s)
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (77.67s)
--- PASS: TestAccAWSSecurityGroup_change (100.40s)
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (76.08s)
--- PASS: TestAccAWSRouteTable_IPv4_To_TransitGateway (372.37s)
--- PASS: TestAccAWSSNSTopicPolicy_basic (65.14s)
--- PASS: TestAccAWSSNSTopicPolicy_disappears_topic (49.78s)
--- PASS: TestAccAWSSNSTopicPolicy_disappears (55.53s)
--- FAIL: TestAccAWSSecurityGroup_rulesDropOnError (81.84s)
--- PASS: TestAccAWSSecurityGroup_ruleDescription (146.80s)
--- PASS: TestAccAWSSNSTopicSubscription_basic (68.02s)
--- PASS: TestAccAWSSecurityGroup_tags (144.22s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (116.80s)
--- PASS: TestAccAWSSNSTopicPolicy_updated (102.39s)
--- PASS: TestAccAWSSNSTopicSubscription_email (52.57s)
--- PASS: TestAccAWSSNSTopic_basic (54.18s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (102.48s)
--- PASS: TestAccAWSSNSTopic_Name (55.28s)
--- PASS: TestAccAWSSNSTopic_NamePrefix (55.77s)
--- PASS: TestAccAWSSNSTopic_policy (56.17s)
--- PASS: TestAccAWSSNSTopic_withIAMRole (58.70s)
--- PASS: TestAccAWSSNSTopicSubscription_disappears_topic (84.42s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAppend (191.74s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (129.19s)
--- PASS: TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError (8.84s)
--- PASS: TestAccAWSSNSTopicSubscription_disappears (103.65s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (190.80s)
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (51.40s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (198.76s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (173.81s)
--- PASS: TestAccAWSSNSTopic_Name_Generated_FIFOTopic (51.53s)
--- PASS: TestAccAWSSNSTopic_Name_FIFOTopic (49.24s)
--- PASS: TestAccAWSSNSTopic_deliveryStatus (58.95s)
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (173.41s)
--- PASS: TestAccAWSSNSTopic_NamePrefix_FIFOTopic (46.95s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_duplicateTag (8.05s)
--- PASS: TestAccAWSSNSTopicSubscription_redrivePolicy (180.46s)
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (179.96s)
--- PASS: TestAccAWSSubnet_basic (54.35s)
--- PASS: TestAccAWSSNSTopicSubscription_firehose (163.60s)
--- SKIP: TestAccAWSSubnet_CustomerOwnedIpv4Pool (1.11s)
--- SKIP: TestAccAWSSubnet_MapCustomerOwnedIpOnLaunch (1.32s)
--- PASS: TestAccAWSSNSTopic_encryption (86.38s)
--- PASS: TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication (91.34s)
--- SKIP: TestAccAWSSubnet_outpost (1.24s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (148.53s)
--- PASS: TestAccAWSSubnet_disappears (58.08s)
--- PASS: TestAccAWSSubnet_availabilityZoneId (68.77s)
--- PASS: TestAccAWSSubnet_defaultTags_updateToProviderOnly (97.20s)
--- PASS: TestAccAWSSubnet_defaultTags_updateToResourceOnly (96.59s)
--- PASS: TestAccAWSSNSTopic_tags (132.43s)
--- PASS: TestAccAWSSubnet_updateTagsKnownAtApply (107.71s)
--- PASS: TestAccAWSSubnet_defaultTags_providerOnly (126.66s)
--- PASS: TestAccAWSSubnet_tags (136.01s)
--- PASS: TestAccAWSSubnet_defaultAndIgnoreTags (113.22s)
--- PASS: TestAccAWSSubnet_ignoreTags (111.73s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_overlappingTag (123.15s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_nonOverlappingTag (124.74s)
--- PASS: TestAccAWSSubnet_enableIpv6 (118.20s)
--- PASS: TestAccAWSSubnet_ipv6 (126.67s)
--- PASS: TestAccAWSTransferUser_UserName_Validation (30.20s)
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (32.03s)
--- PASS: TestAccAWSSubnet_MapPublicIpOnLaunch (123.72s)
--- FAIL: TestAccAWSTransferServer_vpcEndpointId (94.94s)
--- PASS: TestAccAWSTransferServer_basic (216.26s)
--- PASS: TestAccAWSTransferServer_apigateway (207.35s)
--- PASS: TestAccAWSTransferServer_disappears (199.50s)
--- PASS: TestAccAWSTransferServer_Vpc (233.04s)
--- PASS: TestAccAWSTransferServer_hostKey (205.23s)
--- PASS: TestAccAWSTransferServer_forcedestroy (207.94s)
--- PASS: TestAccAWSTransferUser_homeDirectoryMappings (182.29s)
--- PASS: TestAccAWSTransferUser_basic (207.87s)
--- PASS: TestAccAWSTransferUser_disappears (204.53s)
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (43.48s)
--- PASS: TestAccAWSVpcEndpointService_GatewayLoadBalancerArns (182.97s)
--- PASS: TestAccAWSVpcEndpointServiceAllowedPrincipal_basic (223.93s)
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy (70.03s)
--- PASS: TestAccAWSTransferUser_modifyWithOptions (251.05s)
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (67.96s)
--- PASS: TestAccAWSVpcEndpoint_disappears (34.04s)
--- PASS: TestAccAWSVpcEndpoint_tags (56.15s)
--- PASS: TestAccAWSVpcEndpointService_basic (265.17s)
--- PASS: TestAccAWSVpcEndpointConnectionNotification_basic (285.68s)
--- PASS: TestAccAWSVpcEndpointService_disappears (268.86s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (127.84s)
--- FAIL: TestAccAWSVpnConnection_withoutStaticRoutes (17.50s)
--- PASS: TestAccAWSVpcEndpointService_private_dns_name (246.85s)
--- PASS: TestAccAWSVpcEndpointService_tags (281.51s)
--- PASS: TestAccAWSVpcEndpointService_AllowedPrincipals (395.20s)
--- PASS: TestXmlConfigToTunnelInfo (0.00s)
    --- PASS: TestXmlConfigToTunnelInfo/outside_address_sort (0.00s)
    --- PASS: TestXmlConfigToTunnelInfo/Tunnel1PreSharedKey (0.00s)
    --- PASS: TestXmlConfigToTunnelInfo/Tunnel1InsideCidr (0.00s)
    --- PASS: TestXmlConfigToTunnelInfo/Tunnel1InsideIpv6Cidr (0.00s)
--- FAIL: TestAccAWSVpnGatewayAttachment_basic (56.00s)
--- FAIL: TestAccAWSVpnGatewayAttachment_disappears (7.97s)
--- PASS: TestAccAWSVpnConnection_Tunnel1InsideCidr (240.12s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate (296.02s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate (314.15s)
--- PASS: TestAccAWSVpcEndpointSubnetAssociation_basic (362.33s)
--- PASS: TestAccAWSVpcEndpoint_VpcEndpointType_GatewayLoadBalancer (292.88s)
--- PASS: TestAccAWSVpnConnection_tunnelOptions (260.97s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesFalse (981.53s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesTrue (1004.62s)
--- PASS: TestAccAWSVpnConnectionRoute_basic (326.52s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (402.17s)
--- PASS: TestAccAWSVpnGateway_reattach (87.30s)
--- PASS: TestAccAWSVpnConnection_Tunnel1PresharedKey (339.37s)
--- PASS: TestAccAWSVpnGateway_disappears (140.93s)
--- PASS: TestAccAWSVpnGateway_tags (128.84s)
--- PASS: TestAccAWSVPNGatewayRoutePropagation_basic (224.82s)
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (206.97s)
--- PASS: TestAccAWSVpcEndpointSubnetAssociation_multiple (619.13s)
--- PASS: TestAccAWSVpnGateway_basic (376.04s)
--- PASS: TestAccAWSVpnConnection_basic (724.40s)
--- PASS: TestAccAWSVpnConnection_TransitGatewayID (898.28s)
--- PASS: TestAccAWSVpnGateway_delete (599.95s)
--- PASS: TestAccAWSVpnConnection_Tunnel1InsideIpv6Cidr (887.43s)
--- PASS: TestAccAWSVpnConnection_disappears (948.70s)
--- PASS: TestAccAWSVpnConnection_withIpv6 (971.99s)
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (1019.00s)
--- PASS: TestAccAWSVpnConnection_tags (1270.04s)
--- PASS: TestAccAWSVpnConnection_withEnableAcceleration (1644.12s)
```

The test failures are unrelated to this change