### PR TITLE
r/aws_backup_plan: Add missing `tags_all` attribute

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -152,7 +152,8 @@ func resourceAwsBackupPlan() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tagsSchema(),
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
 		},
 
 		CustomizeDiff: SetTagsDiff,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #18715.
Relates: #7926.

Before fix:

```
------- Stdout: -------
=== RUN   TestAccAWSBackupPlanDataSource_basic
=== PAUSE TestAccAWSBackupPlanDataSource_basic
=== CONT  TestAccAWSBackupPlanDataSource_basic
data_source_aws_backup_plan_test.go:18: Step 2/2 error: Error running pre-apply refresh: exit status 1
Error: error setting new tags_all diff: SetNew: invalid key: tags_all
on terraform_plugin_test.tf line 6, in resource "aws_backup_plan" "test":
6: resource "aws_backup_plan" "test" {
--- FAIL: TestAccAWSBackupPlanDataSource_basic (19.28s)
FAIL

------- Stdout: -------
=== RUN   TestAccAWSBackupSelectionDataSource_basic
=== PAUSE TestAccAWSBackupSelectionDataSource_basic
=== CONT  TestAccAWSBackupSelectionDataSource_basic
------- Stderr: -------
panic: interface conversion: interface {} is nil, not map[string]interface {}
goroutine 267 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.SetTagsDiff(0x8e39888, 0xc0036fbfc0, 0xc001683400, 0x706aee0, 0xc0028a0b00, 0x8e577f0, 0xc0009db480)
  /opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/tags.go:123 +0x3a5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0xc00135f470, 0x8e39888, 0xc0036fbfc0, 0xc0016840e0, 0xc0033b6c30, 0x834c9f8, 0x706aee0, 0xc0028a0b00, 0xca42a00, 0x678d820, ...)
  /opt/teamcity-agent/work/2e10e023da0c7520/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/schema.go:540 +0xb29
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0xc001375dc0, 0x8e39888, 0xc0036fbfc0, 0xc0016840e0, 0xc0033b6c30, 0x706aee0, 0xc0028a0b00, 0x0, 0x0, 0x0)
  /opt/teamcity-agent/work/2e10e023da0c7520/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/resource.go:506 +0xa5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).PlanResourceChange(0xc0037f71e8, 0x8e39888, 0xc0036fbfc0, 0xc002e44960, 0xc0036fbfc0, 0x7c0b1c0, 0xc003136d00)
  /opt/teamcity-agent/work/2e10e023da0c7520/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/grpc_provider.go:693 +0x7c5
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).PlanResourceChange(0xc002b7c180, 0x8e39930, 0xc0036fbfc0, 0xc0009e3f80, 0xc002b7c180, 0xc003136d20, 0xc00038d
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

##### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBackupPlanDataSource_basic\|TestAccAWSBackupSelectionDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBackupPlanDataSource_basic\|TestAccAWSBackupSelectionDataSource_basic -timeout 180m
=== RUN   TestAccAWSBackupPlanDataSource_basic
=== PAUSE TestAccAWSBackupPlanDataSource_basic
=== RUN   TestAccAWSBackupSelectionDataSource_basic
=== PAUSE TestAccAWSBackupSelectionDataSource_basic
=== CONT  TestAccAWSBackupPlanDataSource_basic
=== CONT  TestAccAWSBackupSelectionDataSource_basic
--- PASS: TestAccAWSBackupPlanDataSource_basic (17.11s)
--- PASS: TestAccAWSBackupSelectionDataSource_basic (18.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	21.199s
```

##### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBackupPlanDataSource_basic\|TestAccAWSBackupSelectionDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBackupPlanDataSource_basic\|TestAccAWSBackupSelectionDataSource_basic -timeout 180m
=== RUN   TestAccAWSBackupPlanDataSource_basic
=== PAUSE TestAccAWSBackupPlanDataSource_basic
=== RUN   TestAccAWSBackupSelectionDataSource_basic
=== PAUSE TestAccAWSBackupSelectionDataSource_basic
=== CONT  TestAccAWSBackupPlanDataSource_basic
=== CONT  TestAccAWSBackupSelectionDataSource_basic
--- PASS: TestAccAWSBackupPlanDataSource_basic (22.62s)
--- PASS: TestAccAWSBackupSelectionDataSource_basic (24.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.951s
```