### PR TITLE
EKS supports adding KMS envelope encryption to existing clusters

### DIFF
--- a/.changelog/19144.txt
+++ b/.changelog/19144.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Allow updates to `encryption_config`
+```

--- a/aws/data_source_aws_eks_cluster_test.go
+++ b/aws/data_source_aws_eks_cluster_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceResourceName := "data.aws_eks_cluster.test"
 	resourceName := "aws_eks_cluster.test"
 
@@ -57,11 +56,9 @@ func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
 }
 
 func testAccAWSEksClusterDataSourceConfig_Basic(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
+	return composeConfig(testAccAWSEksClusterConfig_Logging(rName, []string{"api", "audit"}), `
 data "aws_eks_cluster" "test" {
   name = aws_eks_cluster.test.name
 }
-`, testAccAWSEksClusterConfig_Logging(rName, []string{"api", "audit"}))
+`)
 }

--- a/aws/internal/service/amplify/waiter/waiter.go
+++ b/aws/internal/service/amplify/waiter/waiter.go
@@ -26,7 +26,7 @@ func DomainAssociationCreated(conn *amplify.Amplify, appID, domainName string) (
 	outputRaw, err := stateConf.WaitForState()
 
 	if v, ok := outputRaw.(*amplify.DomainAssociation); ok {
-		if v != nil && aws.StringValue(v.DomainStatus) == amplify.DomainStatusFailed {
+		if status := aws.StringValue(v.DomainStatus); status == amplify.DomainStatusFailed {
 			tfresource.SetLastError(err, errors.New(aws.StringValue(v.StatusReason)))
 		}
 

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -358,7 +358,7 @@ func RouteTableAssociationCreated(conn *ec2.EC2, id string) (*ec2.RouteTableAsso
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*ec2.RouteTableAssociationState); ok {
-		if output != nil && aws.StringValue(output.State) == ec2.RouteTableAssociationStateCodeFailed {
+		if state := aws.StringValue(output.State); state == ec2.RouteTableAssociationStateCodeFailed {
 			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusMessage)))
 		}
 
@@ -379,7 +379,7 @@ func RouteTableAssociationDeleted(conn *ec2.EC2, id string) (*ec2.RouteTableAsso
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*ec2.RouteTableAssociationState); ok {
-		if output != nil && aws.StringValue(output.State) == ec2.RouteTableAssociationStateCodeFailed {
+		if state := aws.StringValue(output.State); state == ec2.RouteTableAssociationStateCodeFailed {
 			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusMessage)))
 		}
 
@@ -400,7 +400,7 @@ func RouteTableAssociationUpdated(conn *ec2.EC2, id string) (*ec2.RouteTableAsso
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*ec2.RouteTableAssociationState); ok {
-		if output != nil && aws.StringValue(output.State) == ec2.RouteTableAssociationStateCodeFailed {
+		if state := aws.StringValue(output.State); state == ec2.RouteTableAssociationStateCodeFailed {
 			tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusMessage)))
 		}
 
@@ -704,8 +704,8 @@ func VpcEndpointAccepted(conn *ec2.EC2, vpcEndpointID string, timeout time.Durat
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*ec2.VpcEndpoint); ok {
-		if output != nil && aws.StringValue(output.State) == tfec2.VpcEndpointStateFailed && output.LastError != nil {
-			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(output.LastError.Code), aws.StringValue(output.LastError.Message)))
+		if state, lastError := aws.StringValue(output.State), output.LastError; state == tfec2.VpcEndpointStateFailed && lastError != nil {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(lastError.Code), aws.StringValue(lastError.Message)))
 		}
 
 		return output, err

--- a/aws/internal/service/eks/enum.go
+++ b/aws/internal/service/eks/enum.go
@@ -1,0 +1,11 @@
+package eks
+
+const (
+	ResourcesSecrets = "secrets"
+)
+
+func Resources_Values() []string {
+	return []string{
+		ResourcesSecrets,
+	}
+}

--- a/aws/internal/service/eks/finder/finder.go
+++ b/aws/internal/service/eks/finder/finder.go
@@ -37,6 +37,35 @@ func ClusterByName(conn *eks.EKS, name string) (*eks.Cluster, error) {
 	return output.Cluster, nil
 }
 
+func ClusterUpdateByNameAndID(conn *eks.EKS, name, id string) (*eks.Update, error) {
+	input := &eks.DescribeUpdateInput{
+		Name:     aws.String(name),
+		UpdateId: aws.String(id),
+	}
+
+	output, err := conn.DescribeUpdate(input)
+
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Update == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Update, nil
+}
+
 func FargateProfileByClusterNameAndFargateProfileName(conn *eks.EKS, clusterName, fargateProfileName string) (*eks.FargateProfile, error) {
 	input := &eks.DescribeFargateProfileInput{
 		ClusterName:        aws.String(clusterName),
@@ -100,35 +129,6 @@ func NodegroupUpdateByClusterNameNodegroupNameAndID(conn *eks.EKS, clusterName, 
 		Name:          aws.String(clusterName),
 		NodegroupName: aws.String(nodeGroupName),
 		UpdateId:      aws.String(id),
-	}
-
-	output, err := conn.DescribeUpdate(input)
-
-	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if output == nil || output.Update == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
-	}
-
-	return output.Update, nil
-}
-
-func UpdateByNameAndID(conn *eks.EKS, name, id string) (*eks.Update, error) {
-	input := &eks.DescribeUpdateInput{
-		Name:     aws.String(name),
-		UpdateId: aws.String(id),
 	}
 
 	output, err := conn.DescribeUpdate(input)

--- a/aws/internal/service/eks/finder/finder.go
+++ b/aws/internal/service/eks/finder/finder.go
@@ -66,6 +66,65 @@ func FargateProfileByClusterNameAndFargateProfileName(conn *eks.EKS, clusterName
 	return output.FargateProfile, nil
 }
 
+func NodegroupByClusterNameAndNodegroupName(conn *eks.EKS, clusterName, nodeGroupName string) (*eks.Nodegroup, error) {
+	input := &eks.DescribeNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+	}
+
+	output, err := conn.DescribeNodegroup(input)
+
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Nodegroup == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Nodegroup, nil
+}
+
+func NodegroupUpdateByClusterNameNodegroupNameAndID(conn *eks.EKS, clusterName, nodeGroupName, id string) (*eks.Update, error) {
+	input := &eks.DescribeUpdateInput{
+		Name:          aws.String(clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+		UpdateId:      aws.String(id),
+	}
+
+	output, err := conn.DescribeUpdate(input)
+
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Update == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Update, nil
+}
+
 func UpdateByNameAndID(conn *eks.EKS, name, id string) (*eks.Update, error) {
 	input := &eks.DescribeUpdateInput{
 		Name:     aws.String(name),

--- a/aws/internal/service/eks/finder/finder.go
+++ b/aws/internal/service/eks/finder/finder.go
@@ -37,6 +37,35 @@ func ClusterByName(conn *eks.EKS, name string) (*eks.Cluster, error) {
 	return output.Cluster, nil
 }
 
+func FargateProfileByClusterNameAndFargateProfileName(conn *eks.EKS, clusterName, fargateProfileName string) (*eks.FargateProfile, error) {
+	input := &eks.DescribeFargateProfileInput{
+		ClusterName:        aws.String(clusterName),
+		FargateProfileName: aws.String(fargateProfileName),
+	}
+
+	output, err := conn.DescribeFargateProfile(input)
+
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.FargateProfile == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.FargateProfile, nil
+}
+
 func UpdateByNameAndID(conn *eks.EKS, name, id string) (*eks.Update, error) {
 	input := &eks.DescribeUpdateInput{
 		Name:     aws.String(name),

--- a/aws/internal/service/eks/finder/finder.go
+++ b/aws/internal/service/eks/finder/finder.go
@@ -36,3 +36,32 @@ func ClusterByName(conn *eks.EKS, name string) (*eks.Cluster, error) {
 
 	return output.Cluster, nil
 }
+
+func UpdateByNameAndID(conn *eks.EKS, name, id string) (*eks.Update, error) {
+	input := &eks.DescribeUpdateInput{
+		Name:     aws.String(name),
+		UpdateId: aws.String(id),
+	}
+
+	output, err := conn.DescribeUpdate(input)
+
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Update == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Update, nil
+}

--- a/aws/internal/service/eks/finder/finder.go
+++ b/aws/internal/service/eks/finder/finder.go
@@ -1,0 +1,38 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func ClusterByName(conn *eks.EKS, name string) (*eks.Cluster, error) {
+	input := &eks.DescribeClusterInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.DescribeCluster(input)
+
+	// Sometimes the EKS API returns the ResourceNotFound error in this form:
+	// ClientException: No cluster found for name: tf-acc-test-0o1f8
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) || tfawserr.ErrMessageContains(err, eks.ErrCodeClientException, "No cluster found for name:") {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Cluster == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Cluster, nil
+}

--- a/aws/internal/service/eks/id.go
+++ b/aws/internal/service/eks/id.go
@@ -5,6 +5,25 @@ import (
 	"strings"
 )
 
+const fargateProfileResourceIDSeparator = ":"
+
+func FargateProfileCreateResourceID(clusterName, fargateProfileName string) string {
+	parts := []string{clusterName, fargateProfileName}
+	id := strings.Join(parts, fargateProfileResourceIDSeparator)
+
+	return id
+}
+
+func FargateProfileParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, fargateProfileResourceIDSeparator)
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected cluster-name%[2]sfargate-profile-name", id, fargateProfileResourceIDSeparator)
+}
+
 const nodeGroupResourceIDSeparator = ":"
 
 func NodeGroupCreateResourceID(clusterName, nodeGroupName string) string {

--- a/aws/internal/service/eks/id.go
+++ b/aws/internal/service/eks/id.go
@@ -5,6 +5,25 @@ import (
 	"strings"
 )
 
+const addonResourceIDSeparator = ":"
+
+func AddonCreateResourceID(clusterName, addonName string) string {
+	parts := []string{clusterName, addonName}
+	id := strings.Join(parts, addonResourceIDSeparator)
+
+	return id
+}
+
+func AddonParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, addonResourceIDSeparator)
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected cluster-name%[2]saddon-name", id, addonResourceIDSeparator)
+}
+
 const fargateProfileResourceIDSeparator = ":"
 
 func FargateProfileCreateResourceID(clusterName, fargateProfileName string) string {

--- a/aws/internal/service/eks/waiter/status.go
+++ b/aws/internal/service/eks/waiter/status.go
@@ -28,6 +28,22 @@ func ClusterStatus(conn *eks.EKS, name string) resource.StateRefreshFunc {
 	}
 }
 
+func ClusterUpdateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.ClusterUpdateByNameAndID(conn, name, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
 func FargateProfileStatus(conn *eks.EKS, clusterName, fargateProfileName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.FargateProfileByClusterNameAndFargateProfileName(conn, clusterName, fargateProfileName)
@@ -63,22 +79,6 @@ func NodegroupStatus(conn *eks.EKS, clusterName, nodeGroupName string) resource.
 func NodegroupUpdateStatus(conn *eks.EKS, clusterName, nodeGroupName, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.NodegroupUpdateByClusterNameNodegroupNameAndID(conn, clusterName, nodeGroupName, id)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.Status), nil
-	}
-}
-
-func UpdateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := finder.UpdateByNameAndID(conn, name, id)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/aws/internal/service/eks/waiter/status.go
+++ b/aws/internal/service/eks/waiter/status.go
@@ -2,15 +2,45 @@ package waiter
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
+
+func AddonStatus(ctx context.Context, conn *eks.EKS, clusterName, addonName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.AddonByClusterNameAndAddonName(ctx, conn, clusterName, addonName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func AddonUpdateStatus(ctx context.Context, conn *eks.EKS, clusterName, addonName, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.AddonUpdateByClusterNameAddonNameAndID(ctx, conn, clusterName, addonName, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
 
 func ClusterStatus(conn *eks.EKS, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
@@ -89,41 +119,5 @@ func NodegroupUpdateStatus(conn *eks.EKS, clusterName, nodeGroupName, id string)
 		}
 
 		return output, aws.StringValue(output.Status), nil
-	}
-}
-
-func EksAddonStatus(ctx context.Context, conn *eks.EKS, addonName, clusterName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := conn.DescribeAddonWithContext(ctx, &eks.DescribeAddonInput{
-			ClusterName: aws.String(clusterName),
-			AddonName:   aws.String(addonName),
-		})
-		if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
-			return nil, "", nil
-		}
-		if err != nil {
-			return output, "", err
-		}
-		if output == nil || output.Addon == nil {
-			return nil, "", fmt.Errorf("EKS Cluster (%s) add-on (%s) missing", clusterName, addonName)
-		}
-		return output.Addon, aws.StringValue(output.Addon.Status), nil
-	}
-}
-
-func EksAddonUpdateStatus(ctx context.Context, conn *eks.EKS, clusterName, addonName, updateID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := conn.DescribeUpdateWithContext(ctx, &eks.DescribeUpdateInput{
-			Name:      aws.String(clusterName),
-			AddonName: aws.String(addonName),
-			UpdateId:  aws.String(updateID),
-		})
-		if err != nil {
-			return output, "", err
-		}
-		if output == nil || output.Update == nil {
-			return nil, "", fmt.Errorf("EKS Cluster (%s) add-on (%s) update (%s) missing", clusterName, addonName, updateID)
-		}
-		return output.Update, aws.StringValue(output.Update.Status), nil
 	}
 }

--- a/aws/internal/service/eks/waiter/status.go
+++ b/aws/internal/service/eks/waiter/status.go
@@ -28,6 +28,22 @@ func ClusterStatus(conn *eks.EKS, name string) resource.StateRefreshFunc {
 	}
 }
 
+func FargateProfileStatus(conn *eks.EKS, clusterName, fargateProfileName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.FargateProfileByClusterNameAndFargateProfileName(conn, clusterName, fargateProfileName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
 func UpdateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.UpdateByNameAndID(conn, name, id)

--- a/aws/internal/service/eks/waiter/status.go
+++ b/aws/internal/service/eks/waiter/status.go
@@ -44,6 +44,38 @@ func FargateProfileStatus(conn *eks.EKS, clusterName, fargateProfileName string)
 	}
 }
 
+func NodegroupStatus(conn *eks.EKS, clusterName, nodeGroupName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.NodegroupByClusterNameAndNodegroupName(conn, clusterName, nodeGroupName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func NodegroupUpdateStatus(conn *eks.EKS, clusterName, nodeGroupName, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.NodegroupUpdateByClusterNameNodegroupNameAndID(conn, clusterName, nodeGroupName, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
 func UpdateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.UpdateByNameAndID(conn, name, id)

--- a/aws/internal/service/eks/waiter/status.go
+++ b/aws/internal/service/eks/waiter/status.go
@@ -28,7 +28,7 @@ func ClusterStatus(conn *eks.EKS, name string) resource.StateRefreshFunc {
 	}
 }
 
-func UodateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
+func UpdateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.UpdateByNameAndID(conn, name, id)
 

--- a/aws/internal/service/eks/waiter/status.go
+++ b/aws/internal/service/eks/waiter/status.go
@@ -8,7 +8,41 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
+
+func ClusterStatus(conn *eks.EKS, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.ClusterByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func UodateStatus(conn *eks.EKS, name, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.UpdateByNameAndID(conn, name, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
 
 func EksAddonStatus(ctx context.Context, conn *eks.EKS, addonName, clusterName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/aws/internal/service/eks/waiter/waiter.go
+++ b/aws/internal/service/eks/waiter/waiter.go
@@ -3,22 +3,89 @@ package waiter
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
-	EksAddonCreatedTimeout = 20 * time.Minute
-	EksAddonUpdatedTimeout = 20 * time.Minute
-	EksAddonDeletedTimeout = 40 * time.Minute
+	AddonCreatedTimeout = 20 * time.Minute
+	AddonUpdatedTimeout = 20 * time.Minute
+	AddonDeletedTimeout = 40 * time.Minute
 )
+
+func AddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{eks.AddonStatusCreating},
+		Target:  []string{eks.AddonStatusActive},
+		Refresh: AddonStatus(ctx, conn, clusterName, addonName),
+		Timeout: AddonCreatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*eks.Addon); ok {
+		if status, health := aws.StringValue(output.Status), output.Health; status == eks.AddonStatusCreateFailed && health != nil {
+			var errs *multierror.Error
+
+			for _, issue := range health.Issues {
+				errs = multierror.Append(errs, fmt.Errorf("%s: %s", aws.StringValue(issue.Code), aws.StringValue(issue.Message)))
+			}
+			tfresource.SetLastError(err, errs.ErrorOrNil())
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func AddonDeleted(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.AddonStatusActive, eks.AddonStatusDeleting},
+		Target:  []string{},
+		Refresh: AddonStatus(ctx, conn, clusterName, addonName),
+		Timeout: AddonDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*eks.Addon); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func AddonUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, addonName, id string) (*eks.Update, error) {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{eks.UpdateStatusInProgress},
+		Target:  []string{eks.UpdateStatusSuccessful},
+		Refresh: AddonUpdateStatus(ctx, conn, clusterName, addonName, id),
+		Timeout: AddonUpdatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*eks.Update); ok {
+		if status := aws.StringValue(output.Status); status == eks.UpdateStatusCancelled || status == eks.UpdateStatusFailed {
+			var errs *multierror.Error
+
+			for _, e := range output.Errors {
+				errs = multierror.Append(errs, fmt.Errorf("%s: %s", aws.StringValue(e.ErrorCode), aws.StringValue(e.ErrorMessage)))
+			}
+			tfresource.SetLastError(err, errs.ErrorOrNil())
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
 
 func ClusterCreated(conn *eks.EKS, name string, timeout time.Duration) (*eks.Cluster, error) {
 	stateConf := &resource.StateChangeConf{
@@ -172,101 +239,4 @@ func NodegroupUpdateSuccessful(conn *eks.EKS, clusterName, nodeGroupName, id str
 	}
 
 	return nil, err
-}
-
-// EksAddonCreated waits for a EKS add-on to return status "ACTIVE" or "CREATE_FAILED"
-func EksAddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
-	stateConf := resource.StateChangeConf{
-		Pending: []string{eks.AddonStatusCreating},
-		Target: []string{
-			eks.AddonStatusActive,
-			eks.AddonStatusCreateFailed,
-		},
-		Refresh: EksAddonStatus(ctx, conn, addonName, clusterName),
-		Timeout: EksAddonCreatedTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if addon, ok := outputRaw.(*eks.Addon); ok {
-		// If "CREATE_FAILED" status was returned, gather add-on health issues and return error
-		if aws.StringValue(addon.Status) == eks.AddonStatusCreateFailed {
-			var detailedErrors []string
-			for i, addonIssue := range addon.Health.Issues {
-				detailedErrors = append(detailedErrors, fmt.Sprintf("Error %d: Code: %s / Message: %s",
-					i+1, aws.StringValue(addonIssue.Code), aws.StringValue(addonIssue.Message)))
-			}
-
-			return addon, fmt.Errorf("creation not successful (%s): Errors:\n%s",
-				aws.StringValue(addon.Status), strings.Join(detailedErrors, "\n"))
-		}
-
-		return addon, err
-	}
-
-	return nil, err
-}
-
-// EksAddonDeleted waits for a EKS add-on to be deleted
-func EksAddonDeleted(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			eks.AddonStatusActive,
-			eks.AddonStatusDeleting,
-		},
-		Target:  []string{},
-		Refresh: EksAddonStatus(ctx, conn, addonName, clusterName),
-		Timeout: EksAddonDeletedTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		// EKS API returns the ResourceNotFound error in this form:
-		// ResourceNotFoundException: No addon: vpc-cni found in cluster: tf-acc-test-533189557170672934
-		if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
-			return nil, nil
-		}
-	}
-	if v, ok := outputRaw.(*eks.Addon); ok {
-		return v, err
-	}
-
-	return nil, err
-}
-
-// EksAddonUpdateSuccessful waits for a EKS add-on update to return "Successful"
-func EksAddonUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, addonName, updateID string) (*eks.Update, error) {
-	stateConf := resource.StateChangeConf{
-		Pending: []string{eks.UpdateStatusInProgress},
-		Target: []string{
-			eks.UpdateStatusCancelled,
-			eks.UpdateStatusFailed,
-			eks.UpdateStatusSuccessful,
-		},
-		Refresh: EksAddonUpdateStatus(ctx, conn, clusterName, addonName, updateID),
-		Timeout: EksAddonUpdatedTimeout,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	update, ok := outputRaw.(*eks.Update)
-	if !ok {
-		return nil, err
-	}
-
-	if aws.StringValue(update.Status) == eks.UpdateStatusSuccessful {
-		return nil, nil
-	}
-
-	var detailedErrors []string
-	for i, updateError := range update.Errors {
-		detailedErrors = append(detailedErrors, fmt.Sprintf("Error %d: Code: %s / Message: %s",
-			i+1, aws.StringValue(updateError.ErrorCode), aws.StringValue(updateError.ErrorMessage)))
-	}
-
-	return update, fmt.Errorf("EKS add-on (%s:%s) update (%s) not successful (%s): Errors:\n%s",
-		clusterName, addonName, updateID, aws.StringValue(update.Status), strings.Join(detailedErrors, "\n"))
 }

--- a/aws/internal/service/eks/waiter/waiter.go
+++ b/aws/internal/service/eks/waiter/waiter.go
@@ -88,6 +88,66 @@ func FargateProfileDeleted(conn *eks.EKS, clusterName, fargateProfileName string
 	return nil, err
 }
 
+func NodegroupCreated(conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.NodegroupStatusCreating},
+		Target:  []string{eks.NodegroupStatusActive},
+		Refresh: NodegroupStatus(conn, clusterName, nodeGroupName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.Nodegroup); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func NodegroupDeleted(conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.NodegroupStatusActive, eks.NodegroupStatusDeleting},
+		Target:  []string{},
+		Refresh: NodegroupStatus(conn, clusterName, nodeGroupName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.Nodegroup); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func NodegroupUpdateSuccessful(conn *eks.EKS, clusterName, nodeGroupName, id string, timeout time.Duration) (*eks.Update, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.UpdateStatusInProgress},
+		Target:  []string{eks.UpdateStatusSuccessful},
+		Refresh: NodegroupUpdateStatus(conn, clusterName, nodeGroupName, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.Update); ok {
+		if status := aws.StringValue(output.Status); status == eks.UpdateStatusCancelled || status == eks.UpdateStatusFailed {
+			var errs *multierror.Error
+
+			for _, e := range output.Errors {
+				errs = multierror.Append(errs, fmt.Errorf("%s: %s", aws.StringValue(e.ErrorCode), aws.StringValue(e.ErrorMessage)))
+			}
+			tfresource.SetLastError(err, errs.ErrorOrNil())
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
 func UpdateSuccessful(conn *eks.EKS, name, id string, timeout time.Duration) (*eks.Update, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},

--- a/aws/internal/service/eks/waiter/waiter.go
+++ b/aws/internal/service/eks/waiter/waiter.go
@@ -54,6 +54,40 @@ func ClusterDeleted(conn *eks.EKS, name string, timeout time.Duration) (*eks.Clu
 	return nil, err
 }
 
+func FargateProfileCreated(conn *eks.EKS, clusterName, fargateProfileName string, timeout time.Duration) (*eks.FargateProfile, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.FargateProfileStatusCreating},
+		Target:  []string{eks.FargateProfileStatusActive},
+		Refresh: FargateProfileStatus(conn, clusterName, fargateProfileName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.FargateProfile); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func FargateProfileDeleted(conn *eks.EKS, clusterName, fargateProfileName string, timeout time.Duration) (*eks.FargateProfile, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.FargateProfileStatusActive, eks.FargateProfileStatusDeleting},
+		Target:  []string{},
+		Refresh: FargateProfileStatus(conn, clusterName, fargateProfileName),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.FargateProfile); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func UpdateSuccessful(conn *eks.EKS, name, id string, timeout time.Duration) (*eks.Update, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},

--- a/aws/internal/tfresource/errors.go
+++ b/aws/internal/tfresource/errors.go
@@ -25,6 +25,7 @@ func TimedOut(err error) bool {
 }
 
 // SetLastError sets the LastError field on the error if supported.
+// If lastErr is nil it is ignored.
 func SetLastError(err, lastErr error) {
 	var te *resource.TimeoutError
 	var use *resource.UnexpectedStateError

--- a/aws/internal/tfresource/errors_test.go
+++ b/aws/internal/tfresource/errors_test.go
@@ -3,6 +3,7 @@ package tfresource_test
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -93,6 +94,77 @@ func TestTimedOut(t *testing.T) {
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestSetLastError(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		LastErr  error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+		},
+		{
+			Name:    "other error",
+			Err:     errors.New("test"),
+			LastErr: errors.New("last"),
+		},
+		{
+			Name: "timeout error lastErr is nil",
+			Err:  &resource.TimeoutError{},
+		},
+		{
+			Name:     "timeout error",
+			Err:      &resource.TimeoutError{},
+			LastErr:  errors.New("lasttest"),
+			Expected: true,
+		},
+		{
+			Name: "timeout error non-nil last error lastErr is nil",
+			Err:  &resource.TimeoutError{LastError: errors.New("test")},
+		},
+		{
+			Name:    "timeout error non-nil last error no overwrite",
+			Err:     &resource.TimeoutError{LastError: errors.New("test")},
+			LastErr: errors.New("lasttest"),
+		},
+		{
+			Name: "unexpected state error lastErr is nil",
+			Err:  &resource.UnexpectedStateError{},
+		},
+		{
+			Name:     "unexpected state error",
+			Err:      &resource.UnexpectedStateError{},
+			LastErr:  errors.New("lasttest"),
+			Expected: true,
+		},
+		{
+			Name: "unexpected state error non-nil last error lastErr is nil",
+			Err:  &resource.UnexpectedStateError{LastError: errors.New("test")},
+		},
+		{
+			Name:    "unexpected state error non-nil last error no overwrite",
+			Err:     &resource.UnexpectedStateError{LastError: errors.New("test")},
+			LastErr: errors.New("lasttest"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			tfresource.SetLastError(testCase.Err, testCase.LastErr)
+
+			if testCase.Err != nil {
+				got := testCase.Err.Error()
+				contains := strings.Contains(got, "lasttest")
+
+				if (testCase.Expected && !contains) || (!testCase.Expected && contains) {
+					t.Errorf("got %s", got)
+				}
 			}
 		})
 	}

--- a/aws/resource_aws_eks_addon_test.go
+++ b/aws/resource_aws_eks_addon_test.go
@@ -153,7 +153,7 @@ func TestAccAWSEksAddon_disappears_Cluster(t *testing.T) {
 	var addon eks.Addon
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_addon.test"
-	clusterResourceName := "aws_eks_cluster"
+	clusterResourceName := "aws_eks_cluster.test"
 	addonName := "vpc-cni"
 	ctx := context.TODO()
 

--- a/aws/resource_aws_eks_addon_test.go
+++ b/aws/resource_aws_eks_addon_test.go
@@ -6,18 +6,18 @@ import (
 	"log"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/waiter"
+	tfeks "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -32,53 +32,59 @@ func testSweepEksAddon(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-	conn := client.(*AWSClient).eksconn
 	ctx := context.TODO()
+	conn := client.(*AWSClient).eksconn
+	input := &eks.ListClustersInput{}
 	var sweeperErrs *multierror.Error
+	sweepResources := make([]*testSweepResource, 0)
 
-	input := &eks.ListClustersInput{MaxResults: aws.Int64(100)}
 	err = conn.ListClustersPagesWithContext(ctx, input, func(page *eks.ListClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
 		for _, cluster := range page.Clusters {
-			clusterName := aws.StringValue(cluster)
 			input := &eks.ListAddonsInput{
-				ClusterName: aws.String(clusterName),
+				ClusterName: cluster,
 			}
+
 			err := conn.ListAddonsPagesWithContext(ctx, input, func(page *eks.ListAddonsOutput, lastPage bool) bool {
-				for _, addon := range page.Addons {
-					addonName := aws.StringValue(addon)
-					log.Printf("[INFO] Deleting EKS Addon %s from Cluster %s", addonName, clusterName)
-					input := &eks.DeleteAddonInput{
-						AddonName:   aws.String(addonName),
-						ClusterName: aws.String(clusterName),
-					}
-
-					_, err := conn.DeleteAddonWithContext(ctx, input)
-
-					if err != nil && !tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
-						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error deleting EKS Addon %s from Cluster %s: %w", addonName, clusterName, err))
-						continue
-					}
-
-					if _, err := waiter.EksAddonDeleted(ctx, conn, clusterName, addonName); err != nil {
-						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error waiting for EKS Addon %s deletion: %w", addonName, err))
-						continue
-					}
+				if page == nil {
+					return !lastPage
 				}
-				return true
+
+				for _, addon := range page.Addons {
+					r := resourceAwsEksAddon()
+					d := r.Data(nil)
+					d.SetId(tfeks.AddonCreateResourceID(aws.StringValue(cluster), aws.StringValue(addon)))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
 			})
+
 			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing EKS Addons for Cluster %s: %w", clusterName, err))
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing EKS Add-Ons (%s): %w", region, err))
 			}
 		}
 
-		return true
+		return !lastPage
 	})
+
 	if testSweepSkipSweepError(err) {
-		log.Print(fmt.Errorf("[WARN] Skipping EKS Addon sweep for %s: %w", region, err))
+		log.Print(fmt.Errorf("[WARN] Skipping EKS Add-Ons sweep for %s: %w", region, err))
 		return sweeperErrs // In case we have completed some pages, but had errors
 	}
+
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving EKS Clusters: %w", err))
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing EKS Clusters (%s): %w", region, err))
+	}
+
+	err = testSweepResourceOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping EKS Add-Ons (%s): %w", region, err))
 	}
 
 	return sweeperErrs.ErrorOrNil()
@@ -717,40 +723,28 @@ func testAccCheckAWSEksAddonExists(ctx context.Context, resourceName string, add
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no EKS Addon ID is set")
+			return fmt.Errorf("no EKS Add-On ID is set")
 		}
 
-		clusterName, addonName, err := resourceAwsEksAddonParseId(rs.Primary.ID)
+		clusterName, addonName, err := tfeks.AddonParseResourceID(rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).eksconn
-		output, err := conn.DescribeAddonWithContext(ctx, &eks.DescribeAddonInput{
-			ClusterName: aws.String(clusterName),
-			AddonName:   aws.String(addonName),
-		})
+
+		output, err := finder.AddonByClusterNameAndAddonName(ctx, conn, clusterName, addonName)
+
 		if err != nil {
 			return err
 		}
 
-		if output == nil || output.Addon == nil {
-			return fmt.Errorf("EKS Addon (%s) not found", rs.Primary.ID)
-		}
-
-		if aws.StringValue(output.Addon.AddonName) != addonName {
-			return fmt.Errorf("EKS Addon (%s) not found", rs.Primary.ID)
-		}
-
-		if aws.StringValue(output.Addon.ClusterName) != clusterName {
-			return fmt.Errorf("EKS Addon (%s) not found", rs.Primary.ID)
-		}
-
-		*addon = *output.Addon
+		*addon = *output
 
 		return nil
 	}
@@ -758,40 +752,30 @@ func testAccCheckAWSEksAddonExists(ctx context.Context, resourceName string, add
 
 func testAccCheckAWSEksAddonDestroy(s *terraform.State) error {
 	ctx := context.TODO()
+	conn := testAccProvider.Meta().(*AWSClient).eksconn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_eks_addon" {
 			continue
 		}
 
-		clusterName, addonName, err := resourceAwsEksAddonParseId(rs.Primary.ID)
+		clusterName, addonName, err := tfeks.AddonParseResourceID(rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).eksconn
+		_, err = finder.AddonByClusterNameAndAddonName(ctx, conn, clusterName, addonName)
 
-		// Handle eventual consistency
-		err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
-			output, err := conn.DescribeAddonWithContext(ctx, &eks.DescribeAddonInput{
-				AddonName:   aws.String(addonName),
-				ClusterName: aws.String(clusterName),
-			})
+		if tfresource.NotFound(err) {
+			continue
+		}
 
-			if err != nil {
-				if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
-					return nil
-				}
-				return resource.NonRetryableError(err)
-			}
+		if err != nil {
+			return err
+		}
 
-			if output != nil && output.Addon != nil && aws.StringValue(output.Addon.AddonName) == addonName {
-				return resource.RetryableError(fmt.Errorf("EKS Addon (%s) still exists", rs.Primary.ID))
-			}
-
-			return nil
-		})
-
-		return err
+		return fmt.Errorf("EKS Node Group %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -508,7 +508,7 @@ func resourceAwsEksClusterDelete(d *schema.ResourceData, meta interface{}) error
 	_, err = waiter.ClusterDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EKS Cluster (%s) delete: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for EKS Cluster (%s) to delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -74,6 +74,7 @@ func resourceAwsEksCluster() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(eks.LogType_Values(), true),
 				},
+				Set: schema.HashString,
 			},
 			"encryption_config": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -400,7 +400,7 @@ func resourceAwsEksClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		_, err = waiter.UpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.ClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return fmt.Errorf("error waiting for EKS Cluster (%s) version update (%s): %w", d.Id(), updateID, err)
@@ -422,7 +422,7 @@ func resourceAwsEksClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		_, err = waiter.UpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.ClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return fmt.Errorf("error waiting for EKS Cluster (%s) encryption config association (%s): %w", d.Id(), updateID, err)
@@ -444,7 +444,7 @@ func resourceAwsEksClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		_, err = waiter.UpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.ClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return fmt.Errorf("error waiting for EKS Cluster (%s) logging update (%s): %w", d.Id(), updateID, err)
@@ -466,7 +466,7 @@ func resourceAwsEksClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		_, err = waiter.UpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.ClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return fmt.Errorf("error waiting for EKS Cluster (%s) VPC config update (%s): %w", d.Id(), updateID, err)

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfeks "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
@@ -22,7 +23,6 @@ func resourceAwsEksCluster() *schema.Resource {
 		Read:   resourceAwsEksClusterRead,
 		Update: resourceAwsEksClusterUpdate,
 		Delete: resourceAwsEksClusterDelete,
-
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -56,6 +56,14 @@ func resourceAwsEksCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"enabled_cluster_log_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(eks.LogType_Values(), true),
+				},
+			},
 			"encryption_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -80,10 +88,8 @@ func resourceAwsEksCluster() *schema.Resource {
 							MinItems: 1,
 							Required: true,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									"secrets",
-								}, false),
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice(tfeks.Resources_Values(), false),
 							},
 						},
 					},
@@ -113,7 +119,6 @@ func resourceAwsEksCluster() *schema.Resource {
 					},
 				},
 			},
-
 			"kubernetes_network_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -134,7 +139,6 @@ func resourceAwsEksCluster() *schema.Resource {
 					},
 				},
 			},
-
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -183,6 +187,15 @@ func resourceAwsEksCluster() *schema.Resource {
 							Optional: true,
 							Default:  true,
 						},
+						"public_access_cidrs": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
+						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -196,30 +209,12 @@ func resourceAwsEksCluster() *schema.Resource {
 							MinItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
-						"public_access_cidrs": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validateCIDRNetworkAddress,
-							},
-						},
 						"vpc_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 					},
 				},
-			},
-			"enabled_cluster_log_types": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(eks.LogType_Values(), true),
-				},
-				Set: schema.HashString,
 			},
 		},
 	}

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -60,20 +60,17 @@ func resourceAwsEksCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {
 							Type:     schema.TypeList,
 							MaxItems: 1,
 							Required: true,
-							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key_arn": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -82,7 +79,6 @@ func resourceAwsEksCluster() *schema.Resource {
 							Type:     schema.TypeSet,
 							MinItems: 1,
 							Required: true,
-							ForceNew: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -74,7 +74,7 @@ func testSweepEksClusters(region string) error {
 
 func TestAccAWSEksCluster_basic(t *testing.T) {
 	var cluster eks.Cluster
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -121,7 +121,7 @@ func TestAccAWSEksCluster_basic(t *testing.T) {
 
 func TestAccAWSEksCluster_disappears(t *testing.T) {
 	var cluster eks.Cluster
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -142,11 +142,11 @@ func TestAccAWSEksCluster_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEksCluster_EncryptionConfig(t *testing.T) {
+func TestAccAWSEksCluster_EncryptionConfig_Create(t *testing.T) {
 	var cluster eks.Cluster
-	kmsKeyResourceName := "aws_kms_key.test"
-	resourceName := "aws_eks_cluster.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_cluster.test"
+	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
@@ -173,10 +173,47 @@ func TestAccAWSEksCluster_EncryptionConfig(t *testing.T) {
 	})
 }
 
+func TestAccAWSEksCluster_EncryptionConfig_Update(t *testing.T) {
+	var cluster eks.Cluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_cluster.test"
+	kmsKeyResourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		ErrorCheck:   testAccErrorCheck(t, eks.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksClusterConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSEksClusterConfig_EncryptionConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.provider.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_config.0.provider.0.key_arn", kmsKeyResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.resources.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSEksCluster_Version(t *testing.T) {
 	var cluster1, cluster2 eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -211,8 +248,7 @@ func TestAccAWSEksCluster_Version(t *testing.T) {
 
 func TestAccAWSEksCluster_Logging(t *testing.T) {
 	var cluster1, cluster2 eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -304,8 +340,7 @@ func TestAccAWSEksCluster_Tags(t *testing.T) {
 
 func TestAccAWSEksCluster_VpcConfig_SecurityGroupIds(t *testing.T) {
 	var cluster eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -333,8 +368,7 @@ func TestAccAWSEksCluster_VpcConfig_SecurityGroupIds(t *testing.T) {
 
 func TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess(t *testing.T) {
 	var cluster1, cluster2, cluster3 eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -380,8 +414,7 @@ func TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess(t *testing.T) {
 
 func TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess(t *testing.T) {
 	var cluster1, cluster2, cluster3 eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -426,9 +459,8 @@ func TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess(t *testing.T) {
 }
 
 func TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs(t *testing.T) {
-	var cluster1 eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	var cluster eks.Cluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -440,7 +472,7 @@ func TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs(t *testing.T) {
 			{
 				Config: testAccAWSEksClusterConfig_VpcConfig_PublicAccessCidrs(rName, `["1.2.3.4/32", "5.6.7.8/32"]`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEksClusterExists(resourceName, &cluster1),
+					testAccCheckAWSEksClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.public_access_cidrs.#", "2"),
 				),
@@ -453,7 +485,7 @@ func TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs(t *testing.T) {
 			{
 				Config: testAccAWSEksClusterConfig_VpcConfig_PublicAccessCidrs(rName, `["4.3.2.1/32", "8.7.6.5/32"]`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEksClusterExists(resourceName, &cluster1),
+					testAccCheckAWSEksClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.public_access_cidrs.#", "2"),
 				),
@@ -464,8 +496,7 @@ func TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs(t *testing.T) {
 
 func TestAccAWSEksCluster_NetworkConfig_ServiceIpv4Cidr(t *testing.T) {
 	var cluster1, cluster2 eks.Cluster
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -651,7 +682,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name                          = "terraform-testacc-eks-cluster-base"
+    Name                          = %[1]q
     "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }
@@ -664,7 +695,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name                          = "terraform-testacc-eks-cluster-base"
+    Name                          = %[1]q
     "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }
@@ -674,7 +705,7 @@ resource "aws_subnet" "test" {
 func testAccAWSEksClusterConfig_Required(rName string) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -689,9 +720,9 @@ resource "aws_eks_cluster" "test" {
 func testAccAWSEksClusterConfig_Version(rName, version string) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
-  version  = %q
+  version  = %[2]q
 
   vpc_config {
     subnet_ids = aws_subnet.test[*].id
@@ -705,9 +736,9 @@ resource "aws_eks_cluster" "test" {
 func testAccAWSEksClusterConfig_Logging(rName string, logTypes []string) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name                      = %q
+  name                      = %[1]q
   role_arn                  = aws_iam_role.test.arn
-  enabled_cluster_log_types = ["%v"]
+  enabled_cluster_log_types = ["%[2]v"]
 
   vpc_config {
     subnet_ids = aws_subnet.test[*].id
@@ -791,12 +822,12 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-eks-cluster-sg"
+    Name = %[1]q
   }
 }
 
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -812,11 +843,11 @@ resource "aws_eks_cluster" "test" {
 func testAccAWSEksClusterConfig_VpcConfig_EndpointPrivateAccess(rName string, endpointPrivateAccess bool) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
-    endpoint_private_access = %t
+    endpoint_private_access = %[2]t
     endpoint_public_access  = true
     subnet_ids              = aws_subnet.test[*].id
   }
@@ -829,12 +860,12 @@ resource "aws_eks_cluster" "test" {
 func testAccAWSEksClusterConfig_VpcConfig_EndpointPublicAccess(rName string, endpointPublicAccess bool) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
     endpoint_private_access = true
-    endpoint_public_access  = %t
+    endpoint_public_access  = %[2]t
     subnet_ids              = aws_subnet.test[*].id
   }
 
@@ -846,13 +877,13 @@ resource "aws_eks_cluster" "test" {
 func testAccAWSEksClusterConfig_VpcConfig_PublicAccessCidrs(rName string, publicAccessCidr string) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
     endpoint_private_access = true
     endpoint_public_access  = true
-    public_access_cidrs     = %s
+    public_access_cidrs     = %[2]s
     subnet_ids              = aws_subnet.test[*].id
   }
 
@@ -864,7 +895,7 @@ resource "aws_eks_cluster" "test" {
 func testAccAWSEksClusterConfig_NetworkConfig_ServiceIpv4Cidr(rName string, serviceIpv4Cidr string) string {
 	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %q
+  name     = %[1]q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -872,7 +903,7 @@ resource "aws_eks_cluster" "test" {
   }
 
   kubernetes_network_config {
-    service_ipv4_cidr = %s
+    service_ipv4_cidr = %[2]s
   }
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]

--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -14,6 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfeks "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -26,56 +28,63 @@ func init() {
 func testSweepEksFargateProfiles(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).eksconn
-
-	var errors error
 	input := &eks.ListClustersInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]*testSweepResource, 0)
+
 	err = conn.ListClustersPages(input, func(page *eks.ListClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
 		for _, cluster := range page.Clusters {
-			clusterName := aws.StringValue(cluster)
 			input := &eks.ListFargateProfilesInput{
 				ClusterName: cluster,
 			}
+
 			err := conn.ListFargateProfilesPages(input, func(page *eks.ListFargateProfilesOutput, lastPage bool) bool {
-				for _, profile := range page.FargateProfileNames {
-					profileName := aws.StringValue(profile)
-					log.Printf("[INFO] Deleting Fargate Profile %q", profileName)
-					input := &eks.DeleteFargateProfileInput{
-						ClusterName:        cluster,
-						FargateProfileName: profile,
-					}
-					_, err := conn.DeleteFargateProfile(input)
-
-					if err != nil && !isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
-						errors = multierror.Append(errors, fmt.Errorf("error deleting EKS Fargate Profile %q: %w", profileName, err))
-						continue
-					}
-
-					if err := waitForEksFargateProfileDeletion(conn, clusterName, profileName, 10*time.Minute); err != nil {
-						errors = multierror.Append(errors, fmt.Errorf("error waiting for EKS Fargate Profile %q deletion: %w", profileName, err))
-						continue
-					}
+				if page == nil {
+					return !lastPage
 				}
-				return true
+
+				for _, profile := range page.FargateProfileNames {
+					r := resourceAwsEksFargateProfile()
+					d := r.Data(nil)
+					d.SetId(tfeks.FargateProfileCreateResourceID(aws.StringValue(cluster), aws.StringValue(profile)))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
 			})
+
 			if err != nil {
-				errors = multierror.Append(errors, fmt.Errorf("error listing Fargate Profiles for EKS Cluster %s: %w", clusterName, err))
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing EKS Fargate Profiles (%s): %w", region, err))
 			}
 		}
 
-		return true
+		return !lastPage
 	})
+
 	if testSweepSkipSweepError(err) {
-		log.Printf("[WARN] Skipping EKS Clusters sweep for %s: %s", region, err)
-		return errors // In case we have completed some pages, but had errors
-	}
-	if err != nil {
-		errors = multierror.Append(errors, fmt.Errorf("error retrieving EKS Clusters: %w", err))
+		log.Printf("[WARN] Skipping EKS Fargate Profiles sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 	}
 
-	return errors
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing EKS Clusters (%s): %w", region, err))
+	}
+
+	err = testSweepResourceOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping EKS Fargate Profiles (%s): %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
 }
 
 func TestAccAWSEksFargateProfile_basic(t *testing.T) {
@@ -129,7 +138,7 @@ func TestAccAWSEksFargateProfile_disappears(t *testing.T) {
 				Config: testAccAWSEksFargateProfileConfigFargateProfileName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksFargateProfileExists(resourceName, &fargateProfile),
-					testAccCheckAWSEksFargateProfileDisappears(&fargateProfile),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEksFargateProfile(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -242,37 +251,21 @@ func testAccCheckAWSEksFargateProfileExists(resourceName string, fargateProfile 
 			return fmt.Errorf("No EKS Fargate Profile ID is set")
 		}
 
-		clusterName, fargateProfileName, err := resourceAwsEksFargateProfileParseId(rs.Primary.ID)
+		clusterName, fargateProfileName, err := tfeks.FargateProfileParseResourceID(rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).eksconn
 
-		input := &eks.DescribeFargateProfileInput{
-			ClusterName:        aws.String(clusterName),
-			FargateProfileName: aws.String(fargateProfileName),
-		}
-
-		output, err := conn.DescribeFargateProfile(input)
+		output, err := finder.FargateProfileByClusterNameAndFargateProfileName(conn, clusterName, fargateProfileName)
 
 		if err != nil {
 			return err
 		}
 
-		if output == nil || output.FargateProfile == nil {
-			return fmt.Errorf("EKS Fargate Profile (%s) not found", rs.Primary.ID)
-		}
-
-		if aws.StringValue(output.FargateProfile.FargateProfileName) != fargateProfileName {
-			return fmt.Errorf("EKS Fargate Profile (%s) not found", rs.Primary.ID)
-		}
-
-		if got, want := aws.StringValue(output.FargateProfile.Status), eks.FargateProfileStatusActive; got != want {
-			return fmt.Errorf("EKS Fargate Profile (%s) not in %s status, got: %s", rs.Primary.ID, want, got)
-		}
-
-		*fargateProfile = *output.FargateProfile
+		*fargateProfile = *output
 
 		return nil
 	}
@@ -286,51 +279,26 @@ func testAccCheckAWSEksFargateProfileDestroy(s *terraform.State) error {
 			continue
 		}
 
-		clusterName, fargateProfileName, err := resourceAwsEksFargateProfileParseId(rs.Primary.ID)
+		clusterName, fargateProfileName, err := tfeks.FargateProfileParseResourceID(rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
 
-		input := &eks.DescribeFargateProfileInput{
-			ClusterName:        aws.String(clusterName),
-			FargateProfileName: aws.String(fargateProfileName),
-		}
+		_, err = finder.FargateProfileByClusterNameAndFargateProfileName(conn, clusterName, fargateProfileName)
 
-		output, err := conn.DescribeFargateProfile(input)
-
-		if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+		if tfresource.NotFound(err) {
 			continue
 		}
 
-		if output != nil && output.FargateProfile != nil && aws.StringValue(output.FargateProfile.FargateProfileName) == fargateProfileName {
-			return fmt.Errorf("EKS Fargate Profile (%s) still exists", rs.Primary.ID)
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckAWSEksFargateProfileDisappears(fargateProfile *eks.FargateProfile) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).eksconn
-
-		input := &eks.DeleteFargateProfileInput{
-			ClusterName:        fargateProfile.ClusterName,
-			FargateProfileName: fargateProfile.FargateProfileName,
-		}
-
-		_, err := conn.DeleteFargateProfile(input)
-
-		if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}
 
-		return waitForEksFargateProfileDeletion(conn, aws.StringValue(fargateProfile.ClusterName), aws.StringValue(fargateProfile.FargateProfileName), 10*time.Minute)
+		return fmt.Errorf("EKS Fargate Profile %s still exists", rs.Primary.ID)
 	}
+
+	return nil
 }
 
 func testAccPreCheckAWSEksFargateProfile(t *testing.T) {
@@ -445,13 +413,17 @@ resource "aws_vpc" "test" {
   enable_dns_support   = true
 
   tags = {
-    Name                          = "tf-acc-test-eks-fargate-profile"
+    Name                          = %[1]q
     "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route_table" "public" {
@@ -460,6 +432,10 @@ resource "aws_route_table" "public" {
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.test.id
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
 
@@ -476,7 +452,7 @@ resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name                          = "tf-acc-test-eks-fargate-profile-private"
+    Name                          = %[1]q
     "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }
@@ -486,6 +462,10 @@ resource "aws_eip" "private" {
   depends_on = [aws_internet_gateway.test]
 
   vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_nat_gateway" "private" {
@@ -493,6 +473,10 @@ resource "aws_nat_gateway" "private" {
 
   allocation_id = aws_eip.private[count.index].id
   subnet_id     = aws_subnet.private[count.index].id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route_table" "private" {
@@ -503,6 +487,10 @@ resource "aws_route_table" "private" {
   route {
     cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.private[count.index].id
+  }
+
+  tags = {
+    Name = %[1]q
   }
 }
 
@@ -521,7 +509,7 @@ resource "aws_subnet" "public" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name                          = "tf-acc-test-eks-fargate-profile-public"
+    Name                          = %[1]q
     "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -23,7 +23,6 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 		Read:   resourceAwsEksNodeGroupRead,
 		Update: resourceAwsEksNodeGroupUpdate,
 		Delete: resourceAwsEksNodeGroupDelete,
-
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -4,17 +4,20 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 	tfeks "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsEksNodeGroup() *schema.Resource {
@@ -259,6 +262,8 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 
 	clusterName := d.Get("cluster_name").(string)
 	nodeGroupName := naming.Generate(d.Get("node_group_name").(string), d.Get("node_group_name_prefix").(string))
+	id := tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName)
+
 	input := &eks.CreateNodegroupInput{
 		ClientRequestToken: aws.String(resource.UniqueId()),
 		ClusterName:        aws.String(clusterName),
@@ -303,10 +308,6 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 		input.ScalingConfig = expandEksNodegroupScalingConfig(v)
 	}
 
-	if len(tags) > 0 {
-		input.Tags = tags.IgnoreAws().EksTags()
-	}
-
 	if v, ok := d.GetOk("taint"); ok && v.(*schema.Set).Len() > 0 {
 		input.Taints = expandEksTaints(v.(*schema.Set).List())
 	}
@@ -315,23 +316,22 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 		input.Version = aws.String(v.(string))
 	}
 
+	if len(tags) > 0 {
+		input.Tags = tags.IgnoreAws().EksTags()
+	}
+
 	_, err := conn.CreateNodegroup(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EKS Node Group (%s/%s): %w", clusterName, nodeGroupName, err)
+		return fmt.Errorf("error creating EKS Node Group (%s): %w", id, err)
 	}
 
-	d.SetId(tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
+	d.SetId(id)
 
-	stateConf := resource.StateChangeConf{
-		Pending: []string{eks.NodegroupStatusCreating},
-		Target:  []string{eks.NodegroupStatusActive},
-		Timeout: d.Timeout(schema.TimeoutCreate),
-		Refresh: refreshEksNodeGroupStatus(conn, clusterName, nodeGroupName),
-	}
+	_, err = waiter.NodegroupCreated(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutCreate))
 
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("error waiting for EKS Node Group (%s) creation: %w", d.Id(), err)
+	if err != nil {
+		return fmt.Errorf("error waiting for EKS Node Groupe (%s) to create: %w", d.Id(), err)
 	}
 
 	return resourceAwsEksNodeGroupRead(d, meta)
@@ -348,14 +348,9 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	input := &eks.DescribeNodegroupInput{
-		ClusterName:   aws.String(clusterName),
-		NodegroupName: aws.String(nodeGroupName),
-	}
+	nodeGroup, err := finder.NodegroupByClusterNameAndNodegroupName(conn, clusterName, nodeGroupName)
 
-	output, err := conn.DescribeNodegroup(input)
-
-	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EKS Node Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -363,13 +358,6 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 
 	if err != nil {
 		return fmt.Errorf("error reading EKS Node Group (%s): %w", d.Id(), err)
-	}
-
-	nodeGroup := output.Nodegroup
-	if nodeGroup == nil {
-		log.Printf("[WARN] EKS Node Group (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("ami_type", nodeGroup.AmiType)
@@ -413,6 +401,12 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting subnets: %w", err)
 	}
 
+	if err := d.Set("taint", flattenEksTaints(nodeGroup.Taints)); err != nil {
+		return fmt.Errorf("error setting taint: %w", err)
+	}
+
+	d.Set("version", nodeGroup.Version)
+
 	tags := keyvaluetags.EksKeyValueTags(nodeGroup.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
@@ -423,12 +417,6 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("tags_all", tags.Map()); err != nil {
 		return fmt.Errorf("error setting tags_all: %w", err)
 	}
-
-	if err := d.Set("taint", flattenEksTaints(nodeGroup.Taints)); err != nil {
-		return fmt.Errorf("error setting taint: %w", err)
-	}
-
-	d.Set("version", nodeGroup.Version)
 
 	return nil
 }
@@ -442,41 +430,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if d.HasChanges("labels", "scaling_config", "taint") {
-		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
-
-		input := &eks.UpdateNodegroupConfigInput{
-			ClientRequestToken: aws.String(resource.UniqueId()),
-			ClusterName:        aws.String(clusterName),
-			Labels:             expandEksUpdateLabelsPayload(oldLabelsRaw, newLabelsRaw),
-			NodegroupName:      aws.String(nodeGroupName),
-		}
-
-		if v := d.Get("scaling_config").([]interface{}); len(v) > 0 {
-			input.ScalingConfig = expandEksNodegroupScalingConfig(v)
-		}
-
-		oldTaintsRaw, newTaintsRaw := d.GetChange("taint")
-		input.Taints = expandEksUpdateTaintsPayload(oldTaintsRaw.(*schema.Set).List(), newTaintsRaw.(*schema.Set).List())
-
-		output, err := conn.UpdateNodegroupConfig(input)
-
-		if err != nil {
-			return fmt.Errorf("error updating EKS Node Group (%s) config: %w", d.Id(), err)
-		}
-
-		if output == nil || output.Update == nil || output.Update.Id == nil {
-			return fmt.Errorf("error determining EKS Node Group (%s) config update ID: empty response", d.Id())
-		}
-
-		updateID := aws.StringValue(output.Update.Id)
-
-		err = waitForEksNodeGroupUpdate(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return fmt.Errorf("error waiting for EKS Node Group (%s) config update (%s): %w", d.Id(), updateID, err)
-		}
-	}
-
+	// Do any version update first.
 	if d.HasChanges("launch_template", "release_version", "version") {
 		input := &eks.UpdateNodegroupVersionInput{
 			ClientRequestToken: aws.String(resource.UniqueId()),
@@ -519,15 +473,44 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("error updating EKS Node Group (%s) version: %w", d.Id(), err)
 		}
 
-		if output == nil || output.Update == nil || output.Update.Id == nil {
-			return fmt.Errorf("error determining EKS Node Group (%s) version update ID: empty response", d.Id())
+		updateID := aws.StringValue(output.Update.Id)
+
+		_, err = waiter.NodegroupUpdateSuccessful(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return fmt.Errorf("error waiting for EKS Node Group (%s) version update (%s): %w", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChanges("labels", "scaling_config", "taint") {
+		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
+
+		input := &eks.UpdateNodegroupConfigInput{
+			ClientRequestToken: aws.String(resource.UniqueId()),
+			ClusterName:        aws.String(clusterName),
+			Labels:             expandEksUpdateLabelsPayload(oldLabelsRaw, newLabelsRaw),
+			NodegroupName:      aws.String(nodeGroupName),
+		}
+
+		if v := d.Get("scaling_config").([]interface{}); len(v) > 0 {
+			input.ScalingConfig = expandEksNodegroupScalingConfig(v)
+		}
+
+		oldTaintsRaw, newTaintsRaw := d.GetChange("taint")
+		input.Taints = expandEksUpdateTaintsPayload(oldTaintsRaw.(*schema.Set).List(), newTaintsRaw.(*schema.Set).List())
+
+		output, err := conn.UpdateNodegroupConfig(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating EKS Node Group (%s) config: %w", d.Id(), err)
 		}
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		err = waitForEksNodeGroupUpdate(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.NodegroupUpdateSuccessful(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+
 		if err != nil {
-			return fmt.Errorf("error waiting for EKS Node Group (%s) version update (%s): %w", d.Id(), updateID, err)
+			return fmt.Errorf("error waiting for EKS Node Group (%s) config update (%s): %w", d.Id(), updateID, err)
 		}
 	}
 
@@ -550,14 +533,13 @@ func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	input := &eks.DeleteNodegroupInput{
+	log.Printf("[DEBUG] Deleting EKS Node Group: %s", d.Id())
+	_, err = conn.DeleteNodegroup(&eks.DeleteNodegroupInput{
 		ClusterName:   aws.String(clusterName),
 		NodegroupName: aws.String(nodeGroupName),
-	}
+	})
 
-	_, err = conn.DeleteNodegroup(input)
-
-	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, eks.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 
@@ -565,8 +547,10 @@ func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error deleting EKS Node Group (%s): %w", d.Id(), err)
 	}
 
-	if err := waitForEksNodeGroupDeletion(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("error waiting for EKS Node Group (%s) deletion: %w", d.Id(), err)
+	_, err = waiter.NodegroupDeleted(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete))
+
+	if err != nil {
+		return fmt.Errorf("error waiting for EKS Node Group (%s) to delete: %w", d.Id(), err)
 	}
 
 	return nil
@@ -867,115 +851,4 @@ func flattenEksTaints(taints []*eks.Taint) []interface{} {
 		results = append(results, t)
 	}
 	return results
-}
-
-func refreshEksNodeGroupStatus(conn *eks.EKS, clusterName string, nodeGroupName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		input := &eks.DescribeNodegroupInput{
-			ClusterName:   aws.String(clusterName),
-			NodegroupName: aws.String(nodeGroupName),
-		}
-
-		output, err := conn.DescribeNodegroup(input)
-
-		if err != nil {
-			return "", "", err
-		}
-
-		nodeGroup := output.Nodegroup
-
-		if nodeGroup == nil {
-			return nodeGroup, "", fmt.Errorf("EKS Node Group (%s) missing", tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
-		}
-
-		status := aws.StringValue(nodeGroup.Status)
-
-		// Return enhanced error messaging if available, instead of:
-		// unexpected state 'CREATE_FAILED', wanted target 'ACTIVE'. last error: %!s(<nil>)
-		if status == eks.NodegroupStatusCreateFailed || status == eks.NodegroupStatusDeleteFailed {
-			if nodeGroup.Health == nil || len(nodeGroup.Health.Issues) == 0 || nodeGroup.Health.Issues[0] == nil {
-				return nodeGroup, status, fmt.Errorf("unable to find additional information about %s status, check EKS Node Group (%s) health", status, tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName))
-			}
-
-			issue := nodeGroup.Health.Issues[0]
-
-			return nodeGroup, status, fmt.Errorf("%s: %s. Resource IDs: %v", aws.StringValue(issue.Code), aws.StringValue(issue.Message), aws.StringValueSlice(issue.ResourceIds))
-		}
-
-		return nodeGroup, status, nil
-	}
-}
-
-func refreshEksNodeGroupUpdateStatus(conn *eks.EKS, clusterName string, nodeGroupName string, updateID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		input := &eks.DescribeUpdateInput{
-			Name:          aws.String(clusterName),
-			NodegroupName: aws.String(nodeGroupName),
-			UpdateId:      aws.String(updateID),
-		}
-
-		output, err := conn.DescribeUpdate(input)
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		if output == nil || output.Update == nil {
-			return nil, "", fmt.Errorf("EKS Node Group (%s) update (%s) missing", tfeks.NodeGroupCreateResourceID(clusterName, nodeGroupName), updateID)
-		}
-
-		return output.Update, aws.StringValue(output.Update.Status), nil
-	}
-}
-
-func waitForEksNodeGroupDeletion(conn *eks.EKS, clusterName string, nodeGroupName string, timeout time.Duration) error {
-	stateConf := resource.StateChangeConf{
-		Pending: []string{
-			eks.NodegroupStatusActive,
-			eks.NodegroupStatusDeleting,
-		},
-		Target:  []string{""},
-		Timeout: timeout,
-		Refresh: refreshEksNodeGroupStatus(conn, clusterName, nodeGroupName),
-	}
-
-	_, err := stateConf.WaitForState()
-
-	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
-		return nil
-	}
-
-	return err
-}
-
-func waitForEksNodeGroupUpdate(conn *eks.EKS, clusterName, nodeGroupName string, updateID string, timeout time.Duration) error {
-	stateConf := resource.StateChangeConf{
-		Pending: []string{eks.UpdateStatusInProgress},
-		Target: []string{
-			eks.UpdateStatusCancelled,
-			eks.UpdateStatusFailed,
-			eks.UpdateStatusSuccessful,
-		},
-		Timeout: timeout,
-		Refresh: refreshEksNodeGroupUpdateStatus(conn, clusterName, nodeGroupName, updateID),
-	}
-
-	updateRaw, err := stateConf.WaitForState()
-
-	if err != nil {
-		return err
-	}
-
-	update := updateRaw.(*eks.Update)
-
-	if aws.StringValue(update.Status) == eks.UpdateStatusSuccessful {
-		return nil
-	}
-
-	var detailedErrors []string
-	for i, updateError := range update.Errors {
-		detailedErrors = append(detailedErrors, fmt.Sprintf("Error %d: Code: %s / Message: %s", i+1, aws.StringValue(updateError.ErrorCode), aws.StringValue(updateError.ErrorMessage)))
-	}
-
-	return fmt.Errorf("EKS Node Group (%s) update (%s) status (%s) not successful: Errors:\n%s", clusterName, updateID, aws.StringValue(update.Status), strings.Join(detailedErrors, "\n"))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17952 

### References
https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-eks-supports-adding-kms-envelope-encryption-to-existing-clusters/

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
