### PR TITLE
Support for tags `aws_shield_protection`

### DIFF
--- a/.changelog/19168.txt
+++ b/.changelog/19168.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_shield_protection: Add `tags` argument
+```
+
+```release-notes:enhancement
+resource/aws_shield_protection: Add `arn` attribute
+```
+
+```release-notes:enhancement
+resource/aws_shield_protection: Missing resources are now detected and recreated
+```

--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -108,6 +108,7 @@ var serviceNames = []string{
 	"securityhub",
 	"servicediscovery",
 	"sfn",
+	"shield",
 	"signer",
 	"sns",
 	"sqs",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -91,6 +91,7 @@ var sliceServiceNames = []string{
 	"servicecatalog",
 	"servicediscovery",
 	"sfn",
+	"shield",
 	"sns",
 	"ssm",
 	"ssoadmin",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -115,6 +115,7 @@ var serviceNames = []string{
 	"securityhub",
 	"servicediscovery",
 	"sfn",
+	"shield",
 	"signer",
 	"sns",
 	"sqs",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -95,6 +95,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/aws-sdk-go/service/signer"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -1667,6 +1668,23 @@ func SfnListTags(conn *sfn.SFN, identifier string) (KeyValueTags, error) {
 	}
 
 	return SfnKeyValueTags(output.Tags), nil
+}
+
+// ShieldListTags lists shield service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func ShieldListTags(conn *shield.Shield, identifier string) (KeyValueTags, error) {
+	input := &shield.ListTagsForResourceInput{
+		ResourceARN: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return ShieldKeyValueTags(output.Tags), nil
 }
 
 // SignerListTags lists signer service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -106,6 +106,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/aws-sdk-go/service/signer"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -330,6 +331,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(servicediscovery.New)
 	case "sfn":
 		funcType = reflect.TypeOf(sfn.New)
+	case "shield":
+		funcType = reflect.TypeOf(shield.New)
 	case "signer":
 		funcType = reflect.TypeOf(signer.New)
 	case "sns":
@@ -623,6 +626,8 @@ func ServiceTagFunction(serviceName string) string {
 		return "ChangeTagsForResource"
 	case "sagemaker":
 		return "AddTags"
+	case "shield":
+		return "TagResource"
 	case "sqs":
 		return "TagQueue"
 	case "ssm":
@@ -738,6 +743,8 @@ func ServiceTagInputIdentifierField(serviceName string) string {
 	case "secretsmanager":
 		return "SecretId"
 	case "servicediscovery":
+		return "ResourceARN"
+	case "shield":
 		return "ResourceARN"
 	case "sqs":
 		return "QueueUrl"

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -79,6 +79,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
@@ -2608,6 +2609,33 @@ func (tags KeyValueTags) SfnTags() []*sfn.Tag {
 
 // SfnKeyValueTags creates KeyValueTags from sfn service tags.
 func SfnKeyValueTags(tags []*sfn.Tag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// ShieldTags returns shield service tags.
+func (tags KeyValueTags) ShieldTags() []*shield.Tag {
+	result := make([]*shield.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &shield.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// ShieldKeyValueTags creates KeyValueTags from shield service tags.
+func ShieldKeyValueTags(tags []*shield.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -104,6 +104,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/aws-sdk-go/service/signer"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -3638,6 +3639,42 @@ func SfnUpdateTags(conn *sfn.SFN, identifier string, oldTagsMap interface{}, new
 		input := &sfn.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        updatedTags.IgnoreAws().SfnTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// ShieldUpdateTags updates shield service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func ShieldUpdateTags(conn *shield.Shield, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &shield.UntagResourceInput{
+			ResourceARN: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &shield.TagResourceInput{
+			ResourceARN: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().ShieldTags(),
 		}
 
 		_, err := conn.TagResource(input)

--- a/aws/resource_aws_shield_protection.go
+++ b/aws/resource_aws_shield_protection.go
@@ -2,15 +2,18 @@ package aws
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsShieldProtection() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsShieldProtectionCreate,
+		Update: resourceAwsShieldProtectionUpdate,
 		Read:   resourceAwsShieldProtectionRead,
 		Delete: resourceAwsShieldProtectionDelete,
 		Importer: &schema.ResourceImporter{
@@ -18,6 +21,10 @@ func resourceAwsShieldProtection() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -29,16 +36,36 @@ func resourceAwsShieldProtection() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
 		},
+		CustomizeDiff: SetTagsDiff,
 	}
+}
+
+func resourceAwsShieldProtectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).shieldconn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		if err := keyvaluetags.ShieldUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsShieldProtectionRead(d, meta)
 }
 
 func resourceAwsShieldProtectionCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).shieldconn
 
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
 	input := &shield.CreateProtectionInput{
 		Name:        aws.String(d.Get("name").(string)),
 		ResourceArn: aws.String(d.Get("resource_arn").(string)),
+		Tags:        tags.IgnoreAws().ShieldTags(),
 	}
 
 	resp, err := conn.CreateProtection(input)
@@ -51,17 +78,47 @@ func resourceAwsShieldProtectionCreate(d *schema.ResourceData, meta interface{})
 
 func resourceAwsShieldProtectionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).shieldconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &shield.DescribeProtectionInput{
 		ProtectionId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.DescribeProtection(input)
+
+	if isAWSErr(err, shield.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Shield Protection (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error reading Shield Protection (%s): %s", d.Id(), err)
 	}
+
+	arn := aws.StringValue(resp.Protection.ProtectionArn)
+	d.Set("arn", arn)
 	d.Set("name", resp.Protection.Name)
 	d.Set("resource_arn", resp.Protection.ResourceArn)
+
+	tags, err := keyvaluetags.ShieldListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Shield Protection (%s): %s", arn, err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
 	return nil
 }
 

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -75,6 +75,32 @@ func TestAccAWSShieldProtection_ElasticIPAddress(t *testing.T) {
 	})
 }
 
+func TestAccAWSShieldProtection_disappears(t *testing.T) {
+	resourceName := "aws_shield_protection.acctest"
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
+		ErrorCheck:   testAccErrorCheck(t, shield.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccShieldProtectionElasticIPAddressConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSShieldProtectionExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsShieldProtection(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSShieldProtection_Alb(t *testing.T) {
 	resourceName := "aws_shield_protection.acctest"
 	rName := acctest.RandString(10)

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -31,6 +31,8 @@ func TestAccAWSShieldProtection_GlobalAccelerator(t *testing.T) {
 				Config: testAccShieldProtectionGlobalAcceleratorConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
@@ -60,6 +62,8 @@ func TestAccAWSShieldProtection_ElasticIPAddress(t *testing.T) {
 				Config: testAccShieldProtectionElasticIPAddressConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
@@ -89,6 +93,8 @@ func TestAccAWSShieldProtection_Alb(t *testing.T) {
 				Config: testAccShieldProtectionAlbConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
@@ -118,6 +124,8 @@ func TestAccAWSShieldProtection_Elb(t *testing.T) {
 				Config: testAccShieldProtectionElbConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
@@ -148,12 +156,66 @@ func TestAccAWSShieldProtection_Cloudfront(t *testing.T) {
 				Config: testAccShieldProtectionCloudfrontConfig(rName, testAccShieldProtectionCloudfrontRetainConfig()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSShieldProtection_Cloudfront_Tags(t *testing.T) {
+	resourceName := "aws_shield_protection.acctest"
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(shield.EndpointsID, t)
+			testAccPartitionHasServicePreCheck(cloudfront.EndpointsID, t)
+			testAccPreCheckAWSShield(t)
+		},
+		ErrorCheck:   testAccErrorCheck(t, shield.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSShieldProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccShieldProtectionCloudfrontConfigTags1(rName, testAccShieldProtectionCloudfrontRetainConfig(), "Key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccShieldProtectionCloudfrontConfigTags2(rName, testAccShieldProtectionCloudfrontRetainConfig(), "Key1", "value1updated", "Key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "value2"),
+				),
+			},
+			{
+				Config: testAccShieldProtectionCloudfrontConfigTags1(rName, testAccShieldProtectionCloudfrontRetainConfig(), "Key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSShieldProtectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "value2"),
+				),
 			},
 		},
 	})
@@ -520,8 +582,164 @@ resource "aws_cloudfront_distribution" "acctest" {
 resource "aws_shield_protection" "acctest" {
   name         = var.name
   resource_arn = aws_cloudfront_distribution.acctest.arn
+
 }
 `, rName, retainOnDelete)
+}
+
+func testAccShieldProtectionCloudfrontConfigTags1(rName, retainOnDelete, tagKey string, tagValue string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "aws_cloudfront_distribution" "acctest" {
+  origin {
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+
+      origin_ssl_protocols = [
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
+    }
+
+    # This is a fake origin and it's set to this name to indicate that.
+    domain_name = "${var.name}.com"
+    origin_id   = "acctest"
+  }
+
+  enabled             = false
+  wait_for_deployment = false
+
+  default_cache_behavior {
+    allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "acctest"
+
+    forwarded_values {
+      query_string = false
+      headers      = ["*"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    foo  = "bar"
+    Name = var.name
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  %s
+}
+
+resource "aws_shield_protection" "acctest" {
+  name         = var.name
+  resource_arn = aws_cloudfront_distribution.acctest.arn
+
+  tags = {
+    %[3]q = %[4]q
+  }
+}
+`, rName, retainOnDelete, tagKey, tagValue)
+}
+
+func testAccShieldProtectionCloudfrontConfigTags2(rName, retainOnDelete, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "aws_cloudfront_distribution" "acctest" {
+  origin {
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+
+      origin_ssl_protocols = [
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
+    }
+
+    # This is a fake origin and it's set to this name to indicate that.
+    domain_name = "${var.name}.com"
+    origin_id   = "acctest"
+  }
+
+  enabled             = false
+  wait_for_deployment = false
+
+  default_cache_behavior {
+    allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "acctest"
+
+    forwarded_values {
+      query_string = false
+      headers      = ["*"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    foo  = "bar"
+    Name = var.name
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  %s
+}
+
+resource "aws_shield_protection" "acctest" {
+  name         = var.name
+  resource_arn = aws_cloudfront_distribution.acctest.arn
+
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, rName, retainOnDelete, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccShieldProtectionElasticIPAddressConfig(rName string) string {

--- a/website/docs/r/shield_protection.html.markdown
+++ b/website/docs/r/shield_protection.html.markdown
@@ -27,6 +27,10 @@ resource "aws_eip" "example" {
 resource "aws_shield_protection" "example" {
   name         = "example"
   resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+
+  tags = {
+    Environment = "Dev"
+  }
 }
 ```
 
@@ -36,12 +40,15 @@ The following arguments are supported:
 
 * `name` - (Required) A friendly name for the Protection you are creating.
 * `resource_arn` - (Required) The ARN (Amazon Resource Name) of the resource to be protected.
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique identifier (ID) for the Protection object that is created.
+* `arn` - The ARN of the Protection.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Output from acceptance testing:

```
$  make testacc TESTARGS='-run=TestAccAWSShieldProtection_Cloudfront'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.16 test ./aws -v -count 1 -parallel 20 -run=TestAccAWSShieldProtection_Cloudfront -timeout 180m
=== RUN   TestAccAWSShieldProtection_Cloudfront
=== PAUSE TestAccAWSShieldProtection_Cloudfront
=== RUN   TestAccAWSShieldProtection_Cloudfront_Tags
=== PAUSE TestAccAWSShieldProtection_Cloudfront_Tags
=== CONT  TestAccAWSShieldProtection_Cloudfront
=== CONT  TestAccAWSShieldProtection_Cloudfront_Tags
--- PASS: TestAccAWSShieldProtection_Cloudfront (193.39s)
--- PASS: TestAccAWSShieldProtection_Cloudfront_Tags (249.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	250.018s

```

Relates: #13826.
Closes: #18046.