### PR TITLE
Add support for AllowClassicFlow to the Cognito Identity Pool resource.

### DIFF
--- a/.changelog/19176.txt
+++ b/.changelog/19176.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_identity_pool: Add allow_classic_flow argument
+```

--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -72,6 +72,12 @@ func resourceAwsCognitoIdentityPool() *schema.Resource {
 				Default:  false,
 			},
 
+			"allow_classic_flow": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"openid_connect_provider_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -116,6 +122,7 @@ func resourceAwsCognitoIdentityPoolCreate(d *schema.ResourceData, meta interface
 	params := &cognitoidentity.CreateIdentityPoolInput{
 		IdentityPoolName:               aws.String(d.Get("identity_pool_name").(string)),
 		AllowUnauthenticatedIdentities: aws.Bool(d.Get("allow_unauthenticated_identities").(bool)),
+		AllowClassicFlow:               aws.Bool(d.Get("allow_classic_flow").(bool)),
 	}
 
 	if v, ok := d.GetOk("developer_provider_name"); ok {
@@ -180,6 +187,7 @@ func resourceAwsCognitoIdentityPoolRead(d *schema.ResourceData, meta interface{}
 	d.Set("arn", arn.String())
 	d.Set("identity_pool_name", ip.IdentityPoolName)
 	d.Set("allow_unauthenticated_identities", ip.AllowUnauthenticatedIdentities)
+	d.Set("allow_classic_flow", ip.AllowClassicFlow)
 	d.Set("developer_provider_name", ip.DeveloperProviderName)
 	tags := keyvaluetags.CognitoidentityKeyValueTags(ip.IdentityPoolTags).IgnoreAws().IgnoreConfig(ignoreTagsConfig)
 
@@ -218,6 +226,7 @@ func resourceAwsCognitoIdentityPoolUpdate(d *schema.ResourceData, meta interface
 	params := &cognitoidentity.IdentityPool{
 		IdentityPoolId:                 aws.String(d.Id()),
 		AllowUnauthenticatedIdentities: aws.Bool(d.Get("allow_unauthenticated_identities").(bool)),
+		AllowClassicFlow:               aws.Bool(d.Get("allow_classic_flow").(bool)),
 		IdentityPoolName:               aws.String(d.Get("identity_pool_name").(string)),
 	}
 

--- a/website/docs/r/cognito_identity_pool.markdown
+++ b/website/docs/r/cognito_identity_pool.markdown
@@ -51,7 +51,7 @@ The Cognito Identity Pool argument layout is a structure composed of several sub
 
 * `identity_pool_name` (Required) - The Cognito Identity Pool name.
 * `allow_unauthenticated_identities` (Required) - Whether the identity pool supports unauthenticated logins or not.
-* `allow_classic_flow` (Optional) - Enables or disables the classic / basic authentication flow.
+* `allow_classic_flow` (Optional) - Enables or disables the classic / basic authentication flow. Default is `false`.
 * `developer_provider_name` (Optional) - The "domain" by which Cognito will refer to your users. This name acts as a placeholder that allows your
 backend and the Cognito service to communicate about the developer provider.
 * `cognito_identity_providers` (Optional) - An array of [Amazon Cognito Identity user pools](#cognito-identity-providers) and their client IDs.

--- a/website/docs/r/cognito_identity_pool.markdown
+++ b/website/docs/r/cognito_identity_pool.markdown
@@ -21,6 +21,7 @@ resource "aws_iam_saml_provider" "default" {
 resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool"
   allow_unauthenticated_identities = false
+  allow_classic_flow               = false
 
   cognito_identity_providers {
     client_id               = "6lhlkkfbfb4q5kpp90urffae"
@@ -50,6 +51,7 @@ The Cognito Identity Pool argument layout is a structure composed of several sub
 
 * `identity_pool_name` (Required) - The Cognito Identity Pool name.
 * `allow_unauthenticated_identities` (Required) - Whether the identity pool supports unauthenticated logins or not.
+* `allow_classic_flow` (Optional) - Enables or disables the classic / basic authentication flow.
 * `developer_provider_name` (Optional) - The "domain" by which Cognito will refer to your users. This name acts as a placeholder that allows your
 backend and the Cognito service to communicate about the developer provider.
 * `cognito_identity_providers` (Optional) - An array of [Amazon Cognito Identity user pools](#cognito-identity-providers) and their client IDs.


### PR DESCRIPTION
This adds an allow_classic_flow attribute to the aws_cognito_identity_pool
resource type. The default was chosen based on the current default when
using the AWS APIs directly.

Closes #12926

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCognitoIdentityPool*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoIdentityPool* -timeout 180m
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== RUN   TestAccAWSCognitoIdentityPool_basic
=== PAUSE TestAccAWSCognitoIdentityPool_basic
=== RUN   TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== PAUSE TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== RUN   TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_samlProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== PAUSE TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (32.15s)
=== RUN   TestAccAWSCognitoIdentityPool_tags
=== PAUSE TestAccAWSCognitoIdentityPool_tags
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== CONT  TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== CONT  TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_disappears
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== CONT  TestAccAWSCognitoIdentityPool_tags
=== CONT  TestAccAWSCognitoIdentityPool_basic
=== CONT  TestAccAWSCognitoIdentityPool_samlProviderArns
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== CONT  TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (16.25s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (17.98s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (18.63s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_disappears (24.19s)
--- PASS: TestAccAWSCognitoIdentityPool_basic (31.41s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (37.44s)
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (40.10s)
--- PASS: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (40.12s)
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (40.81s)
--- PASS: TestAccAWSCognitoIdentityPool_tags (40.82s)
--- PASS: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (40.95s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (51.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	83.568s
```