### PR TITLE
add awsbackup snapshot type

### DIFF
--- a/website/docs/d/db_cluster_snapshot.html.markdown
+++ b/website/docs/d/db_cluster_snapshot.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `snapshot_type` - (Optional) The type of snapshots to be returned. If you don't specify a SnapshotType
 value, then both automated and manual DB cluster snapshots are returned. Shared and public DB Cluster Snapshots are not
-included in the returned results by default. Possible values are, `automated`, `manual`, `shared` and `public`.
+included in the returned results by default. Possible values are, `automated`, `manual`, `shared`, `public` and `awsbackup`.
 
 * `include_shared` - (Optional) Set this value to true to include shared manual DB Cluster Snapshots from other
 AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to false.

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -60,7 +60,7 @@ recent Snapshot.
 
 * `snapshot_type` - (Optional) The type of snapshots to be returned. If you don't specify a SnapshotType
 value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not
-included in the returned results by default. Possible values are, `automated`, `manual`, `shared` and `public`.
+included in the returned results by default. Possible values are, `automated`, `manual`, `shared`, `public` and `awsbackup`.
 
 * `include_shared` - (Optional) Set this value to true to include shared manual DB snapshots from other
 AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to false.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/19173

Output from acceptance testing:

this is only update of docs, but tested code as below:

```
provider "aws" {
  region = "us-east-1"
}

data "aws_db_snapshot" "latest_prod_snapshot" {
  db_instance_identifier = "staging-db"
  most_recent            = true
  snapshot_type          = "awsbackup"
}

output "snapshot" {
  value = data.aws_db_snapshot.latest_prod_snapshot
}
```

Which returned me outputs:

```
snapshot = {
  "allocated_storage" = 300
  "availability_zone" = ""
  "db_instance_identifier" = "staging-db"
  "db_snapshot_arn" = "arn:aws:rds:us-east-1:****************:snapshot:awsbackup:copyjob-aaaaaaaaa-0a11-a6db-c3d8-25ab0f8e8b5e"
  "db_snapshot_identifier" = "awsbackup:copyjob-aaaaaaaaa-0a11-a6db-c3d8-25ab0f8e8b5e"
  "encrypted" = true
  "engine" = "mysql"
  "engine_version" = "5.7.26"
  "id" = "awsbackup:copyjob-aaaaaaaaa-0a11-a6db-c3d8-25ab0f8e8b5e"
  "include_public" = false
  "include_shared" = false
  "iops" = 0
  "kms_key_id" = "arn:aws:kms:us-east-1:****************:key/faaaaaaa-cf02-47d6-8feb-8eccf106ed11"
  "license_model" = "general-public-license"
  "most_recent" = true
  "option_group_name" = ""
  "port" = 3306
  "snapshot_create_time" = "2021-04-29T12:44:03Z"
  "snapshot_type" = "awsbackup"
  "source_db_snapshot_identifier" = "arn:aws:rds:us-west-2:****************:snapshot:awsbackup:job-aaaaaaaa-c8ac-9868-3aa9-8716be4adc3a"
  "source_region" = "us-west-2"
  "status" = "available"
  "storage_type" = "gp2"
  "vpc_id" = ""
}
```

What confrims that it is working with ```"snapshot_type" = "awsbackup"```
