### PR TITLE
r/aws_batch_compute_environment: `service_role` is optional, fix "At least one compute-resources attribute must be specified" error.

### DIFF
--- a/.changelog/19205.txt
+++ b/.changelog/19205.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+aws_batch_compute_environment: `service_role` argument is optional 
+```
+
+```release-note:bug
+aws_batch_compute_environment: Allow update of just `service_role` for managed compute environments
+```

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -682,6 +682,8 @@ func TestAccAWSBatchComputeEnvironment_updateServiceRole(t *testing.T) {
 	resourceName := "aws_batch_compute_environment.test"
 	serviceRoleResourceName1 := "aws_iam_role.batch_service"
 	serviceRoleResourceName2 := "aws_iam_role.batch_service_2"
+	securityGroupResourceName := "aws_security_group.test"
+	subnetResourceName := "aws_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
@@ -690,37 +692,131 @@ func TestAccAWSBatchComputeEnvironment_updateServiceRole(t *testing.T) {
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigBasic(rName),
+				Config: testAccAWSBatchComputeEnvironmentConfigFargate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(resourceName, &ce),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
-					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_key_pair", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_role", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.spot_iam_fleet_role", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "FARGATE"),
 					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "service_role", serviceRoleResourceName1, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "type", "UNMANAGED"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
 				),
 			},
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigUpdatedServiceRole(rName),
+				Config: testAccAWSBatchComputeEnvironmentConfigFargateUpdatedServiceRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(resourceName, &ce),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
-					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_key_pair", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_role", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.spot_iam_fleet_role", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "FARGATE"),
 					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "service_role", serviceRoleResourceName2, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "type", "UNMANAGED"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_defaultServiceRole(t *testing.T) {
+	var ce batch.ComputeEnvironmentDetail
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_batch_compute_environment.test"
+	securityGroupResourceName := "aws_security_group.test"
+	subnetResourceName := "aws_subnet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSBatch(t)
+			testAccPreCheckIamServiceLinkedRole(t, "/aws-service-role/batch")
+		},
+		ErrorCheck:   testAccErrorCheck(t, batch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigFargateDefaultServiceRole(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(resourceName, &ce),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.allocation_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.bid_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.desired_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.ec2_key_pair", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.image_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_role", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.instance_type.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.launch_template.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.max_vcpus", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.min_vcpus", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.security_group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.security_group_ids.*", securityGroupResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.spot_iam_fleet_role", ""),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.subnets.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "compute_resources.0.subnets.*", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_resources.0.type", "FARGATE"),
+					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
+					testAccMatchResourceAttrGlobalARN(resourceName, "service_role", "iam", regexp.MustCompile(`role/aws-service-role/batch`)),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "MANAGED"),
 				),
 			},
 			{
@@ -1671,6 +1767,76 @@ resource "aws_batch_compute_environment" "test" {
 `, rName))
 }
 
+func testAccAWSBatchComputeEnvironmentConfigFargateDefaultServiceRole(rName string) string {
+	return composeConfig(
+		testAccAWSBatchComputeEnvironmentConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+    max_vcpus = 16
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "FARGATE"
+  }
+
+  type = "MANAGED"
+}
+`, rName))
+}
+
+func testAccAWSBatchComputeEnvironmentConfigFargateUpdatedServiceRole(rName string) string {
+	return composeConfig(
+		testAccAWSBatchComputeEnvironmentConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+
+  compute_resources {
+    max_vcpus = 16
+    security_group_ids = [
+      aws_security_group.test.id
+    ]
+    subnets = [
+      aws_subnet.test.id
+    ]
+    type = "FARGATE"
+  }
+
+  service_role = aws_iam_role.batch_service_2.arn
+  type         = "MANAGED"
+  depends_on   = [aws_iam_role_policy_attachment.batch_service_2]
+}
+
+resource "aws_iam_role" "batch_service_2" {
+  name = "%[1]s_batch_service_2"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": "sts:AssumeRole",
+    "Effect": "Allow",
+    "Principal": {
+      "Service": "batch.${data.aws_partition.current.dns_suffix}"
+    }
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "batch_service_2" {
+  role       = aws_iam_role.batch_service_2.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+`, rName))
+}
+
 func testAccAWSBatchComputeEnvironmentConfigFargateSpot(rName string) string {
 	return composeConfig(
 		testAccAWSBatchComputeEnvironmentConfigBase(rName),
@@ -1773,42 +1939,6 @@ resource "aws_batch_compute_environment" "test" {
   depends_on   = [aws_iam_role_policy_attachment.batch_service]
 }
 `, rName, state))
-}
-
-func testAccAWSBatchComputeEnvironmentConfigUpdatedServiceRole(rName string) string {
-	return composeConfig(
-		testAccAWSBatchComputeEnvironmentConfigBase(rName),
-		fmt.Sprintf(`
-resource "aws_batch_compute_environment" "test" {
-  compute_environment_name = %[1]q
-
-  service_role = aws_iam_role.batch_service_2.arn
-  type         = "UNMANAGED"
-  depends_on   = [aws_iam_role_policy_attachment.batch_service_2]
-}
-
-resource "aws_iam_role" "batch_service_2" {
-  name = "%[1]s_batch_service_2"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Action": "sts:AssumeRole",
-    "Effect": "Allow",
-    "Principal": {
-      "Service": "batch.${data.aws_partition.current.dns_suffix}"
-    }
-  }]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "batch_service_2" {
-  role       = aws_iam_role.batch_service_2.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
-}
-`, rName))
 }
 
 func testAccAWSBatchComputeEnvironmentConfigComputeResourcesMaxVcpusMinVcpus(rName string, maxVcpus int, minVcpus int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19178.
Closes #19177.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

In account with service-linked role:

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchComputeEnvironment_defaultServiceRole\|TestAccAWSBatchComputeEnvironment_updateServiceRole'
==> Checking that code complies with gofmt requirements...
 F_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchComputeEnvironment_defaultServiceRole\|TestAccAWSBatchComputeEnvironment_updateServiceRole -timeout 180m
=== RUN   TestAccAWSBatchComputeEnvironment_updateServiceRole
=== PAUSE TestAccAWSBatchComputeEnvironment_updateServiceRole
=== RUN   TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== PAUSE TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== CONT  TestAccAWSBatchComputeEnvironment_updateServiceRole
=== CONT  TestAccAWSBatchComputeEnvironment_defaultServiceRole
--- PASS: TestAccAWSBatchComputeEnvironment_defaultServiceRole (36.49s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateServiceRole (76.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       79.455s
```

##### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchComputeEnvironment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchComputeEnvironment_ -timeout 180m
=== RUN   TestAccAWSBatchComputeEnvironment_basic
=== PAUSE TestAccAWSBatchComputeEnvironment_basic
=== RUN   TestAccAWSBatchComputeEnvironment_disappears
=== PAUSE TestAccAWSBatchComputeEnvironment_disappears
=== RUN   TestAccAWSBatchComputeEnvironment_NameGenerated
=== PAUSE TestAccAWSBatchComputeEnvironment_NameGenerated
=== RUN   TestAccAWSBatchComputeEnvironment_NamePrefix
=== PAUSE TestAccAWSBatchComputeEnvironment_NamePrefix
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
=== PAUSE TestAccAWSBatchComputeEnvironment_createEc2
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags
=== PAUSE TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpot
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage
=== RUN   TestAccAWSBatchComputeEnvironment_createFargate
=== PAUSE TestAccAWSBatchComputeEnvironment_createFargate
=== RUN   TestAccAWSBatchComputeEnvironment_createFargateSpot
=== PAUSE TestAccAWSBatchComputeEnvironment_createFargateSpot
=== RUN   TestAccAWSBatchComputeEnvironment_updateState
=== PAUSE TestAccAWSBatchComputeEnvironment_updateState
=== RUN   TestAccAWSBatchComputeEnvironment_updateServiceRole
=== PAUSE TestAccAWSBatchComputeEnvironment_updateServiceRole
=== RUN   TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== PAUSE TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== RUN   TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus
=== PAUSE TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus
=== RUN   TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus
=== PAUSE TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus
=== RUN   TestAccAWSBatchComputeEnvironment_launchTemplate
=== PAUSE TestAccAWSBatchComputeEnvironment_launchTemplate
=== RUN   TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== PAUSE TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== RUN   TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate
=== PAUSE TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate
=== RUN   TestAccAWSBatchComputeEnvironment_Tags
=== PAUSE TestAccAWSBatchComputeEnvironment_Tags
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
=== PAUSE TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
=== PAUSE TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole
=== CONT  TestAccAWSBatchComputeEnvironment_basic
=== CONT  TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== CONT  TestAccAWSBatchComputeEnvironment_createSpot
=== CONT  TestAccAWSBatchComputeEnvironment_NamePrefix
=== CONT  TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags
=== CONT  TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage
=== CONT  TestAccAWSBatchComputeEnvironment_createEc2
=== CONT  TestAccAWSBatchComputeEnvironment_Tags
=== CONT  TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole
=== CONT  TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
=== CONT  TestAccAWSBatchComputeEnvironment_launchTemplate
=== CONT  TestAccAWSBatchComputeEnvironment_updateServiceRole
=== CONT  TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== CONT  TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate
=== CONT  TestAccAWSBatchComputeEnvironment_NameGenerated
=== CONT  TestAccAWSBatchComputeEnvironment_disappears
=== CONT  TestAccAWSBatchComputeEnvironment_updateState
=== CONT  TestAccAWSBatchComputeEnvironment_createFargateSpot
=== CONT  TestAccAWSBatchComputeEnvironment_createFargate
=== CONT  TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
=== CONT  TestAccAWSBatchComputeEnvironment_defaultServiceRole
    provider_test.go:821: skipping tests; missing IAM service-linked role /aws-service-role/batch. Please create the role and retry
--- SKIP: TestAccAWSBatchComputeEnvironment_defaultServiceRole (1.62s)
=== CONT  TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole (31.65s)
=== CONT  TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (34.04s)
--- PASS: TestAccAWSBatchComputeEnvironment_createFargateSpot (52.71s)
--- PASS: TestAccAWSBatchComputeEnvironment_NamePrefix (53.88s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (54.27s)
--- PASS: TestAccAWSBatchComputeEnvironment_NameGenerated (55.52s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage (66.50s)
--- PASS: TestAccAWSBatchComputeEnvironment_disappears (67.25s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (70.52s)
--- PASS: TestAccAWSBatchComputeEnvironment_basic (71.05s)
--- PASS: TestAccAWSBatchComputeEnvironment_createFargate (74.05s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (81.18s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (94.07s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate (103.72s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateServiceRole (104.97s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (105.38s)
--- PASS: TestAccAWSBatchComputeEnvironment_Tags (114.62s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus (119.19s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags (198.31s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus (226.88s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (498.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	504.096s
```

##### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchComputeEnvironment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchComputeEnvironment_ -timeout 180m
=== RUN   TestAccAWSBatchComputeEnvironment_basic
=== PAUSE TestAccAWSBatchComputeEnvironment_basic
=== RUN   TestAccAWSBatchComputeEnvironment_disappears
=== PAUSE TestAccAWSBatchComputeEnvironment_disappears
=== RUN   TestAccAWSBatchComputeEnvironment_NameGenerated
=== PAUSE TestAccAWSBatchComputeEnvironment_NameGenerated
=== RUN   TestAccAWSBatchComputeEnvironment_NamePrefix
=== PAUSE TestAccAWSBatchComputeEnvironment_NamePrefix
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
=== PAUSE TestAccAWSBatchComputeEnvironment_createEc2
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags
=== PAUSE TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpot
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage
=== RUN   TestAccAWSBatchComputeEnvironment_createFargate
=== PAUSE TestAccAWSBatchComputeEnvironment_createFargate
=== RUN   TestAccAWSBatchComputeEnvironment_createFargateSpot
=== PAUSE TestAccAWSBatchComputeEnvironment_createFargateSpot
=== RUN   TestAccAWSBatchComputeEnvironment_updateState
=== PAUSE TestAccAWSBatchComputeEnvironment_updateState
=== RUN   TestAccAWSBatchComputeEnvironment_updateServiceRole
=== PAUSE TestAccAWSBatchComputeEnvironment_updateServiceRole
=== RUN   TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== PAUSE TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== RUN   TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus
=== PAUSE TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus
=== RUN   TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus
=== PAUSE TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus
=== RUN   TestAccAWSBatchComputeEnvironment_launchTemplate
=== PAUSE TestAccAWSBatchComputeEnvironment_launchTemplate
=== RUN   TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== PAUSE TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== RUN   TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate
=== PAUSE TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate
=== RUN   TestAccAWSBatchComputeEnvironment_Tags
=== PAUSE TestAccAWSBatchComputeEnvironment_Tags
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
=== PAUSE TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
=== PAUSE TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole
=== CONT  TestAccAWSBatchComputeEnvironment_basic
=== CONT  TestAccAWSBatchComputeEnvironment_launchTemplate
=== CONT  TestAccAWSBatchComputeEnvironment_Tags
=== CONT  TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate
=== CONT  TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== CONT  TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole
=== CONT  TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
=== CONT  TestAccAWSBatchComputeEnvironment_createEc2
=== CONT  TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
=== CONT  TestAccAWSBatchComputeEnvironment_updateServiceRole
=== CONT  TestAccAWSBatchComputeEnvironment_createFargate
=== CONT  TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage
=== CONT  TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus
=== CONT  TestAccAWSBatchComputeEnvironment_createSpot
=== CONT  TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags
=== CONT  TestAccAWSBatchComputeEnvironment_updateState
=== CONT  TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus
=== CONT  TestAccAWSBatchComputeEnvironment_createFargateSpot
=== CONT  TestAccAWSBatchComputeEnvironment_defaultServiceRole
=== CONT  TestAccAWSBatchComputeEnvironment_NameGenerated
=== CONT  TestAccAWSBatchComputeEnvironment_defaultServiceRole
    provider_test.go:821: skipping tests; missing IAM service-linked role /aws-service-role/batch. Please create the role and retry
--- SKIP: TestAccAWSBatchComputeEnvironment_defaultServiceRole (2.65s)
=== CONT  TestAccAWSBatchComputeEnvironment_NamePrefix
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (34.24s)
=== CONT  TestAccAWSBatchComputeEnvironment_disappears
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutIamFleetRole (35.42s)
--- PASS: TestAccAWSBatchComputeEnvironment_basic (61.14s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (67.69s)
--- PASS: TestAccAWSBatchComputeEnvironment_createFargateSpot (71.51s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot_AllocationStrategy_BidPercentage (73.49s)
--- PASS: TestAccAWSBatchComputeEnvironment_createFargate (73.71s)
--- PASS: TestAccAWSBatchComputeEnvironment_NameGenerated (75.96s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (78.08s)
--- PASS: TestAccAWSBatchComputeEnvironment_NamePrefix (76.09s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (79.94s)
--- PASS: TestAccAWSBatchComputeEnvironment_disappears (50.94s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_Fargate (96.76s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (103.02s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (109.39s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateServiceRole (109.65s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus (118.94s)
--- PASS: TestAccAWSBatchComputeEnvironment_Tags (120.09s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2_DesiredVcpus_Ec2KeyPair_ImageId_ComputeResourcesTags (176.01s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus (236.55s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (499.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	502.314s
```