### PR TITLE
r/aws_batch_job_definition: Prevent diff with default Fargate platform configuration

### DIFF
--- a/.changelog/19207.txt
+++ b/.changelog/19207.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Prevent diff with default value of `fargatePlatformConfiguration`
+```

--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -29,6 +29,13 @@ func (cp *containerProperties) Reduce() error {
 		cp.Environment = nil
 	}
 
+	// Prevent difference of API response that contains the default Fargate platform configuration
+	if cp.FargatePlatformConfiguration != nil {
+		if aws.StringValue(cp.FargatePlatformConfiguration.PlatformVersion) == "LATEST" {
+			cp.FargatePlatformConfiguration = nil
+		}
+	}
+
 	// Prevent difference of API response that adds an empty array when not configured during the request
 	if cp.LogConfiguration != nil {
 		if len(cp.LogConfiguration.SecretOptions) == 0 {

--- a/aws/internal/service/batch/equivalency/container_properties_test.go
+++ b/aws/internal/service/batch/equivalency/container_properties_test.go
@@ -248,6 +248,43 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
+		{
+			Name: "no fargatePlatformConfiguration",
+			ApiJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"resourceRequirements": [
+	  {
+		"type": "MEMORY",
+		"value": "512"
+	  },
+	  {
+		"type": "VCPU",
+		"value": "0.25"
+	  }
+	],
+	"fargatePlatformConfiguration": {
+		"platformVersion": "LATEST"
+	}
+}
+`,
+			ConfigurationJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"resourceRequirements": [
+	  {
+		  "type": "MEMORY",
+		  "value": "512"
+	  },
+	  {
+		"type": "VCPU",
+		"value": "0.25"
+	  }
+	]
+}
+`,
+			ExpectEquivalent: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19180.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition_'                            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_ -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_disappears
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
--- PASS: TestAccAWSBatchJobDefinition_disappears (17.91s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (23.27s)
--- PASS: TestAccAWSBatchJobDefinition_basic (23.44s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (24.88s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (24.88s)
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (24.92s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (27.32s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (35.70s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (45.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.841s
```

##### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_ -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== CONT  TestAccAWSBatchJobDefinition_disappears
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_Tags
--- PASS: TestAccAWSBatchJobDefinition_disappears (24.21s)
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (24.37s)
--- PASS: TestAccAWSBatchJobDefinition_basic (26.01s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (26.13s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (29.91s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (30.16s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (32.80s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (39.14s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (50.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.913s
```