### PR TITLE
Bugfix retry behavior in  aws_ssoadmin_managed_policy_attachment for eventual consistency issue

### DIFF
--- a/.changelog/19216.txt
+++ b/.changelog/19216.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssoadmin_managed_policy_attachment: Retry attachment/detachment when other permisison-set attachment event was not yet propagated, to avoid ConflictException.
+```

--- a/.changelog/19216.txt
+++ b/.changelog/19216.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ssoadmin_managed_policy_attachment: Retry attachment/detachment when other permisison-set attachment event was not yet propagated, to avoid ConflictException.
+resource/aws_ssoadmin_managed_policy_attachment: Retry attachment/detachment when other permission-set attachment event was not yet propagated, to avoid ConflictException.
 ```

--- a/aws/internal/service/ssoadmin/waiter/waiter.go
+++ b/aws/internal/service/ssoadmin/waiter/waiter.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	AWSSSOAdminAccountAssignmentCreateTimeout      = 5 * time.Minute
-	AWSSSOAdminAccountAssignmentDeleteTimeout      = 5 * time.Minute
-	AWSSSOAdminAccountAssignmentDelay              = 5 * time.Second
-	AWSSSOAdminAccountAssignmentMinTimeout         = 3 * time.Second
-	AWSSSOAdminPermissionSetProvisioningRetryDelay = 5 * time.Second
-	AWSSSOAdminPermissionSetProvisionTimeout       = 10 * time.Minute
+	AWSSSOAdminAccountAssignmentCreateTimeout            = 5 * time.Minute
+	AWSSSOAdminAccountAssignmentDeleteTimeout            = 5 * time.Minute
+	AWSSSOAdminAccountAssignmentDelay                    = 5 * time.Second
+	AWSSSOAdminAccountAssignmentMinTimeout               = 3 * time.Second
+	AWSSSOAdminPermissionSetProvisioningRetryDelay       = 5 * time.Second
+	AWSSSOAdminPermissionSetProvisionTimeout             = 10 * time.Minute
+	AWSSSOAdminManagedPolicyAttachmentPropagationTimeout = 2 * time.Minute
 )
 
 func AccountAssignmentCreated(conn *ssoadmin.SSOAdmin, instanceArn, requestID string) (*ssoadmin.AccountAssignmentOperationStatus, error) {

--- a/aws/internal/service/ssoadmin/waiter/waiter.go
+++ b/aws/internal/service/ssoadmin/waiter/waiter.go
@@ -8,13 +8,12 @@ import (
 )
 
 const (
-	AWSSSOAdminAccountAssignmentCreateTimeout            = 5 * time.Minute
-	AWSSSOAdminAccountAssignmentDeleteTimeout            = 5 * time.Minute
-	AWSSSOAdminAccountAssignmentDelay                    = 5 * time.Second
-	AWSSSOAdminAccountAssignmentMinTimeout               = 3 * time.Second
-	AWSSSOAdminPermissionSetProvisioningRetryDelay       = 5 * time.Second
-	AWSSSOAdminPermissionSetProvisionTimeout             = 10 * time.Minute
-	AWSSSOAdminManagedPolicyAttachmentPropagationTimeout = 2 * time.Minute
+	AWSSSOAdminAccountAssignmentCreateTimeout      = 5 * time.Minute
+	AWSSSOAdminAccountAssignmentDeleteTimeout      = 5 * time.Minute
+	AWSSSOAdminAccountAssignmentDelay              = 5 * time.Second
+	AWSSSOAdminAccountAssignmentMinTimeout         = 3 * time.Second
+	AWSSSOAdminPermissionSetProvisioningRetryDelay = 5 * time.Second
+	AWSSSOAdminPermissionSetProvisionTimeout       = 10 * time.Minute
 )
 
 func AccountAssignmentCreated(conn *ssoadmin.SSOAdmin, instanceArn, requestID string) (*ssoadmin.AccountAssignmentOperationStatus, error) {

--- a/aws/resource_aws_ssoadmin_managed_policy_attachment.go
+++ b/aws/resource_aws_ssoadmin_managed_policy_attachment.go
@@ -8,10 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ssoadmin/finder"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ssoadmin/waiter"
 )
 
 func resourceAwsSsoAdminManagedPolicyAttachment() *schema.Resource {
@@ -65,18 +63,7 @@ func resourceAwsSsoAdminManagedPolicyAttachmentCreate(d *schema.ResourceData, me
 		PermissionSetArn: aws.String(permissionSetArn),
 	}
 
-	err := resource.Retry(waiter.AWSSSOAdminManagedPolicyAttachmentPropagationTimeout, func() *resource.RetryError {
-		_, err := conn.AttachManagedPolicyToPermissionSet(input)
-		if tfawserr.ErrMessageContains(err, ssoadmin.ErrCodeConflictException, "There is a conflicting operation in process") {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
+	_, err := conn.AttachManagedPolicyToPermissionSet(input)
 
 	if err != nil {
 		return fmt.Errorf("error attaching Managed Policy to SSO Permission Set (%s): %w", permissionSetArn, err)
@@ -140,18 +127,7 @@ func resourceAwsSsoAdminManagedPolicyAttachmentDelete(d *schema.ResourceData, me
 		ManagedPolicyArn: aws.String(managedPolicyArn),
 	}
 
-	err = resource.Retry(waiter.AWSSSOAdminManagedPolicyAttachmentPropagationTimeout, func() *resource.RetryError {
-		_, err = conn.DetachManagedPolicyFromPermissionSet(input)
-		if tfawserr.ErrMessageContains(err, ssoadmin.ErrCodeConflictException, "There is a conflicting operation in process") {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
+	_, err = conn.DetachManagedPolicyFromPermissionSet(input)
 
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19215 

This PR adds a retry behavior for Create and destroy in the aws_ssoadmin_managed_policy_attachment-consitency resource.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
No acceptance testes where created, because they are not reliable to cover eventual consistency issues: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/retries-and-waiters.md#eventual-consistency

Full trace log from the fix being used during a destroy: https://gist.github.com/jvitor03/89cb2d10213cebefcd76e95046118968

Log retry summary:
```
-----------------------------------------------------: timestamp=2021-05-03T01:28:54.732-0300
2021-05-03T01:28:54.732-0300 [INFO]  plugin.terraform-provider-aws: 2021/05/03 01:28:54 [DEBUG] [aws-sdk-go] {"__type":"ConflictException","Message":"There is a conflicting operation in process."}: timestamp=2021-05-03T01:28:54.732-0300
2021-05-03T01:28:54.732-0300 [INFO]  plugin.terraform-provider-aws: 2021/05/03 01:28:54 [DEBUG] [aws-sdk-go] DEBUG: Validate Response SSO Admin/DetachManagedPolicyFromPermissionSet failed, attempt 0/25, error ConflictException: There is a conflicting operation in process.: timestamp=2021-05-03T01:28:54.732-0300
2021-05-03T01:28:54.732-0300 [INFO]  plugin.terraform-provider-aws: 2021/05/03 01:28:54 [TRACE] Waiting 500ms before next try: timestamp=2021-05-03T01:28:54.732-0300
2021-05-03T01:28:54.896-0300 [INFO]  plugin.terraform-provider-aws: 2021/05/03 01:28:54 [DEBUG] [aws-sdk-go] DEBUG: Response SSO Admin/DeleteAccountAssignment Details:
---[ RESPONSE ]--------------------------------------

[...]

{"InstanceArn":"arn:aws:sso:::instance/ssoins-7223f43a8b17208a","ManagedPolicyArn":"arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-7223f43a8b17208a/ps-eb12a5e3a0d6a825"}
-----------------------------------------------------: timestamp=2021-05-03T01:28:55.935-0300
2021-05-03T01:28:56.638-0300 [INFO]  plugin.terraform-provider-aws: 2021/05/03 01:28:56 [DEBUG] [aws-sdk-go] DEBUG: Retrying Request SSO Admin/DetachManagedPolicyFromPermissionSet, attempt 1: timestamp=2021-05-03T01:28:56.638-0300
2021-05-03T01:28:56.638-0300 [INFO]  plugin.terraform-provider-aws: 2021/05/03 01:28:56 [DEBUG] [aws-sdk-go] DEBUG: Request SSO Admin/DetachManagedPolicyFromPermissionSet Details:
---[ REQUEST POST-SIGN ]-----------------------------
```