### PR TITLE
d/aws_cloudwatch_event_source: New Data Source

### DIFF
--- a/.changelog/19219.txt
+++ b/.changelog/19219.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_cloudwatch_event_source
+```

--- a/aws/data_source_aws_cloudwatch_event_source.go
+++ b/aws/data_source_aws_cloudwatch_event_source.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/aws/data_source_aws_cloudwatch_event_source.go
+++ b/aws/data_source_aws_cloudwatch_event_source.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsCloudWatchEventSource() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudWatchEventSourceRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCloudWatchEventSourceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	input := &events.ListEventSourcesInput{}
+	if v, ok := d.GetOk("name_prefix"); ok {
+		input.NamePrefix = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Listing cloudwatch Event sources: %s", input)
+
+	resp, err := conn.ListEventSources(input)
+	if err != nil {
+		return fmt.Errorf("error listing cloudwatch event sources: %w", err)
+	}
+
+	if resp == nil || len(resp.EventSources) == 0 {
+		return fmt.Errorf("no matching partner event source")
+	}
+	if len(resp.EventSources) > 1 {
+		return fmt.Errorf("multiple event sources matched; use additional constraints to reduce matches to a single event source")
+	}
+
+	es := resp.EventSources[0]
+
+	d.SetId(aws.StringValue(es.Name))
+	d.Set("arn", es.Arn)
+	d.Set("created_by", es.CreatedBy)
+	d.Set("name", es.Name)
+	d.Set("state", es.State)
+
+	return nil
+}

--- a/aws/data_source_aws_cloudwatch_event_source_test.go
+++ b/aws/data_source_aws_cloudwatch_event_source_test.go
@@ -12,18 +12,20 @@ import (
 )
 
 func TestAccDataSourceAwsCloudWatchEventSource(t *testing.T) {
-	dataSourceName := "data.aws_cloudwatch_event_source.test"
-
-	key := "EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME"
+	key := "EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME"
 	busName := os.Getenv(key)
 	if busName == "" {
 		t.Skipf("Environment variable %s is not set", key)
 	}
+
 	parts := strings.Split(busName, "/")
 	if len(parts) < 2 {
 		t.Errorf("unable to parse partner event bus name %s", busName)
 	}
 	namePrefix := parts[0] + "/" + parts[1]
+
+	dataSourceName := "data.aws_cloudwatch_event_source.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
 		ErrorCheck: testAccErrorCheck(t, cloudwatchevents.EndpointsID),

--- a/aws/data_source_aws_cloudwatch_event_source_test.go
+++ b/aws/data_source_aws_cloudwatch_event_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceAwsCloudWatchEventSource(t *testing.T) {
+func TestAccDataSourceAwsCloudWatchEventSource_basic(t *testing.T) {
 	key := "EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME"
 	busName := os.Getenv(key)
 	if busName == "" {

--- a/aws/data_source_aws_cloudwatch_event_source_test.go
+++ b/aws/data_source_aws_cloudwatch_event_source_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceAwsCloudWatchEventSource(t *testing.T) {
 	if len(parts) < 2 {
 		t.Errorf("unable to parse partner event bus name %s", busName)
 	}
-	namePrefix := parts[0] + "/" + parts[1]
+	createdBy := parts[0] + "/" + parts[1]
 
 	dataSourceName := "data.aws_cloudwatch_event_source.test"
 
@@ -32,10 +32,10 @@ func TestAccDataSourceAwsCloudWatchEventSource(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsDataSourcePartnerEventSourceConfig(namePrefix),
+				Config: testAccAwsDataSourcePartnerEventSourceConfig(busName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", busName),
-					resource.TestCheckResourceAttr(dataSourceName, "created_by", namePrefix),
+					resource.TestCheckResourceAttr(dataSourceName, "created_by", createdBy),
 					resource.TestCheckResourceAttrSet(dataSourceName, "arn"),
 				),
 			},

--- a/aws/data_source_aws_cloudwatch_event_source_test.go
+++ b/aws/data_source_aws_cloudwatch_event_source_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccDataSourceAwsCloudWatchEventSource(t *testing.T) {
-	//resourceName := "aws_cloudwatch_event_bus.test"
 	dataSourceName := "data.aws_cloudwatch_event_source.test"
 
 	key := "EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME"

--- a/aws/data_source_aws_cloudwatch_event_source_test.go
+++ b/aws/data_source_aws_cloudwatch_event_source_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/aws/data_source_aws_cloudwatch_event_source_test.go
+++ b/aws/data_source_aws_cloudwatch_event_source_test.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceAwsCloudWatchEventSource(t *testing.T) {
+	//resourceName := "aws_cloudwatch_event_bus.test"
+	dataSourceName := "data.aws_cloudwatch_event_source.test"
+
+	key := "EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME"
+	busName := os.Getenv(key)
+	if busName == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+	parts := strings.Split(busName, "/")
+	if len(parts) < 2 {
+		t.Errorf("unable to parse partner event bus name %s", busName)
+	}
+	namePrefix := parts[0] + "/" + parts[1]
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, cloudwatchevents.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDataSourcePartnerEventSourceConfig(namePrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", busName),
+					resource.TestCheckResourceAttr(dataSourceName, "created_by", namePrefix),
+					resource.TestCheckResourceAttrSet(dataSourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsDataSourcePartnerEventSourceConfig(namePrefix string) string {
+	return fmt.Sprintf(`
+data "aws_cloudwatch_event_source" "test" {
+  name_prefix = "%s"
+}
+`, namePrefix)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -217,6 +217,7 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_origin_request_policy":           dataSourceAwsCloudFrontOriginRequestPolicy(),
 			"aws_cloudhsm_v2_cluster":                        dataSourceCloudHsmV2Cluster(),
 			"aws_cloudtrail_service_account":                 dataSourceAwsCloudTrailServiceAccount(),
+			"aws_cloudwatch_event_source":                    dataSourceAwsCloudWatchEventSource(),
 			"aws_cloudwatch_log_group":                       dataSourceAwsCloudwatchLogGroup(),
 			"aws_codeartifact_authorization_token":           dataSourceAwsCodeArtifactAuthorizationToken(),
 			"aws_codeartifact_repository_endpoint":           dataSourceAwsCodeArtifactRepositoryEndpoint(),

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -388,6 +388,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `DX_VIRTUAL_INTERFACE_ID` | Identifier for Direct Connect Virtual Interface testing. |
 | `EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT` | EC2 Quota for Rules per Security Group. Defaults to 50. **DEPRECATED:** Can be augmented or replaced with Service Quotas lookup. |
 | `EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME` | Amazon EventBridge partner event bus name. |
+| `EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME` | Amazon EventBridge partner event source name. |
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -388,7 +388,6 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `DX_VIRTUAL_INTERFACE_ID` | Identifier for Direct Connect Virtual Interface testing. |
 | `EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT` | EC2 Quota for Rules per Security Group. Defaults to 50. **DEPRECATED:** Can be augmented or replaced with Service Quotas lookup. |
 | `EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME` | Amazon EventBridge partner event bus name. |
-| `EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME` | Amazon EventBridge partner event source name. |
 | `GCM_API_KEY` | API Key for Google Cloud Messaging in Pinpoint and SNS Platform Application testing. |
 | `GITHUB_TOKEN` | GitHub token for CodePipeline testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |

--- a/website/docs/d/cloudwatch_event_source.html.markdown
+++ b/website/docs/d/cloudwatch_event_source.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "CloudWatch"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_source"
+description: |-
+  Get information on an EventBridge (Cloudwatch) Event Source.
+---
+
+# Data Source: aws_cloudwatch_event_source
+
+Use this data source to get information about an EventBridge Partner Event Source. This data source will only return one partner event source. An error will be returned if multiple sources match the same name prefix.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
+
+## Example Usage
+
+```terraform
+data "aws_cloudwatch_event_source" "examplepartner" {
+  name_prefix = "aws.partner/examplepartner.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_prefix` - (Optional) A name prefix to filter results returned. Only API destinations with a name that starts with the prefix are returned
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the Partner event source
+* `created_by` - The name of the SaaS partner that created the event source.
+* `state` - The state of the event source (`ACTIVE` or `PENDING`)

--- a/website/docs/d/cloudwatch_event_source.html.markdown
+++ b/website/docs/d/cloudwatch_event_source.html.markdown
@@ -24,12 +24,13 @@ data "aws_cloudwatch_event_source" "examplepartner" {
 
 The following arguments are supported:
 
-* `name_prefix` - (Optional) A name prefix to filter results returned. Only API destinations with a name that starts with the prefix are returned
+* `name_prefix` - (Optional) Specifying this limits the results to only those partner event sources with names that start with the specified prefix
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the Partner event source
-* `created_by` - The name of the SaaS partner that created the event source.
+* `arn` - The ARN of the partner event source
+* `created_by` - The name of the SaaS partner that created the event source
+* `name` - The name of the event source
 * `state` - The state of the event source (`ACTIVE` or `PENDING`)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Split off from #19072
Relates #18491
Relates #18431

Output from acceptance testing:

```
$ EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME=aws.partner/foo.com/bar/uuid make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsCloudWatchEventSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccDataSourceAwsCloudWatchEventSource -timeout 240m
=== RUN   TestAccDataSourceAwsCloudWatchEventSource
=== PAUSE TestAccDataSourceAwsCloudWatchEventSource
=== CONT  TestAccDataSourceAwsCloudWatchEventSource
--- PASS: TestAccDataSourceAwsCloudWatchEventSource (13.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.999s
```
```
