### PR TITLE
Adds check to ensure `isResourceTimeoutError()` check returns value if the `resource.Retry()` does

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -432,6 +432,60 @@ rules:
               return ...
     severity: WARNING
 
+  - id: helper-schema-TimeoutError-check-doesnt-return-output
+    languages: [go]
+    message: If the resource.Retry() or resource.RetryContext() function returns a value, ensure the isResourceTimeoutError() check does as well
+    paths:
+      exclude:
+        - "*_test.go"
+      include:
+        - aws/
+    patterns:
+      - pattern-either:
+        - patterns:
+          - pattern: |
+              if isResourceTimeoutError($ERR) {
+                _, $ERR = $CONN.$FUNC(...)
+              }
+          - pattern-not-inside: |
+              $ERR = resource.Retry(..., func() *resource.RetryError {
+                ...
+                _, $ERR2 = $CONN.$FUNC(...)
+                ...
+              })
+              ...
+              if isResourceTimeoutError($ERR) { ... }
+          - pattern-not-inside: |
+              $ERR = resource.RetryContext(..., func() *resource.RetryError {
+                ...
+                _, $ERR2 = $CONN.$FUNC(...)
+                ...
+              })
+              ...
+              if isResourceTimeoutError($ERR) { ... }
+        - patterns:
+          - pattern: |
+              if tfresource.TimedOut($ERR) {
+                _, $ERR = $CONN.$FUNC(...)
+              }
+          - pattern-not-inside: |
+              $ERR = resource.Retry(..., func() *resource.RetryError {
+                ...
+                _, $ERR2 = $CONN.$FUNC(...)
+                ...
+              })
+              ...
+              if tfresource.TimedOut($ERR) { ... }
+          - pattern-not-inside: |
+              $ERR = resource.RetryContext(..., func() *resource.RetryError {
+                ...
+                _, $ERR2 = $CONN.$FUNC(...)
+                ...
+              })
+              ...
+              if tfresource.TimedOut($ERR) { ... }
+    severity: WARNING
+
   - id: is-not-found-error
     languages: [go]
     message: Check for resource.NotFoundError errors with tfresource.NotFound()

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -1457,7 +1457,8 @@ func resourceAutoScalingGroupWarmPoolDelete(g *autoscaling.Group, d *schema.Reso
 		}
 
 		err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-			if _, err := conn.DeleteWarmPool(&deleteopts); err != nil {
+			_, err := conn.DeleteWarmPool(&deleteopts)
+			if err != nil {
 				if callerr, ok := err.(awserr.Error); ok {
 					switch callerr.Code() {
 					case "ResourceInUse", "ScalingActivityInProgress":

--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -133,7 +133,7 @@ func resourceAwsCloudWatchEventRuleCreate(d *schema.ResourceData, meta interface
 		return nil
 	})
 	if isResourceTimeoutError(err) {
-		_, err = conn.PutRule(input)
+		out, err = conn.PutRule(input)
 	}
 
 	if err != nil {

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -1439,9 +1439,7 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 
 	// Handle IAM eventual consistency
 	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-		var err error
-
-		_, err = conn.UpdateProject(params)
+		_, err := conn.UpdateProject(params)
 		if err != nil {
 			// InvalidInputException: CodeBuild is not authorized to perform
 			// InvalidInputException: Not authorized to perform DescribeSecurityGroups

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -1147,8 +1147,7 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 		// IAM roles & policies can take some time to propagate and be attached
 		// to the User Pool.
 		err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-			var err error
-			_, err = conn.UpdateUserPool(params)
+			_, err := conn.UpdateUserPool(params)
 			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
 				log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
 				return resource.RetryableError(err)

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1260,7 +1260,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			return nil
 		})
 		if isResourceTimeoutError(err) {
-			_, err = conn.CreateDBInstance(&opts)
+			createdDBInstanceOutput, err = conn.CreateDBInstance(&opts)
 		}
 		if err != nil {
 			if isAWSErr(err, "InvalidParameterValue", "") {

--- a/aws/resource_aws_db_option_group.go
+++ b/aws/resource_aws_db_option_group.go
@@ -282,9 +282,7 @@ func resourceAwsDbOptionGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			log.Printf("[DEBUG] Modify DB Option Group: %s", modifyOpts)
 
 			err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-				var err error
-
-				_, err = rdsconn.ModifyOptionGroup(modifyOpts)
+				_, err := rdsconn.ModifyOptionGroup(modifyOpts)
 				if err != nil {
 					// InvalidParameterValue: IAM role ARN value is invalid or does not include the required permissions for: SQLSERVER_BACKUP_RESTORE
 					if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -1218,8 +1218,6 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 	}
 	// Wait until the ECS service is drained
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		log.Printf("[DEBUG] Trying to delete ECS service %s", input)
-
 		_, err := conn.DeleteService(&input)
 
 		if err != nil {

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -458,8 +458,7 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		var err error
-		_, err = ec2conn.ReleaseAddress(input)
+		_, err := ec2conn.ReleaseAddress(input)
 
 		if err == nil {
 			return nil
@@ -561,7 +560,7 @@ func waitForEc2AddressAssociationClassic(conn *ec2.EC2, publicIP string, instanc
 		return nil
 	})
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.DescribeAddresses(input)
 	}
 

--- a/aws/resource_aws_glue_trigger.go
+++ b/aws/resource_aws_glue_trigger.go
@@ -213,8 +213,7 @@ func resourceAwsGlueTriggerCreate(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Creating Glue Trigger: %s", input)
 	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-		var err error
-		_, err = conn.CreateTrigger(input)
+		_, err := conn.CreateTrigger(input)
 		if err != nil {
 			if tfawserr.ErrMessageContains(err, glue.ErrCodeInvalidInputException, "Service is unable to assume role") {
 				return resource.RetryableError(err)

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -127,8 +127,7 @@ func instanceProfileAddRole(conn *iam.IAM, profileName, roleName string) error {
 	}
 
 	err := resource.Retry(waiter.PropagationTimeout, func() *resource.RetryError {
-		var err error
-		_, err = conn.AddRoleToInstanceProfile(request)
+		_, err := conn.AddRoleToInstanceProfile(request)
 		// IAM unfortunately does not provide a better error code or message for eventual consistency
 		// InvalidParameterValue: Value (XXX) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name
 		// NoSuchEntity: The request was rejected because it referenced an entity that does not exist. The error message describes the entity. HTTP Status Code: 404

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -235,7 +235,7 @@ func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.PutBot(input)
 	}
 

--- a/aws/resource_aws_lex_bot_alias.go
+++ b/aws/resource_aws_lex_bot_alias.go
@@ -154,7 +154,7 @@ func resourceAwsLexBotAliasCreate(d *schema.ResourceData, meta interface{}) erro
 		return nil
 	})
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.PutBotAlias(input)
 	}
 

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -310,7 +310,7 @@ func resourceAwsLexIntentCreate(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	})
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.PutIntent(input)
 	}
 

--- a/aws/resource_aws_lex_slot_type.go
+++ b/aws/resource_aws_lex_slot_type.go
@@ -138,7 +138,7 @@ func resourceAwsLexSlotTypeCreate(d *schema.ResourceData, meta interface{}) erro
 		return nil
 	})
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.PutSlotType(input)
 	}
 

--- a/aws/resource_aws_macie2_account.go
+++ b/aws/resource_aws_macie2_account.go
@@ -68,9 +68,8 @@ func resourceMacie2AccountCreate(ctx context.Context, d *schema.ResourceData, me
 		input.Status = aws.String(v.(string))
 	}
 
-	var err error
-	err = resource.RetryContext(ctx, 4*time.Minute, func() *resource.RetryError {
-		_, err = conn.EnableMacieWithContext(ctx, input)
+	err := resource.RetryContext(ctx, 4*time.Minute, func() *resource.RetryError {
+		_, err := conn.EnableMacieWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, macie2.ErrorCodeClientError) {
 				return resource.RetryableError(err)

--- a/aws/resource_aws_networkfirewall_firewall_policy.go
+++ b/aws/resource_aws_networkfirewall_firewall_policy.go
@@ -231,8 +231,7 @@ func resourceAwsNetworkFirewallFirewallPolicyDelete(ctx context.Context, d *sche
 	}
 
 	err := resource.RetryContext(ctx, waiter.FirewallPolicyTimeout, func() *resource.RetryError {
-		var err error
-		_, err = conn.DeleteFirewallPolicyWithContext(ctx, input)
+		_, err := conn.DeleteFirewallPolicyWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrMessageContains(err, networkfirewall.ErrCodeInvalidOperationException, "Unable to delete the object because it is still in use") {
 				return resource.RetryableError(err)

--- a/aws/resource_aws_networkfirewall_rule_group.go
+++ b/aws/resource_aws_networkfirewall_rule_group.go
@@ -547,8 +547,7 @@ func resourceAwsNetworkFirewallRuleGroupDelete(ctx context.Context, d *schema.Re
 		RuleGroupArn: aws.String(d.Id()),
 	}
 	err := resource.RetryContext(ctx, waiter.RuleGroupDeleteTimeout, func() *resource.RetryError {
-		var err error
-		_, err = conn.DeleteRuleGroupWithContext(ctx, input)
+		_, err := conn.DeleteRuleGroupWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrMessageContains(err, networkfirewall.ErrCodeInvalidOperationException, "Unable to delete the object because it is still in use") {
 				return resource.RetryableError(err)

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -681,11 +681,9 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		log.Printf("[DEBUG] Trying to create new S3 bucket: %q", bucket)
 		_, err := s3conn.CreateBucket(req)
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "OperationAborted" {
-				log.Printf("[WARN] Got an error while trying to create S3 bucket %s: %s", bucket, err)
 				return resource.RetryableError(
 					fmt.Errorf("Error creating S3 bucket %s, retrying: %s", bucket, err))
 			}

--- a/aws/resource_aws_s3_bucket_analytics_configuration.go
+++ b/aws/resource_aws_s3_bucket_analytics_configuration.go
@@ -449,7 +449,7 @@ func waitForDeleteS3BucketAnalyticsConfiguration(conn *s3.S3, bucket, name strin
 		return nil
 	})
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.GetBucketAnalyticsConfiguration(input)
 	}
 

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -168,8 +168,7 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		}
 
 		err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-			var err error
-			_, err = conn.PutResourcePolicy(input)
+			_, err := conn.PutResourcePolicy(input)
 			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
 				"This resource policy contains an unsupported principal") {
 				return resource.RetryableError(err)
@@ -343,8 +342,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 
 			log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
 			err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-				var err error
-				_, err = conn.PutResourcePolicy(input)
+				_, err := conn.PutResourcePolicy(input)
 				if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
 					"This resource policy contains an unsupported principal") {
 					return resource.RetryableError(err)

--- a/aws/resource_aws_secretsmanager_secret_policy.go
+++ b/aws/resource_aws_secretsmanager_secret_policy.go
@@ -159,8 +159,7 @@ func resourceAwsSecretsManagerSecretPolicyUpdate(d *schema.ResourceData, meta in
 
 		log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
 		err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-			var err error
-			_, err = conn.PutResourcePolicy(input)
+			_, err := conn.PutResourcePolicy(input)
 			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
 				"This resource policy contains an unsupported principal") {
 				return resource.RetryableError(err)

--- a/aws/resource_aws_signer_signing_profile_permission.go
+++ b/aws/resource_aws_signer_signing_profile_permission.go
@@ -113,11 +113,9 @@ func resourceAwsSignerSigningProfilePermissionCreate(d *schema.ResourceData, met
 	}
 
 	log.Printf("[DEBUG] Adding new Signer signing profile permission: %s", addProfilePermissionInput)
-	//var addProfilePermissionOutput *signer.AddProfilePermissionOutput
 	// Retry for IAM eventual consistency
 	err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
-		var err error
-		_, err = conn.AddProfilePermission(addProfilePermissionInput)
+		_, err := conn.AddProfilePermission(addProfilePermissionInput)
 
 		if isAWSErr(err, signer.ErrCodeConflictException, "") || isAWSErr(err, signer.ErrCodeResourceNotFoundException, "") {
 			return resource.RetryableError(err)

--- a/aws/resource_aws_vpc_dhcp_options.go
+++ b/aws/resource_aws_vpc_dhcp_options.go
@@ -237,7 +237,6 @@ func resourceAwsVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*AWSClient).ec2conn
 
 	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
-		log.Printf("[INFO] Deleting DHCP Options ID %s...", d.Id())
 		_, err := conn.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{
 			DhcpOptionsId: aws.String(d.Id()),
 		})
@@ -245,8 +244,6 @@ func resourceAwsVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) e
 		if err == nil {
 			return nil
 		}
-
-		log.Printf("[WARN] %s", err)
 
 		ec2err, ok := err.(awserr.Error)
 		if !ok {

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -227,8 +227,7 @@ func resourceAwsWafRuleDelete(d *schema.ResourceData, meta interface{}) error {
 
 	wr := newWafRetryer(conn)
 	err := resource.Retry(WafRuleDeleteTimeout, func() *resource.RetryError {
-		var err error
-		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.DeleteRuleInput{
 				ChangeToken: token,
 				RuleId:      aws.String(d.Id()),

--- a/aws/resource_aws_wafv2_ip_set.go
+++ b/aws/resource_aws_wafv2_ip_set.go
@@ -253,8 +253,7 @@ func resourceAwsWafv2IPSetDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		var err error
-		_, err = conn.DeleteIPSet(params)
+		_, err := conn.DeleteIPSet(params)
 		if err != nil {
 			if isAWSErr(err, wafv2.ErrCodeWAFAssociatedItemException, "") {
 				return resource.RetryableError(err)

--- a/aws/resource_aws_wafv2_rule_group.go
+++ b/aws/resource_aws_wafv2_rule_group.go
@@ -150,7 +150,7 @@ func resourceAwsWafv2RuleGroupCreate(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err = conn.CreateRuleGroup(params)
+		resp, err = conn.CreateRuleGroup(params)
 	}
 
 	if err != nil {

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -177,7 +177,7 @@ func resourceAwsWafv2WebACLCreate(d *schema.ResourceData, meta interface{}) erro
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err = conn.CreateWebACL(params)
+		resp, err = conn.CreateWebACL(params)
 	}
 
 	if err != nil {

--- a/aws/resource_aws_wafv2_web_acl_association.go
+++ b/aws/resource_aws_wafv2_web_acl_association.go
@@ -60,8 +60,7 @@ func resourceAwsWafv2WebACLAssociationCreate(d *schema.ResourceData, meta interf
 	}
 
 	err := resource.Retry(Wafv2WebACLAssociationCreateTimeout, func() *resource.RetryError {
-		var err error
-		_, err = conn.AssociateWebACL(params)
+		_, err := conn.AssociateWebACL(params)
 		if err != nil {
 			if isAWSErr(err, wafv2.ErrCodeWAFUnavailableEntityException, "") {
 				return resource.RetryableError(err)


### PR DESCRIPTION
When the provider code uses the `resource.Retry()` or `resource.RetryContext()` functions to retry an API call, we require one last call to the API if the retry times out. Ensure that the last chance call to the API returns an output value if the API call in the retry does.

Example detected
https://github.com/hashicorp/terraform-provider-aws/blob/28b717690168f63c9981516f2ebfd4d684f4b932/aws/resource_aws_cloudwatch_event_rule.go#L122-L137

Resolved

```go
var out *events.PutRuleOutput
err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
	out, err = conn.PutRule(input)

	if isAWSErr(err, "ValidationException", "cannot be assumed by principal") {
		log.Printf("[DEBUG] Retrying update of CloudWatch Events Rule %q", aws.StringValue(input.Name))
		return resource.RetryableError(err)
	}
	if err != nil {
		return resource.NonRetryableError(err)
	}
	return nil
})
if isResourceTimeoutError(err) {
	out, err = conn.PutRule(input)
}
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsLexSlotType\|TestAccAwsSecretsManagerSecretRotation\|TestAccAwsLexBot\|TestAccAwsNetworkFirewallRuleGroup\|TestAccAWSS3Bucket\|TestAccAWSCodeBuildProject\|TestAccAwsLexBotAlias\|TestAccAWSAutoScalingGroup\|TestAccAWSWafRule\|TestAccAwsWafv2WebACL\|TestAccAWSEIP\|TestAccAWSS3BucketAnalyticsConfiguration\|TestAccAWSDHCPOptions\|TestAccAwsNetworkFirewallFirewallPolicy\|TestAccAwsWafv2IPSet\|TestAccAWSSignerSigningProfilePermission\|TestAccAwsWafv2RuleGroup\|TestAccAWSELB\|TestAccAWSGlueTrigger\|TestAccAWSDBInstance\|TestAccAwsSecretsManagerSecretPolicy\|TestAccAWSCognitoUserPool\|TestAccAwsLexIntent\|TestAccAwsSecretsManagerSecret\|TestAccAWSEcsService\|TestAccAWSDBOptionGroup\|TestAccAWSCloudWatchEventRule\|TestAccAWSIAMInstanceProfile'

--- PASS: TestAccAWSAutoScalingGroup_NamePrefix (77.11s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (83.18s)
--- PASS: TestAccAWSAutoScalingGroup_Name_Generated (84.93s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (87.50s)
--- PASS: TestAccAWSEcsServiceDataSource_basic (91.42s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (92.81s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (55.29s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (147.64s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (153.43s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (203.20s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (115.72s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (206.95s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (211.18s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (57.84s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Basic (227.40s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (234.98s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (110.69s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (263.82s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_CapacityRebalance (62.34s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (68.94s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (282.35s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (79.41s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (81.13s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (59.08s)
--- PASS: TestCreateAutoScalingGroupInstanceRefreshInput (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/empty_list (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/nil (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/defaults (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_only (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_zero (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_empty_string (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/min_healthy_percentage_only (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/preferences (0.00s)
--- PASS: TestPutWarmPoolInput (0.00s)
    --- PASS: TestPutWarmPoolInput/empty_interface (0.00s)
    --- PASS: TestPutWarmPoolInput/nil (0.00s)
    --- PASS: TestPutWarmPoolInput/only_pool_state (0.00s)
    --- PASS: TestPutWarmPoolInput/0_min_size (0.00s)
    --- PASS: TestPutWarmPoolInput/-1_max_prepared_size (0.00s)
    --- PASS: TestPutWarmPoolInput/all_values (0.00s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (68.11s)
--- PASS: TestFlattenWarmPoolConfiguration (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/empty_interface (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/only_pool_state (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/only_max_group_prepared_capacity (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/all_values (0.00s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (203.74s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (40.95s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (113.18s)
--- PASS: TestAccAWSAutoScalingGroup_tags (322.08s)
--- PASS: TestAccAWSAutoScalingGroup_basic (331.21s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (336.43s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType_With_LaunchTemplateSpecification (58.28s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (77.75s)
--- PASS: TestAccAWSCloudWatchEventRule_role (63.80s)
--- SKIP: TestAccAWSCloudWatchEventRule_PartnerEventBus (0.00s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Start (286.64s)
--- PASS: TestAccAWSCloudWatchEventRule_ScheduleAndPattern (41.53s)
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (71.05s)
--- PASS: TestAccAWSCloudWatchEventRule_description (65.56s)
--- PASS: TestAccAWSCloudWatchEventRule_NamePrefix (47.47s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (380.13s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (115.88s)
--- PASS: TestAccAWSCloudWatchEventRule_Name_Generated (48.53s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (133.90s)
--- PASS: TestAccAWSCloudWatchEventRule_pattern (74.71s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (100.06s)
--- PASS: TestAccAWSCloudWatchEventRule_EventBusName (100.27s)
--- PASS: TestAccAWSCodeBuildProject_basic (62.37s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (64.17s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (60.91s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (447.82s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (63.76s)
--- PASS: TestAccAWSCloudWatchEventRule_IsEnabled (101.44s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (68.50s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (102.44s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (102.13s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (136.08s)
--- PASS: TestAccAWSCodeBuildProject_Description (101.39s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (203.61s)
--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Triggers (437.08s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (157.73s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (169.96s)
--- PASS: TestAccAWSCodeBuildProject_Source_BuildStatusConfig_GitHubEnterprise (81.64s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (115.67s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (173.63s)
--- PASS: TestAccAWSCodeBuildProject_BuildBatchConfig (131.04s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (126.41s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (128.76s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (168.87s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (131.82s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (132.58s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (172.66s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (129.06s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (128.08s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (169.82s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (43.00s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (490.31s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (78.96s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (125.35s)
--- PASS: TestAccAWSCodeBuildProject_FileSystemLocations (269.44s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (84.07s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (85.42s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (81.44s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (84.43s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (82.64s)
--- PASS: TestAccAWSCodeBuildProject_Cache (293.81s)
--- PASS: TestAccAWSCodeBuildProject_WindowsServer2019Container (77.32s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (126.01s)
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (77.49s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (125.71s)
--- PASS: TestAccAWSAutoScalingGroup_WarmPool (605.86s)
--- PASS: TestAccAWSCodeBuildProject_Tags (106.65s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (130.75s)
--- PASS: TestAWSCodeBuildProject_nameValidation (0.00s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (137.71s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (141.10s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (142.79s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (140.67s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (185.58s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (95.25s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (147.33s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (150.25s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (146.29s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (145.29s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (97.44s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (145.21s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (147.32s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (148.66s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (144.74s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (142.31s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (147.56s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (147.85s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (153.28s)
--- FAIL: TestAccAWSCognitoUserPoolDomain_custom (16.85s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (78.06s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (68.43s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears_userPool (69.04s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (80.49s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn (84.95s)
--- PASS: TestAccAWSCognitoUserPoolDomain_disappears (71.71s)
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (84.59s)
--- PASS: TestAccAWSCodeBuildProject_ConcurrentBuildLimit (157.71s)
--- PASS: TestAccAWSCognitoUserPoolClient_idTokenValidity (132.84s)
--- PASS: TestAccAWSCognitoUserPoolClient_refreshTokenValidity (137.99s)
--- PASS: TestAccAWSCognitoUserPool_basic (81.53s)
--- PASS: TestAccAWSCognitoUserPoolClient_accessTokenValidity (139.21s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnits (134.29s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity (131.65s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (156.89s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (133.39s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (136.30s)
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfigurationSource (0.00s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (78.95s)
--- PASS: TestAccAWSCognitoUserPoolClient_enableRevocation (189.01s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (129.45s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (199.51s)
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (76.11s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (132.58s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (133.27s)
--- PASS: TestAccAWSCognitoUserPool_recovery (187.08s)
--- PASS: TestAccAWSCognitoUserPool_SmsAuthenticationMessage (127.00s)
--- PASS: TestAccAWSCognitoUserPool_SmsVerificationMessage (124.44s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration (144.46s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (182.82s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration (147.84s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (128.86s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId (165.66s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration (177.84s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn (166.82s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameAttributes (130.24s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration (200.90s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (127.85s)
--- PASS: TestAccAWSCognitoUserPool_withTags (180.18s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration (204.68s)
--- PASS: TestAccAWSCognitoUserPool_disappears (60.36s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration (228.39s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameConfiguration (128.74s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesRemoved (90.57s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesModified (89.86s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributes (127.62s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_Disappears (72.71s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (163.54s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_Client_Disappears (71.05s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig (164.89s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (127.51s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig (161.38s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_CSS (127.69s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_ImageFile (122.03s)
--- FAIL: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (33.00s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_Client_CSS (120.29s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_UpdateAllToClient_CSS (96.01s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_Client_Image (111.44s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_UpdateClientToAll_CSS (99.14s)
--- PASS: TestAccAWSCognitoUserPool_update (172.76s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_ClientAndAll_CSS (115.76s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_CSSAndImageFile (140.01s)
--- PASS: TestAccAWSDBInstance_basic (342.62s)
--- PASS: TestAccAWSDBInstance_Password (330.50s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (380.13s)
--- PASS: TestAccAWSDBInstance_generatedName (470.21s)
--- PASS: TestAccAWSDBInstance_namePrefix (479.31s)
--- PASS: TestAccAWSDBInstance_iamAuth (464.59s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (476.54s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName (487.84s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (453.95s)
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds (488.33s)
--- PASS: TestAccAWSDBInstance_kmsKey (531.14s)
--- PASS: TestAccAWSDBInstance_optionGroup (547.62s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (573.31s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (729.35s)
--- PASS: TestAccAWSDBInstance_subnetGroup (939.52s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (982.07s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1273.58s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared (858.71s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1447.48s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1129.07s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1269.38s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1441.12s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1360.07s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1480.80s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1452.82s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1400.77s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Iops (1853.46s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorageAndIops (1902.84s)
--- FAIL: TestAccAWSDBInstance_S3Import (693.19s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1593.66s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1713.48s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (1850.98s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1632.86s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1490.31s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1389.69s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (2053.93s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1106.94s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2197.22s)
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared (726.26s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifierRemoved (1258.61s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1026.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1046.50s)
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1417.68s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (1803.49s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName (1190.28s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1378.26s)
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1340.59s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1639.63s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds (1239.62s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1139.29s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1126.28s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1149.38s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1216.40s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1722.35s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1369.12s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (649.57s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1015.61s)
--- PASS: TestAccAWSDBInstance_portUpdate (531.73s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (698.51s)
--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (2.52s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1146.79s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (784.66s)
--- PASS: TestAccAWSDBInstance_separateIopsUpdate (754.71s)
--- PASS: TestAccAWSDBInstance_MinorVersion (500.88s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1247.30s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2287.03s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1207.67s)
--- PASS: TestAccAWSDBInstance_ec2Classic (483.31s)
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1243.75s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (495.31s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1267.69s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (450.26s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1782.73s)
--- PASS: TestAccAWSDBOptionGroup_basic (14.69s)
--- PASS: TestAccAWSDBOptionGroup_timeoutBlock (15.10s)
--- PASS: TestAccAWSDBOptionGroup_namePrefix (14.29s)
--- PASS: TestAccAWSDBOptionGroup_generatedName (13.96s)
--- PASS: TestAccAWSDBOptionGroup_OptionGroupDescription (13.94s)
--- FAIL: TestAccAWSDBOptionGroup_Option_OptionSettings (5.22s)
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (23.84s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_IAMRole (25.88s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_MultipleNonDefault (24.65s)
--- PASS: TestAccAWSDBOptionGroup_OracleOptionsUpdate (26.23s)
--- FAIL: TestAccAWSDBOptionGroup_multipleOptions (5.42s)
--- PASS: TestAccAWSDBOptionGroup_Tags (33.11s)
--- PASS: TestAccAWSDBOptionGroup_Tags_WithOptions (33.09s)
--- PASS: TestAccAWSEcsService_basicImport (55.64s)
--- PASS: TestAccAWSEcsService_withARN (92.37s)
--- PASS: TestAccAWSEcsService_disappears (67.77s)
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (650.91s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (656.40s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (744.39s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (67.42s)
--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL (774.48s)
--- PASS: TestAccAWSEcsService_withIamRole (42.41s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (80.71s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (95.61s)
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (128.84s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_External (39.53s)
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy (192.84s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (83.28s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (68.61s)
--- PASS: TestAccAWSEcsService_withDeploymentCircuitBreaker (83.56s)
--- PASS: TestAccAWSEcsService_withLbChanges (89.20s)
--- PASS: TestAccAWSDBInstance_CACertificateIdentifier (553.10s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (83.35s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy_Type_Missing (1.89s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (304.88s)
--- PASS: TestAccAWSEcsService_withForceNewDeployment (77.49s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (283.78s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (98.28s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (94.00s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (67.43s)
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (702.26s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (110.90s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (982.54s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod (992.05s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (141.04s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (97.56s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (38.15s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (40.30s)
--- PASS: TestAccAWSEcsService_withAlb (301.29s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (289.34s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndUpdateWaitForSteadyState (170.91s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndWaitForSteadyState (178.47s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (84.27s)
--- PASS: TestAccAWSEcsService_ExecuteCommand (58.92s)
--- PASS: TestAccAWSEcsService_ManagedTags (72.48s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1758.58s)
--- PASS: TestAccAWSEcsService_Tags (99.67s)
--- PASS: TestAccAWSEIPAssociation_networkInterface (60.65s)
--- PASS: TestAccAWSEIP_basic (16.56s)
--- PASS: TestAccAWSEIPAssociation_instance (73.54s)
--- PASS: TestAccAWSEIP_disappears (13.08s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (151.14s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (166.15s)
--- PASS: TestAccAWSEcsService_PropagateTags (170.83s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsKmsKeyId (1214.25s)
--- PASS: TestAccAWSEIPAssociation_basic (163.40s)
--- PASS: TestAccAWSEIP_Instance_reassociate (106.51s)
--- PASS: TestAccAWSEIP_Instance (120.94s)
--- PASS: TestAccAWSEIP_NetworkInterface (61.33s)
--- PASS: TestAccAWSEIP_Tags_EC2VPC_withVPCTrue (25.93s)
--- PASS: TestAccAWSEIP_Tags_EC2Classic_withoutVPCTrue (9.77s)
--- SKIP: TestAccAWSEIP_PublicIPv4Pool_custom (0.00s)
--- SKIP: TestAccAWSEIP_CustomerOwnedIPv4Pool (0.90s)
--- PASS: TestAccAWSEIP_Tags_EC2VPC_withoutVPCTrue (29.70s)
--- PASS: TestAccAWSEIP_PublicIPv4Pool_default (20.31s)
--- PASS: TestAccAWSEIP_Instance_notAssociated (125.82s)
--- PASS: TestAccAWSEIP_NetworkInterface_twoEIPsOneInterface (64.58s)
--- SKIP: TestAccAWSEIP_BYOIPAddress_custom (0.00s)
--- SKIP: TestAccAWSEIP_BYOIPAddress_custom_with_PublicIpv4Pool (0.00s)
--- PASS: TestAccAWSEIP_networkBorderGroup (21.09s)
--- PASS: TestAccAWSEIP_carrierIP (20.90s)
--- PASS: TestAccAWSEIP_BYOIPAddress_default (17.63s)
--- PASS: TestAccAWSEIP_Tags_EC2Classic_withVPCTrue (43.13s)
--- PASS: TestAccAWSEIP_Instance_ec2Classic (132.80s)
--- PASS: TestAccAWSEcsService_withServiceRegistriesChanges (295.63s)
--- PASS: TestAccAWSELB_basic (21.79s)
--- PASS: TestAccAWSELB_disappears (18.75s)
--- PASS: TestAccAWSELB_fullCharacterRange (19.51s)
--- PASS: TestAccAWSEIPAssociation_disappears (208.37s)
--- PASS: TestAccAWSEIPAssociation_ec2Classic (237.44s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (20.75s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (45.22s)
--- PASS: TestAccAWSELB_availabilityZones (45.27s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (42.19s)
--- PASS: TestAccAWSELB_HealthCheck (41.52s)
--- PASS: TestAccAWSELB_swap_subnets (78.03s)
--- PASS: TestAccAWSELBAttachment_drift (132.15s)
--- PASS: TestAccAWSEIPAssociation_spotInstance (329.53s)
--- PASS: TestResourceAwsElbListenerHash (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotBeginWithHyphen (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCanBeAnEmptyString (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotBeLongerThan32Characters (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotHaveSpecialCharacters (0.00s)
--- PASS: TestResourceAWSELB_validateElbNameCannotEndWithHyphen (0.00s)
--- PASS: TestResourceAWSELB_validateAccessLogsInterval (0.00s)
--- PASS: TestResourceAWSELB_validateHealthCheckTarget (0.06s)
--- PASS: TestAccAWSELB_generatedName (122.79s)
--- PASS: TestAccAWSELB_Timeout (46.76s)
--- PASS: TestAccAWSELB_tags (146.74s)
--- PASS: TestAccAWSELB_SecurityGroups (50.03s)
--- PASS: TestAccAWSELB_ConnectionDraining (64.41s)
--- PASS: TestAccAWSELB_listener (114.82s)
--- PASS: TestAccAWSELBAttachment_basic (197.89s)
--- PASS: TestAccAWSGlueTrigger_basic (53.38s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (179.34s)
--- PASS: TestAccAWSGlueTrigger_WorkflowName (44.41s)
--- PASS: TestAccAWSGlueTrigger_actions_securityConfig (47.07s)
--- PASS: TestAccAWSGlueTrigger_Description (81.52s)
--- PASS: TestAccAWSELB_namePrefix (233.21s)
--- PASS: TestAccAWSIAMInstanceProfile_withoutRole (21.70s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (25.07s)
--- PASS: TestAccAWSGlueTrigger_Crawler (128.92s)
--- PASS: TestAccAWSEIP_Instance_associatedUserPrivateIP (429.57s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (2078.14s)
--- PASS: TestAccAWSIAMInstanceProfile_disappears (22.99s)
--- PASS: TestAccAWSGlueTrigger_disappears (56.43s)
--- PASS: TestAccAWSGlueTrigger_Predicate (123.15s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (28.58s)
--- PASS: TestAccAWSGlueTrigger_Tags (113.30s)
--- PASS: TestAccAWSGlueTrigger_Schedule (115.50s)
--- PASS: TestAccAWSIAMInstanceProfile_disappears_role (31.83s)
--- PASS: TestAccAWSGlueTrigger_actions_notify (122.07s)
--- PASS: TestAccAWSGlueTrigger_Enabled (151.09s)
--- PASS: TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID (1366.66s)
--- PASS: TestAccAWSIAMInstanceProfile_tags (78.12s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsText (57.50s)
--- PASS: TestAccAwsLexBotAlias_basic (71.11s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsBoth (64.36s)
--- PASS: TestAccAwsLexBot_basic (74.39s)
--- FAIL: TestAccAwsLexBotAlias_description (76.96s)
--- PASS: TestAccAWSGlueTrigger_onDemandDisable (157.85s)
--- PASS: TestAccAwsLexBot_childDirected (63.75s)
--- PASS: TestAccAwsLexBot_abortStatement (81.34s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsAudio (104.97s)
--- PASS: TestAccAwsLexBotAlias_disappears (112.50s)
--- PASS: TestAccAWSELB_InstanceAttaching (360.02s)
--- PASS: TestAccAwsLexIntent_basic (20.42s)
--- PASS: TestAccAwsLexBot_description (72.78s)
--- PASS: TestAccAwsLexBot_clarificationPrompt (96.41s)
--- PASS: TestAccAwsLexBot_detectSentiment (87.16s)
--- PASS: TestAccAwsLexBot_disappears (51.23s)
--- PASS: TestAccAwsLexBot_enableModelImprovements (94.17s)
--- PASS: TestAccAwsLexBot_intents (75.70s)
--- PASS: TestAccAwsLexBot_voiceId (67.29s)
--- PASS: TestAccAwsLexIntent_createVersion (61.37s)
--- PASS: TestAccAwsLexBot_idleSessionTtlInSeconds (114.13s)
--- PASS: TestAccAwsLexIntent_dialogCodeHook (71.49s)
--- PASS: TestAccAwsLexBot_locale (112.15s)
--- PASS: TestAccAwsLexIntent_confirmationPromptAndRejectionStatement (75.85s)
--- PASS: TestAccAwsLexIntent_conclusionStatement (88.86s)
--- PASS: TestAccAwsLexIntent_disappears (52.55s)
--- PASS: TestAccAwsLexIntent_slotsCustom (55.66s)
--- PASS: TestAccAwsLexIntent_fulfillmentActivity (84.40s)
--- PASS: TestAccAwsLexIntent_followUpPrompt (88.36s)
--- PASS: TestAccAwsLexSlotType_basic (49.55s)
--- PASS: TestAccAwsLexIntent_sampleUtterances (94.27s)
--- PASS: TestAccAwsLexIntent_slots (94.34s)
--- PASS: TestAccAwsLexIntent_updateWithExternalChange (84.27s)
--- PASS: TestAccAwsLexSlotType_disappears (41.59s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1754.90s)
--- PASS: TestAccAwsLexSlotType_createVersion (99.67s)
--- PASS: TestAccAwsLexSlotType_description (96.51s)
--- PASS: TestAccAwsLexSlotType_name (98.65s)
--- PASS: TestAccAwsLexSlotType_enumerationValues (101.91s)
--- PASS: TestAccAwsLexSlotType_valueSelectionStrategy (95.36s)
--- FAIL: TestAccAwsLexBot_version_serial (331.93s)
    --- PASS: TestAccAwsLexBot_version_serial/DataSourceLexBotAlias_basic (109.33s)
    --- FAIL: TestAccAwsLexBot_version_serial/LexBot_createVersion (82.20s)
    --- FAIL: TestAccAwsLexBot_version_serial/LexBotAlias_botVersion (99.38s)
    --- PASS: TestAccAwsLexBot_version_serial/DataSourceLexBot_withVersion (41.02s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_basic (169.59s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statefulRuleGroupReference (172.96s)
--- PASS: TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier (1745.64s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statelessCustomAction (158.06s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences (193.74s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference (224.64s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_disappears (146.59s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rulesSourceList (142.34s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statelessRuleGroupReference (229.25s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_tags (177.16s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences (224.13s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference (231.75s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statefulRule (158.07s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statelessRule (148.25s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rules (148.66s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_basic (15.87s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateRulesSourceList (141.39s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (2.04s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statelessRuleWithCustomAction (159.62s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_removed (26.37s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateRules (150.65s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_multipleStatelessCustomActions (304.15s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatefulRule (144.39s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (3.43s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix (38.22s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_updateBasic (53.32s)
--- PASS: TestExpandS3AnalyticsFilter (0.00s)
--- PASS: TestExpandS3StorageClassAnalysis (0.00s)
--- PASS: TestFlattenS3AnalyticsFilter (0.00s)
--- PASS: TestFlattenS3StorageClassAnalysis (0.00s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag (40.70s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags (42.80s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags (42.84s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction (314.64s)
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (3.99s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (179.01s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateMultipleStatefulRules (171.21s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default (30.89s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full (32.14s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_header (159.95s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (32.52s)
--- PASS: TestAccAWSS3BucketInventory_basic (38.86s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatelessRule (167.59s)
--- PASS: TestAccAWSS3BucketMetric_basic (39.33s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (39.61s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_action (173.51s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_tags (167.00s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove (60.62s)
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (13.53s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (2233.63s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (82.31s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_disappears (185.44s)
--- PASS: TestAccAWSS3BucketObject_empty (52.66s)
--- PASS: TestAccAWSS3BucketObject_source (51.53s)
--- PASS: TestAccAWSS3BucketNotification_Queue (62.97s)
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (62.69s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (90.46s)
--- PASS: TestAccAWSS3BucketNotification_Topic (65.13s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (92.89s)
--- PASS: TestAccAWSS3BucketObject_content (57.15s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (56.61s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (86.17s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (85.84s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (99.08s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (99.19s)
--- PASS: TestAccAWSS3BucketNotification_update (101.65s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (59.17s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (62.09s)
--- PASS: TestAccAWSS3BucketObject_NonVersioned (58.97s)
--- PASS: TestAccAWSS3BucketObject_kms (63.20s)
--- PASS: TestAccAWSS3BucketObject_sse (62.45s)
--- PASS: TestAccAWSS3BucketObject_updates (109.73s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (108.03s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (106.74s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (110.19s)
--- PASS: TestAccAwsNetworkFirewallFirewallPolicy_updateStatelessCustomAction (568.28s)
--- PASS: TestAccAWSS3BucketObject_objectBucketKeyEnabled (56.59s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (108.08s)
--- PASS: TestAccAWSS3BucketObject_acl (151.85s)
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (59.69s)
--- PASS: TestAccAWSS3BucketObject_bucketBucketKeyEnabled (63.54s)
--- PASS: TestAccAWSS3BucketObject_metadata (158.88s)
--- PASS: TestAccAWSS3BucketOwnershipControls_disappears (61.52s)
--- PASS: TestAccAWSS3BucketOwnershipControls_disappears_Bucket (54.39s)
--- PASS: TestAccAWSS3BucketOwnershipControls_basic (68.40s)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3059.29s)
--- FAIL: TestAccAWSS3BucketObject_ignoreTags (82.46s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (155.75s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (157.76s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSingleSlash (199.71s)
--- PASS: TestAccAWSS3BucketObject_tags (208.92s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes (205.77s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (64.59s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears_Bucket (55.47s)
--- PASS: TestAccAWSS3BucketPolicy_basic (74.38s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (74.42s)
--- PASS: TestAccAWSS3BucketObject_tagsMultipleSlashes (211.25s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (205.06s)
--- PASS: TestAccAWSS3BucketObject_storageClass (259.80s)
--- PASS: TestAccAWSS3Bucket_Basic_basic (74.43s)
--- PASS: TestAccAWSS3BucketOwnershipControls_Rule_ObjectOwnership (124.34s)
--- PASS: TestAccAWSS3Bucket_Basic_emptyString (71.96s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (122.22s)
--- PASS: TestAccAWSS3Bucket_Basic_namePrefix (69.54s)
--- PASS: TestAccAWSS3Bucket_Tags_basic (72.59s)
--- PASS: TestAccAWSS3Bucket_Basic_generatedName (72.25s)
--- PASS: TestAccAWSS3Bucket_Tags_ignoreTags (115.99s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (167.94s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (173.16s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (171.56s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (178.21s)
--- PASS: TestAccAWSS3Bucket_Basic_acceleration (125.29s)
--- PASS: TestAccAWSS3Bucket_Basic_requestPayer (125.23s)
--- PASS: TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenTypical (75.54s)
--- PASS: TestAccAWSS3Bucket_Security_ACLToGrant (115.90s)
--- PASS: TestAccAWSS3Bucket_Security_GrantToACL (114.47s)
--- PASS: TestAccAWSS3Bucket_Security_updateACL (126.05s)
--- PASS: TestAccAWSS3Bucket_Basic_shouldFailNotFound (53.28s)
--- PASS: TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (72.08s)
--- PASS: TestAccAWSS3Bucket_Basic_keyEnabled (76.36s)
--- PASS: TestAccAWSS3Bucket_Web_routingRules (124.23s)
--- PASS: TestAccAWSS3Bucket_Tags_withNoSystemTags (224.41s)
--- PASS: TestAccAWSS3Bucket_Security_corsDelete (64.42s)
--- PASS: TestAccAWSS3Bucket_Security_policy (176.19s)
--- PASS: TestAccAWSS3Bucket_Security_updateGrant (176.41s)
--- PASS: TestAccAWSS3Bucket_Security_corsEmptyOrigin (74.88s)
--- PASS: TestAccAWSS3Bucket_Web_simple (177.20s)
--- PASS: TestAccAWSS3Bucket_Security_logging (80.23s)
--- PASS: TestAccAWSS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (129.34s)
--- PASS: TestAccAWSS3Bucket_Manage_lifecycleRuleExpirationEmptyConfigurationBlock (66.15s)
--- PASS: TestAccAWSS3Bucket_Web_redirect (175.78s)
--- PASS: TestAccAWSS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (74.96s)
--- PASS: TestAccAWSS3Bucket_Security_corsUpdate (124.51s)
--- PASS: TestAccAWSS3Bucket_Tags_withSystemTags (275.15s)
--- PASS: TestAccAWSS3Bucket_Replication_expectVersioningValidationError (57.55s)
--- PASS: TestAWSS3BucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- PASS: TestAccAWSS3Bucket_Manage_lifecycleExpireMarkerOnly (130.22s)
--- PASS: TestAccAWSS3Bucket_Manage_versioning (183.96s)
--- PASS: TestAccAWSS3Bucket_Replication_multipleDestinationsEmptyFilter (124.05s)
--- PASS: TestAccAWSS3Bucket_Basic_forceDestroy (69.09s)
--- PASS: TestAccAWSS3Bucket_Replication_schemaV2SameRegion (81.64s)
--- PASS: TestAccAWSS3Bucket_Basic_forceDestroyWithEmptyPrefixes (68.46s)
--- PASS: TestAccAWSS3Bucket_Replication_multipleDestinationsNonEmptyFilter (123.69s)
--- PASS: TestAccAWSS3Bucket_Replication_twoDestination (125.39s)
--- PASS: TestAccAWSS3Bucket_Basic_forceDestroyWithObjectLockEnabled (69.18s)
--- PASS: TestAccAWSS3Bucket_Manage_lifecycleBasic (183.71s)
--- PASS: TestAccAWSS3Bucket_Replication_withoutStorageClass (119.26s)
--- PASS: TestAccAWSS3Bucket_Replication_withoutPrefix (121.09s)
--- PASS: TestAccAWSS3Bucket_Manage_objectLock (127.33s)
--- PASS: TestAccAwsSecretsManagerSecretPolicy_disappears (74.56s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (65.82s)
--- PASS: TestAccAwsSecretsManagerSecret_basic (70.85s)
--- FAIL: TestAccAwsSecretsManagerSecretVersion_BasicString (34.43s)
--- PASS: TestAccAWSS3Bucket_Replication_configurationRuleDestinationAccessControlTranslation (207.72s)
--- PASS: TestAccAwsSecretsManagerSecretPolicy_basic (131.51s)
--- PASS: TestAccAWSS3Bucket_Replication_configurationRuleDestinationAddAccessControlTranslation (206.97s)
--- PASS: TestAccAwsSecretsManagerSecretRotation_basic (105.55s)
--- PASS: TestAccAwsSecretsManagerSecret_Description (118.08s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (119.05s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (118.84s)
--- FAIL: TestAccAwsSecretsManagerSecret_policy (100.18s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_Base64Binary (75.36s)
--- PASS: TestAccAWSSignerSigningProfilePermission_basic (79.02s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (148.64s)
--- PASS: TestAccAwsSecretsManagerSecretPolicy_blockPublicPolicy (199.06s)
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3618.23s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_vpc (65.51s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (154.53s)
--- PASS: TestAccAWSSignerSigningProfilePermission_StartSigningJob_GetSP (80.69s)
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (76.30s)
--- PASS: TestAccAWSSignerSigningProfilePermission_StatementPrefix (80.11s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears (64.79s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_dhcp (69.04s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (53.45s)
--- PASS: TestAccAWSDHCPOptions_basic (72.02s)
--- PASS: TestAccAWSDHCPOptions_disappears (51.32s)
--- PASS: TestAccAWSSignerSigningProfilePermission_GetSigningProfile (131.01s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (161.83s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (210.24s)
--- PASS: TestAccAWSS3Bucket_Replication_basic (365.52s)
--- PASS: TestAccAWSWafRuleGroup_noActivatedRules (59.57s)
--- PASS: TestAccAWSWafRuleGroup_disappears (74.89s)
--- PASS: TestAccAWSWafRule_disappears (63.55s)
--- PASS: TestAccAWSWafRuleGroup_basic (97.91s)
--- PASS: TestAccAWSWafRule_noPredicates (53.51s)
--- PASS: TestAccAwsWafv2IPSet_Disappears (41.59s)
--- PASS: TestAccAWSWafRule_geoMatchSetPredicate (88.57s)
--- PASS: TestAccAwsWafv2IPSet_IPv6 (55.46s)
--- PASS: TestAccAWSDHCPOptions_tags (147.06s)
--- PASS: TestAccAwsWafv2IPSet_Minimal (56.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4467.15s)
--- PASS: TestAccAWSWafRuleGroup_changeActivatedRules (128.99s)
--- PASS: TestAccAWSWafRule_changeNameForceNew (134.37s)
--- PASS: TestAccAwsWafv2IPSet_Large (71.70s)
--- PASS: TestAccAWSWafRule_webACL (132.78s)
--- PASS: TestAccAWSWafRule_basic (156.88s)
--- PASS: TestAccAwsWafv2RuleGroup_basic (78.68s)
--- PASS: TestAccAWSWafRuleGroup_Tags (160.69s)
--- PASS: TestAccAwsWafv2IPSet_basic (108.13s)
--- PASS: TestAccAwsWafv2IPSet_ChangeNameForceNew (109.72s)
--- PASS: TestAccAWSS3Bucket_Replication_schemaV2 (446.99s)
--- PASS: TestAccAWSWafRuleGroup_changeNameForceNew (198.19s)
--- PASS: TestAccAwsWafv2RuleGroup_Disappears (65.69s)
--- PASS: TestAccAWSWafRule_changePredicates (199.53s)
--- PASS: TestAccAwsWafv2RuleGroup_Minimal (76.15s)
--- PASS: TestAccAwsWafv2RuleGroup_updateRule (146.79s)
--- PASS: TestAccAwsWafv2RuleGroup_IpSetReferenceStatement (88.77s)
--- PASS: TestAccAwsWafv2IPSet_Tags (175.82s)
--- PASS: TestAccAwsWafv2RuleGroup_ChangeNameForceNew (141.68s)
--- PASS: TestAccAwsWafv2RuleGroup_ChangeCapacityForceNew (143.74s)
--- PASS: TestAccAwsWafv2RuleGroup_ByteMatchStatement (153.81s)
--- PASS: TestAccAwsWafv2RuleGroup_ChangeMetricNameForceNew (143.72s)
--- PASS: TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement (92.02s)
--- PASS: TestAccAWSWafRule_Tags (246.33s)
--- PASS: TestAccAwsWafv2RuleGroup_RuleAction_CustomResponse (85.66s)
--- PASS: TestAccAwsWafv2RuleGroup_GeoMatchStatement (149.73s)
--- PASS: TestAccAwsWafv2RuleGroup_GeoMatchStatement_ForwardedIPConfig (152.11s)
--- PASS: TestAccAwsWafv2RuleGroup_updateRuleProperties (213.47s)
--- PASS: TestAccAwsWafv2RuleGroup_RuleAction_CustomRequestHandling (139.45s)
--- PASS: TestAccAwsWafv2RuleGroup_SizeConstraintStatement (127.42s)
--- PASS: TestAccAwsWafv2RuleGroup_LogicalRuleStatements (190.19s)
--- PASS: TestAccAwsWafv2RuleGroup_SqliMatchStatement (118.11s)
--- PASS: TestAccAwsWafv2RuleGroup_XssMatchStatement (112.99s)
--- PASS: TestAccAwsWafv2RuleGroup_RuleAction (174.97s)
--- PASS: TestAccAwsWafv2WebACLAssociation_basic (126.74s)
--- PASS: TestAccAwsWafv2RuleGroup_IpSetReferenceStatement_IPSetForwardedIPConfig (231.72s)
--- PASS: TestAccAwsWafv2RuleGroup_Tags (156.70s)
--- PASS: TestAccAwsWafv2WebACL_basic (86.61s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_basic (190.72s)
--- PASS: TestAccAwsWafv2WebACLAssociation_Disappears (202.32s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_disappears (152.67s)
--- PASS: TestAccAwsWafv2WebACL_Disappears (83.03s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_emptyRedactedFields (161.55s)
--- PASS: TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch (402.56s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateQueryStringRedactedField (245.58s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_disappears_WebAcl (168.71s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateMethodRedactedField (257.93s)
--- PASS: TestAccAwsWafv2WebACL_updateRule (176.05s)
--- PASS: TestAccAwsWafv2WebACL_Minimal (83.88s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateUriPathRedactedField (266.37s)
--- PASS: TestAccAwsWafv2WebACL_ChangeNameForceNew (165.08s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateEmptyRedactedFields (213.99s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateSingleHeaderRedactedField (306.98s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement (96.78s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeResourceARNForceNew (303.28s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_updateMultipleRedactedFields (314.47s)
--- PASS: TestAccAwsWafv2WebACL_ManagedRuleGroupStatement (169.87s)
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement (168.40s)
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement (160.32s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_changeLogDestinationConfigsForceNew (328.97s)
--- PASS: TestAccAwsWafv2WebACL_UpdateRuleProperties (260.26s)
--- PASS: TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements (87.01s)
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig (157.69s)
--- PASS: TestAccAwsWafv2WebACL_MaxNestedOperatorStatements (89.07s)
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig (139.37s)
--- PASS: TestAccAwsWafv2WebACL_CustomRequestHandling (132.57s)
--- PASS: TestAccAwsWafv2WebACL_RuleGroupReferenceStatement (142.82s)
--- PASS: TestAccAwsWafv2WebACL_CustomResponse (123.89s)
--- PASS: TestAccAwsWafv2WebACL_Tags (130.52s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig (166.94s)
--- PASS: TestAccAwsWafv2WebACLLoggingConfiguration_loggingFilter (342.85s)
```

Acceptance test failures are unrelated to this change