### PR TITLE
Handle Ceph radosgw S3 MethodNotAllowed when reading bucket website

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -979,7 +979,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	if err != nil && !tfawserr.ErrMessageContains(err, "NotImplemented", "") && !tfawserr.ErrMessageContains(err, "NoSuchWebsiteConfiguration", "") {
+	if err != nil && !tfawserr.ErrMessageContains(err, "NotImplemented", "") && !tfawserr.ErrMessageContains(err, "NoSuchWebsiteConfiguration", "") && !tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") {
 		return fmt.Errorf("error getting S3 Bucket website configuration: %s", err)
 	}
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Description

Ceph's S3 implementation will return `405 MethodNotAllowed` on `GetBucketWebsite` when configured with `rgw_enable_static_website = false` (the default).

This PR adds this error to the ignore list.