### PR TITLE
Correct MWAA cloud_watch_log_group_arn attribute in documentation

### DIFF
--- a/website/docs/r/mwaa_environment.html.markdown
+++ b/website/docs/r/mwaa_environment.html.markdown
@@ -176,7 +176,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the MWAA Environment
 * `created_at` - The Created At date of the MWAA Environment
-* `logging_configuration.<LOG_TYPE>.cloud_watch_log_group_arn` - Provides the ARN for the CloudWatch group where the logs will be published
+* `logging_configuration[0].<LOG_CONFIGURATION_TYPE>[0].cloud_watch_log_group_arn` - Provides the ARN for the CloudWatch group where the logs will be published
 * `service_role_arn` - The Service Role ARN of the Amazon MWAA Environment
 * `status` - The status of the Amazon MWAA Environment
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).


### PR DESCRIPTION
When attempting to reference the `cloud_watch_log_group_arn` in another resource, I ran up against a few errors. One of them being:
> Block type "task_logs" is represented by a list of objects, so it must be
indexed using a numeric key, like .task_logs[0].

I then realized that I needed to reference the first item in the list based on the following error:
> aws_mwaa_environment.default.logging_configuration is list of object with 1 element

I'm proposing this update to the documentation to help clear up any confusion.

Working example:
```
aws_mwaa_environment.default.logging_configuration[0].dag_processing_logs[0].cloud_watch_log_group_arn
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
