### PR TITLE
provider: add additional if-condition when setting `tags_all` to new computed

### DIFF
--- a/.changelog/19251.txt
+++ b/.changelog/19251.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Prevent `Provider produced inconsistent final plan` errors when lifecycle arguments apply to resource `tags` not known until apply
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18366

#### Notes
* https://github.com/hashicorp/terraform-provider-aws/issues/18366#issuecomment-832642196 revealed that in cases where resource tags are dynamic (e.g. using `timestamp()`) and the `lifecycle` `ignore_changes` is applied, the `SetTagsDiff` CustomizeDiff does not correctly set the `tags_all` attribute to new Computed as expected, but rather tries to remove all previous values by setting them to `null` since the result of `len(diff.Get("tags_all").(map[string]interface{}))` is 0. 
* To handle this, an additional condition is in place to look just for a change in `tags_all`

Output from acceptance testing (2 new tests created to showcase behavior in https://github.com/hashicorp/terraform-provider-aws/issues/18366#issuecomment-832642196 before code change):

```
=== CONT  TestAccAWSVpc_DynamicResourceTags_IgnoreChanges
    resource_aws_vpc_test.go:507: Step 2/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent final plan

        When expanding the plan for aws_vpc.test to include new values learned so far
        during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "created_at" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

        Error: Provider produced inconsistent final plan

        When expanding the plan for aws_vpc.test to include new values learned so far
        during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "updated_at" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

=== CONT  TestAccAWSVpc_DynamicResourceTagsMergedWithLocals_IgnoreChanges
    resource_aws_vpc_test.go:451: Step 2/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent final plan

        When expanding the plan for aws_vpc.test to include new values learned so far
        during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "created_at" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

        Error: Provider produced inconsistent final plan

        When expanding the plan for aws_vpc.test to include new values learned so far
        during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "localkey" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

        Error: Provider produced inconsistent final plan

        When expanding the plan for aws_vpc.test to include new values learned so far
        during apply, provider "registry.terraform.io/hashicorp/aws" produced an
        invalid new value for .tags_all: new element "updated_at" has appeared.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```

Output from acceptance testing (after code change):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

--- PASS: TestAccAWSVpc_DynamicResourceTagsMergedWithLocals_IgnoreChanges (149.66s)
--- PASS: TestAccAWSVpc_DynamicResourceTags_IgnoreChanges (157.73s)

--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (184.34s)
--- PASS: TestAccAWSProvider_Region_AwsC2S (184.66s)
--- PASS: TestAccAWSProvider_Region_AwsChina (184.91s)
--- PASS: TestAccAWSProvider_Region_AwsSC2S (184.97s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (185.36s)
--- PASS: TestAccAWSProvider_DefaultTags_Tags_One (189.87s)
--- PASS: TestAccAWSProvider_DefaultTags_Tags_Multiple (190.05s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (190.26s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (190.28s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (190.28s)
--- PASS: TestAccAWSProvider_DefaultTags_Tags_None (190.28s)
--- PASS: TestAccAWSProvider_DefaultTags_EmptyConfigurationBlock (190.36s)
--- PASS: TestAccAWSProvider_DefaultAndIgnoreTags_EmptyConfigurationBlocks (190.46s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (190.46s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (190.46s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (190.47s)
--- PASS: TestAccAWSProvider_Endpoints (190.47s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (190.75s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (211.21s)

--- PASS: TestAccAWSVpc_coreMismatchedDiffs (91.47s)
--- PASS: TestAccAWSVpc_disappears (93.96s)
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (99.73s)
--- PASS: TestAccAWSVpc_DisabledDnsSupport (110.61s)
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (121.47s)
--- PASS: TestAccAWSVpc_classiclinkOptionSet (121.76s)
--- PASS: TestAccAWSVpc_defaultTags_updateToProviderOnly (149.23s)
--- PASS: TestAccAWSVpc_defaultTags_updateToResourceOnly (150.30s)
--- PASS: TestAccAWSVpc_basic (143.80s)
--- PASS: TestAccAWSVpc_defaultTags_providerAndResource_overlappingTag (170.79s)
--- PASS: TestAccAWSVpc_defaultAndIgnoreTags (172.16s)
--- PASS: TestAccAWSVpc_defaultTags_providerAndResource_nonOverlappingTag (181.99s)
--- PASS: TestAccAWSVpc_ignoreTags (184.20s)
--- PASS: TestAccAWSVpc_defaultTags_providerOnly (186.45s)
--- PASS: TestAccAWSVpc_update (186.67s)
--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (212.00s)
--- PASS: TestAccAWSVpc_tags (214.55s)
--- PASS: TestAccAWSVpc_Tenancy (216.03s)

--- SKIP: TestAccAWSSubnet_CustomerOwnedIpv4Pool (5.42s)
--- SKIP: TestAccAWSSubnet_MapCustomerOwnedIpOnLaunch (5.50s)
--- SKIP: TestAccAWSSubnet_outpost (5.71s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_duplicateTag (6.43s)
--- PASS: TestAccAWSSubnet_disappears (96.41s)
--- PASS: TestAccAWSSubnet_basic (112.04s)
--- PASS: TestAccAWSSubnet_availabilityZoneId (120.06s)
--- PASS: TestAccAWSSubnet_defaultTags_updateToResourceOnly (171.81s)
--- PASS: TestAccAWSSubnet_defaultTags_updateToProviderOnly (173.02s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_nonOverlappingTag (185.60s)
--- PASS: TestAccAWSSubnet_ignoreTags (188.70s)
--- PASS: TestAccAWSSubnet_defaultAndIgnoreTags (193.26s)
--- PASS: TestAccAWSSubnet_defaultTags_providerAndResource_overlappingTag (195.20s)
--- PASS: TestAccAWSSubnet_defaultTags_providerOnly (198.85s)
--- PASS: TestAccAWSSubnet_tags (203.89s)
--- PASS: TestAccAWSSubnet_updateTagsKnownAtApply (205.46s)
--- PASS: TestAccAWSSubnet_enableIpv6 (206.40s)
--- PASS: TestAccAWSSubnet_MapPublicIpOnLaunch (215.81s)
--- PASS: TestAccAWSSubnet_ipv6 (221.08s)
```