### PR TITLE
resource/aws_elasticache_global_replication_group: Disassociate members of global replication group

### DIFF
--- a/aws/resource_aws_elasticache_global_replication_group.go
+++ b/aws/resource_aws_elasticache_global_replication_group.go
@@ -278,7 +278,7 @@ func deleteElasticacheGlobalReplicationGroup(conn *elasticache.ElastiCache, id s
 				LastRequest: input,
 			})
 		}
-		if tfawserr.ErrMessageContains(err, elasticache.ErrCodeInvalidGlobalReplicationGroupStateFault, "is not empty") {
+		if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeInvalidGlobalReplicationGroupStateFault) {
 			return resource.RetryableError(err)
 		}
 		if err != nil {


### PR DESCRIPTION
Avoid sweeper errors by disassociating members of `aws_elasticache_global_replication_group`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18533

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make sweep SWEEPARGS=-sweep-run=aws_elasticache_global_replication_group

Sweeper Tests ran successfully:
	- aws_elasticache_global_replication_group
```
