### PR TITLE
resource/elasticache_subnet_group: appropriately ignore default tags configuration in `default` resource

### DIFF
--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -55,6 +55,15 @@ func (tags KeyValueTags) IgnoreAws() KeyValueTags {
 	return result
 }
 
+// GetTags is convenience method that returns the DefaultConfig's Tags, if any
+func (dc *DefaultConfig) GetTags() KeyValueTags {
+	if dc == nil {
+		return nil
+	}
+
+	return dc.Tags
+}
+
 // MergeTags returns the result of keyvaluetags.Merge() on the given
 // DefaultConfig.Tags with KeyValueTags provided as an argument,
 // overriding the value of any tag with a matching key.

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -4,6 +4,45 @@ import (
 	"testing"
 )
 
+func TestKeyValueTagsDefaultConfigGetTags(t *testing.T) {
+	testCases := []struct {
+		name          string
+		defaultConfig *DefaultConfig
+		want          KeyValueTags
+	}{
+		{
+			name:          "empty config",
+			defaultConfig: &DefaultConfig{},
+			want:          KeyValueTags{},
+		},
+		{
+			name:          "nil config",
+			defaultConfig: nil,
+			want:          nil,
+		},
+		{
+			name: "with Tags config",
+			defaultConfig: &DefaultConfig{
+				Tags: New(map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				}),
+			},
+			want: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.defaultConfig.GetTags()
+			testKeyValueTagsVerifyMap(t, got.Map(), testCase.want.Map())
+		})
+	}
+}
+
 func TestKeyValueTagsDefaultConfigMergeTags(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/aws/resource_aws_elasticache_subnet_group_test.go
@@ -142,6 +142,8 @@ func TestAccAWSElasticacheSubnetGroup_tags(t *testing.T) {
 					testAccCheckAWSElasticacheSubnetGroupExists(resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.key1", "value1"),
 				),
 			},
 			{
@@ -158,6 +160,9 @@ func TestAccAWSElasticacheSubnetGroup_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.key2", "value2"),
 				),
 			},
 			{
@@ -166,6 +171,8 @@ func TestAccAWSElasticacheSubnetGroup_tags(t *testing.T) {
 					testAccCheckAWSElasticacheSubnetGroupExists(resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.key2", "value2"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19213

### Notes
* Code change following a viable workaround which is to `ignore_changes` to `tags_all` (on pre-existing resources)
* Testing the "default" subnet group I believe requires importing, trying to create a new one in a test returns 
```
"│ Error: error creating ElastiCache Subnet Group (default): InvalidParameterValue: The value for parameter CacheSubnetGroupName is not a valid identifier. The identifier default is reserved."
```
Using the following config with reference to the default ElastiCacheSubnetGroup in `us-west-2`:
```hcl
provider "aws" {
  default_tags {
    tags = {
      Name = "terraform-default"
    }
  }
}

resource "aws_elasticache_subnet_group" "default" {
  name        = "default"
  description = "Default CacheSubnetGroup"
  subnet_ids  = data.aws_subnet_ids.test.ids
}

data "aws_subnet_ids" "test" {
  vpc_id = "XXXXXXX"
}
```
With `v3.38.0` of the provider, Terraform plan after import returns:
```
aws_elasticache_subnet_group.default: Refreshing state... [id=default]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_elasticache_subnet_group.default will be updated in-place
  ~ resource "aws_elasticache_subnet_group" "default" {
        id          = "default"
        name        = "default"
        tags        = {}
      ~ tags_all    = {
          + "Name" = "terraform-default"
        }
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
With provider built from this branch, Terraform plan after import returns:
```
aws_elasticache_subnet_group.default: Refreshing state... [id=default]

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your configuration and the remote system(s). As a result, there are no actions to take.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```

ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.755s

--- PASS: TestAccAWSElasticacheSubnetGroup_basic (27.39s)
--- PASS: TestAccAWSElasticacheSubnetGroup_update (50.82s)
--- PASS: TestAccAWSElasticacheSubnetGroup_tags (64.58s)
```
