### PR TITLE
Stop re-enabling termination protection during delete of aws_instance

### DIFF
--- a/internal/service/ec2/instance.go
+++ b/internal/service/ec2/instance.go
@@ -1726,13 +1726,15 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	err := resourceInstanceDisableAPITermination(conn, d.Id(), d.Get("disable_api_termination").(bool))
+	if !d.Get("disable_api_termination").(bool) {
+		err := resourceInstanceDisableAPITermination(conn, d.Id(), false)
 
-	if err != nil {
-		log.Printf("[WARN] attempting to terminate EC2 instance (%s) despite error modifying attribute (%s): %s", d.Id(), ec2.InstanceAttributeNameDisableApiTermination, err)
+		if err != nil {
+			log.Printf("[WARN] attempting to terminate EC2 instance (%s) despite error modifying attribute (%s): %s", d.Id(), ec2.InstanceAttributeNameDisableApiTermination, err)
+		}
 	}
 
-	err = terminateInstance(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+	err := terminateInstance(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return fmt.Errorf("error terminating EC2 Instance (%s): %s", d.Id(), err)


### PR DESCRIPTION
Closes #19275

This just restores the previous behavior. Another option would be to
just always modify the attribute to false so that deleting works even if
`disable_api_termination` is true.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


