### PR TITLE
r/aws_globalaccelerator_endpoint_group: Remove MaxItems from endpoint_configuration

### DIFF
--- a/aws/resource_aws_globalaccelerator_endpoint_group.go
+++ b/aws/resource_aws_globalaccelerator_endpoint_group.go
@@ -43,7 +43,6 @@ func resourceAwsGlobalAcceleratorEndpointGroup() *schema.Resource {
 			"endpoint_configuration": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				MaxItems: 10,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"client_ip_preservation_enabled": {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes: #13468.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md):

```
resource/aws_globalaccelerator_endpoint_group: Remove `MaxItems` from `endpoint_configuration`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsGlobalAcceleratorEndpointGroup_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAwsGlobalAcceleratorEndpointGroup_ -timeout 180m
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_disappears
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_disappears
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_Update
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_basic
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_basic (254.72s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_PortOverrides (309.84s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_MultiRegion (182.91s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_InstanceEndpoint (668.90s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_disappears
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_disappears (193.36s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_Update
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_ALBEndpoint_ClientIP (786.95s)
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_Update (263.93s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_TCPHealthCheckProtocol (199.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1480.707s
```
