### PR TITLE
New resource for Macie2 Findings Filter

### DIFF
--- a/.changelog/19283.txt
+++ b/.changelog/19283.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_macie2_findings_filter
+```

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -845,6 +845,7 @@ func Provider() *schema.Provider {
 			"aws_macie2_account":                                      resourceAwsMacie2Account(),
 			"aws_macie2_classification_job":                           resourceAwsMacie2ClassificationJob(),
 			"aws_macie2_custom_data_identifier":                       resourceAwsMacie2CustomDataIdentifier(),
+			"aws_macie2_findings_filter":                              resourceAwsMacie2FindingsFilter(),
 			"aws_macie_member_account_association":                    resourceAwsMacieMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":                         resourceAwsMacieS3BucketAssociation(),
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -243,7 +243,7 @@ func resourceMacie2FindingsFilterDelete(ctx context.Context, d *schema.ResourceD
 
 	_, err := conn.DeleteFindingsFilterWithContext(ctx, input)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, macie2.ErrorCodeInternalError) {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) {
 			return nil
 		}
 		return diag.FromErr(fmt.Errorf("error deleting Macie2 FindingsFilter (%s): %w", d.Id(), err))

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -92,7 +92,7 @@ func resourceAwsMacie2FindingsFilter() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.StringLenBetween(0, 500),
+				ValidateFunc:  validation.StringLenBetween(0, 500-resource.UniqueIDSuffixLength),
 			},
 			"description": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -160,7 +160,7 @@ func resourceMacie2FindingsFilterCreate(ctx context.Context, d *schema.ResourceD
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err = conn.CreateFindingsFilterWithContext(ctx, input)
+		output, err = conn.CreateFindingsFilterWithContext(ctx, input)
 	}
 
 	if err != nil {

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,36 +59,24 @@ func resourceAwsMacie2FindingsFilter() *schema.Resource {
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"lt": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.Any(
-											validation.IsRFC3339Time,
-											validation.StringMatch(regexp.MustCompile(`-?[0-9]{0,10}`), "must be a positive integer value"),
-										),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateTypeStringIsDateOrPositiveInt,
 									},
 									"lte": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.Any(
-											validation.IsRFC3339Time,
-											validation.StringMatch(regexp.MustCompile(`-?[0-9]{0,10}`), "must be a positive integer value"),
-										),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateTypeStringIsDateOrPositiveInt,
 									},
 									"gt": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.Any(
-											validation.IsRFC3339Time,
-											validation.StringMatch(regexp.MustCompile(`-?[0-9]{0,10}`), "must be a positive integer value"),
-										),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateTypeStringIsDateOrPositiveInt,
 									},
 									"gte": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.Any(
-											validation.IsRFC3339Time,
-											validation.StringMatch(regexp.MustCompile(`-?[0-9]{0,10}`), "must be a positive integer value"),
-										),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateTypeStringIsDateOrPositiveInt,
 									},
 								},
 							},
@@ -246,7 +233,7 @@ func resourceMacie2FindingsFilterUpdate(ctx context.Context, d *schema.ResourceD
 	if d.HasChange("finding_criteria") {
 		input.FindingCriteria, err = expandFindingCriteriaFilter(d.Get("finding_criteria").([]interface{}))
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.FromErr(fmt.Errorf("error updating Macie FindingsFilter (%s): %w", d.Id(), err))
 		}
 	}
 	if d.HasChange("name") {

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -138,7 +138,7 @@ func resourceMacie2FindingsFilterCreate(ctx context.Context, d *schema.ResourceD
 	var err error
 	input.FindingCriteria, err = expandFindingCriteriaFilter(d.Get("finding_criteria").([]interface{}))
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("error creating Macie FindingsFilter: %w", err))
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -281,7 +281,7 @@ func testAccAwsMacie2FindingsFilter_WithNumber(t *testing.T) {
 	dataSourceRegion := "data.aws_region.current"
 	description := "this is a description"
 	descriptionUpdated := "this is a description updated"
-	firstNumber := "-12"
+	firstNumber := "12"
 	secondNumber := "13"
 
 	resource.Test(t, resource.TestCase{

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 )
 
-func TestAccAwsMacie2FindingsFilter_basic(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_basic(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 
@@ -40,7 +40,7 @@ func TestAccAwsMacie2FindingsFilter_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 
@@ -67,7 +67,7 @@ func TestAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	namePrefix := "tf-acc-test-prefix-"
@@ -95,7 +95,7 @@ func TestAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 
@@ -119,7 +119,7 @@ func TestAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
@@ -159,7 +159,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
@@ -180,6 +180,8 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key", "value"),
 				),
 			},
 			{
@@ -191,6 +193,8 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key", "value"),
 				),
 			},
 			{
@@ -277,14 +281,14 @@ func testAccAwsMacieFindingsFilterconfigNamePrefix(name string) string {
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
-	name_prefix = %q
-	action = "ARCHIVE"
-	finding_criteria {
-		criterion {
-			field  = "region"
-		}
-	}
-	depends_on = [aws_macie2_account.test]
+  name_prefix = %[1]q
+  action = "ARCHIVE"
+  finding_criteria {
+    criterion {
+      field  = "region"
+    }
+  }
+  depends_on = [aws_macie2_account.test]
 }
 `, name)
 }
@@ -296,16 +300,16 @@ data "aws_region" "current" {}
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
-	description = %q
-	action      = %q
-	position    = %d
-	finding_criteria {
-		criterion {
-		  field = "region"
-		  eq    = [data.aws_region.current.name]
-		}
-	}
-	depends_on = [aws_macie2_account.test]
+  description = %[1]q
+  action      = %[2]q
+  position    = %[3]d
+  finding_criteria {
+    criterion {
+      field = "region"
+      eq    = [data.aws_region.current.name]
+    }
+  }
+  depends_on = [aws_macie2_account.test]
 }
 `, description, action, position)
 }
@@ -317,9 +321,9 @@ data "aws_region" "current" {}
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
-  description = %q
-  action      = %q
-  position    = %d
+  description = %[1]q
+  action      = %[2]q
+  position    = %[3]d
   finding_criteria {
     criterion {
       field = "region"

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -95,9 +95,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
-	action := "ARCHIVE"
 	descriptionUpdated := "this is a description updated"
-	actionUpdated := "NOOP"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -106,25 +104,21 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(description, action, 1),
+				Config: testaccawsmacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(descriptionUpdated, actionUpdated, 1),
+				Config: testaccawsmacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
 				),
 			},
 			{
@@ -140,9 +134,7 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
-	action := "ARCHIVE"
 	descriptionUpdated := "this is a description updated"
-	actionUpdated := "NOOP"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -151,25 +143,21 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(description, action, 1),
+				Config: testaccawsmacieFindingsFilterconfigWithTags(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(descriptionUpdated, actionUpdated, 1),
+				Config: testaccawsmacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
 				),
 			},
 			{

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -23,7 +23,7 @@ func TestAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigNameGenerated(),
+				Config: testAccAwsMacieFindingsFilterconfigNameGenerated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -51,7 +51,7 @@ func TestAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigNamePrefix(namePrefix),
+				Config: testAccAwsMacieFindingsFilterconfigNamePrefix(namePrefix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameFromPrefix(resourceName, "name", namePrefix),
@@ -78,7 +78,7 @@ func TestAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigNameGenerated(),
+				Config: testAccAwsMacieFindingsFilterconfigNameGenerated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -104,7 +104,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
+				Config: testAccAwsMacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -113,7 +113,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
+				Config: testAccAwsMacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -143,7 +143,7 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(description, macie2.FindingsFilterActionArchive, 1),
+				Config: testAccAwsMacieFindingsFilterconfigWithTags(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -152,7 +152,7 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
+				Config: testAccAwsMacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -186,7 +186,7 @@ func testAccCheckAwsMacie2FindingsFilterExists(resourceName string, macie2Sessio
 		}
 
 		if resp == nil {
-			return fmt.Errorf("macie2 FindingsFilter %q does not exist", rs.Primary.ID)
+			return fmt.Errorf("macie FindingsFilter %q does not exist", rs.Primary.ID)
 		}
 
 		*macie2Session = *resp
@@ -215,7 +215,7 @@ func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
 		}
 
 		if resp != nil {
-			return fmt.Errorf("macie2 FindingsFilter %q still exists", rs.Primary.ID)
+			return fmt.Errorf("macie FindingsFilter %q still exists", rs.Primary.ID)
 		}
 	}
 
@@ -223,7 +223,7 @@ func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
 
 }
 
-func testaccawsmacieFindingsFilterconfigNameGenerated() string {
+func testAccAwsMacieFindingsFilterconfigNameGenerated() string {
 	return `resource "aws_macie2_account" "test" {}
 
 	resource "aws_macie2_findings_filter" "test" {
@@ -238,7 +238,7 @@ func testaccawsmacieFindingsFilterconfigNameGenerated() string {
 `
 }
 
-func testaccawsmacieFindingsFilterconfigNamePrefix(name string) string {
+func testAccAwsMacieFindingsFilterconfigNamePrefix(name string) string {
 	return fmt.Sprintf(`resource "aws_macie2_account" "test" {}
 
 	resource "aws_macie2_findings_filter" "test" {
@@ -254,7 +254,7 @@ func testaccawsmacieFindingsFilterconfigNamePrefix(name string) string {
 `, name)
 }
 
-func testaccawsmacieFindingsFilterconfigComplete(description, action string, position int) string {
+func testAccAwsMacieFindingsFilterconfigComplete(description, action string, position int) string {
 	return fmt.Sprintf(`data "aws_region" "current" {}
 
 	resource "aws_macie2_account" "test" {}
@@ -274,7 +274,7 @@ func testaccawsmacieFindingsFilterconfigComplete(description, action string, pos
 `, description, action, position)
 }
 
-func testaccawsmacieFindingsFilterconfigWithTags(description, action string, position int) string {
+func testAccAwsMacieFindingsFilterconfigWithTags(description, action string, position int) string {
 	return fmt.Sprintf(`data "aws_region" "current" {}
 
 	resource "aws_macie2_account" "test" {}

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -1,0 +1,222 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+)
+
+func TestAccAwsMacie2FindingsFilter_basic(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	name := acctest.RandomWithPrefix("testacc-findings-filter")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccawsmacieFindingsFilterconfigBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	name := acctest.RandomWithPrefix("testacc-findings-filter")
+	clientToken := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccawsmacieFindingsFilterconfigComplete(clientToken, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "action"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "position"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_token"},
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	name := acctest.RandomWithPrefix("testacc-findings-filter")
+	clientToken := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccawsmacieFindingsFilterconfigWithTags(clientToken, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "action"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "position"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_token"},
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMacie2FindingsFilterExists(resourceName string, macie2Session *macie2.GetFindingsFilterOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).macie2conn
+		input := &macie2.GetFindingsFilterInput{Id: aws.String(rs.Primary.ID)}
+
+		resp, err := conn.GetFindingsFilter(input)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("macie2 FindingsFilter %q does not exist", rs.Primary.ID)
+		}
+
+		*macie2Session = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_findings_filter" {
+			continue
+		}
+
+		input := &macie2.GetFindingsFilterInput{Id: aws.String(rs.Primary.ID)}
+		resp, err := conn.GetFindingsFilter(input)
+
+		if isAWSErr(err, macie2.ErrCodeAccessDeniedException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if resp != nil {
+			return fmt.Errorf("macie2 FindingsFilter %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testaccawsmacieFindingsFilterconfigBasic(name string) string {
+	return fmt.Sprintf(`
+	resource "aws_macie2_account" "test" {}
+
+	resource "aws_macie2_findings_filter" "test" {
+		name = "%s"
+		action = "ARCHIVE"
+		finding_criteria {
+			criterion {
+				field  = "region"
+			}
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, name)
+}
+
+func testaccawsmacieFindingsFilterconfigComplete(clientToken, name string) string {
+	return fmt.Sprintf(`
+	data "aws_region" "current" {}
+
+	resource "aws_macie2_account" "test" {
+		client_token = "%s"
+	}
+
+	resource "aws_macie2_findings_filter" "test" {
+		name = "%s"
+		client_token = aws_macie2_account.test.client_token
+		description = "this a description"
+		position = 1
+		action = "ARCHIVE"
+		finding_criteria {
+			criterion {
+				field  = "region"
+      			eq = [data.aws_region.current.name]
+			}
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, clientToken, name)
+}
+
+func testaccawsmacieFindingsFilterconfigWithTags(clientToken, name string) string {
+	return fmt.Sprintf(`
+	data "aws_region" "current" {}
+
+	resource "aws_macie2_account" "test" {
+		client_token = "%s"
+	}
+
+	resource "aws_macie2_findings_filter" "test" {
+		name = "%s"
+		client_token = aws_macie2_account.test.client_token
+		description = "this a description"
+		position = 1
+		action = "ARCHIVE"
+		finding_criteria {
+			criterion {
+				field  = "region"
+      			eq = [data.aws_region.current.name]
+			}
+		}
+		tags = {
+    		Key = "value"
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, clientToken, name)
+}

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -124,6 +124,7 @@ func testAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 func testAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
+	dataSourceRegion := "data.aws_region.current"
 	description := "this is a description"
 	descriptionUpdated := "this is a description updated"
 
@@ -141,6 +142,12 @@ func testAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "position", "1"),
@@ -156,6 +163,179 @@ func testAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
 					resource.TestCheckResourceAttr(resourceName, "position", "1"),
+					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
+				),
+			},
+			{
+				Config: testAccAwsMacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
+					resource.TestCheckResourceAttr(resourceName, "position", "1"),
+					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsMacie2FindingsFilter_WithDate(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	dataSourceRegion := "data.aws_region.current"
+	description := "this is a description"
+	descriptionUpdated := "this is a description updated"
+	startDate := "2020-01-01T00:00:00Z"
+	endDate := "2020-02-01T00:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
+					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "position", "1"),
+				),
+			},
+			{
+				Config: testAccAwsMacieFindingsFilterconfigCompleteMultipleCriterion(descriptionUpdated, macie2.FindingsFilterActionNoop, startDate, endDate, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
+					resource.TestCheckResourceAttr(resourceName, "position", "1"),
+					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "updatedAt",
+						"gte":   startDate,
+						"lt":    endDate,
+					}),
+					testAccCheckResourceAttrRfc3339(resourceName, "finding_criteria.0.criterion.2.gte"),
+					testAccCheckResourceAttrRfc3339(resourceName, "finding_criteria.0.criterion.2.lt"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "sample",
+						"neq.#": "2",
+						"neq.0": "another-sample",
+						"neq.1": "some-sample",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsMacie2FindingsFilter_WithNumber(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	dataSourceRegion := "data.aws_region.current"
+	description := "this is a description"
+	descriptionUpdated := "this is a description updated"
+	firstNumber := "-12"
+	secondNumber := "13"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
+					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "position", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
+				),
+			},
+			{
+				Config: testAccAwsMacieFindingsFilterconfigCompleteMultipleCriterionNumber(descriptionUpdated, macie2.FindingsFilterActionNoop, firstNumber, secondNumber, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
+					resource.TestCheckResourceAttr(resourceName, "position", "1"),
+					resource.TestCheckResourceAttr(resourceName, "finding_criteria.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "count",
+						"gte":   firstNumber,
+						"lt":    secondNumber,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "sample",
+						"neq.#": "2",
+						"neq.0": "another-sample",
+						"neq.1": "some-sample",
+					}),
 				),
 			},
 			{
@@ -171,7 +351,6 @@ func testAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
-	descriptionUpdated := "this is a description updated"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -193,22 +372,11 @@ func testAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "position", "1"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-				),
-			},
-			{
-				Config: testAccAwsMacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
-					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
-					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key", "value"),
-					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags_all.Key", "value"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
-					resource.TestCheckResourceAttr(resourceName, "position", "1"),
-					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
+						"field": "region",
+						"eq.#":  "1",
+						"eq.0":  testAccGetRegion(),
+					}),
 				),
 			},
 			{
@@ -276,7 +444,8 @@ func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
 }
 
 func testAccAwsMacieFindingsFilterconfigNameGenerated() string {
-	return `resource "aws_macie2_account" "test" {}
+	return `
+resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
   action = "ARCHIVE"
@@ -326,6 +495,66 @@ resource "aws_macie2_findings_filter" "test" {
   depends_on = [aws_macie2_account.test]
 }
 `, description, action, position)
+}
+
+func testAccAwsMacieFindingsFilterconfigCompleteMultipleCriterion(description, action, startDate, endDate string, position int) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_macie2_account" "test" {}
+
+resource "aws_macie2_findings_filter" "test" {
+  description = %[1]q
+  action      = %[2]q
+  position    = %[3]d
+  finding_criteria {
+    criterion {
+      field = "region"
+      eq    = [data.aws_region.current.name]
+    }
+    criterion {
+      field = "sample"
+      neq   = ["some-sample", "another-sample"]
+    }
+    criterion {
+      field = "updatedAt"
+      gte   = %[4]q
+      lt    = %[5]q
+    }
+  }
+  depends_on = [aws_macie2_account.test]
+}
+`, description, action, position, startDate, endDate)
+}
+
+func testAccAwsMacieFindingsFilterconfigCompleteMultipleCriterionNumber(description, action, firstNum, secondNum string, position int) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_macie2_account" "test" {}
+
+resource "aws_macie2_findings_filter" "test" {
+  description = %[1]q
+  action      = %[2]q
+  position    = %[3]d
+  finding_criteria {
+    criterion {
+      field = "region"
+      eq    = [data.aws_region.current.name]
+    }
+    criterion {
+      field = "sample"
+      neq   = ["some-sample", "another-sample"]
+    }
+    criterion {
+      field = "count"
+      gte   = %[4]q
+      lt    = %[5]q
+    }
+  }
+  depends_on = [aws_macie2_account.test]
+}
+`, description, action, position, firstNum, secondNum)
 }
 
 func testAccAwsMacieFindingsFilterconfigWithTags(description, action string, position int) string {

--- a/aws/resource_aws_macie2_test.go
+++ b/aws/resource_aws_macie2_test.go
@@ -30,6 +30,14 @@ func TestAccAWSMacie2_serial(t *testing.T) {
 			"classification_job": testAccAwsMacie2CustomDataIdentifier_WithClassificationJob,
 			"tags":               testAccAwsMacie2CustomDataIdentifier_WithTags,
 		},
+		"FindingsFilter": {
+			"basic":          testAccAwsMacie2FindingsFilter_basic,
+			"name_generated": testAccAwsMacie2FindingsFilter_Name_Generated,
+			"name_prefix":    testAccAwsMacie2FindingsFilter_NamePrefix,
+			"disappears":     testAccAwsMacie2FindingsFilter_disappears,
+			"complete":       testAccAwsMacie2FindingsFilter_complete,
+			"tags":           testAccAwsMacie2FindingsFilter_withTags,
+		},
 	}
 
 	for group, m := range testCases {

--- a/aws/resource_aws_macie2_test.go
+++ b/aws/resource_aws_macie2_test.go
@@ -36,6 +36,8 @@ func TestAccAWSMacie2_serial(t *testing.T) {
 			"name_prefix":    testAccAwsMacie2FindingsFilter_NamePrefix,
 			"disappears":     testAccAwsMacie2FindingsFilter_disappears,
 			"complete":       testAccAwsMacie2FindingsFilter_complete,
+			"date":           testAccAwsMacie2FindingsFilter_WithDate,
+			"number":         testAccAwsMacie2FindingsFilter_WithNumber,
 			"tags":           testAccAwsMacie2FindingsFilter_withTags,
 		},
 	}

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -1,9 +1,9 @@
 ---
-subcategory: "Macie2"
+subcategory: "Macie"
 layout: "aws"
 page_title: "AWS: aws_macie2_findings_filter"
 description: |-
-  Provides a resource to manage an AWS Macie2 Findings Filter.
+  Provides a resource to manage an AWS Macie Findings Filter.
 ---
 
 # Resource: aws_macie2_findings_filter

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -13,20 +13,17 @@ Provides a resource to manage an [AWS Macie Findings Filter](https://docs.aws.am
 ## Example Usage
 
 ```terraform
-resource "aws_macie2_account" "example" {
-  client_token = "CLIENT TOKEN"
-}
+resource "aws_macie2_account" "example" {}
 
 resource "aws_macie2_findings_filter" "test" {
-  name = "NAME OF THE FINDINGS FILTER"
-  client_token = aws_macie2_account.test.client_token
+  name        = "NAME OF THE FINDINGS FILTER"
   description = "DESCRIPTION"
-  position = 1
-  action = "ARCHIVE"
+  position    = 1
+  action      = "ARCHIVE"
   finding_criteria {
     criterion {
-      field  = "region"
-      eq = [data.aws_region.current.name]
+      field = "region"
+      eq    = [data.aws_region.current.name]
     }
   }
   depends_on = [aws_macie2_account.test]
@@ -38,8 +35,8 @@ resource "aws_macie2_findings_filter" "test" {
 The following arguments are supported:
 
 * `finding_criteria` - (Required) The criteria to use to filter findings.
-* `client_token` - (Optional) A unique, case-sensitive token that you provide to ensure the idempotency of the request.
-* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters.
+* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `name_prefix` -  (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - (Optional) A custom description of the filter. The description can contain as many as 512 characters.
 * `action` - (Required) The action to perform on findings that meet the filter criteria (`finding_criteria`). Valid values are: `ARCHIVE`, suppress (automatically archive) the findings; and, `NOOP`, don't perform any action on the findings.
 * `position` - (Optional) The position of the filter in the list of saved filters on the Amazon Macie console. This value also determines the order in which the filter is applied to findings, relative to other filters that are also applied to the findings.
@@ -51,7 +48,7 @@ The `finding_criteria` object supports the following:
 
 The `criterion` object supports the following:
 
-* `field` - (Required) The name of the field to be evaluated. 
+* `field` - (Required) The name of the field to be evaluated.
 * `eq_exact_match` - (Optional) The value for the property exclusively matches (equals an exact match for) all the specified values. If you specify multiple values, Amazon Macie uses AND logic to join the values.
 * `eq` - (Optional) The value for the property matches (equals) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
 * `neq` - (Optional) The value for the property doesn't match (doesn't equal) the specified value. If you specify multiple values, Macie uses OR logic to join the values.

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Macie2"
+layout: "aws"
+page_title: "AWS: aws_macie2_findings_filter"
+description: |-
+  Provides a resource to manage an AWS Macie2 Findings Filter.
+---
+
+# Resource: aws_macie2_findings_filter
+
+Provides a resource to manage an [AWS Macie Findings Filter](https://docs.aws.amazon.com/macie/latest/APIReference/findingsfilters-id.html).
+
+## Example Usage
+
+```terraform
+resource "aws_macie2_account" "example" {
+  client_token = "CLIENT TOKEN"
+}
+
+resource "aws_macie2_findings_filter" "test" {
+  name = "NAME OF THE FINDINGS FILTER"
+  client_token = aws_macie2_account.test.client_token
+  description = "DESCRIPTION"
+  position = 1
+  action = "ARCHIVE"
+  finding_criteria {
+    criterion {
+      field  = "region"
+      eq = [data.aws_region.current.name]
+    }
+  }
+  depends_on = [aws_macie2_account.test]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `finding_criteria` - (Required) The criteria to use to filter findings.
+* `client_token` - (Optional) A unique, case-sensitive token that you provide to ensure the idempotency of the request.
+* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters.
+* `description` - (Optional) A custom description of the filter. The description can contain as many as 512 characters.
+* `action` - (Required) The action to perform on findings that meet the filter criteria (`finding_criteria`). Valid values are: `ARCHIVE`, suppress (automatically archive) the findings; and, `NOOP`, don't perform any action on the findings.
+* `position` - (Optional) The position of the filter in the list of saved filters on the Amazon Macie console. This value also determines the order in which the filter is applied to findings, relative to other filters that are also applied to the findings.
+* `tags` - (Optional) A map of key-value pairs that specifies the tags to associate with the filter.
+
+The `finding_criteria` object supports the following:
+
+* `criterion` -  (Optional) A condition that specifies the property, operator, and one or more values to use to filter the results.  (documented below)
+
+The `criterion` object supports the following:
+
+* `field` - (Required) The name of the field to be evaluated. 
+* `eq_exact_match` - (Optional) The value for the property exclusively matches (equals an exact match for) all the specified values. If you specify multiple values, Amazon Macie uses AND logic to join the values.
+* `eq` - (Optional) The value for the property matches (equals) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
+* `neq` - (Optional) The value for the property doesn't match (doesn't equal) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
+* `lt` - (Optional) The value for the property is less than the specified value.
+* `lte` - (Optional) The value for the property is less than or equal to the specified value.
+* `gt` - (Optional) The value for the property is greater than the specified value.
+* `gte` - (Optional) The value for the property is greater than or equal to the specified value.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier (ID) of the macie2 Findings Filter.
+* `arn` - The Amazon Resource Name (ARN) of the Findings Filter.
+
+## Import
+
+`aws_macie2_findings_filter` can be imported using the id, e.g.
+
+```
+$ terraform import aws_macie2_findings_filter.example abcd1
+```

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -62,7 +62,7 @@ The `criterion` object supports the following:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique identifier (ID) of the macie2 Findings Filter.
+* `id` - The unique identifier (ID) of the macie Findings Filter.
 * `arn` - The Amazon Resource Name (ARN) of the Findings Filter.
 
 ## Import

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Macie"
 layout: "aws"
 page_title: "AWS: aws_macie2_findings_filter"
 description: |-
-  Provides a resource to manage an AWS Macie Findings Filter.
+  Provides a resource to manage an Amazon Macie Findings Filter.
 ---
 
 # Resource: aws_macie2_findings_filter
 
-Provides a resource to manage an [AWS Macie Findings Filter](https://docs.aws.amazon.com/macie/latest/APIReference/findingsfilters-id.html).
+Provides a resource to manage an [Amazon Macie Findings Filter](https://docs.aws.amazon.com/macie/latest/APIReference/findingsfilters-id.html).
 
 ## Example Usage
 
@@ -35,7 +35,7 @@ resource "aws_macie2_findings_filter" "test" {
 The following arguments are supported:
 
 * `finding_criteria` - (Required) The criteria to use to filter findings.
-* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `name` - (Optional) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` -  (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - (Optional) A custom description of the filter. The description can contain as many as 512 characters.
 * `action` - (Required) The action to perform on findings that meet the filter criteria (`finding_criteria`). Valid values are: `ARCHIVE`, suppress (automatically archive) the findings; and, `NOOP`, don't perform any action on the findings.
@@ -50,8 +50,8 @@ The `criterion` object supports the following:
 
 * `field` - (Required) The name of the field to be evaluated.
 * `eq_exact_match` - (Optional) The value for the property exclusively matches (equals an exact match for) all the specified values. If you specify multiple values, Amazon Macie uses AND logic to join the values.
-* `eq` - (Optional) The value for the property matches (equals) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
-* `neq` - (Optional) The value for the property doesn't match (doesn't equal) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
+* `eq` - (Optional) The value for the property matches (equals) the specified value. If you specify multiple values, Amazon Macie uses OR logic to join the values.
+* `neq` - (Optional) The value for the property doesn't match (doesn't equal) the specified value. If you specify multiple values, Amazon Macie uses OR logic to join the values.
 * `lt` - (Optional) The value for the property is less than the specified value.
 * `lte` - (Optional) The value for the property is less than or equal to the specified value.
 * `gt` - (Optional) The value for the property is greater than the specified value.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->
Added a new resource, docs and tests for [Macie Findings Filter](https://docs.aws.amazon.com/macie/latest/APIReference/findingsfilters-id.html) called `aws_macie2_findings_filter`
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13432

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSMacie2_serial/FindingsFilter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMacie2_serial/FindingsFilter -timeout 180m
=== RUN   TestAccAWSMacie2_serial
=== RUN   TestAccAWSMacie2_serial/FindingsFilter
=== RUN   TestAccAWSMacie2_serial/FindingsFilter/basic
=== RUN   TestAccAWSMacie2_serial/FindingsFilter/name_generated
=== RUN   TestAccAWSMacie2_serial/FindingsFilter/name_prefix
=== RUN   TestAccAWSMacie2_serial/FindingsFilter/disappears
=== RUN   TestAccAWSMacie2_serial/FindingsFilter/complete
=== RUN   TestAccAWSMacie2_serial/FindingsFilter/tags
--- PASS: TestAccAWSMacie2_serial (158.20s)
    --- PASS: TestAccAWSMacie2_serial/FindingsFilter (158.20s)
        --- PASS: TestAccAWSMacie2_serial/FindingsFilter/basic (23.90s)
        --- PASS: TestAccAWSMacie2_serial/FindingsFilter/name_generated (21.83s)
        --- PASS: TestAccAWSMacie2_serial/FindingsFilter/name_prefix (21.53s)
        --- PASS: TestAccAWSMacie2_serial/FindingsFilter/disappears (16.42s)
        --- PASS: TestAccAWSMacie2_serial/FindingsFilter/complete (37.22s)
        --- PASS: TestAccAWSMacie2_serial/FindingsFilter/tags (37.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       158.253s

...
```
