### PR TITLE
r/servicecatalog_tag_option: New resource

### DIFF
--- a/.changelog/19300.txt
+++ b/.changelog/19300.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicecatalog_tag_option
+```

--- a/aws/internal/service/servicecatalog/waiter/waiter.go
+++ b/aws/internal/service/servicecatalog/waiter/waiter.go
@@ -73,7 +73,7 @@ func TagOptionReady(conn *servicecatalog.ServiceCatalog, id string) (*servicecat
 	return nil, err
 }
 
-func TagOptionDeleted(conn *servicecatalog.ServiceCatalog, id string) (*servicecatalog.TagOptionDetail, error) {
+func TagOptionDeleted(conn *servicecatalog.ServiceCatalog, id string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{servicecatalog.StatusAvailable},
 		Target:  []string{StatusNotFound, StatusUnavailable},
@@ -84,8 +84,8 @@ func TagOptionDeleted(conn *servicecatalog.ServiceCatalog, id string) (*servicec
 	_, err := stateConf.WaitForState()
 
 	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
-		return nil, nil
+		return nil
 	}
 
-	return nil, err
+	return err
 }

--- a/aws/internal/service/servicecatalog/waiter/waiter.go
+++ b/aws/internal/service/servicecatalog/waiter/waiter.go
@@ -12,6 +12,9 @@ const (
 	ProductReadyTimeout  = 3 * time.Minute
 	ProductDeleteTimeout = 3 * time.Minute
 
+	TagOptionReadyTimeout  = 3 * time.Minute
+	TagOptionDeleteTimeout = 3 * time.Minute
+
 	StatusNotFound    = "NOT_FOUND"
 	StatusUnavailable = "UNAVAILABLE"
 
@@ -42,6 +45,40 @@ func ProductDeleted(conn *servicecatalog.ServiceCatalog, acceptLanguage, product
 		Target:  []string{StatusNotFound},
 		Refresh: ProductStatus(conn, acceptLanguage, productID),
 		Timeout: ProductReadyTimeout,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil, nil
+	}
+
+	return nil, err
+}
+
+func TagOptionReady(conn *servicecatalog.ServiceCatalog, id string) (*servicecatalog.TagOptionDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{StatusNotFound, StatusUnavailable},
+		Target:  []string{servicecatalog.StatusAvailable},
+		Refresh: TagOptionStatus(conn, id),
+		Timeout: TagOptionReadyTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*servicecatalog.TagOptionDetail); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func TagOptionDeleted(conn *servicecatalog.ServiceCatalog, id string) (*servicecatalog.TagOptionDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{servicecatalog.StatusAvailable},
+		Target:  []string{StatusNotFound, StatusUnavailable},
+		Refresh: TagOptionStatus(conn, id),
+		Timeout: TagOptionDeleteTimeout,
 	}
 
 	_, err := stateConf.WaitForState()

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1006,6 +1006,7 @@ func Provider() *schema.Provider {
 			"aws_securityhub_standards_subscription":                  resourceAwsSecurityHubStandardsSubscription(),
 			"aws_servicecatalog_portfolio":                            resourceAwsServiceCatalogPortfolio(),
 			"aws_servicecatalog_product":                              resourceAwsServiceCatalogProduct(),
+			"aws_servicecatalog_tag_option":                           resourceAwsServiceCatalogTagOption(),
 			"aws_service_discovery_http_namespace":                    resourceAwsServiceDiscoveryHttpNamespace(),
 			"aws_service_discovery_private_dns_namespace":             resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":              resourceAwsServiceDiscoveryPublicDnsNamespace(),

--- a/aws/resource_aws_servicecatalog_tag_option.go
+++ b/aws/resource_aws_servicecatalog_tag_option.go
@@ -198,7 +198,7 @@ func resourceAwsServiceCatalogTagOptionDelete(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error deleting Service Catalog Tag Option (%s): %w", d.Id(), err)
 	}
 
-	if _, err := waiter.TagOptionDeleted(conn, d.Id()); err != nil {
+	if err := waiter.TagOptionDeleted(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for Service Catalog Tag Option (%s) to be deleted: %w", d.Id(), err)
 	}
 

--- a/aws/resource_aws_servicecatalog_tag_option.go
+++ b/aws/resource_aws_servicecatalog_tag_option.go
@@ -140,20 +140,12 @@ func resourceAwsServiceCatalogTagOptionUpdate(d *schema.ResourceData, meta inter
 	// UpdateTagOption() is very particular about what it receives. Only fields that change should
 	// be included or it will throw servicecatalog.ErrCodeDuplicateResourceException, "already exists"
 
-	makeChange := false
-
 	if d.HasChange("active") {
 		input.Active = aws.Bool(d.Get("active").(bool))
-		makeChange = true
 	}
 
 	if d.HasChange("value") {
 		input.Value = aws.String(d.Get("value").(string))
-		makeChange = true
-	}
-
-	if !makeChange {
-		return resourceAwsServiceCatalogTagOptionRead(d, meta)
 	}
 
 	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {

--- a/aws/resource_aws_servicecatalog_tag_option.go
+++ b/aws/resource_aws_servicecatalog_tag_option.go
@@ -35,7 +35,7 @@ func resourceAwsServiceCatalogTagOption() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"owner_id": {
+			"owner": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -124,7 +124,7 @@ func resourceAwsServiceCatalogTagOptionRead(d *schema.ResourceData, meta interfa
 
 	d.Set("active", output.Active)
 	d.Set("key", output.Key)
-	d.Set("owner_id", output.Owner)
+	d.Set("owner", output.Owner)
 	d.Set("value", output.Value)
 
 	return nil

--- a/aws/resource_aws_servicecatalog_tag_option.go
+++ b/aws/resource_aws_servicecatalog_tag_option.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsServiceCatalogTagOption() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceCatalogTagOptionCreate,
+		Read:   resourceAwsServiceCatalogTagOptionRead,
+		Update: resourceAwsServiceCatalogTagOptionUpdate,
+		Delete: resourceAwsServiceCatalogTagOptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsServiceCatalogTagOptionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.CreateTagOptionInput{
+		Key:   aws.String(d.Get("key").(string)),
+		Value: aws.String(d.Get("value").(string)),
+	}
+
+	var output *servicecatalog.CreateTagOptionOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.CreateTagOption(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateTagOption(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating Service Catalog Tag Option: %w", err)
+	}
+
+	if output == nil || output.TagOptionDetail == nil {
+		return fmt.Errorf("error creating Service Catalog Tag Option: empty response")
+	}
+
+	d.SetId(aws.StringValue(output.TagOptionDetail.Id))
+
+	// Active is not a field of CreateTagOption but is a field of UpdateTagOption. In order to create an
+	// inactive Tag Option, you must create an active one and then update it (but calling this resource's
+	// Update will error with ErrCodeDuplicateResourceException because Value is unchanged).
+	if v, ok := d.GetOk("active"); !ok {
+		_, err = conn.UpdateTagOption(&servicecatalog.UpdateTagOptionInput{
+			Id:     aws.String(d.Id()),
+			Active: aws.Bool(v.(bool)),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error creating Service Catalog Tag Option, updating active (%s): %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsServiceCatalogTagOptionRead(d, meta)
+}
+
+func resourceAwsServiceCatalogTagOptionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	output, err := waiter.TagOptionReady(conn, d.Id())
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Service Catalog Tag Option (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Tag Option (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Catalog Tag Option (%s): empty response", d.Id())
+	}
+
+	d.Set("active", output.Active)
+	d.Set("key", output.Key)
+	d.Set("owner_id", output.Owner)
+	d.Set("value", output.Value)
+
+	return nil
+}
+
+func resourceAwsServiceCatalogTagOptionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.UpdateTagOptionInput{
+		Id: aws.String(d.Id()),
+	}
+
+	// UpdateTagOption() is very particular about what it receives. Only fields that change should
+	// be included or it will throw servicecatalog.ErrCodeDuplicateResourceException, "already exists"
+
+	makeChange := false
+
+	if d.HasChange("active") {
+		input.Active = aws.Bool(d.Get("active").(bool))
+		makeChange = true
+	}
+
+	if d.HasChange("value") {
+		input.Value = aws.String(d.Get("value").(string))
+		makeChange = true
+	}
+
+	if !makeChange {
+		return resourceAwsServiceCatalogTagOptionRead(d, meta)
+	}
+
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		_, err := conn.UpdateTagOption(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.UpdateTagOption(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error updating Service Catalog Tag Option (%s): %w", d.Id(), err)
+	}
+
+	return resourceAwsServiceCatalogTagOptionRead(d, meta)
+}
+
+func resourceAwsServiceCatalogTagOptionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.DeleteTagOptionInput{
+		Id: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteTagOption(input)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Service Catalog Tag Option (%s): %w", d.Id(), err)
+	}
+
+	if _, err := waiter.TagOptionDeleted(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for Service Catalog Tag Option (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_servicecatalog_tag_option_test.go
+++ b/aws/resource_aws_servicecatalog_tag_option_test.go
@@ -1,0 +1,276 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// add sweeper to delete known test servicecat tag options
+func init() {
+	resource.AddTestSweepers("aws_servicecatalog_tag_option", &resource.Sweeper{
+		Name:         "aws_servicecatalog_tag_option",
+		Dependencies: []string{},
+		F:            testSweepServiceCatalogTagOptions,
+	})
+}
+
+func testSweepServiceCatalogTagOptions(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).scconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &servicecatalog.ListTagOptionsInput{}
+
+	err = conn.ListTagOptionsPages(input, func(page *servicecatalog.ListTagOptionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, tod := range page.TagOptionDetails {
+			if tod == nil {
+				continue
+			}
+
+			id := aws.StringValue(tod.Id)
+
+			r := resourceAwsServiceCatalogTagOption()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Tag Options for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Service Catalog Tag Options for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Service Catalog Tag Options sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func TestAccAWSServiceCatalogTagOption_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_tag_option.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogTagOptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde", "active = true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogTagOptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogTagOption_disappears(t *testing.T) {
+	resourceName := "aws_servicecatalog_tag_option.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogTagOptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde", "active = true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogTagOptionExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogTagOption(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogTagOption_update(t *testing.T) {
+	resourceName := "aws_servicecatalog_tag_option.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	// UpdateTagOption() is very particular about what it receives. Only fields that change should
+	// be included or it will throw servicecatalog.ErrCodeDuplicateResourceException, "already exists"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogTagOptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde ett", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
+				),
+			},
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde två", "active = true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde två"),
+				),
+			},
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde två", "active = false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "false"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName), // cannot be updated in place
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde två"),
+				),
+			},
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde två", "active = true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName), // cannot be updated in place
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde två"),
+				),
+			},
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName2, "värde ett", "active = true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName2),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogTagOption_notActive(t *testing.T) {
+	resourceName := "aws_servicecatalog_tag_option.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogTagOptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogTagOptionConfig_basic(rName, "värde ett", "active = false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "false"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogTagOptionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).scconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_servicecatalog_tag_option" {
+			continue
+		}
+
+		input := &servicecatalog.DescribeTagOptionInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeTagOption(input)
+
+		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Service Catalog Tag Option (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("Service Catalog Tag Option (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsServiceCatalogTagOptionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).scconn
+
+		input := &servicecatalog.DescribeTagOptionInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeTagOption(input)
+
+		if err != nil {
+			return fmt.Errorf("error describing Service Catalog Tag Option (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSServiceCatalogTagOptionConfig_basic(key, value, active string) string {
+	return fmt.Sprintf(`
+resource "aws_servicecatalog_tag_option" "test" {
+  key    = %[1]q
+  value  = %[2]q
+  %[3]s
+}
+`, key, value, active)
+}

--- a/aws/resource_aws_servicecatalog_tag_option_test.go
+++ b/aws/resource_aws_servicecatalog_tag_option_test.go
@@ -90,7 +90,7 @@ func TestAccAWSServiceCatalogTagOption_basic(t *testing.T) {
 					testAccCheckAwsServiceCatalogTagOptionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde"),
 				),
 			},
@@ -144,7 +144,7 @@ func TestAccAWSServiceCatalogTagOption_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
 				),
 			},
@@ -153,7 +153,7 @@ func TestAccAWSServiceCatalogTagOption_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde två"),
 				),
 			},
@@ -162,7 +162,7 @@ func TestAccAWSServiceCatalogTagOption_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "active", "false"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName), // cannot be updated in place
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde två"),
 				),
 			},
@@ -171,7 +171,7 @@ func TestAccAWSServiceCatalogTagOption_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName), // cannot be updated in place
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde två"),
 				),
 			},
@@ -180,7 +180,7 @@ func TestAccAWSServiceCatalogTagOption_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName2),
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
 				),
 			},
@@ -203,7 +203,7 @@ func TestAccAWSServiceCatalogTagOption_notActive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "active", "false"),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
 					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
 				),
 			},

--- a/aws/resource_aws_servicecatalog_tag_option_test.go
+++ b/aws/resource_aws_servicecatalog_tag_option_test.go
@@ -268,8 +268,8 @@ func testAccCheckAwsServiceCatalogTagOptionExists(resourceName string) resource.
 func testAccAWSServiceCatalogTagOptionConfig_basic(key, value, active string) string {
 	return fmt.Sprintf(`
 resource "aws_servicecatalog_tag_option" "test" {
-  key    = %[1]q
-  value  = %[2]q
+  key   = %[1]q
+  value = %[2]q
   %[3]s
 }
 `, key, value, active)

--- a/website/docs/r/servicecatalog_tag_option.html.markdown
+++ b/website/docs/r/servicecatalog_tag_option.html.markdown
@@ -28,13 +28,16 @@ The following arguments are required:
 * `key` - (Required) Tag option key.
 * `value` - (Required) Tag option value.
 
+The following arguments are optional:
+
+* `active` - (Optional) Whether tag option is active. Default is `true`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `active` - Active state.
-* `id` - Identifier.
-* `owner` - AWS account ID of the owner account that created the tag option.
+* `id` - Identifier (e.g., `tag-pjtvagohlyo3m`).
+* `owner_id` - AWS account ID of the owner account that created the tag option.
 
 ## Import
 

--- a/website/docs/r/servicecatalog_tag_option.html.markdown
+++ b/website/docs/r/servicecatalog_tag_option.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_tag_option"
+description: |-
+  Manages a Service Catalog Tag Option
+---
+
+# Resource: aws_servicecatalog_tag_option
+
+Manages a Service Catalog Tag Option.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_tag_option" "example" {
+  key   = "nyckel"
+  value = "värde"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `key` - (Required) Tag option key.
+* `value` - (Required) Tag option value.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `active` - Active state.
+* `id` - Identifier.
+* `owner` - AWS account ID of the owner account that created the tag option.
+
+## Import
+
+`aws_servicecatalog_tag_option` can be imported using the tag option ID, e.g.
+
+```
+$ terraform import aws_servicecatalog_tag_option.example tag-pjtvagohlyo3m
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19122

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogTagOption_disappears (11.33s)
--- PASS: TestAccAWSServiceCatalogTagOption_notActive (13.42s)
--- PASS: TestAccAWSServiceCatalogTagOption_basic (14.49s)
--- PASS: TestAccAWSServiceCatalogTagOption_update (47.60s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogTagOption_disappears (14.15s)
--- PASS: TestAccAWSServiceCatalogTagOption_notActive (16.09s)
--- PASS: TestAccAWSServiceCatalogTagOption_basic (18.25s)
--- PASS: TestAccAWSServiceCatalogTagOption_update (60.28s)
```

Note: I'm not sure an AWS Organizations tests can ever run in GovCloud. GovCloud accounts are always tied to an existing commercial account so may not have the capacity of being a "payer" account.