### PR TITLE
New resource for Macie2 Organization Admin Account

### DIFF
--- a/.changelog/19283.txt
+++ b/.changelog/19283.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_macie2_findings_filter
+```

--- a/.changelog/19302.txt
+++ b/.changelog/19302.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_macie2_organization_admin_account
+```

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -847,6 +847,7 @@ func Provider() *schema.Provider {
 			"aws_macie2_custom_data_identifier":                       resourceAwsMacie2CustomDataIdentifier(),
 			"aws_macie2_findings_filter":                              resourceAwsMacie2FindingsFilter(),
 			"aws_macie2_member":                                       resourceAwsMacie2Member(),
+			"aws_macie2_organization_admin_account":                   resourceAwsMacie2OrganizationAdminAccount(),
 			"aws_macie_member_account_association":                    resourceAwsMacieMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":                         resourceAwsMacieS3BucketAssociation(),
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -845,6 +845,7 @@ func Provider() *schema.Provider {
 			"aws_macie2_account":                                      resourceAwsMacie2Account(),
 			"aws_macie2_classification_job":                           resourceAwsMacie2ClassificationJob(),
 			"aws_macie2_custom_data_identifier":                       resourceAwsMacie2CustomDataIdentifier(),
+			"aws_macie2_findings_filter":                              resourceAwsMacie2FindingsFilter(),
 			"aws_macie_member_account_association":                    resourceAwsMacieMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":                         resourceAwsMacieS3BucketAssociation(),
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -846,6 +846,7 @@ func Provider() *schema.Provider {
 			"aws_macie2_classification_job":                           resourceAwsMacie2ClassificationJob(),
 			"aws_macie2_custom_data_identifier":                       resourceAwsMacie2CustomDataIdentifier(),
 			"aws_macie2_findings_filter":                              resourceAwsMacie2FindingsFilter(),
+			"aws_macie2_member":                                       resourceAwsMacie2Member(),
 			"aws_macie_member_account_association":                    resourceAwsMacieMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":                         resourceAwsMacieS3BucketAssociation(),
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -243,7 +243,7 @@ func resourceMacie2FindingsFilterDelete(ctx context.Context, d *schema.ResourceD
 
 	_, err := conn.DeleteFindingsFilterWithContext(ctx, input)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, macie2.ErrorCodeInternalError) {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) {
 			return nil
 		}
 		return diag.FromErr(fmt.Errorf("error deleting Macie2 FindingsFilter (%s): %w", d.Id(), err))

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -92,7 +92,7 @@ func resourceAwsMacie2FindingsFilter() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.StringLenBetween(0, 500),
+				ValidateFunc:  validation.StringLenBetween(0, 500-resource.UniqueIDSuffixLength),
 			},
 			"description": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_macie2_findings_filter.go
+++ b/aws/resource_aws_macie2_findings_filter.go
@@ -160,7 +160,7 @@ func resourceMacie2FindingsFilterCreate(ctx context.Context, d *schema.ResourceD
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err = conn.CreateFindingsFilterWithContext(ctx, input)
+		output, err = conn.CreateFindingsFilterWithContext(ctx, input)
 	}
 
 	if err != nil {

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 )
 
-func TestAccAwsMacie2FindingsFilter_basic(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_basic(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 
@@ -40,7 +40,7 @@ func TestAccAwsMacie2FindingsFilter_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 
@@ -67,7 +67,7 @@ func TestAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	namePrefix := "tf-acc-test-prefix-"
@@ -95,7 +95,7 @@ func TestAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 
@@ -119,7 +119,7 @@ func TestAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
@@ -159,7 +159,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
+func testAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
@@ -180,6 +180,8 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key", "value"),
 				),
 			},
 			{
@@ -191,6 +193,8 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key", "value"),
 				),
 			},
 			{
@@ -277,14 +281,14 @@ func testAccAwsMacieFindingsFilterconfigNamePrefix(name string) string {
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
-	name_prefix = %q
-	action = "ARCHIVE"
-	finding_criteria {
-		criterion {
-			field  = "region"
-		}
-	}
-	depends_on = [aws_macie2_account.test]
+  name_prefix = %[1]q
+  action = "ARCHIVE"
+  finding_criteria {
+    criterion {
+      field  = "region"
+    }
+  }
+  depends_on = [aws_macie2_account.test]
 }
 `, name)
 }
@@ -296,16 +300,16 @@ data "aws_region" "current" {}
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
-	description = %q
-	action      = %q
-	position    = %d
-	finding_criteria {
-		criterion {
-		  field = "region"
-		  eq    = [data.aws_region.current.name]
-		}
-	}
-	depends_on = [aws_macie2_account.test]
+  description = %[1]q
+  action      = %[2]q
+  position    = %[3]d
+  finding_criteria {
+    criterion {
+      field = "region"
+      eq    = [data.aws_region.current.name]
+    }
+  }
+  depends_on = [aws_macie2_account.test]
 }
 `, description, action, position)
 }
@@ -317,9 +321,9 @@ data "aws_region" "current" {}
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_findings_filter" "test" {
-  description = %q
-  action      = %q
-  position    = %d
+  description = %[1]q
+  action      = %[2]q
+  position    = %[3]d
   finding_criteria {
     criterion {
       field = "region"

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -95,9 +95,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
-	action := "ARCHIVE"
 	descriptionUpdated := "this is a description updated"
-	actionUpdated := "NOOP"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -106,25 +104,21 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(description, action, 1),
+				Config: testaccawsmacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(descriptionUpdated, actionUpdated, 1),
+				Config: testaccawsmacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
 				),
 			},
 			{
@@ -140,9 +134,7 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 	var macie2Output macie2.GetFindingsFilterOutput
 	resourceName := "aws_macie2_findings_filter.test"
 	description := "this is a description"
-	action := "ARCHIVE"
 	descriptionUpdated := "this is a description updated"
-	actionUpdated := "NOOP"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -151,25 +143,21 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(description, action, 1),
+				Config: testaccawsmacieFindingsFilterconfigWithTags(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(descriptionUpdated, actionUpdated, 1),
+				Config: testaccawsmacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttrSet(resourceName, "action"),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-					resource.TestCheckResourceAttrSet(resourceName, "position"),
+					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionNoop),
 				),
 			},
 			{

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -23,7 +23,7 @@ func TestAccAwsMacie2FindingsFilter_Name_Generated(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigNameGenerated(),
+				Config: testAccAwsMacieFindingsFilterconfigNameGenerated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -51,7 +51,7 @@ func TestAccAwsMacie2FindingsFilter_NamePrefix(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigNamePrefix(namePrefix),
+				Config: testAccAwsMacieFindingsFilterconfigNamePrefix(namePrefix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameFromPrefix(resourceName, "name", namePrefix),
@@ -78,7 +78,7 @@ func TestAccAwsMacie2FindingsFilter_disappears(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigNameGenerated(),
+				Config: testAccAwsMacieFindingsFilterconfigNameGenerated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -104,7 +104,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
+				Config: testAccAwsMacieFindingsFilterconfigComplete(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -113,7 +113,7 @@ func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
+				Config: testAccAwsMacieFindingsFilterconfigComplete(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -143,7 +143,7 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(description, macie2.FindingsFilterActionArchive, 1),
+				Config: testAccAwsMacieFindingsFilterconfigWithTags(description, macie2.FindingsFilterActionArchive, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -152,7 +152,7 @@ func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testaccawsmacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
+				Config: testAccAwsMacieFindingsFilterconfigWithTags(descriptionUpdated, macie2.FindingsFilterActionNoop, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
@@ -186,7 +186,7 @@ func testAccCheckAwsMacie2FindingsFilterExists(resourceName string, macie2Sessio
 		}
 
 		if resp == nil {
-			return fmt.Errorf("macie2 FindingsFilter %q does not exist", rs.Primary.ID)
+			return fmt.Errorf("macie FindingsFilter %q does not exist", rs.Primary.ID)
 		}
 
 		*macie2Session = *resp
@@ -215,7 +215,7 @@ func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
 		}
 
 		if resp != nil {
-			return fmt.Errorf("macie2 FindingsFilter %q still exists", rs.Primary.ID)
+			return fmt.Errorf("macie FindingsFilter %q still exists", rs.Primary.ID)
 		}
 	}
 
@@ -223,7 +223,7 @@ func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
 
 }
 
-func testaccawsmacieFindingsFilterconfigNameGenerated() string {
+func testAccAwsMacieFindingsFilterconfigNameGenerated() string {
 	return `resource "aws_macie2_account" "test" {}
 
 	resource "aws_macie2_findings_filter" "test" {
@@ -238,7 +238,7 @@ func testaccawsmacieFindingsFilterconfigNameGenerated() string {
 `
 }
 
-func testaccawsmacieFindingsFilterconfigNamePrefix(name string) string {
+func testAccAwsMacieFindingsFilterconfigNamePrefix(name string) string {
 	return fmt.Sprintf(`resource "aws_macie2_account" "test" {}
 
 	resource "aws_macie2_findings_filter" "test" {
@@ -254,7 +254,7 @@ func testaccawsmacieFindingsFilterconfigNamePrefix(name string) string {
 `, name)
 }
 
-func testaccawsmacieFindingsFilterconfigComplete(description, action string, position int) string {
+func testAccAwsMacieFindingsFilterconfigComplete(description, action string, position int) string {
 	return fmt.Sprintf(`data "aws_region" "current" {}
 
 	resource "aws_macie2_account" "test" {}
@@ -274,7 +274,7 @@ func testaccawsmacieFindingsFilterconfigComplete(description, action string, pos
 `, description, action, position)
 }
 
-func testaccawsmacieFindingsFilterconfigWithTags(description, action string, position int) string {
+func testAccAwsMacieFindingsFilterconfigWithTags(description, action string, position int) string {
 	return fmt.Sprintf(`data "aws_region" "current" {}
 
 	resource "aws_macie2_account" "test" {}

--- a/aws/resource_aws_macie2_findings_filter_test.go
+++ b/aws/resource_aws_macie2_findings_filter_test.go
@@ -1,0 +1,222 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+)
+
+func TestAccAwsMacie2FindingsFilter_basic(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	name := acctest.RandomWithPrefix("testacc-findings-filter")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccawsmacieFindingsFilterconfigBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2FindingsFilter_complete(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	name := acctest.RandomWithPrefix("testacc-findings-filter")
+	clientToken := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccawsmacieFindingsFilterconfigComplete(clientToken, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "action"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "position"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_token"},
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2FindingsFilter_withTags(t *testing.T) {
+	var macie2Output macie2.GetFindingsFilterOutput
+	resourceName := "aws_macie2_findings_filter.test"
+	name := acctest.RandomWithPrefix("testacc-findings-filter")
+	clientToken := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2FindingsFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccawsmacieFindingsFilterconfigWithTags(clientToken, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2FindingsFilterExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "action"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "position"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_token"},
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMacie2FindingsFilterExists(resourceName string, macie2Session *macie2.GetFindingsFilterOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).macie2conn
+		input := &macie2.GetFindingsFilterInput{Id: aws.String(rs.Primary.ID)}
+
+		resp, err := conn.GetFindingsFilter(input)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("macie2 FindingsFilter %q does not exist", rs.Primary.ID)
+		}
+
+		*macie2Session = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAwsMacie2FindingsFilterDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_findings_filter" {
+			continue
+		}
+
+		input := &macie2.GetFindingsFilterInput{Id: aws.String(rs.Primary.ID)}
+		resp, err := conn.GetFindingsFilter(input)
+
+		if isAWSErr(err, macie2.ErrCodeAccessDeniedException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if resp != nil {
+			return fmt.Errorf("macie2 FindingsFilter %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testaccawsmacieFindingsFilterconfigBasic(name string) string {
+	return fmt.Sprintf(`
+	resource "aws_macie2_account" "test" {}
+
+	resource "aws_macie2_findings_filter" "test" {
+		name = "%s"
+		action = "ARCHIVE"
+		finding_criteria {
+			criterion {
+				field  = "region"
+			}
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, name)
+}
+
+func testaccawsmacieFindingsFilterconfigComplete(clientToken, name string) string {
+	return fmt.Sprintf(`
+	data "aws_region" "current" {}
+
+	resource "aws_macie2_account" "test" {
+		client_token = "%s"
+	}
+
+	resource "aws_macie2_findings_filter" "test" {
+		name = "%s"
+		client_token = aws_macie2_account.test.client_token
+		description = "this a description"
+		position = 1
+		action = "ARCHIVE"
+		finding_criteria {
+			criterion {
+				field  = "region"
+      			eq = [data.aws_region.current.name]
+			}
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, clientToken, name)
+}
+
+func testaccawsmacieFindingsFilterconfigWithTags(clientToken, name string) string {
+	return fmt.Sprintf(`
+	data "aws_region" "current" {}
+
+	resource "aws_macie2_account" "test" {
+		client_token = "%s"
+	}
+
+	resource "aws_macie2_findings_filter" "test" {
+		name = "%s"
+		client_token = aws_macie2_account.test.client_token
+		description = "this a description"
+		position = 1
+		action = "ARCHIVE"
+		finding_criteria {
+			criterion {
+				field  = "region"
+      			eq = [data.aws_region.current.name]
+			}
+		}
+		tags = {
+    		Key = "value"
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, clientToken, name)
+}

--- a/aws/resource_aws_macie2_member.go
+++ b/aws/resource_aws_macie2_member.go
@@ -29,10 +29,12 @@ func resourceAwsMacie2Member() *schema.Resource {
 			"account_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"email": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
@@ -127,7 +129,7 @@ func resourceMacie2MemberRead(ctx context.Context, d *schema.ResourceData, meta 
 	resp, err := conn.GetMemberWithContext(ctx, input)
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
-			tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) ||
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeConflictException, "member accounts are associated with your account") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "account is not associated with your account") {
 			log.Printf("[WARN] Macie Member (%s) not found, removing from state", d.Id())
@@ -186,7 +188,7 @@ func resourceMacie2MemberDelete(ctx context.Context, d *schema.ResourceData, met
 	_, err := conn.DeleteMemberWithContext(ctx, input)
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
-			tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) ||
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeConflictException, "member accounts are associated with your account") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "account is not associated with your account") {
 			return nil

--- a/aws/resource_aws_macie2_member.go
+++ b/aws/resource_aws_macie2_member.go
@@ -1,0 +1,175 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsMacie2Member() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceMacie2MemberCreate,
+		ReadWithoutTimeout:   resourceMacie2MemberRead,
+		UpdateWithoutTimeout: resourceMacie2MemberUpdate,
+		DeleteWithoutTimeout: resourceMacie2MemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": tagsSchemaComputed(),
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"relationship_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"administrator_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"invited_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(macie2.MacieStatus_Values(), false),
+			},
+		},
+	}
+}
+
+func resourceMacie2MemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.CreateMemberInput{
+		Account: &macie2.AccountDetail{
+			AccountId: aws.String(d.Get("account_id").(string)),
+			Email:     aws.String(d.Get("email").(string)),
+		},
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.SetTags(keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().AppsyncTags())
+	}
+
+	var err error
+	err = resource.RetryContext(ctx, 4*time.Minute, func() *resource.RetryError {
+		_, err := conn.CreateMemberWithContext(ctx, input)
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrorCodeClientError) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateMemberWithContext(ctx, input)
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating Macie Member: %w", err))
+	}
+
+	d.SetId(meta.(*AWSClient).accountid)
+
+	return resourceMacie2MemberRead(ctx, d, meta)
+}
+
+func resourceMacie2MemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+	input := &macie2.GetMemberInput{
+		Id: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetMemberWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) {
+			log.Printf("[WARN] Macie Member does not exist, removing from state: %s", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading Macie Member (%s): %w", d.Id(), err))
+	}
+
+	d.Set("account_id", aws.StringValue(resp.AccountId))
+	d.Set("email", aws.StringValue(resp.Email))
+	d.Set("relationship_status", aws.StringValue(resp.RelationshipStatus))
+	d.Set("administrator_account_id", aws.StringValue(resp.AdministratorAccountId))
+	d.Set("invited_at", aws.TimeValue(resp.InvitedAt).Format(time.RFC3339))
+	d.Set("updated_at", aws.TimeValue(resp.UpdatedAt).Format(time.RFC3339))
+	d.Set("arn", aws.StringValue(resp.Arn))
+	if err = d.Set("tags", keyvaluetags.AppsyncKeyValueTags(resp.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `%s` for Macie Member (%s): %w", "tags", d.Id(), err))
+	}
+
+	return nil
+}
+
+func resourceMacie2MemberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.UpdateMemberSessionInput{
+		Id: aws.String(d.Id()),
+	}
+
+	if d.HasChange("status") {
+		input.SetStatus(d.Get("status").(string))
+	}
+
+	_, err := conn.UpdateMemberSessionWithContext(ctx, input)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating Macie Member (%s): %w", d.Id(), err))
+	}
+
+	return resourceMacie2MemberRead(ctx, d, meta)
+}
+
+func resourceMacie2MemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.DeleteMemberInput{
+		Id: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteMemberWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting Macie Member (%s): %w", d.Id(), err))
+	}
+	return nil
+}

--- a/aws/resource_aws_macie2_member.go
+++ b/aws/resource_aws_macie2_member.go
@@ -62,6 +62,10 @@ func resourceAwsMacie2Member() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(macie2.MacieStatus_Values(), false),
 			},
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Second),
+			Update: schema.DefaultTimeout(60 * time.Second),
+		},
 	}
 }
 

--- a/aws/resource_aws_macie2_member_test.go
+++ b/aws/resource_aws_macie2_member_test.go
@@ -1,0 +1,185 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsMacie2Member_basic(t *testing.T) {
+	var macie2Output macie2.GetMemberOutput
+	resourceName := "aws_macie2_member.test"
+	accountID := "520983883852" //os.Getenv("AWS_ACCOUNT_ID")
+	email := "test@test.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2MemberDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieMemberConfigBasic(accountID, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttr(resourceName, "status", macie2.MacieStatusEnabled),
+					testAccCheckResourceAttrRfc3339(resourceName, "invited_at"),
+					testAccCheckResourceAttrRfc3339(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2Member_disappears(t *testing.T) {
+	var macie2Output macie2.GetMemberOutput
+	resourceName := "aws_macie2_member.test"
+	accountID := "520983883852" //os.Getenv("AWS_ACCOUNT_ID")
+	email := "test@test.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2MemberDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieMemberConfigBasic(accountID, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsMacie2Account(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2Member_withTags(t *testing.T) {
+	var macie2Output macie2.GetMemberOutput
+	resourceName := "aws_macie2_member.test"
+	accountID := "520983883852" //os.Getenv("AWS_ACCOUNT_ID")
+	email := "test@test.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2MemberDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieMemberConfigWithTags(accountID, email, macie2.MacieStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttr(resourceName, "status", macie2.MacieStatusEnabled),
+					testAccCheckResourceAttrRfc3339(resourceName, "invited_at"),
+					testAccCheckResourceAttrRfc3339(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccAwsMacieMemberConfigWithTags(accountID, email, macie2.MacieStatusPaused),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
+					resource.TestCheckResourceAttr(resourceName, "status", macie2.MacieStatusPaused),
+					testAccCheckResourceAttrRfc3339(resourceName, "invited_at"),
+					testAccCheckResourceAttrRfc3339(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMacie2MemberExists(resourceName string, macie2Session *macie2.GetMemberOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).macie2conn
+		input := &macie2.GetMemberInput{Id: aws.String(rs.Primary.ID)}
+
+		resp, err := conn.GetMember(input)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("macie Member %q does not exist", rs.Primary.ID)
+		}
+
+		*macie2Session = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAwsMacie2MemberDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_member" {
+			continue
+		}
+
+		input := &macie2.GetMemberInput{Id: aws.String(rs.Primary.ID)}
+		resp, err := conn.GetMember(input)
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if resp != nil {
+			return fmt.Errorf("macie Member %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccAwsMacieMemberConfigBasic(accountID, email string) string {
+	return fmt.Sprintf(`resource "aws_macie2_account" "test" {}
+
+	resource "aws_macie2_member" "test" {
+		account_id = "%s"
+		email = "%s"
+		depends_on = [aws_macie2_account.test]
+	}
+`, accountID, email)
+}
+
+func testAccAwsMacieMemberConfigWithTags(accountID, email, status string) string {
+	return fmt.Sprintf(`resource "aws_macie2_account" "test" {}
+
+	resource "aws_macie2_member" "test" {
+		account_id = "%s"
+		email = "%s"
+		status = "%s"
+		tags = {
+    		key = "value"
+		}
+		depends_on = [aws_macie2_account.test]
+	}
+`, accountID, email, status)
+}

--- a/aws/resource_aws_macie2_member_test.go
+++ b/aws/resource_aws_macie2_member_test.go
@@ -161,7 +161,7 @@ resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_member" "test" {
   account_id = %[1]q
-  email = %[2]q
+  email      = %[2]q
   depends_on = [aws_macie2_account.test]
 }
 `, accountID, email)
@@ -173,7 +173,7 @@ resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_member" "test" {
   account_id = %[1]q
-  email = %[2]q
+  email      = %[2]q
   tags = {
     Key = "value"
   }

--- a/aws/resource_aws_macie2_member_test.go
+++ b/aws/resource_aws_macie2_member_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAwsMacie2Member_basic(t *testing.T) {
+func testAccAwsMacie2Member_basic(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.test"
-	accountID := "520983883852"
-	email := "labs@digitalonus.com"
+	accountID := "520433213222"
+	email := "test@test.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -41,11 +41,11 @@ func TestAccAwsMacie2Member_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2Member_disappears(t *testing.T) {
+func testAccAwsMacie2Member_disappears(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.test"
-	accountID := "520983883852" //os.Getenv("AWS_ACCOUNT_ID")
-	email := "labs@digitalonus.com"
+	accountID := "520433213222"
+	email := "test@test.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -65,11 +65,11 @@ func TestAccAwsMacie2Member_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2Member_withTags(t *testing.T) {
+func testAccAwsMacie2Member_withTags(t *testing.T) {
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.test"
-	accountID := "520983883852" //os.Getenv("AWS_ACCOUNT_ID")
-	email := "labs@digitalonus.com"
+	accountID := "520433213222"
+	email := "test@test.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -85,6 +85,8 @@ func TestAccAwsMacie2Member_withTags(t *testing.T) {
 					testAccCheckResourceAttrRfc3339(resourceName, "updated_at"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key", "value"),
 				),
 			},
 			{
@@ -158,9 +160,9 @@ func testAccAwsMacieMemberConfigBasic(accountID, email string) string {
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_member" "test" {
-	account_id = %q
-	email = %q
-	depends_on = [aws_macie2_account.test]
+  account_id = %[1]q
+  email = %[2]q
+  depends_on = [aws_macie2_account.test]
 }
 `, accountID, email)
 }
@@ -170,12 +172,12 @@ func testAccAwsMacieMemberConfigWithTags(accountID, email string) string {
 resource "aws_macie2_account" "test" {}
 
 resource "aws_macie2_member" "test" {
-	account_id = %q
-	email = %q
-	tags = {
-		Key = "value"
-	}
-	depends_on = [aws_macie2_account.test]
+  account_id = %[1]q
+  email = %[2]q
+  tags = {
+    Key = "value"
+  }
+  depends_on = [aws_macie2_account.test]
 }
 `, accountID, email)
 }

--- a/aws/resource_aws_macie2_member_test.go
+++ b/aws/resource_aws_macie2_member_test.go
@@ -136,7 +136,7 @@ func testAccCheckAwsMacie2MemberDestroy(s *terraform.State) error {
 		resp, err := conn.GetMember(input)
 
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
-			tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) ||
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeConflictException, "member accounts are associated with your account") ||
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "account is not associated with your account") {
 			continue

--- a/aws/resource_aws_macie2_organization_admin_account.go
+++ b/aws/resource_aws_macie2_organization_admin_account.go
@@ -106,7 +106,7 @@ func resourceMacie2OrganizationAdminAccountDelete(ctx context.Context, d *schema
 	_, err := conn.DisableOrganizationAdminAccountWithContext(ctx, input)
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
-			tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) {
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 			return nil
 		}
 		return diag.FromErr(fmt.Errorf("error deleting Macie OrganizationAdminAccount (%s): %w", d.Id(), err))
@@ -127,9 +127,6 @@ func getMacie2OrganizationAdminAccount(conn *macie2.Macie2, adminAccountID strin
 				continue
 			}
 
-			log.Printf("[DEBUG] imprimo adminAccount : %+v", adminAccount)
-			log.Printf("[DEBUG] imprimo adminAccount.AccountId : %+v", adminAccount.AccountId)
-			log.Printf("[DEBUG] imprimo adminAccountID : %+v", adminAccountID)
 			if aws.StringValue(adminAccount.AccountId) == adminAccountID {
 				res = adminAccount
 				return false

--- a/aws/resource_aws_macie2_organization_admin_account.go
+++ b/aws/resource_aws_macie2_organization_admin_account.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsMacie2OrganizationAdminAccount() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceMacie2OrganizationAdminAccountCreate,
+		ReadWithoutTimeout:   resourceMacie2OrganizationAdminAccountRead,
+		DeleteWithoutTimeout: resourceMacie2OrganizationAdminAccountDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"admin_account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceMacie2OrganizationAdminAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.EnableOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(d.Get("admin_account_id").(string)),
+		ClientToken:    aws.String(resource.UniqueId()),
+	}
+
+	var err error
+	err = resource.RetryContext(ctx, 4*time.Minute, func() *resource.RetryError {
+		_, err := conn.EnableOrganizationAdminAccountWithContext(ctx, input)
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrorCodeClientError) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.EnableOrganizationAdminAccountWithContext(ctx, input)
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating Macie OrganizationAdminAccount: %w", err))
+	}
+
+	d.SetId(meta.(*AWSClient).accountid)
+
+	return resourceMacie2OrganizationAdminAccountRead(ctx, d, meta)
+}
+
+func resourceMacie2OrganizationAdminAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	var err error
+	var res *macie2.AdminAccount
+
+	err = conn.ListOrganizationAdminAccountsPages(&macie2.ListOrganizationAdminAccountsInput{}, func(page *macie2.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+		for _, account := range page.AdminAccounts {
+			if aws.StringValue(account.AccountId) != d.Get("admin_account_id").(string) {
+				res = account
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) {
+			log.Printf("[WARN] Macie OrganizationAdminAccount does not exist, removing from state: %s", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading Macie OrganizationAdminAccount (%s): %w", d.Id(), err))
+	}
+
+	if res == nil {
+		log.Printf("[WARN] Macie OrganizationAdminAccount (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("account_id", res.AccountId)
+	d.Set("status", res.Status)
+
+	return nil
+}
+
+func resourceMacie2OrganizationAdminAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.DisableOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DisableOrganizationAdminAccountWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting Macie OrganizationAdminAccount (%s): %w", d.Id(), err))
+	}
+	return nil
+}

--- a/aws/resource_aws_macie2_organization_admin_account_test.go
+++ b/aws/resource_aws_macie2_organization_admin_account_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
+func testAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
 	resourceName := "aws_macie2_organization_admin_account.test"
-	adminAccountID := os.Getenv("AWS_ADMIN_ACCOUNT_ID")
+	adminAccountID := "123471550386"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -37,9 +36,9 @@ func TestAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
+func testAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
 	resourceName := "aws_macie2_organization_admin_account.test"
-	adminAccountID := os.Getenv("AWS_ADMIN_ACCOUNT_ID")
+	adminAccountID := "123471550386"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -111,7 +110,8 @@ func testAccCheckAwsMacie2OrganizationAdminAccountDestroy(s *terraform.State) er
 			return true
 		})
 
-		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
+			tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) {
 			continue
 		}
 
@@ -129,11 +129,12 @@ func testAccCheckAwsMacie2OrganizationAdminAccountDestroy(s *terraform.State) er
 }
 
 func testAccAwsMacieOrganizationAdminAccountConfigBasic(accountID string) string {
-	return fmt.Sprintf(`resource "aws_macie2_account" "test" {}
+	return fmt.Sprintf(`
+resource "aws_macie2_account" "test" {}
 
-	resource "aws_macie2_organization_admin_account" "test" {
-		admin_account_id = "%s"
-		depends_on = [aws_macie2_account.test]
-	}
+resource "aws_macie2_organization_admin_account" "test" {
+  admin_account_id = %[1]q
+  depends_on = [aws_macie2_account.test]
+}
 `, accountID)
 }

--- a/aws/resource_aws_macie2_organization_admin_account_test.go
+++ b/aws/resource_aws_macie2_organization_admin_account_test.go
@@ -1,0 +1,139 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
+	resourceName := "aws_macie2_organization_admin_account.test"
+	adminAccountID := os.Getenv("AWS_ADMIN_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieOrganizationAdminAccountConfigBasic(adminAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
+	resourceName := "aws_macie2_organization_admin_account.test"
+	adminAccountID := os.Getenv("AWS_ADMIN_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieOrganizationAdminAccountConfigBasic(adminAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsMacie2Account(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+		exists := false
+		err := conn.ListOrganizationAdminAccountsPages(&macie2.ListOrganizationAdminAccountsInput{}, func(page *macie2.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+			for _, account := range page.AdminAccounts {
+				if aws.StringValue(account.AccountId) != rs.Primary.Attributes["admin_account_id"] {
+					exists = true
+					return false
+				}
+			}
+
+			return true
+		})
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return fmt.Errorf("macie OrganizationAdminAccount %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsMacie2OrganizationAdminAccountDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_organization_admin_account" {
+			continue
+		}
+
+		deleted := true
+		err := conn.ListOrganizationAdminAccountsPages(&macie2.ListOrganizationAdminAccountsInput{}, func(page *macie2.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+			for _, account := range page.AdminAccounts {
+				if aws.StringValue(account.AccountId) != rs.Primary.Attributes["admin_account_id"] {
+					deleted = false
+					return false
+				}
+			}
+
+			return true
+		})
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeAccessDeniedException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if !deleted {
+			return fmt.Errorf("macie OrganizationAdminAccount %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccAwsMacieOrganizationAdminAccountConfigBasic(accountID string) string {
+	return fmt.Sprintf(`resource "aws_macie2_account" "test" {}
+
+	resource "aws_macie2_organization_admin_account" "test" {
+		admin_account_id = "%s"
+		depends_on = [aws_macie2_account.test]
+	}
+`, accountID)
+}

--- a/aws/resource_aws_macie2_test.go
+++ b/aws/resource_aws_macie2_test.go
@@ -43,6 +43,10 @@ func TestAccAWSMacie2_serial(t *testing.T) {
 			"disappears": testAccAwsMacie2Member_disappears,
 			"tags":       testAccAwsMacie2Member_withTags,
 		},
+		"OrganizationAdminAccount": {
+			"basic":      testAccAwsMacie2OrganizationAdminAccount_basic,
+			"disappears": testAccAwsMacie2OrganizationAdminAccount_disappears,
+		},
 	}
 
 	for group, m := range testCases {

--- a/aws/resource_aws_macie2_test.go
+++ b/aws/resource_aws_macie2_test.go
@@ -30,6 +30,14 @@ func TestAccAWSMacie2_serial(t *testing.T) {
 			"classification_job": testAccAwsMacie2CustomDataIdentifier_WithClassificationJob,
 			"tags":               testAccAwsMacie2CustomDataIdentifier_WithTags,
 		},
+		"FindingsFilter": {
+			"basic":          testAccAwsMacie2FindingsFilter_basic,
+			"name_generated": testAccAwsMacie2FindingsFilter_Name_Generated,
+			"name_prefix":    testAccAwsMacie2FindingsFilter_NamePrefix,
+			"disappears":     testAccAwsMacie2FindingsFilter_disappears,
+			"complete":       testAccAwsMacie2FindingsFilter_complete,
+			"tags":           testAccAwsMacie2FindingsFilter_withTags,
+		},
 	}
 
 	for group, m := range testCases {

--- a/aws/resource_aws_macie2_test.go
+++ b/aws/resource_aws_macie2_test.go
@@ -38,6 +38,11 @@ func TestAccAWSMacie2_serial(t *testing.T) {
 			"complete":       testAccAwsMacie2FindingsFilter_complete,
 			"tags":           testAccAwsMacie2FindingsFilter_withTags,
 		},
+		"Member": {
+			"basic":      testAccAwsMacie2Member_basic,
+			"disappears": testAccAwsMacie2Member_disappears,
+			"tags":       testAccAwsMacie2Member_withTags,
+		},
 	}
 
 	for group, m := range testCases {

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -1,9 +1,9 @@
 ---
-subcategory: "Macie2"
+subcategory: "Macie"
 layout: "aws"
 page_title: "AWS: aws_macie2_findings_filter"
 description: |-
-  Provides a resource to manage an AWS Macie2 Findings Filter.
+  Provides a resource to manage an AWS Macie Findings Filter.
 ---
 
 # Resource: aws_macie2_findings_filter

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -13,20 +13,17 @@ Provides a resource to manage an [AWS Macie Findings Filter](https://docs.aws.am
 ## Example Usage
 
 ```terraform
-resource "aws_macie2_account" "example" {
-  client_token = "CLIENT TOKEN"
-}
+resource "aws_macie2_account" "example" {}
 
 resource "aws_macie2_findings_filter" "test" {
-  name = "NAME OF THE FINDINGS FILTER"
-  client_token = aws_macie2_account.test.client_token
+  name        = "NAME OF THE FINDINGS FILTER"
   description = "DESCRIPTION"
-  position = 1
-  action = "ARCHIVE"
+  position    = 1
+  action      = "ARCHIVE"
   finding_criteria {
     criterion {
-      field  = "region"
-      eq = [data.aws_region.current.name]
+      field = "region"
+      eq    = [data.aws_region.current.name]
     }
   }
   depends_on = [aws_macie2_account.test]
@@ -38,8 +35,8 @@ resource "aws_macie2_findings_filter" "test" {
 The following arguments are supported:
 
 * `finding_criteria` - (Required) The criteria to use to filter findings.
-* `client_token` - (Optional) A unique, case-sensitive token that you provide to ensure the idempotency of the request.
-* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters.
+* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `name_prefix` -  (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - (Optional) A custom description of the filter. The description can contain as many as 512 characters.
 * `action` - (Required) The action to perform on findings that meet the filter criteria (`finding_criteria`). Valid values are: `ARCHIVE`, suppress (automatically archive) the findings; and, `NOOP`, don't perform any action on the findings.
 * `position` - (Optional) The position of the filter in the list of saved filters on the Amazon Macie console. This value also determines the order in which the filter is applied to findings, relative to other filters that are also applied to the findings.
@@ -51,7 +48,7 @@ The `finding_criteria` object supports the following:
 
 The `criterion` object supports the following:
 
-* `field` - (Required) The name of the field to be evaluated. 
+* `field` - (Required) The name of the field to be evaluated.
 * `eq_exact_match` - (Optional) The value for the property exclusively matches (equals an exact match for) all the specified values. If you specify multiple values, Amazon Macie uses AND logic to join the values.
 * `eq` - (Optional) The value for the property matches (equals) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
 * `neq` - (Optional) The value for the property doesn't match (doesn't equal) the specified value. If you specify multiple values, Macie uses OR logic to join the values.

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Macie2"
+layout: "aws"
+page_title: "AWS: aws_macie2_findings_filter"
+description: |-
+  Provides a resource to manage an AWS Macie2 Findings Filter.
+---
+
+# Resource: aws_macie2_findings_filter
+
+Provides a resource to manage an [AWS Macie Findings Filter](https://docs.aws.amazon.com/macie/latest/APIReference/findingsfilters-id.html).
+
+## Example Usage
+
+```terraform
+resource "aws_macie2_account" "example" {
+  client_token = "CLIENT TOKEN"
+}
+
+resource "aws_macie2_findings_filter" "test" {
+  name = "NAME OF THE FINDINGS FILTER"
+  client_token = aws_macie2_account.test.client_token
+  description = "DESCRIPTION"
+  position = 1
+  action = "ARCHIVE"
+  finding_criteria {
+    criterion {
+      field  = "region"
+      eq = [data.aws_region.current.name]
+    }
+  }
+  depends_on = [aws_macie2_account.test]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `finding_criteria` - (Required) The criteria to use to filter findings.
+* `client_token` - (Optional) A unique, case-sensitive token that you provide to ensure the idempotency of the request.
+* `name` - (Required) A custom name for the filter. The name must contain at least 3 characters and can contain as many as 64 characters.
+* `description` - (Optional) A custom description of the filter. The description can contain as many as 512 characters.
+* `action` - (Required) The action to perform on findings that meet the filter criteria (`finding_criteria`). Valid values are: `ARCHIVE`, suppress (automatically archive) the findings; and, `NOOP`, don't perform any action on the findings.
+* `position` - (Optional) The position of the filter in the list of saved filters on the Amazon Macie console. This value also determines the order in which the filter is applied to findings, relative to other filters that are also applied to the findings.
+* `tags` - (Optional) A map of key-value pairs that specifies the tags to associate with the filter.
+
+The `finding_criteria` object supports the following:
+
+* `criterion` -  (Optional) A condition that specifies the property, operator, and one or more values to use to filter the results.  (documented below)
+
+The `criterion` object supports the following:
+
+* `field` - (Required) The name of the field to be evaluated. 
+* `eq_exact_match` - (Optional) The value for the property exclusively matches (equals an exact match for) all the specified values. If you specify multiple values, Amazon Macie uses AND logic to join the values.
+* `eq` - (Optional) The value for the property matches (equals) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
+* `neq` - (Optional) The value for the property doesn't match (doesn't equal) the specified value. If you specify multiple values, Macie uses OR logic to join the values.
+* `lt` - (Optional) The value for the property is less than the specified value.
+* `lte` - (Optional) The value for the property is less than or equal to the specified value.
+* `gt` - (Optional) The value for the property is greater than the specified value.
+* `gte` - (Optional) The value for the property is greater than or equal to the specified value.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier (ID) of the macie2 Findings Filter.
+* `arn` - The Amazon Resource Name (ARN) of the Findings Filter.
+
+## Import
+
+`aws_macie2_findings_filter` can be imported using the id, e.g.
+
+```
+$ terraform import aws_macie2_findings_filter.example abcd1
+```

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -62,7 +62,7 @@ The `criterion` object supports the following:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique identifier (ID) of the macie2 Findings Filter.
+* `id` - The unique identifier (ID) of the macie Findings Filter.
 * `arn` - The Amazon Resource Name (ARN) of the Findings Filter.
 
 ## Import

--- a/website/docs/r/macie2_member.html.markdown
+++ b/website/docs/r/macie2_member.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_macie2_member
 
-Provides a resource to manage an [AWS Macie Member](https://docs.aws.amazon.com/macie/latest/APIReference/members-id.htmll).
+Provides a resource to manage an [AWS Macie Member](https://docs.aws.amazon.com/macie/latest/APIReference/members-id.html).
 
 ## Example Usage
 

--- a/website/docs/r/macie2_member.html.markdown
+++ b/website/docs/r/macie2_member.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "Macie"
+layout: "aws"
+page_title: "AWS: aws_macie2_member"
+description: |-
+  Provides a resource to manage an AWS Macie Member.
+---
+
+# Resource: aws_macie2_member
+
+Provides a resource to manage an [AWS Macie Member](https://docs.aws.amazon.com/macie/latest/APIReference/members-id.htmll).
+
+## Example Usage
+
+```terraform
+resource "aws_macie2_account" "example" {}
+
+
+resource "aws_macie2_member" "test" {
+  account_id = "NAME OF THE MEMBER"
+  email      = "EMAIL"
+  depends_on = [aws_macie2_account.test]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The AWS account ID for the account.
+* `email` - (Required) The email address for the account.
+* `tags` - (Optional) A map of key-value pairs that specifies the tags to associate with the account in Amazon Macie.
+* `status` - (Optional) Specifies the status for the account. To enable Amazon Macie and start all Macie activities for the account, set this value to `ENABLED`. Valid values are `ENABLED` or `PAUSED`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier (ID) of the macie Member.
+* `arn` - The Amazon Resource Name (ARN) of the account.
+* `relationship_status` - The current status of the relationship between the account and the administrator account.
+* `administrator_account_id` - The AWS account ID for the administrator account.
+* `invited_at` - The date and time, in UTC and extended RFC 3339 format, when an Amazon Macie membership invitation was last sent to the account. This value is null if a Macie invitation hasn't been sent to the account.
+* `updated_at` - The date and time, in UTC and extended RFC 3339 format, of the most recent change to the status of the relationship between the account and the administrator account.
+
+## Import
+
+`aws_macie2_member` can be imported using the id, e.g.
+
+```
+$ terraform import aws_macie2_member.example abcd1
+```

--- a/website/docs/r/macie2_organization_admin_account.html.markdown
+++ b/website/docs/r/macie2_organization_admin_account.html.markdown
@@ -15,7 +15,6 @@ Provides a resource to manage an [AWS Macie Organization Admin Account](https://
 ```terraform
 resource "aws_macie2_account" "example" {}
 
-
 resource "aws_macie2_organization_admin_account" "test" {
   admin_account_id = "ID OF THE ADMIN ACCOUNT"
   depends_on       = [aws_macie2_account.test]
@@ -33,8 +32,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique identifier (ID) of the macie organization admin account.
-* `status` - The current status of the account as the delegated administrator of Amazon Macie for the organization.
-* `account_id` - The AWS account ID for the account.
 
 ## Import
 

--- a/website/docs/r/macie2_organization_admin_account.html.markdown
+++ b/website/docs/r/macie2_organization_admin_account.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Macie"
 layout: "aws"
 page_title: "AWS: aws_macie2_organization_admin_account"
 description: |-
-  Provides a resource to manage an AWS Macie Organization Admin Account.
+Provides a resource to manage an AWS Macie Organization Admin Account.
 ---
 
 # Resource: aws_macie2_organization_admin_account
@@ -18,7 +18,7 @@ resource "aws_macie2_account" "example" {}
 
 resource "aws_macie2_organization_admin_account" "test" {
   admin_account_id = "ID OF THE ADMIN ACCOUNT"
-  depends_on = [aws_macie2_account.test]
+  depends_on       = [aws_macie2_account.test]
 }
 ```
 
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique identifier (ID) of the macie Member.
+* `id` - The unique identifier (ID) of the macie organization admin account.
 * `status` - The current status of the account as the delegated administrator of Amazon Macie for the organization.
 * `account_id` - The AWS account ID for the account.
 

--- a/website/docs/r/macie2_organization_admin_account.html.markdown
+++ b/website/docs/r/macie2_organization_admin_account.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Macie"
+layout: "aws"
+page_title: "AWS: aws_macie2_organization_admin_account"
+description: |-
+  Provides a resource to manage an AWS Macie Organization Admin Account.
+---
+
+# Resource: aws_macie2_organization_admin_account
+
+Provides a resource to manage an [AWS Macie Organization Admin Account](https://docs.aws.amazon.com/macie/latest/APIReference/admin.html).
+
+## Example Usage
+
+```terraform
+resource "aws_macie2_account" "example" {}
+
+
+resource "aws_macie2_organization_admin_account" "test" {
+  admin_account_id = "ID OF THE ADMIN ACCOUNT"
+  depends_on = [aws_macie2_account.test]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `admin_account_id` - (Required) The AWS account ID for the account to designate as the delegated Amazon Macie administrator account for the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier (ID) of the macie Member.
+* `status` - The current status of the account as the delegated administrator of Amazon Macie for the organization.
+* `account_id` - The AWS account ID for the account.
+
+## Import
+
+`aws_macie2_organization_admin_account` can be imported using the id, e.g.
+
+```
+$ terraform import aws_macie2_organization_admin_account.example abcd1
+```

--- a/website/docs/r/macie2_organization_admin_account.html.markdown
+++ b/website/docs/r/macie2_organization_admin_account.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Macie"
 layout: "aws"
 page_title: "AWS: aws_macie2_organization_admin_account"
 description: |-
-Provides a resource to manage an AWS Macie Organization Admin Account.
+Provides a resource to manage an Amazon Macie Organization Admin Account.
 ---
 
 # Resource: aws_macie2_organization_admin_account
 
-Provides a resource to manage an [AWS Macie Organization Admin Account](https://docs.aws.amazon.com/macie/latest/APIReference/admin.html).
+Provides a resource to manage an [Amazon Macie Organization Admin Account](https://docs.aws.amazon.com/macie/latest/APIReference/admin.html).
 
 ## Example Usage
 

--- a/website/docs/r/macie2_organization_admin_account.html.markdown
+++ b/website/docs/r/macie2_organization_admin_account.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Macie"
 layout: "aws"
 page_title: "AWS: aws_macie2_organization_admin_account"
 description: |-
-Provides a resource to manage an Amazon Macie Organization Admin Account.
+  Provides a resource to manage an Amazon Macie Organization Admin Account.
 ---
 
 # Resource: aws_macie2_organization_admin_account


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->
Added a new resource, docs and tests for [Macie Organization Admin Account](https://docs.aws.amazon.com/macie/latest/APIReference/admin.html) called `aws_macie2_organization_admin_account`
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13432

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSMacie2_serial/OrganizationAdminAccount'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMacie2_serial/OrganizationAdminAccount -timeout 180m
=== RUN   TestAccAWSMacie2_serial
=== RUN   TestAccAWSMacie2_serial/OrganizationAdminAccount
=== RUN   TestAccAWSMacie2_serial/OrganizationAdminAccount/basic
=== RUN   TestAccAWSMacie2_serial/OrganizationAdminAccount/disappears
--- PASS: TestAccAWSMacie2_serial (47.13s)
    --- PASS: TestAccAWSMacie2_serial/OrganizationAdminAccount (47.13s)
        --- PASS: TestAccAWSMacie2_serial/OrganizationAdminAccount/basic (25.81s)
        --- PASS: TestAccAWSMacie2_serial/OrganizationAdminAccount/disappears (21.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       47.184s

...
```
