### PR TITLE
New resource for Macie2 Organization Admin Account

### DIFF
--- a/.changelog/19303.txt
+++ b/.changelog/19303.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_macie2_organization_admin_account
+```

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -846,6 +846,7 @@ func Provider() *schema.Provider {
 			"aws_macie2_classification_job":                           resourceAwsMacie2ClassificationJob(),
 			"aws_macie2_custom_data_identifier":                       resourceAwsMacie2CustomDataIdentifier(),
 			"aws_macie2_findings_filter":                              resourceAwsMacie2FindingsFilter(),
+			"aws_macie2_organization_admin_account":                   resourceAwsMacie2OrganizationAdminAccount(),
 			"aws_macie_member_account_association":                    resourceAwsMacieMemberAccountAssociation(),
 			"aws_macie_s3_bucket_association":                         resourceAwsMacieS3BucketAssociation(),
 			"aws_main_route_table_association":                        resourceAwsMainRouteTableAssociation(),

--- a/aws/resource_aws_macie2_organization_admin_account.go
+++ b/aws/resource_aws_macie2_organization_admin_account.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsMacie2OrganizationAdminAccount() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceMacie2OrganizationAdminAccountCreate,
+		ReadWithoutTimeout:   resourceMacie2OrganizationAdminAccountRead,
+		DeleteWithoutTimeout: resourceMacie2OrganizationAdminAccountDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"admin_account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceMacie2OrganizationAdminAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+	adminAccountID := d.Get("admin_account_id").(string)
+	input := &macie2.EnableOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(adminAccountID),
+		ClientToken:    aws.String(resource.UniqueId()),
+	}
+
+	var err error
+	err = resource.RetryContext(ctx, 4*time.Minute, func() *resource.RetryError {
+		_, err := conn.EnableOrganizationAdminAccountWithContext(ctx, input)
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrorCodeClientError) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.EnableOrganizationAdminAccountWithContext(ctx, input)
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating Macie OrganizationAdminAccount: %w", err))
+	}
+
+	d.SetId(adminAccountID)
+
+	return resourceMacie2OrganizationAdminAccountRead(ctx, d, meta)
+}
+
+func resourceMacie2OrganizationAdminAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	var err error
+
+	res, err := getMacie2OrganizationAdminAccount(conn, d.Id())
+
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
+			log.Printf("[WARN] Macie OrganizationAdminAccount (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error reading Macie OrganizationAdminAccount (%s): %w", d.Id(), err))
+	}
+
+	if res == nil {
+		log.Printf("[WARN] Macie OrganizationAdminAccount (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("admin_account_id", res.AccountId)
+
+	return nil
+}
+
+func resourceMacie2OrganizationAdminAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*AWSClient).macie2conn
+
+	input := &macie2.DisableOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DisableOrganizationAdminAccountWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting Macie OrganizationAdminAccount (%s): %w", d.Id(), err))
+	}
+	return nil
+}
+
+func getMacie2OrganizationAdminAccount(conn *macie2.Macie2, adminAccountID string) (*macie2.AdminAccount, error) {
+	var res *macie2.AdminAccount
+
+	err := conn.ListOrganizationAdminAccountsPages(&macie2.ListOrganizationAdminAccountsInput{}, func(page *macie2.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, adminAccount := range page.AdminAccounts {
+			if adminAccount == nil {
+				continue
+			}
+
+			if aws.StringValue(adminAccount.AccountId) == adminAccountID {
+				res = adminAccount
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return res, err
+}

--- a/aws/resource_aws_macie2_organization_admin_account_test.go
+++ b/aws/resource_aws_macie2_organization_admin_account_test.go
@@ -17,7 +17,7 @@ func testAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
-		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		ErrorCheck:        testAccErrorCheckSkipMacie2OrganizationAdminAccount(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsMacieOrganizationAdminAccountConfigBasic(),
@@ -42,7 +42,7 @@ func testAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
-		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		ErrorCheck:        testAccErrorCheckSkipMacie2OrganizationAdminAccount(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsMacieOrganizationAdminAccountConfigBasic(),
@@ -54,6 +54,12 @@ func testAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccErrorCheckSkipMacie2OrganizationAdminAccount(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"AccessDeniedException: The request failed because you must be a user of the management account for your AWS organization to perform this operation",
+	)
 }
 
 func testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName string) resource.TestCheckFunc {

--- a/aws/resource_aws_macie2_organization_admin_account_test.go
+++ b/aws/resource_aws_macie2_organization_admin_account_test.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/macie2"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
+	resourceName := "aws_macie2_organization_admin_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieOrganizationAdminAccountConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "admin_account_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
+	resourceName := "aws_macie2_organization_admin_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
+		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsMacieOrganizationAdminAccountConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsMacie2Account(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMacie2OrganizationAdminAccountExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+		adminAccount, err := getMacie2OrganizationAdminAccount(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if adminAccount == nil {
+			return fmt.Errorf("macie OrganizationAdminAccount (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsMacie2OrganizationAdminAccountDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macie2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie2_organization_admin_account" {
+			continue
+		}
+
+		adminAccount, err := getMacie2OrganizationAdminAccount(conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, macie2.ErrCodeResourceNotFoundException) ||
+			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
+			continue
+		}
+
+		if adminAccount == nil {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("macie OrganizationAdminAccount %q still exists", rs.Primary.ID)
+	}
+
+	return nil
+
+}
+
+func testAccAwsMacieOrganizationAdminAccountConfigBasic() string {
+	return `
+data "aws_caller_identity" "current" {}
+
+resource "aws_macie2_account" "test" {}
+
+resource "aws_macie2_organization_admin_account" "test" {
+  admin_account_id = data.aws_caller_identity.current.account_id
+  depends_on       = [aws_macie2_account.test]
+}
+`
+}

--- a/aws/resource_aws_macie2_organization_admin_account_test.go
+++ b/aws/resource_aws_macie2_organization_admin_account_test.go
@@ -14,7 +14,10 @@ func testAccAwsMacie2OrganizationAdminAccount_basic(t *testing.T) {
 	resourceName := "aws_macie2_organization_admin_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOrganizationsAccountPreCheck(t)
+		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
 		ErrorCheck:        testAccErrorCheckSkipMacie2OrganizationAdminAccount(t),
@@ -39,7 +42,10 @@ func testAccAwsMacie2OrganizationAdminAccount_disappears(t *testing.T) {
 	resourceName := "aws_macie2_organization_admin_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOrganizationsAccountPreCheck(t)
+		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsMacie2OrganizationAdminAccountDestroy,
 		ErrorCheck:        testAccErrorCheckSkipMacie2OrganizationAdminAccount(t),

--- a/aws/resource_aws_macie2_organization_admin_account_test.go
+++ b/aws/resource_aws_macie2_organization_admin_account_test.go
@@ -121,9 +121,16 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_macie2_account" "test" {}
 
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["macie.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
 resource "aws_macie2_organization_admin_account" "test" {
   admin_account_id = data.aws_caller_identity.current.account_id
-  depends_on       = [aws_macie2_account.test]
+  depends_on       = [aws_macie2_account.test, aws_organizations_organization.test]
 }
 `
 }

--- a/aws/resource_aws_macie2_test.go
+++ b/aws/resource_aws_macie2_test.go
@@ -40,6 +40,10 @@ func TestAccAWSMacie2_serial(t *testing.T) {
 			"number":         testAccAwsMacie2FindingsFilter_WithNumber,
 			"tags":           testAccAwsMacie2FindingsFilter_withTags,
 		},
+		"OrganizationAdminAccount": {
+			"basic":      testAccAwsMacie2OrganizationAdminAccount_basic,
+			"disappears": testAccAwsMacie2OrganizationAdminAccount_disappears,
+		},
 	}
 
 	for group, m := range testCases {

--- a/website/docs/r/macie2_organization_admin_account.html.markdown
+++ b/website/docs/r/macie2_organization_admin_account.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Macie"
+layout: "aws"
+page_title: "AWS: aws_macie2_organization_admin_account"
+description: |-
+  Provides a resource to manage an Amazon Macie Organization Admin Account.
+---
+
+# Resource: aws_macie2_organization_admin_account
+
+Provides a resource to manage an [Amazon Macie Organization Admin Account](https://docs.aws.amazon.com/macie/latest/APIReference/admin.html).
+
+## Example Usage
+
+```terraform
+resource "aws_macie2_account" "example" {}
+
+resource "aws_macie2_organization_admin_account" "test" {
+  admin_account_id = "ID OF THE ADMIN ACCOUNT"
+  depends_on       = [aws_macie2_account.test]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `admin_account_id` - (Required) The AWS account ID for the account to designate as the delegated Amazon Macie administrator account for the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique identifier (ID) of the macie organization admin account.
+
+## Import
+
+`aws_macie2_organization_admin_account` can be imported using the id, e.g.
+
+```
+$ terraform import aws_macie2_organization_admin_account.example abcd1
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->
Added a new resource, docs and tests for [Macie Organization Admin Account](https://docs.aws.amazon.com/macie/latest/APIReference/admin.html) called `aws_macie2_organization_admin_account`
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13432

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMacie2_serial/OrganizationAdminAccount'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMacie2_serial/OrganizationAdminAccount -timeout 180m
=== RUN   TestAccAWSMacie2_serial
=== RUN   TestAccAWSMacie2_serial/OrganizationAdminAccount
=== RUN   TestAccAWSMacie2_serial/OrganizationAdminAccount/basic
=== RUN   TestAccAWSMacie2_serial/OrganizationAdminAccount/disappears
--- PASS: TestAccAWSMacie2_serial (49.20s)
    --- PASS: TestAccAWSMacie2_serial/OrganizationAdminAccount (49.20s)
        --- PASS: TestAccAWSMacie2_serial/OrganizationAdminAccount/basic (27.50s)
        --- PASS: TestAccAWSMacie2_serial/OrganizationAdminAccount/disappears (21.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       49.250s

...
```
