### PR TITLE
r/servicecatalog_provisioning_artifact: New resource

### DIFF
--- a/.changelog/19316.txt
+++ b/.changelog/19316.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicecatalog_provisioning_artifact
+```

--- a/aws/internal/service/servicecatalog/id.go
+++ b/aws/internal/service/servicecatalog/id.go
@@ -66,9 +66,10 @@ func ProvisioningArtifactID(artifactID, productID string) string {
 }
 
 func ProvisioningArtifactParseID(id string) (string, string, error) {
-	parts := strings.Split(id, ":")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Please make sure the ID is in the form artifact_id:product_id (i.e. pa-r2d2slrtcob:prod-c3pohcrhmisy")
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected artifactID:productID", id)
 	}
 	return parts[0], parts[1], nil
 }

--- a/aws/internal/service/servicecatalog/id.go
+++ b/aws/internal/service/servicecatalog/id.go
@@ -60,3 +60,15 @@ func TagOptionResourceAssociationParseID(id string) (string, string, error) {
 func TagOptionResourceAssociationID(tagOptionID, resourceID string) string {
 	return strings.Join([]string{tagOptionID, resourceID}, ":")
 }
+
+func ProvisioningArtifactID(artifactID, productID string) string {
+	return strings.Join([]string{artifactID, productID}, ":")
+}
+
+func ProvisioningArtifactParseID(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Please make sure the ID is in the form artifact_id:product_id (i.e. pa-r2d2slrtcob:prod-c3pohcrhmisy")
+	}
+	return parts[0], parts[1], nil
+}

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -274,3 +274,28 @@ func TagOptionResourceAssociationStatus(conn *servicecatalog.ServiceCatalog, tag
 		return output, servicecatalog.StatusAvailable, err
 	}
 }
+
+func ProvisioningArtifactStatus(conn *servicecatalog.ServiceCatalog, id, productID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &servicecatalog.DescribeProvisioningArtifactInput{
+			ProvisioningArtifactId: aws.String(id),
+			ProductId:              aws.String(productID),
+		}
+
+		output, err := conn.DescribeProvisioningArtifact(input)
+
+		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+			return nil, StatusNotFound, err
+		}
+
+		if err != nil {
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing Service Catalog Provisioning Artifact (%s): %w", id, err)
+		}
+
+		if output == nil || output.ProvisioningArtifactDetail == nil {
+			return nil, StatusUnavailable, fmt.Errorf("error describing Service Catalog Provisioning Artifact (%s): empty response", id)
+		}
+
+		return output, aws.StringValue(output.Status), err
+	}
+}

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -289,11 +289,11 @@ func ProvisioningArtifactStatus(conn *servicecatalog.ServiceCatalog, id, product
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing Service Catalog Provisioning Artifact (%s): %w", id, err)
+			return nil, servicecatalog.StatusFailed, err
 		}
 
 		if output == nil || output.ProvisioningArtifactDetail == nil {
-			return nil, StatusUnavailable, fmt.Errorf("error describing Service Catalog Provisioning Artifact (%s): empty response", id)
+			return nil, StatusUnavailable, err
 		}
 
 		return output, aws.StringValue(output.Status), err

--- a/aws/internal/service/servicecatalog/waiter/waiter.go
+++ b/aws/internal/service/servicecatalog/waiter/waiter.go
@@ -42,10 +42,9 @@ const (
 	StatusUnavailable = "UNAVAILABLE"
 
 	// AWS documentation is wrong, says that status will be "AVAILABLE" but it is actually "CREATED"
-	ProductStatusCreated = "CREATED"
+	StatusCreated = "CREATED"
 
 	OrganizationAccessStatusError = "ERROR"
-	StatusCreated                 = "CREATED"
 )
 
 func ProductReady(conn *servicecatalog.ServiceCatalog, acceptLanguage, productID string) (*servicecatalog.DescribeProductAsAdminOutput, error) {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1031,6 +1031,7 @@ func Provider() *schema.Provider {
 			"aws_servicecatalog_tag_option":                           resourceAwsServiceCatalogTagOption(),
 			"aws_servicecatalog_tag_option_resource_association":      resourceAwsServiceCatalogTagOptionResourceAssociation(),
 			"aws_servicecatalog_product_portfolio_association":        resourceAwsServiceCatalogProductPortfolioAssociation(),
+			"aws_servicecatalog_provisioning_artifact":                resourceAwsServiceCatalogProvisioningArtifact(),
 			"aws_service_discovery_http_namespace":                    resourceAwsServiceDiscoveryHttpNamespace(),
 			"aws_service_discovery_private_dns_namespace":             resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":              resourceAwsServiceDiscoveryPublicDnsNamespace(),

--- a/aws/resource_aws_servicecatalog_constraint_test.go
+++ b/aws/resource_aws_servicecatalog_constraint_test.go
@@ -240,31 +240,27 @@ resource "aws_s3_bucket_object" "test" {
   bucket = aws_s3_bucket.test.id
   key    = "%[1]s.json"
 
-  content = <<EOF
-{
-  "Resources" : {
-    "MyVPC": {
-      "Type" : "AWS::EC2::VPC",
-      "Properties" : {
-        "CidrBlock" : "10.0.0.0/16",
-        "Tags" : [
-          {"Key": "Name", "Value": "Primary_CF_VPC"}
-        ]
+  content = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+
+    Resources = {
+      MyVPC = {
+        Type = "AWS::EC2::VPC"
+        Properties = {
+          CidrBlock = "10.1.0.0/16"
+        }
       }
     }
-  },
-  "Outputs" : {
-    "DefaultSgId" : {
-      "Description": "The ID of default security group",
-      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
-    },
-    "VpcID" : {
-      "Description": "The VPC ID",
-      "Value" : { "Ref" : "MyVPC" }
+
+    Outputs = {
+      VpcID = {
+        Description = "VPC ID"
+        Value = {
+          Ref = "MyVPC"
+        }
+      }
     }
-  }
-}
-EOF
+  })
 }
 
 resource "aws_servicecatalog_product" "test" {
@@ -275,7 +271,7 @@ resource "aws_servicecatalog_product" "test" {
   provisioning_artifact_parameters {
     disable_template_validation = true
     name                        = %[1]q
-    template_url                = "s3://${aws_s3_bucket.test.id}/${aws_s3_bucket_object.test.key}"
+    template_url                = "https://${aws_s3_bucket.test.bucket_regional_domain_name}/${aws_s3_bucket_object.test.key}"
     type                        = "CLOUD_FORMATION_TEMPLATE"
   }
 

--- a/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
@@ -227,31 +227,27 @@ func testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName string
 resource "aws_cloudformation_stack" "test" {
   name = %[1]q
 
-  template_body = <<STACK
-{
-  "Resources" : {
-    "MyVPC": {
-      "Type" : "AWS::EC2::VPC",
-      "Properties" : {
-        "CidrBlock" : "10.0.0.0/16",
-        "Tags" : [
-          {"Key": "Name", "Value": "Primary_CF_VPC"}
-        ]
+  template_body = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+
+    Resources = {
+      MyVPC = {
+        Type = "AWS::EC2::VPC"
+        Properties = {
+          CidrBlock = "10.1.0.0/16"
+        }
       }
     }
-  },
-  "Outputs" : {
-    "DefaultSgId" : {
-      "Description": "The ID of default security group",
-      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
-    },
-    "VpcID" : {
-      "Description": "The VPC ID",
-      "Value" : { "Ref" : "MyVPC" }
+
+    Outputs = {
+      VpcID = {
+        Description = "VPC ID"
+        Value = {
+          Ref = "MyVPC"
+        }
+      }
     }
-  }
-}
-STACK
+  })
 }
 
 resource "aws_servicecatalog_product" "test" {

--- a/aws/resource_aws_servicecatalog_product_test.go
+++ b/aws/resource_aws_servicecatalog_product_test.go
@@ -19,9 +19,11 @@ import (
 // add sweeper to delete known test servicecat products
 func init() {
 	resource.AddTestSweepers("aws_servicecatalog_product", &resource.Sweeper{
-		Name:         "aws_servicecatalog_product",
-		Dependencies: []string{},
-		F:            testSweepServiceCatalogProducts,
+		Name: "aws_servicecatalog_product",
+		Dependencies: []string{
+			"aws_servicecatalog_provisioning_artifact",
+		},
+		F: testSweepServiceCatalogProducts,
 	})
 }
 
@@ -104,7 +106,7 @@ func TestAccAWSServiceCatalogProduct_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.0.name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "provisioning_artifact_parameters.0.template_url"),
 					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.0.type", servicecatalog.ProvisioningArtifactTypeCloudFormationTemplate),
-					resource.TestCheckResourceAttr(resourceName, "status", waiter.ProductStatusCreated),
+					resource.TestCheckResourceAttr(resourceName, "status", waiter.StatusCreated),
 					resource.TestCheckResourceAttr(resourceName, "support_description", "supportbeskrivning"),
 					resource.TestCheckResourceAttr(resourceName, "support_email", "support@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "support_url", "http://example.com"),

--- a/aws/resource_aws_servicecatalog_product_test.go
+++ b/aws/resource_aws_servicecatalog_product_test.go
@@ -322,31 +322,27 @@ resource "aws_s3_bucket_object" "test" {
   bucket = aws_s3_bucket.test.id
   key    = "%[1]s.json"
 
-  content = <<EOF
-{
-  "Resources" : {
-    "MyVPC": {
-      "Type" : "AWS::EC2::VPC",
-      "Properties" : {
-        "CidrBlock" : "10.0.0.0/16",
-        "Tags" : [
-          {"Key": "Name", "Value": "Primary_CF_VPC"}
-        ]
+  content = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+
+    Resources = {
+      MyVPC = {
+        Type = "AWS::EC2::VPC"
+        Properties = {
+          CidrBlock = "10.1.0.0/16"
+        }
       }
     }
-  },
-  "Outputs" : {
-    "DefaultSgId" : {
-      "Description": "The ID of default security group",
-      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
-    },
-    "VpcID" : {
-      "Description": "The VPC ID",
-      "Value" : { "Ref" : "MyVPC" }
+
+    Outputs = {
+      VpcID = {
+        Description = "VPC ID"
+        Value = {
+          Ref = "MyVPC"
+        }
+      }
     }
-  }
-}
-EOF
+  })
 }
 `, rName)
 }
@@ -369,7 +365,7 @@ resource "aws_servicecatalog_product" "test" {
     description                 = "artefaktbeskrivning"
     disable_template_validation = true
     name                        = %[1]q
-    template_url                = "https://s3.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket.test.id}/${aws_s3_bucket_object.test.key}"
+    template_url                = "https://${aws_s3_bucket.test.bucket_regional_domain_name}/${aws_s3_bucket_object.test.key}"
     type                        = "CLOUD_FORMATION_TEMPLATE"
   }
 
@@ -398,7 +394,7 @@ resource "aws_servicecatalog_product" "test" {
     description                 = "artefaktbeskrivning"
     disable_template_validation = true
     name                        = %[1]q
-    template_url                = "https://s3.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket.test.id}/${aws_s3_bucket_object.test.key}"
+    template_url                = "https://${aws_s3_bucket.test.bucket_regional_domain_name}/${aws_s3_bucket_object.test.key}"
     type                        = "CLOUD_FORMATION_TEMPLATE"
   }
 
@@ -415,31 +411,27 @@ func testAccAWSServiceCatalogProductConfig_physicalID(rName string) string {
 resource "aws_cloudformation_stack" "test" {
   name = %[1]q
 
-  template_body = <<STACK
-{
-  "Resources" : {
-    "MyVPC": {
-      "Type" : "AWS::EC2::VPC",
-      "Properties" : {
-        "CidrBlock" : "10.0.0.0/16",
-        "Tags" : [
-          {"Key": "Name", "Value": "Primary_CF_VPC"}
-        ]
+  template_body = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+
+    Resources = {
+      MyVPC = {
+        Type = "AWS::EC2::VPC"
+        Properties = {
+          CidrBlock = "10.1.0.0/16"
+        }
       }
     }
-  },
-  "Outputs" : {
-    "DefaultSgId" : {
-      "Description": "The ID of default security group",
-      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
-    },
-    "VpcID" : {
-      "Description": "The VPC ID",
-      "Value" : { "Ref" : "MyVPC" }
+
+    Outputs = {
+      VpcID = {
+        Description = "VPC ID"
+        Value = {
+          Ref = "MyVPC"
+        }
+      }
     }
-  }
-}
-STACK
+  })
 }
 
 resource "aws_servicecatalog_product" "test" {

--- a/aws/resource_aws_servicecatalog_provisioning_artifact.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact.go
@@ -1,0 +1,313 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsServiceCatalogProvisioningArtifact() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceCatalogProvisioningArtifactCreate,
+		Read:   resourceAwsServiceCatalogProvisioningArtifactRead,
+		Update: resourceAwsServiceCatalogProvisioningArtifactUpdate,
+		Delete: resourceAwsServiceCatalogProvisioningArtifactDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"disable_template_validation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"guidance": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      servicecatalog.ProvisioningArtifactGuidanceDefault,
+				ValidateFunc: validation.StringInSlice(servicecatalog.ProvisioningArtifactGuidance_Values(), false),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template_physical_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ExactlyOneOf: []string{
+					"template_url",
+					"template_physical_id",
+				},
+			},
+			"template_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ExactlyOneOf: []string{
+					"template_url",
+					"template_physical_id",
+				},
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(servicecatalog.ProvisioningArtifactType_Values(), false),
+			},
+		},
+	}
+}
+
+func resourceAwsServiceCatalogProvisioningArtifactCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	parameters := make(map[string]interface{})
+	parameters["description"] = d.Get("description")
+	parameters["disable_template_validation"] = d.Get("disable_template_validation")
+	parameters["name"] = d.Get("name")
+	parameters["template_physical_id"] = d.Get("template_physical_id")
+	parameters["template_url"] = d.Get("template_url")
+	parameters["type"] = d.Get("type")
+
+	input := &servicecatalog.CreateProvisioningArtifactInput{
+		IdempotencyToken: aws.String(resource.UniqueId()),
+		Parameters:       expandProvisioningArtifactParameters(parameters),
+		ProductId:        aws.String(d.Get("product_id").(string)),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	var output *servicecatalog.CreateProvisioningArtifactOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.CreateProvisioningArtifact(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateProvisioningArtifact(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating Service Catalog Provisioning Artifact: %w", err)
+	}
+
+	if output == nil || output.ProvisioningArtifactDetail == nil || output.ProvisioningArtifactDetail.Id == nil {
+		return fmt.Errorf("error creating Service Catalog Provisioning Artifact: empty response")
+	}
+
+	d.SetId(serviceCatalogProvisioningArtifactID(aws.StringValue(output.ProvisioningArtifactDetail.Id), d.Get("product_id").(string)))
+
+	// Active and Guidance are not fields of CreateProvisioningArtifact but are fields of UpdateProvisioningArtifact.
+	// In order to set these to non-default values, you must create and then update.
+
+	return resourceAwsServiceCatalogProvisioningArtifactUpdate(d, meta)
+}
+
+func resourceAwsServiceCatalogProvisioningArtifactRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", d.Id(), err)
+	}
+
+	output, err := waiter.ProvisioningArtifactReady(conn, artifactID, productID)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Service Catalog Provisioning Artifact (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Provisioning Artifact (%s): %w", d.Id(), err)
+	}
+
+	if output == nil || output.ProvisioningArtifactDetail == nil {
+		return fmt.Errorf("error getting Service Catalog Provisioning Artifact (%s): empty response", d.Id())
+	}
+
+	if v, ok := output.Info["ImportFromPhysicalId"]; ok {
+		d.Set("template_physical_id", v)
+	}
+
+	if v, ok := output.Info["LoadTemplateFromURL"]; ok {
+		d.Set("template_url", v)
+	}
+
+	pad := output.ProvisioningArtifactDetail
+
+	d.Set("active", pad.Active)
+	if pad.CreatedTime != nil {
+		d.Set("created_time", pad.CreatedTime.Format(time.RFC3339))
+	}
+	d.Set("description", pad.Description)
+	d.Set("guidance", pad.Guidance)
+	d.Set("name", pad.Name)
+	d.Set("product_id", productID)
+	d.Set("type", pad.Type)
+
+	return nil
+}
+
+func resourceAwsServiceCatalogProvisioningArtifactUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	if d.HasChanges("accept_language", "active", "description", "guidance", "name", "product_id") {
+		artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(d.Id())
+
+		if err != nil {
+			return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", d.Id(), err)
+		}
+
+		input := &servicecatalog.UpdateProvisioningArtifactInput{
+			ProductId:              aws.String(productID),
+			ProvisioningArtifactId: aws.String(artifactID),
+		}
+
+		if v, ok := d.GetOk("accept_language"); ok {
+			input.AcceptLanguage = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("active"); ok {
+			input.Active = aws.Bool(v.(bool))
+		}
+
+		if v, ok := d.GetOk("description"); ok {
+			input.Description = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("guidance"); ok {
+			input.Guidance = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("name"); ok {
+			input.Name = aws.String(v.(string))
+		}
+
+		err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+			_, err := conn.UpdateProvisioningArtifact(input)
+
+			if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		})
+
+		if tfresource.TimedOut(err) {
+			_, err = conn.UpdateProvisioningArtifact(input)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating Service Catalog Provisioning Artifact (%s): %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsServiceCatalogProvisioningArtifactRead(d, meta)
+}
+
+func resourceAwsServiceCatalogProvisioningArtifactDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", d.Id(), err)
+	}
+
+	input := &servicecatalog.DeleteProvisioningArtifactInput{
+		ProductId:              aws.String(productID),
+		ProvisioningArtifactId: aws.String(artifactID),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	_, err = conn.DeleteProvisioningArtifact(input)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Service Catalog Provisioning Artifact (%s): %w", d.Id(), err)
+	}
+
+	if err := waiter.ProvisioningArtifactDeleted(conn, artifactID, productID); err != nil {
+		return fmt.Errorf("error waiting for Service Catalog Provisioning Artifact (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func serviceCatalogProvisioningArtifactID(artifactID, productID string) string {
+	return strings.Join([]string{artifactID, productID}, ":")
+}
+
+func parseServiceCatalogProvisioningArtifactID(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Please make sure the ID is in the form artifact_id:product_id (i.e. pa-r2d2slrtcob:prod-c3pohcrhmisy")
+	}
+	return parts[0], parts[1], nil
+}

--- a/aws/resource_aws_servicecatalog_provisioning_artifact.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact.go
@@ -216,14 +216,11 @@ func resourceAwsServiceCatalogProvisioningArtifactUpdate(d *schema.ResourceData,
 		input := &servicecatalog.UpdateProvisioningArtifactInput{
 			ProductId:              aws.String(productID),
 			ProvisioningArtifactId: aws.String(artifactID),
+			Active:                 aws.Bool(d.Get("active").(bool)),
 		}
 
 		if v, ok := d.GetOk("accept_language"); ok {
 			input.AcceptLanguage = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("active"); ok {
-			input.Active = aws.Bool(v.(bool))
 		}
 
 		if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_servicecatalog_provisioning_artifact.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -148,7 +147,7 @@ func resourceAwsServiceCatalogProvisioningArtifactCreate(d *schema.ResourceData,
 		return fmt.Errorf("error creating Service Catalog Provisioning Artifact: empty response")
 	}
 
-	d.SetId(serviceCatalogProvisioningArtifactID(aws.StringValue(output.ProvisioningArtifactDetail.Id), d.Get("product_id").(string)))
+	d.SetId(tfservicecatalog.ProvisioningArtifactID(aws.StringValue(output.ProvisioningArtifactDetail.Id), d.Get("product_id").(string)))
 
 	// Active and Guidance are not fields of CreateProvisioningArtifact but are fields of UpdateProvisioningArtifact.
 	// In order to set these to non-default values, you must create and then update.
@@ -159,7 +158,7 @@ func resourceAwsServiceCatalogProvisioningArtifactCreate(d *schema.ResourceData,
 func resourceAwsServiceCatalogProvisioningArtifactRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).scconn
 
-	artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(d.Id())
+	artifactID, productID, err := tfservicecatalog.ProvisioningArtifactParseID(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", d.Id(), err)
@@ -208,7 +207,7 @@ func resourceAwsServiceCatalogProvisioningArtifactUpdate(d *schema.ResourceData,
 	conn := meta.(*AWSClient).scconn
 
 	if d.HasChanges("accept_language", "active", "description", "guidance", "name", "product_id") {
-		artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(d.Id())
+		artifactID, productID, err := tfservicecatalog.ProvisioningArtifactParseID(d.Id())
 
 		if err != nil {
 			return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", d.Id(), err)
@@ -268,7 +267,7 @@ func resourceAwsServiceCatalogProvisioningArtifactUpdate(d *schema.ResourceData,
 func resourceAwsServiceCatalogProvisioningArtifactDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).scconn
 
-	artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(d.Id())
+	artifactID, productID, err := tfservicecatalog.ProvisioningArtifactParseID(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", d.Id(), err)
@@ -298,16 +297,4 @@ func resourceAwsServiceCatalogProvisioningArtifactDelete(d *schema.ResourceData,
 	}
 
 	return nil
-}
-
-func serviceCatalogProvisioningArtifactID(artifactID, productID string) string {
-	return strings.Join([]string{artifactID, productID}, ":")
-}
-
-func parseServiceCatalogProvisioningArtifactID(id string) (string, string, error) {
-	parts := strings.Split(id, ":")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Please make sure the ID is in the form artifact_id:product_id (i.e. pa-r2d2slrtcob:prod-c3pohcrhmisy")
-	}
-	return parts[0], parts[1], nil
 }

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -1,0 +1,443 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// add sweeper to delete known test servicecat provisioning artifacts
+func init() {
+	resource.AddTestSweepers("aws_servicecatalog_provisioning_artifact", &resource.Sweeper{
+		Name:         "aws_servicecatalog_provisioning_artifact",
+		Dependencies: []string{},
+		F:            testSweepServiceCatalogProvisioningArtifacts,
+	})
+}
+
+func testSweepServiceCatalogProvisioningArtifacts(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).scconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &servicecatalog.SearchProductsAsAdminInput{}
+
+	err = conn.SearchProductsAsAdminPages(input, func(page *servicecatalog.SearchProductsAsAdminOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, pvd := range page.ProductViewDetails {
+			if pvd == nil || pvd.ProductViewSummary == nil || pvd.ProductViewSummary.ProductId == nil {
+				continue
+			}
+
+			productID := aws.StringValue(pvd.ProductViewSummary.ProductId)
+
+			artInput := &servicecatalog.ListProvisioningArtifactsInput{
+				ProductId: aws.String(productID),
+			}
+
+			// there's no paginator for ListProvisioningArtifacts
+			for {
+				output, err := conn.ListProvisioningArtifacts(artInput)
+
+				if err != nil {
+					err := fmt.Errorf("error listing Service Catalog Provisioning Artifacts for product (%s): %w", productID, err)
+					log.Printf("[ERROR] %s", err)
+					errs = multierror.Append(errs, err)
+					break
+				}
+
+				for _, pad := range output.ProvisioningArtifactDetails {
+					r := resourceAwsServiceCatalogProvisioningArtifact()
+					d := r.Data(nil)
+
+					d.SetId(aws.StringValue(pad.Id))
+					d.Set("product_id", productID)
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				/*
+					// Currently, the API has no token field on input (AWS oops)
+					if aws.StringValue(output.NextPageToken) == "" {
+						break
+					}
+
+					artInput.NextPageToken = output.NextPageToken
+				*/
+				break
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Provisioning Artifacts for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Service Catalog Provisioning Artifacts for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Service Catalog Provisioning Artifacts sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func TestAccAWSServiceCatalogProvisioningArtifact_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_provisioning_artifact.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, "beskrivning"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "beskrivning"),
+					resource.TestCheckResourceAttr(resourceName, "disable_template_validation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "guidance", "DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-2", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "template_url"),
+					resource.TestCheckResourceAttr(resourceName, "type", servicecatalog.ProductTypeCloudFormationTemplate),
+					testAccCheckResourceAttrRfc3339(resourceName, "created_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"disable_template_validation",
+					"template_url",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogProvisioningArtifact_disappears(t *testing.T) {
+	resourceName := "aws_servicecatalog_provisioning_artifact.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogProvisioningArtifact(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
+	resourceName := "aws_servicecatalog_provisioning_artifact.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, "beskrivning"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "beskrivning"),
+					resource.TestCheckResourceAttr(resourceName, "support_description", "supportbeskrivning"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+			{
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, "ny beskrivning"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "ny beskrivning"),
+					resource.TestCheckResourceAttr(resourceName, "support_description", "ny supportbeskrivning"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogProvisioningArtifact_physicalID(t *testing.T) {
+	resourceName := "aws_servicecatalog_provisioning_artifact.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "catalog", regexp.MustCompile(`product/prod-.*`)),
+					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.0.description", "artefaktbeskrivning"),
+					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.0.name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioning_artifact_parameters.0.template_physical_id"),
+					testAccMatchResourceAttrRegionalARN(
+						resourceName,
+						"provisioning_artifact_parameters.0.template_physical_id",
+						"cloudformation",
+						regexp.MustCompile(fmt.Sprintf(`stack/%s/.*`, rName)),
+					),
+					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.0.type", servicecatalog.ProvisioningArtifactTypeCloudFormationTemplate),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"provisioning_artifact_parameters",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogProvisioningArtifactDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).scconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_servicecatalog_provisioning_artifact" {
+			continue
+		}
+
+		artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		input := &servicecatalog.DescribeProvisioningArtifactInput{
+			ProductId:              aws.String(productID),
+			ProvisioningArtifactId: aws.String(artifactID),
+		}
+
+		output, err := conn.DescribeProvisioningArtifact(input)
+
+		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Service Catalog Provisioning Artifact (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("Service Catalog Provisioning Artifact (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).scconn
+
+		artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		input := &servicecatalog.DescribeProvisioningArtifactInput{
+			ProductId:              aws.String(productID),
+			ProvisioningArtifactId: aws.String(artifactID),
+		}
+
+		_, err = conn.DescribeProvisioningArtifact(input)
+
+		if err != nil {
+			return fmt.Errorf("error describing Service Catalog Provisioning Artifact (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_object" "test" {
+  bucket = aws_s3_bucket.test.id
+  key    = "%[1]s.json"
+
+  content = <<EOF
+{
+  "Resources" : {
+    "MyVPC": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : "10.0.0.0/16",
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  },
+  "Outputs" : {
+    "DefaultSgId" : {
+      "Description": "The ID of default security group",
+      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
+    },
+    "VpcID" : {
+      "Description": "The VPC ID",
+      "Value" : { "Ref" : "MyVPC" }
+    }
+  }
+}
+EOF
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_servicecatalog_product" "test" {
+  description         = "Produktbeskrivning"
+  distributor         = "distributör"
+  name                = %[1]q
+  owner               = "ägare"
+  type                = "CLOUD_FORMATION_TEMPLATE"
+  support_description = "supportbeskrivning"
+  support_email       = "support@example.com"
+  support_url         = "http://example.com"
+
+  provisioning_artifact_parameters {
+    description                 = "artefaktbeskrivning"
+    disable_template_validation = true
+    name                        = "%[1]s-1"
+    template_url                = "s3://${aws_s3_bucket_object.test.bucket}/${aws_s3_bucket_object.test.key}"
+    #template_url                = "https://s3.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket.test.id}/${aws_s3_bucket_object.test.key}"
+    type                        = "CLOUD_FORMATION_TEMPLATE"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, description string) string {
+	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName), fmt.Sprintf(`
+resource "aws_servicecatalog_provisioning_artifact" "test" {
+  accept_language             = "en"
+  active                      = "true"
+  description                 = %[2]q
+  disable_template_validation = true
+  guidance                    = "DEFAULT"
+  name                        = "%[1]s-2"
+  product_id                  = aws_servicecatalog_product.test.id
+  template_url                = "https://s3.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket.test.id}/${aws_s3_bucket_object.test.key}"
+  type                        = "CLOUD_FORMATION_TEMPLATE"
+}
+`, rName, description))
+}
+
+func testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
+
+  template_body = <<STACK
+{
+  "Resources" : {
+    "MyVPC": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : "10.0.0.0/16",
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  },
+  "Outputs" : {
+    "DefaultSgId" : {
+      "Description": "The ID of default security group",
+      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
+    },
+    "VpcID" : {
+      "Description": "The VPC ID",
+      "Value" : { "Ref" : "MyVPC" }
+    }
+  }
+}
+STACK
+}
+
+resource "aws_servicecatalog_provisioning_artifact" "test" {
+  description         = "beskrivning"
+  distributor         = "distributör"
+  name                = %[1]q
+  owner               = "ägare"
+  type                = "CLOUD_FORMATION_TEMPLATE"
+  support_description = "supportbeskrivning"
+  support_email       = "support@example.com"
+  support_url         = "http://example.com"
+  description          = "artefaktbeskrivning"
+  name                 = %[1]q
+  template_physical_id = aws_cloudformation_stack.test.id
+  type                 = "CLOUD_FORMATION_TEMPLATE"
+}
+`, rName)
+}

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -349,8 +349,8 @@ resource "aws_s3_bucket_object" "test" {
     Outputs = {
       VpcID = {
         Description = "VPC ID"
-        Value = { 
-          Ref = "MyVPC" 
+        Value = {
+          Ref = "MyVPC"
         }
       }
     }

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -198,6 +198,16 @@ func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-3", rName)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"disable_template_validation",
+					"template_url",
+				},
+			},
 		},
 	})
 }
@@ -227,6 +237,16 @@ func TestAccAWSServiceCatalogProvisioningArtifact_physicalID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", servicecatalog.ProductTypeCloudFormationTemplate),
 					testAccCheckResourceAttrRfc3339(resourceName, "created_time"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"disable_template_validation",
+					"template_physical_id",
+				},
 			},
 		},
 	})

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 )
 
 // add sweeper to delete known test servicecat provisioning artifacts
@@ -250,7 +251,7 @@ func testAccCheckAwsServiceCatalogProvisioningArtifactDestroy(s *terraform.State
 			continue
 		}
 
-		artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(rs.Primary.ID)
+		artifactID, productID, err := tfservicecatalog.ProvisioningArtifactParseID(rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", rs.Primary.ID, err)
@@ -289,7 +290,7 @@ func testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName string
 
 		conn := testAccProvider.Meta().(*AWSClient).scconn
 
-		artifactID, productID, err := parseServiceCatalogProvisioningArtifactID(rs.Primary.ID)
+		artifactID, productID, err := tfservicecatalog.ProvisioningArtifactParseID(rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("error parsing Service Catalog Provisioning Artifact ID (%s): %w", rs.Primary.ID, err)

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -167,28 +167,6 @@ func TestAccAWSServiceCatalogProvisioningArtifact_disappears(t *testing.T) {
 	})
 }
 
-/*
-	if v, ok := d.GetOk("accept_language"); ok {
-		input.AcceptLanguage = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("active"); ok {
-		input.Active = aws.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("description"); ok {
-		input.Description = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("guidance"); ok {
-		input.Guidance = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("name"); ok {
-		input.Name = aws.String(v.(string))
-	}
-*/
-
 func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
+++ b/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_provisioning_artifact"
+description: |-
+  Manages a Service Catalog Provisioning Artifact
+---
+
+# Resource: aws_servicecatalog_provisioning_artifact
+
+Manages a Service Catalog Provisioning Artifact for a specified product.
+
+-> A "provisioning artifact" is also referred to as a "version."
+
+~> **NOTE:** You cannot create a provisioning artifact for a product that was shared with you.
+
+~> **NOTE:** The user or role that use this resource must have the `cloudformation:GetTemplate` IAM policy permission. This policy permission is required when using the `template_physical_id` argument.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_provisioning_artifact" "example" {
+  name         = "example"
+  product_id   = aws_servicecatalog_product.example.id
+  type         = "CLOUD_FORMATION_TEMPLATE"
+  template_url = "https://s3.amazonaws.com/cf-templates-ozkq9d3hgiq2-us-east-1/temp1.json"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `product_id` - (Required) Identifier of the product.
+* `template_physical_id` - (Required if `template_url` is not provided) Template source as the physical ID of the resource that contains the template. Currently only supports CloudFormation stack ARN. Specify the physical ID as `arn:[partition]:cloudformation:[region]:[account ID]:stack/[stack name]/[resource ID]`.
+* `template_url` - (Required if `template_physical_id` is not provided) Template source as URL of the CloudFormation template in Amazon S3.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). The default value is `en`.
+* `active` - (Optional) Whether the product version is active. Inactive provisioning artifacts are invisible to end users. End users cannot launch or update a provisioned product from an inactive provisioning artifact. Default is `true`.
+* `description` - (Optional) Description of the provisioning artifact (i.e., version), including how it differs from the previous provisioning artifact.
+* `disable_template_validation` - (Optional) Whether AWS Service Catalog stops validating the specified provisioning artifact template even if it is invalid.
+* `guidance` - (Optional) Information set by the administrator to provide guidance to end users about which provisioning artifacts to use. Valid values are `DEFAULT` and `DEPRECATED`. The default is `DEFAULT`. Users are able to make updates to a provisioned product of a deprecated version but cannot launch new provisioned products using a deprecated version.
+* `name` - (Optional) Name of the provisioning artifact (for example, `v1`, `v2beta`). No spaces are allowed.
+* `type` - (Optional) Type of provisioning artifact. Valid values: `CLOUD_FORMATION_TEMPLATE`, `MARKETPLACE_AMI`, `MARKETPLACE_CAR` (Marketplace Clusters and AWS Resources).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `created_time` - Time when the provisioning artifact was created.
+* `id` - Provisioning Artifact identifier.
+* `status` - Status of the provisioning artifact.
+
+## Import
+
+`aws_servicecatalog_provisioning_artifact` can be imported using the provisioning artifact ID, e.g.
+
+```
+$ terraform import aws_servicecatalog_provisioning_artifact.example pa-ij2b6lusy6dec
+```

--- a/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
+++ b/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
@@ -52,13 +52,13 @@ The following arguments are optional:
 In addition to all arguments above, the following attributes are exported:
 
 * `created_time` - Time when the provisioning artifact was created.
-* `id` - Provisioning Artifact identifier.
+* `id` - Provisioning Artifact identifier and product identifier separated by a colon.
 * `status` - Status of the provisioning artifact.
 
 ## Import
 
-`aws_servicecatalog_provisioning_artifact` can be imported using the provisioning artifact ID, e.g.
+`aws_servicecatalog_provisioning_artifact` can be imported using the provisioning artifact ID and product ID separated by a colon, e.g.
 
 ```
-$ terraform import aws_servicecatalog_provisioning_artifact.example pa-ij2b6lusy6dec
+$ terraform import aws_servicecatalog_provisioning_artifact.example pa-ij2b6lusy6dec:prod-el3an0rma3
 ```

--- a/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
+++ b/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
@@ -25,7 +25,7 @@ resource "aws_servicecatalog_provisioning_artifact" "example" {
   name         = "example"
   product_id   = aws_servicecatalog_product.example.id
   type         = "CLOUD_FORMATION_TEMPLATE"
-  template_url = "https://s3.amazonaws.com/cf-templates-ozkq9d3hgiq2-us-east-1/temp1.json"
+  template_url = "https://${aws_s3_bucket.example.bucket_regional_domain_name}/${aws_s3_bucket_object.example.key}"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19122

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogConstraint_basic (38.59s)
--- PASS: TestAccAWSServiceCatalogConstraint_disappears (36.14s)
--- PASS: TestAccAWSServiceCatalogConstraint_update (57.15s)

--- PASS: TestAccAWSServiceCatalogProduct_basic (35.98s)
--- PASS: TestAccAWSServiceCatalogProduct_disappears (34.19s)
--- PASS: TestAccAWSServiceCatalogProduct_physicalID (74.97s)
--- PASS: TestAccAWSServiceCatalogProduct_update (53.49s)
--- PASS: TestAccAWSServiceCatalogProduct_updateTags (51.04s)

--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_basic (76.22s)
--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_disappears (74.70s)

--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_basic (37.53s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_disappears (35.13s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_physicalID (76.61s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_update (58.26s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogConstraint_basic (39.99s)
--- PASS: TestAccAWSServiceCatalogConstraint_disappears (38.20s)
--- PASS: TestAccAWSServiceCatalogConstraint_update (61.19s)

--- PASS: TestAccAWSServiceCatalogProduct_basic (37.55s)
--- PASS: TestAccAWSServiceCatalogProduct_disappears (34.19s)
--- PASS: TestAccAWSServiceCatalogProduct_physicalID (78.46s)
--- PASS: TestAccAWSServiceCatalogProduct_update (58.29s)
--- PASS: TestAccAWSServiceCatalogProduct_updateTags (58.19s)

--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_basic (79.64s)
--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_disappears (77.50s)

--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_basic (43.20s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_disappears (36.54s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_physicalID (79.18s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_update (59.69s)
```
