### PR TITLE
Add delete marker replication to v2 s3 config

### DIFF
--- a/.changelog/19323.txt
+++ b/.changelog/19323.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_s3_bucket: Add the delete_marker_replication option to s3 bucket replication_configuration v2 rules
+resource/aws_s3_bucket: Add the delete_marker_replication_status argument for V2 replication configurations
 ```

--- a/.changelog/19323.txt
+++ b/.changelog/19323.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add the delete_marker_replication option to s3 bucket replication_configuration v2 rules
+```

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -524,6 +524,21 @@ func resourceAwsS3Bucket() *schema.Resource {
 											},
 										},
 									},
+									"delete_marker_replication": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"status": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Default:  s3.DeleteMarkerReplicationStatusDisabled,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -2109,12 +2124,17 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 			} else {
 				rcRule.Filter.Prefix = aws.String(filter["prefix"].(string))
 			}
-			rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
-				Status: aws.String(s3.DeleteMarkerReplicationStatusDisabled),
-			}
+
 		} else {
 			// XML schema V1.
 			rcRule.Prefix = aws.String(rr["prefix"].(string))
+		}
+
+		if d, ok := rr["delete_marker_replication"].([]interface{}); ok && len(d) > 0 && d[0] != nil {
+			dmr := d[0].(map[string]interface{})
+			rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
+				Status: aws.String(dmr["status"].(string)),
+			}
 		}
 
 		rules = append(rules, rcRule)
@@ -2409,6 +2429,14 @@ func flattenAwsS3BucketReplicationConfiguration(r *s3.ReplicationConfiguration) 
 			t["filter"] = []interface{}{m}
 		}
 
+		if dmr := v.DeleteMarkerReplication; dmr != nil {
+			m := map[string]interface{}{}
+			if dmr.Status != nil {
+				m["status"] = aws.StringValue(v.DeleteMarkerReplication.Status)
+			}
+			t["delete_marker_replication"] = []interface{}{m}
+		}
+
 		rules = append(rules, t)
 	}
 	m["rules"] = schema.NewSet(rulesHash, rules)
@@ -2574,6 +2602,9 @@ func rulesHash(v interface{}) int {
 	if v, ok := m["priority"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
+	if v, ok := m["delete_marker_replication"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		buf.WriteString(fmt.Sprintf("%d-", deleteMarkerReplicationHash(v[0])))
+	}
 	if v, ok := m["filter"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		buf.WriteString(fmt.Sprintf("%d-", replicationRuleFilterHash(v[0])))
 	}
@@ -2594,6 +2625,21 @@ func replicationRuleFilterHash(v interface{}) int {
 	if v, ok := m["tags"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", keyvaluetags.New(v).Hash()))
 	}
+	return hashcode.String(buf.String())
+}
+
+func deleteMarkerReplicationHash(v interface{}) int {
+	var buf bytes.Buffer
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
+	if v, ok := m["status"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -2124,7 +2124,6 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 					Status: aws.String(s3.DeleteMarkerReplicationStatusDisabled),
 				}
 			}
-
 		} else {
 			// XML schema V1.
 			rcRule.Prefix = aws.String(rr["prefix"].(string))

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -4646,7 +4646,7 @@ resource "aws_s3_bucket" "bucket" {
         prefix = "foo"
       }
 
-	  delete_marker_replication_status = "Enabled"
+      delete_marker_replication_status = "Enabled"
 
       destination {
         bucket        = aws_s3_bucket.destination.arn

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -164,7 +164,7 @@ func testS3BucketObjectLockEnabled(conn *s3.S3, bucket string) (bool, error) {
 	return aws.StringValue(output.ObjectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled, nil
 }
 
-func TestAccAWSS3Bucket_basic(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_basic(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	region := testAccGetRegion()
 	hostedZoneID, _ := HostedZoneIDForRegion(region)
@@ -201,7 +201,7 @@ func TestAccAWSS3Bucket_basic(t *testing.T) {
 
 // Support for common Terraform 0.11 pattern
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/7868
-func TestAccAWSS3Bucket_Bucket_EmptyString(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_emptyString(t *testing.T) {
 	resourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -227,7 +227,7 @@ func TestAccAWSS3Bucket_Bucket_EmptyString(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_tagsWithNoSystemTags(t *testing.T) {
+func TestAccAWSS3Bucket_Tags_withNoSystemTags(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 
@@ -286,7 +286,7 @@ func TestAccAWSS3Bucket_tagsWithNoSystemTags(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
+func TestAccAWSS3Bucket_Tags_withSystemTags(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 
@@ -371,7 +371,7 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_ignoreTags(t *testing.T) {
+func TestAccAWSS3Bucket_Tags_ignoreTags(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -416,7 +416,7 @@ func TestAccAWSS3Bucket_ignoreTags(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_withTags(t *testing.T) {
+func TestAccAWSS3Bucket_Tags_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "aws_s3_bucket.bucket1"
 
@@ -439,7 +439,7 @@ func TestAccAWSS3Bucket_withTags(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_namePrefix(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_namePrefix(t *testing.T) {
 	resourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -465,7 +465,7 @@ func TestAccAWSS3Bucket_namePrefix(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_generatedName(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_generatedName(t *testing.T) {
 	resourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -490,7 +490,7 @@ func TestAccAWSS3Bucket_generatedName(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_acceleration(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_acceleration(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -527,7 +527,7 @@ func TestAccAWSS3Bucket_acceleration(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_RequestPayer(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_requestPayer(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -563,7 +563,7 @@ func TestAccAWSS3Bucket_RequestPayer(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Policy(t *testing.T) {
+func TestAccAWSS3Bucket_Security_policy(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	partition := testAccGetPartition()
 	resourceName := "aws_s3_bucket.bucket"
@@ -615,7 +615,7 @@ func TestAccAWSS3Bucket_Policy(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_UpdateAcl(t *testing.T) {
+func TestAccAWSS3Bucket_Security_updateACL(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -649,7 +649,7 @@ func TestAccAWSS3Bucket_UpdateAcl(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_UpdateGrant(t *testing.T) {
+func TestAccAWSS3Bucket_Security_updateGrant(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -707,7 +707,7 @@ func TestAccAWSS3Bucket_UpdateGrant(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_AclToGrant(t *testing.T) {
+func TestAccAWSS3Bucket_Security_ACLToGrant(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -737,7 +737,7 @@ func TestAccAWSS3Bucket_AclToGrant(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_GrantToAcl(t *testing.T) {
+func TestAccAWSS3Bucket_Security_GrantToACL(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -767,7 +767,7 @@ func TestAccAWSS3Bucket_GrantToAcl(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Website_Simple(t *testing.T) {
+func TestAccAWSS3Bucket_Web_simple(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	region := testAccGetRegion()
 	resourceName := "aws_s3_bucket.bucket"
@@ -812,7 +812,7 @@ func TestAccAWSS3Bucket_Website_Simple(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
+func TestAccAWSS3Bucket_Web_redirect(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	region := testAccGetRegion()
 	resourceName := "aws_s3_bucket.bucket"
@@ -857,7 +857,7 @@ func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_WebsiteRoutingRules(t *testing.T) {
+func TestAccAWSS3Bucket_Web_routingRules(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	region := testAccGetRegion()
 	resourceName := "aws_s3_bucket.bucket"
@@ -909,7 +909,7 @@ func TestAccAWSS3Bucket_WebsiteRoutingRules(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical(t *testing.T) {
+func TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenTypical(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.arbitrary"
 
@@ -940,7 +940,7 @@ func TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed(t *testing.T) {
+func TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.arbitrary"
 
@@ -971,7 +971,7 @@ func TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled(t *testing.T) {
+func TestAccAWSS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.arbitrary"
 
@@ -1004,7 +1004,7 @@ func TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled(
 	})
 }
 
-func TestAccAWSS3Bucket_bucketKeyEnabled(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_keyEnabled(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.arbitrary"
 
@@ -1036,10 +1036,10 @@ func TestAccAWSS3Bucket_bucketKeyEnabled(t *testing.T) {
 	})
 }
 
-// Test TestAccAWSS3Bucket_shouldFailNotFound is designed to fail with a "plan
+// Test TestAccAWSS3Bucket_Basic_shouldFailNotFound is designed to fail with a "plan
 // not empty" error in Terraform, to check against regresssions.
 // See https://github.com/hashicorp/terraform/pull/2925
-func TestAccAWSS3Bucket_shouldFailNotFound(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_shouldFailNotFound(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1061,7 +1061,7 @@ func TestAccAWSS3Bucket_shouldFailNotFound(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Versioning(t *testing.T) {
+func TestAccAWSS3Bucket_Manage_versioning(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1102,7 +1102,7 @@ func TestAccAWSS3Bucket_Versioning(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Cors_Update(t *testing.T) {
+func TestAccAWSS3Bucket_Security_corsUpdate(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1187,7 +1187,7 @@ func TestAccAWSS3Bucket_Cors_Update(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Cors_Delete(t *testing.T) {
+func TestAccAWSS3Bucket_Security_corsDelete(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1227,7 +1227,7 @@ func TestAccAWSS3Bucket_Cors_Delete(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Cors_EmptyOrigin(t *testing.T) {
+func TestAccAWSS3Bucket_Security_corsEmptyOrigin(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1265,7 +1265,7 @@ func TestAccAWSS3Bucket_Cors_EmptyOrigin(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Logging(t *testing.T) {
+func TestAccAWSS3Bucket_Security_logging(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1292,7 +1292,7 @@ func TestAccAWSS3Bucket_Logging(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_LifecycleBasic(t *testing.T) {
+func TestAccAWSS3Bucket_Manage_lifecycleBasic(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1409,7 +1409,7 @@ func TestAccAWSS3Bucket_LifecycleBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_LifecycleExpireMarkerOnly(t *testing.T) {
+func TestAccAWSS3Bucket_Manage_lifecycleExpireMarkerOnly(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1447,7 +1447,7 @@ func TestAccAWSS3Bucket_LifecycleExpireMarkerOnly(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11420
-func TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock(t *testing.T) {
+func TestAccAWSS3Bucket_Manage_lifecycleRuleExpirationEmptyConfigurationBlock(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1468,7 +1468,7 @@ func TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock(t *test
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15138
-func TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpiration(t *testing.T) {
+func TestAccAWSS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1494,7 +1494,7 @@ func TestAccAWSS3Bucket_LifecycleRule_AbortIncompleteMultipartUploadDays_NoExpir
 	})
 }
 
-func TestAccAWSS3Bucket_Replication(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
@@ -1612,7 +1612,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Replication_MultipleDestinations_EmptyFilter(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_multipleDestinationsEmptyFilter(t *testing.T) {
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
@@ -1679,7 +1679,7 @@ func TestAccAWSS3Bucket_Replication_MultipleDestinations_EmptyFilter(t *testing.
 	})
 }
 
-func TestAccAWSS3Bucket_Replication_MultipleDestinations_NonEmptyFilter(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_multipleDestinationsNonEmptyFilter(t *testing.T) {
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
@@ -1749,7 +1749,7 @@ func TestAccAWSS3Bucket_Replication_MultipleDestinations_NonEmptyFilter(t *testi
 	})
 }
 
-func TestAccAWSS3Bucket_Replication_MultipleDestinations_TwoDestination(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_twoDestination(t *testing.T) {
 	// This tests 2 destinations since GovCloud and possibly other non-standard partitions allow a max of 2
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
@@ -1808,7 +1808,7 @@ func TestAccAWSS3Bucket_Replication_MultipleDestinations_TwoDestination(t *testi
 	})
 }
 
-func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_configurationRuleDestinationAccessControlTranslation(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
@@ -1901,7 +1901,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12480
-func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_configurationRuleDestinationAddAccessControlTranslation(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
@@ -1983,7 +1983,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessContr
 }
 
 // StorageClass issue: https://github.com/hashicorp/terraform/issues/10909
-func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_withoutStorageClass(t *testing.T) {
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
@@ -2019,7 +2019,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_expectVersioningValidationError(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	// record the initialized providers so that we can use them to check for the instances in each region
@@ -2043,7 +2043,7 @@ func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T)
 }
 
 // Prefix issue: https://github.com/hashicorp/terraform-provider-aws/issues/6340
-func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_withoutPrefix(t *testing.T) {
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
@@ -2079,7 +2079,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_schemaV2(t *testing.T) {
 	rInt := acctest.RandInt()
 	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
@@ -2296,7 +2296,7 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_SameRegionReplicationSchemaV2(t *testing.T) {
+func TestAccAWSS3Bucket_Replication_schemaV2SameRegion(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	destinationResourceName := "aws_s3_bucket.destination"
@@ -2331,7 +2331,7 @@ func TestAccAWSS3Bucket_SameRegionReplicationSchemaV2(t *testing.T) {
 								},
 								Priority: aws.Int64(0),
 								DeleteMarkerReplication: &s3.DeleteMarkerReplication{
-									Status: aws.String(s3.DeleteMarkerReplicationStatusDisabled),
+									Status: aws.String(s3.DeleteMarkerReplicationStatusEnabled),
 								},
 							},
 						},
@@ -2350,7 +2350,7 @@ func TestAccAWSS3Bucket_SameRegionReplicationSchemaV2(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_objectLock(t *testing.T) {
+func TestAccAWSS3Bucket_Manage_objectLock(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.arbitrary"
 
@@ -2390,7 +2390,7 @@ func TestAccAWSS3Bucket_objectLock(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_forceDestroy(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_forceDestroy(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 
@@ -2416,7 +2416,7 @@ func TestAccAWSS3Bucket_forceDestroy(t *testing.T) {
 // While the aws_s3_bucket_object resource automatically cleans the key
 // to not contain these extra slashes, out-of-band handling and other AWS
 // services may create keys with extra slashes (empty "directory" prefixes).
-func TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_forceDestroyWithEmptyPrefixes(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 
@@ -2437,7 +2437,7 @@ func TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled(t *testing.T) {
+func TestAccAWSS3Bucket_Basic_forceDestroyWithObjectLockEnabled(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 
@@ -4574,9 +4574,7 @@ resource "aws_s3_bucket" "bucket" {
         prefix = "testprefix"
       }
 
-      delete_marker_replication {
-        status = "Enabled"
-      }
+      delete_marker_replication_status = "Enabled"
 
       destination {
         bucket        = aws_s3_bucket.destination.arn
@@ -4617,8 +4615,6 @@ resource "aws_s3_bucket" "bucket" {
         prefix = "foo"
       }
 
-      delete_marker_replication {}
-
       destination {
         bucket        = aws_s3_bucket.destination.arn
         storage_class = "STANDARD"
@@ -4650,9 +4646,7 @@ resource "aws_s3_bucket" "bucket" {
         prefix = "foo"
       }
 
-      delete_marker_replication {
-        status = "Enabled"
-      }
+	  delete_marker_replication_status = "Enabled"
 
       destination {
         bucket        = aws_s3_bucket.destination.arn
@@ -4687,10 +4681,6 @@ resource "aws_s3_bucket" "bucket" {
         tags = {
           ReplicateMe = "Yes"
         }
-      }
-
-      delete_marker_replication {
-        status = "Disabled"
       }
 
       destination {
@@ -4731,10 +4721,6 @@ resource "aws_s3_bucket" "bucket" {
         }
       }
 
-      delete_marker_replication {
-        status = "Disabled"
-      }
-
       destination {
         bucket        = aws_s3_bucket.destination.arn
         storage_class = "STANDARD"
@@ -4768,10 +4754,6 @@ resource "aws_s3_bucket" "bucket" {
           Foo         = "Bar"
           ReplicateMe = "Yes"
         }
-      }
-
-      delete_marker_replication {
-        status = "Disabled"
       }
 
       destination {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -429,14 +429,14 @@ The `replication_configuration` object supports the following:
 
 The `rules` object supports the following:
 
-* `id` - (Optional) Unique identifier for the rule. Must be less than or equal to 255 characters in length.
-* `priority` - (Optional) The priority associated with the rule.
+* `delete_marker_replication_status` - (Optional) Whether delete markers are replicated. The only valid value is `Enabled`. To disable, omit this argument. This argument is only valid with V2 replication configurations (i.e., when `filter` is used).
 * `destination` - (Required) Specifies the destination for the rule (documented below).
-* `source_selection_criteria` - (Optional) Specifies special object selection criteria (documented below).
-* `prefix` - (Optional) Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
-* `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
 * `filter` - (Optional) Filter that identifies subset of objects to which the replication rule applies (documented below).
-* `delete_marker_replication` - (Optional) Specifies whether delete markers are replicated (documented below).
+* `id` - (Optional) Unique identifier for the rule. Must be less than or equal to 255 characters in length.
+* `prefix` - (Optional) Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
+* `priority` - (Optional) The priority associated with the rule.
+* `source_selection_criteria` - (Optional) Specifies special object selection criteria (documented below).
+* `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
 
 ~> **NOTE on `prefix` and `filter`:** Amazon S3's latest version of the replication configuration is V2, which includes the `filter` attribute for replication rules.
 With the `filter` attribute, you can specify object filters based on the object key prefix, tags, or both to scope the objects that the rule applies to.
@@ -445,10 +445,6 @@ Replication configuration V1 supports filtering based on only the `prefix` attri
 * For a specific rule, `prefix` conflicts with `filter`
 * If any rule has `filter` specified then they all must
 * `priority` is optional (with a default value of `0`) but must be unique between multiple rules
-* If a rule has `filter` then it **must** have a `delete_marker_replication` object
-* If a rule has `prefix` then it **must not** have a `delete_marker_replication` object
-
-~> **NOTE:** Delete markers are always replicated when using `prefix` in a rule and is not configurable. The default behavior when using `filter` can be achieved by providing an empty configuration block `delete_marker_replication {}`.
 
 ~> **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
 
@@ -475,10 +471,6 @@ The `filter` object supports the following:
 * `prefix` - (Optional) Object keyname prefix that identifies subset of objects to which the rule applies. Must be less than or equal to 1024 characters in length.
 * `tags` - (Optional)  A map of tags that identifies subset of objects to which the rule applies.
 The rule applies only to objects having all the tags in its tagset.
-
-The `delete_marker_replication` object supports the following:
-
-* `status` - (Optional) The delete marker replication status. Either `Enabled` or `Disabled`. Default `Disabled`. If `tags` is set in the `filter` object, then `status` must be set to `Disabled`.
 
 The `server_side_encryption_configuration` object supports the following:
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -436,6 +436,7 @@ The `rules` object supports the following:
 * `prefix` - (Optional) Object keyname prefix identifying one or more objects to which the rule applies. Must be less than or equal to 1024 characters in length.
 * `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
 * `filter` - (Optional) Filter that identifies subset of objects to which the replication rule applies (documented below).
+* `delete_marker_replication` - (Optional) Specifies whether delete markers are replicated (documented below).
 
 ~> **NOTE on `prefix` and `filter`:** Amazon S3's latest version of the replication configuration is V2, which includes the `filter` attribute for replication rules.
 With the `filter` attribute, you can specify object filters based on the object key prefix, tags, or both to scope the objects that the rule applies to.
@@ -444,6 +445,10 @@ Replication configuration V1 supports filtering based on only the `prefix` attri
 * For a specific rule, `prefix` conflicts with `filter`
 * If any rule has `filter` specified then they all must
 * `priority` is optional (with a default value of `0`) but must be unique between multiple rules
+* If a rule has `filter` then it **must** have a `delete_marker_replication` object
+* If a rule has `prefix` then it **must not** have a `delete_marker_replication` object
+
+~> **NOTE:** Delete markers are always replicated when using `prefix` in a rule and is not configurable. The default behavior when using `filter` can be achieved by providing an empty configuration block `delete_marker_replication {}`.
 
 ~> **NOTE:** Replication to multiple destination buckets requires that `priority` is specified in the `rules` object. If the corresponding rule requires no filter, an empty configuration block `filter {}` must be specified.
 
@@ -470,6 +475,10 @@ The `filter` object supports the following:
 * `prefix` - (Optional) Object keyname prefix that identifies subset of objects to which the rule applies. Must be less than or equal to 1024 characters in length.
 * `tags` - (Optional)  A map of tags that identifies subset of objects to which the rule applies.
 The rule applies only to objects having all the tags in its tagset.
+
+The `delete_marker_replication` object supports the following:
+
+* `status` - (Optional) The delete marker replication status. Either `Enabled` or `Disabled`. Default `Disabled`. If `tags` is set in the `filter` object, then `status` must be set to `Disabled`.
 
 The `server_side_encryption_configuration` object supports the following:
 


### PR DESCRIPTION
Noted by issue 16250

This adds in the option to Enable or Disable delete marker replication when working with v2 s3 replication config.

This change makes the `delete_marker_replication` block required when using v2 replication configuration. I could not find a better approach without requiring the object.

Note that the v1 replication config does not support the ability to toggle delete marker replication, it is always on by default.

Example usage:
```
replication_configuration {
  role = aws_iam_role.role.arn

  rules {
    id     = "foobar"
    status = "Enabled"

    filter {
      prefix = "foo"
    }

    delete_marker_replication_status = "Enabled"

    destination {
      bucket        = aws_s3_bucket.destination.arn
      storage_class = "STANDARD"
    }
  }
}
```
**Updated (July 12, 2021): Config above has changed to reflect new argument implementation.**

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/hashicorp/terraform-provider-aws/issues/16250

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_ReplicationSchemaV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_ReplicationSchemaV2 -timeout 180m
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_ReplicationSchemaV2
=== CONT  TestAccAWSS3Bucket_ReplicationSchemaV2
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (272.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	273.949s
```
