### PR TITLE
sweepers/timestreamwrite_database: fix sweeper error handling; add _disappears test

### DIFF
--- a/aws/resource_aws_timestreamwrite_database_test.go
+++ b/aws/resource_aws_timestreamwrite_database_test.go
@@ -48,6 +48,7 @@ func testSweepTimestreamWriteDatabases(region string) error {
 
 			dbName := aws.StringValue(database.DatabaseName)
 
+			log.Printf("[INFO] Deleting Timestream Database (%s)", dbName)
 			r := resourceAwsTimestreamWriteDatabase()
 			d := r.Data(nil)
 			d.SetId(dbName)

--- a/aws/resource_aws_timestreamwrite_database_test.go
+++ b/aws/resource_aws_timestreamwrite_database_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -28,12 +30,13 @@ func testSweepTimestreamWriteDatabases(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*AWSClient).timestreamwriteconn
+	ctx := context.Background()
 
 	var sweeperErrs *multierror.Error
 
 	input := &timestreamwrite.ListDatabasesInput{}
 
-	err = conn.ListDatabasesPages(input, func(page *timestreamwrite.ListDatabasesOutput, lastPage bool) bool {
+	err = conn.ListDatabasesPagesWithContext(ctx, input, func(page *timestreamwrite.ListDatabasesOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
@@ -49,13 +52,16 @@ func testSweepTimestreamWriteDatabases(region string) error {
 			d := r.Data(nil)
 			d.SetId(dbName)
 
-			err := r.Delete(d, client)
+			diags := r.DeleteWithoutTimeout(ctx, d, client)
 
-			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting Timestream Database (%s): %w", dbName, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
+			if diags != nil && diags.HasError() {
+				for _, d := range diags {
+					if d.Severity == diag.Error {
+						sweeperErr := fmt.Errorf("error deleting Timestream Database (%s): %s", dbName, d.Summary)
+						log.Printf("[ERROR] %s", sweeperErr)
+						sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+					}
+				}
 			}
 		}
 
@@ -98,6 +104,28 @@ func TestAccAWSTimestreamWriteDatabase_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSTimestreamWriteDatabase_disappears(t *testing.T) {
+	resourceName := "aws_timestreamwrite_database.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTimestreamWrite(t) },
+		ErrorCheck:   testAccErrorCheck(t, timestreamwrite.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTimestreamWriteDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTimestreamWriteDatabaseConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTimestreamWriteDatabaseExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsTimestreamWriteDatabase(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Description:

* previously, the sweeper did not account for `DeleteWithoutTimeout` usage implemented in resource

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSTimestreamWriteDatabase_disappears (15.24s)
```
