### PR TITLE
r/glue_catalog_database - add `target_database` argument

### DIFF
--- a/.changelog/19371.txt
+++ b/.changelog/19371.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_catalog_database: Add `target_database` argument
+```

--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -60,6 +60,7 @@ func resourceAwsGlueCatalogDatabase() *schema.Resource {
 			"target_database": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -147,13 +148,9 @@ func resourceAwsGlueCatalogDatabaseUpdate(d *schema.ResourceData, meta interface
 		dbInput.Parameters = expandStringMap(v.(map[string]interface{}))
 	}
 
-	if v, ok := d.GetOk("target_database"); ok {
-		dbInput.TargetDatabase = expandGlueDatabaseTargetDatabase(v.([]interface{}))
-	}
-
 	dbUpdateInput.DatabaseInput = dbInput
 
-	if d.HasChanges("description", "location_uri", "parameters", "target_database") {
+	if d.HasChanges("description", "location_uri", "parameters") {
 		if _, err := conn.UpdateDatabase(dbUpdateInput); err != nil {
 			return err
 		}

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -78,8 +78,10 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 					testAccCheckGlueCatalogDatabaseExists(resourceName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("database/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", ""), resource.TestCheckResourceAttr(resourceName, "location_uri", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "location_uri", ""),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "target_database.#", "0"),
 				),
 			},
 			{
@@ -111,6 +113,44 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 				),
 			},
 		},
+	})
+}
+
+func TestAccAWSGlueCatalogDatabase_targetDatabase(t *testing.T) {
+	resourceName := "aws_glue_catalog_database.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, glue.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogDatabaseConfigTargetDatabase(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test2", "catalog_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:  testAccGlueCatalogDatabaseConfigTargetDatabaseUpdated(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test3", "catalog_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test3", "name"),
+				),
+			}},
 	})
 }
 
@@ -190,6 +230,43 @@ resource "aws_glue_catalog_database" "test" {
 `, rName, desc)
 }
 
+func testAccGlueCatalogDatabaseConfigTargetDatabase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  target_database {
+    catalog_id    = aws_glue_catalog_database.test2.catalog_id
+    database_name = aws_glue_catalog_database.test2.name
+  }
+}
+
+resource "aws_glue_catalog_database" "test2" {
+  name = "%[1]s-2"
+}
+`, rName)
+}
+
+func testAccGlueCatalogDatabaseConfigTargetDatabaseUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  target_database {
+    catalog_id    = aws_glue_catalog_database.test3.catalog_id
+    database_name = aws_glue_catalog_database.test3.name
+  }
+}
+
+resource "aws_glue_catalog_database" "test2" {
+  name = "%[1]s-2"
+}
+
+resource "aws_glue_catalog_database" "test3" {
+  name = "%[1]s-3"
+}
+`, rName)
+}
 func testAccCheckGlueCatalogDatabaseExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -141,16 +141,7 @@ func TestAccAWSGlueCatalogDatabase_targetDatabase(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config:  testAccGlueCatalogDatabaseConfigTargetDatabaseUpdated(rName),
-				Destroy: false,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogDatabaseExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test3", "catalog_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test3", "name"),
-				),
-			}},
+		},
 	})
 }
 
@@ -247,26 +238,6 @@ resource "aws_glue_catalog_database" "test2" {
 `, rName)
 }
 
-func testAccGlueCatalogDatabaseConfigTargetDatabaseUpdated(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_glue_catalog_database" "test" {
-  name = %[1]q
-
-  target_database {
-    catalog_id    = aws_glue_catalog_database.test3.catalog_id
-    database_name = aws_glue_catalog_database.test3.name
-  }
-}
-
-resource "aws_glue_catalog_database" "test2" {
-  name = "%[1]s-2"
-}
-
-resource "aws_glue_catalog_database" "test3" {
-  name = "%[1]s-3"
-}
-`, rName)
-}
 func testAccCheckGlueCatalogDatabaseExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]

--- a/website/docs/r/glue_catalog_database.html.markdown
+++ b/website/docs/r/glue_catalog_database.html.markdown
@@ -22,24 +22,24 @@ resource "aws_glue_catalog_database" "aws_glue_catalog_database" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the database. The acceptable characters are lowercase letters, numbers, and the underscore character.
 * `catalog_id` - (Optional) ID of the Glue Catalog to create the database in. If omitted, this defaults to the AWS Account ID.
 * `description` - (Optional) Description of the database.
-* `location_uri` - (Optional) The location of the database (for example, an HDFS path).
-* `parameters` - (Optional) A list of key-value pairs that define parameters and properties of the database.
-* `target_database` - (Optional) describes a target database for resource linking. see [Target Database](#target-database) below.
+* `location_uri` - (Optional) Location of the database (for example, an HDFS path).
+* `name` - (Required) Name of the database. The acceptable characters are lowercase letters, numbers, and the underscore character.
+* `parameters` - (Optional) List of key-value pairs that define parameters and properties of the database.
+* `target_database` - (Optional) Configuration block for a target database for resource linking. See [`target_database`](#target_database) below.
 
-### Target Database
+### target_database
 
-* `catalog_id` - (Required) The ID of the Data Catalog in which the database resides.
-* `database_name` - (Required) The name of the catalog database.
+* `catalog_id` - (Required) ID of the Data Catalog in which the database resides.
+* `database_name` - (Required) Name of the catalog database.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - ARN of the Glue Catalog Database.
 * `id` - Catalog ID and name of the database
-* `arn` - The ARN of the Glue Catalog Database.
 
 ## Import
 

--- a/website/docs/r/glue_catalog_database.html.markdown
+++ b/website/docs/r/glue_catalog_database.html.markdown
@@ -27,6 +27,12 @@ The following arguments are supported:
 * `description` - (Optional) Description of the database.
 * `location_uri` - (Optional) The location of the database (for example, an HDFS path).
 * `parameters` - (Optional) A list of key-value pairs that define parameters and properties of the database.
+* `target_database` - (Optional) describes a target database for resource linking. see [Target Database](#target-database) below.
+
+### Target Database
+
+* `catalog_id` - (Required) The ID of the Data Catalog in which the database resides.
+* `database_name` - (Required) The name of the catalog database.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15296

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogDatabase_'
--- PASS: TestAccAWSGlueCatalogDatabase_disappears (25.77s)
--- PASS: TestAccAWSGlueCatalogDatabase_targetDatabase (41.92s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (86.02s)
```
