### PR TITLE
ConnectionProperties should be optional to create glue connection

### DIFF
--- a/.changelog/19375.txt
+++ b/.changelog/19375.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_connection: `connection_properties` are optional
+```

--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -35,7 +35,7 @@ func resourceAwsGlueConnection() *schema.Resource {
 			},
 			"connection_properties": {
 				Type:         schema.TypeMap,
-				Required:     true,
+				Optional:     true,
 				Sensitive:    true,
 				ValidateFunc: MapKeyInSlice(glue.ConnectionPropertyKey_Values(), false),
 				Elem:         &schema.Schema{Type: schema.TypeString},
@@ -243,8 +243,10 @@ func deleteGlueConnection(conn *glue.Glue, catalogID, connectionName string) err
 
 func expandGlueConnectionInput(d *schema.ResourceData) *glue.ConnectionInput {
 	connectionProperties := make(map[string]string)
-	for k, v := range d.Get("connection_properties").(map[string]interface{}) {
-		connectionProperties[k] = v.(string)
+	if val, ok := d.GetOkExists("connection_properties"); ok {
+		for k, v := range val.(map[string]interface{}) {
+			connectionProperties[k] = v.(string)
+		}
 	}
 
 	connectionInput := &glue.ConnectionInput{

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -157,6 +157,40 @@ func TestAccAWSGlueConnection_Kafka(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueConnection_Network(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, glue.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_Network(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "NETWORK"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "physical_connection_requirements.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "physical_connection_requirements.0.availability_zone"),
+					resource.TestCheckResourceAttr(resourceName, "physical_connection_requirements.0.security_group_id_list.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "physical_connection_requirements.0.subnet_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueConnection_Description(t *testing.T) {
 	var connection glue.Connection
 
@@ -561,6 +595,60 @@ resource "aws_glue_connection" "test" {
   connection_type = "KAFKA"
 
   name = "%s"
+}
+`, rName)
+}
+
+func testAccAWSGlueConnectionConfig_Network(rName string) string {
+    return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-glue-connection-network"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "terraform-testacc-glue-connection-network"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = "%[1]s"
+  vpc_id = aws_vpc.test.id
+
+  ingress {
+    protocol  = "tcp"
+    self      = true
+    from_port = 1
+    to_port   = 65535
+  }
+}
+
+resource "aws_glue_connection" "test" {
+  connection_type = "NETWORK"
+  name            = "%[1]s"
+
+  physical_connection_requirements {
+    availability_zone      = aws_subnet.test.availability_zone
+    security_group_id_list = [aws_security_group.test.id]
+    subnet_id              = aws_subnet.test.id
+  }
 }
 `, rName)
 }

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -600,7 +600,7 @@ resource "aws_glue_connection" "test" {
 }
 
 func testAccAWSGlueConnectionConfig_Network(rName string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -53,7 +53,7 @@ resource "aws_glue_connection" "example" {
 The following arguments are supported:
 
 * `catalog_id` – (Optional) The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.
-* `connection_properties` – (Required) A map of key-value pairs used as parameters for this connection.
+* `connection_properties` – (Optional) A map of key-value pairs used as parameters for this connection.
 * `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`, and `NETWORK`. Defaults to `JBDC`.
 * `description` – (Optional) Description of the connection.
 * `match_criteria` – (Optional) A list of criteria that can be used in selecting this connection.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #19374

Release note for CHANGELOG:
```release-notes:note
resource/aws_glue_connection: ConnectionProperties to be opional (especially for network type of glue connection)
```

Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueConnection_Network'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGlueConnection_Network -timeout 180m
=== RUN   TestAccAWSGlueConnection_Network
=== PAUSE TestAccAWSGlueConnection_Network
=== CONT  TestAccAWSGlueConnection_Network
--- PASS: TestAccAWSGlueConnection_Network (60.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       60.494s
```