### PR TITLE
r/servicecatalog: New resources (constraint, product_portfolio_association)

### DIFF
--- a/.changelog/19385.txt
+++ b/.changelog/19385.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicecatalog_constraint
+```

--- a/.changelog/19385.txt
+++ b/.changelog/19385.txt
@@ -1,3 +1,7 @@
 ```release-note:new-resource
 aws_servicecatalog_constraint
 ```
+
+```release-note:new-resource
+aws_servicecatalog_product_portfolio_association
+```

--- a/aws/internal/service/servicecatalog/enum.go
+++ b/aws/internal/service/servicecatalog/enum.go
@@ -1,9 +1,17 @@
 package servicecatalog
 
 const (
+	// If AWS adds these to the API, we should use those and remove these.
+
 	ServiceCatalogAcceptLanguageEnglish  = "en"
 	ServiceCatalogAcceptLanguageJapanese = "jp"
 	ServiceCatalogAcceptLanguageChinese  = "zh"
+
+	ConstraintTypeLaunch         = "LAUNCH"
+	ConstraintTypeNotification   = "NOTIFICATION"
+	ConstraintTypeResourceUpdate = "RESOURCE_UPDATE"
+	ConstraintTypeStackset       = "STACKSET"
+	ConstraintTypeTemplate       = "TEMPLATE"
 )
 
 func AcceptLanguage_Values() []string {
@@ -11,5 +19,15 @@ func AcceptLanguage_Values() []string {
 		ServiceCatalogAcceptLanguageEnglish,
 		ServiceCatalogAcceptLanguageJapanese,
 		ServiceCatalogAcceptLanguageChinese,
+	}
+}
+
+func ConstraintType_Values() []string {
+	return []string{
+		ConstraintTypeLaunch,
+		ConstraintTypeNotification,
+		ConstraintTypeResourceUpdate,
+		ConstraintTypeStackset,
+		ConstraintTypeTemplate,
 	}
 }

--- a/aws/internal/service/servicecatalog/finder/finder.go
+++ b/aws/internal/service/servicecatalog/finder/finder.go
@@ -35,3 +35,37 @@ func PortfolioShare(conn *servicecatalog.ServiceCatalog, portfolioID, shareType,
 
 	return result, err
 }
+
+func ProductPortfolioAssociation(conn *servicecatalog.ServiceCatalog, acceptLanguage, portfolioID, productID string) (*servicecatalog.PortfolioDetail, error) {
+	// seems odd that the sourcePortfolioID is not returned or searchable...
+	input := &servicecatalog.ListPortfoliosForProductInput{
+		ProductId: aws.String(productID),
+	}
+
+	if acceptLanguage != "" {
+		input.AcceptLanguage = aws.String(acceptLanguage)
+	}
+
+	var result *servicecatalog.PortfolioDetail
+
+	err := conn.ListPortfoliosForProductPages(input, func(page *servicecatalog.ListPortfoliosForProductOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, deet := range page.PortfolioDetails {
+			if deet == nil {
+				continue
+			}
+
+			if aws.StringValue(deet.Id) == portfolioID {
+				result = deet
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}

--- a/aws/internal/service/servicecatalog/id.go
+++ b/aws/internal/service/servicecatalog/id.go
@@ -18,3 +18,17 @@ func PortfolioShareParseResourceID(id string) (string, string, string, error) {
 func PortfolioShareCreateResourceID(portfolioID, shareType, principalID string) string {
 	return strings.Join([]string{portfolioID, shareType, principalID}, ":")
 }
+
+func ProductPortfolioAssociationParseID(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, ":", 3)
+
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%s), expected acceptLanguage:portfolioID:productID", id)
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}
+
+func ProductPortfolioAssociationCreateID(acceptLanguage, portfolioID, productID string) string {
+	return strings.Join([]string{acceptLanguage, portfolioID, productID}, ":")
+}

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -156,7 +156,7 @@ func ConstraintStatus(conn *servicecatalog.ServiceCatalog, acceptLanguage, id st
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("constraint not found (accept language %s, ID: %s): %w", acceptLanguage, id, err),
+				Message: fmt.Sprintf("constraint not found (accept language %s, ID: %s): %s", acceptLanguage, id, err),
 			}
 		}
 
@@ -180,7 +180,7 @@ func ProductPortfolioAssociationStatus(conn *servicecatalog.ServiceCatalog, acce
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("product portfolio association not found (%s): %w", tfservicecatalog.ProductPortfolioAssociationCreateID(acceptLanguage, portfolioID, productID), err),
+				Message: fmt.Sprintf("product portfolio association not found (%s): %s", tfservicecatalog.ProductPortfolioAssociationCreateID(acceptLanguage, portfolioID, productID), err),
 			}
 		}
 

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -155,7 +155,7 @@ func ConstraintStatus(conn *servicecatalog.ServiceCatalog, acceptLanguage, id st
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("constraint not found (accept language %s, ID: %s): %w", acceptLanguage, id, err),
+				Message: fmt.Sprintf("constraint not found (accept language %s, ID: %s): %s", acceptLanguage, id, err),
 			}
 		}
 
@@ -179,7 +179,7 @@ func ProductPortfolioAssociationStatus(conn *servicecatalog.ServiceCatalog, acce
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("product portfolio association not found (%s:%s:%s): %w", acceptLanguage, portfolioID, productID, err),
+				Message: fmt.Sprintf("product portfolio association not found (%s:%s:%s): %s", acceptLanguage, portfolioID, productID, err),
 			}
 		}
 

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/finder"
 )
 
@@ -155,7 +156,7 @@ func ConstraintStatus(conn *servicecatalog.ServiceCatalog, acceptLanguage, id st
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("constraint not found (accept language %s, ID: %s): %s", acceptLanguage, id, err),
+				Message: fmt.Sprintf("constraint not found (accept language %s, ID: %s): %w", acceptLanguage, id, err),
 			}
 		}
 
@@ -179,7 +180,7 @@ func ProductPortfolioAssociationStatus(conn *servicecatalog.ServiceCatalog, acce
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("product portfolio association not found (%s:%s:%s): %s", acceptLanguage, portfolioID, productID, err),
+				Message: fmt.Sprintf("product portfolio association not found (%s): %w", tfservicecatalog.ProductPortfolioAssociationCreateID(acceptLanguage, portfolioID, productID), err),
 			}
 		}
 
@@ -189,7 +190,7 @@ func ProductPortfolioAssociationStatus(conn *servicecatalog.ServiceCatalog, acce
 
 		if output == nil {
 			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("finding product portfolio association (%s:%s:%s): empty response", acceptLanguage, portfolioID, productID),
+				Message: fmt.Sprintf("finding product portfolio association (%s): empty response", tfservicecatalog.ProductPortfolioAssociationCreateID(acceptLanguage, portfolioID, productID)),
 			}
 		}
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1005,6 +1005,7 @@ func Provider() *schema.Provider {
 			"aws_securityhub_organization_admin_account":              resourceAwsSecurityHubOrganizationAdminAccount(),
 			"aws_securityhub_product_subscription":                    resourceAwsSecurityHubProductSubscription(),
 			"aws_securityhub_standards_subscription":                  resourceAwsSecurityHubStandardsSubscription(),
+			"aws_servicecatalog_constraint":                           resourceAwsServiceCatalogConstraint(),
 			"aws_servicecatalog_organizations_access":                 resourceAwsServiceCatalogOrganizationsAccess(),
 			"aws_servicecatalog_portfolio":                            resourceAwsServiceCatalogPortfolio(),
 			"aws_servicecatalog_portfolio_share":                      resourceAwsServiceCatalogPortfolioShare(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1011,6 +1011,7 @@ func Provider() *schema.Provider {
 			"aws_servicecatalog_portfolio_share":                      resourceAwsServiceCatalogPortfolioShare(),
 			"aws_servicecatalog_product":                              resourceAwsServiceCatalogProduct(),
 			"aws_servicecatalog_tag_option":                           resourceAwsServiceCatalogTagOption(),
+			"aws_servicecatalog_product_portfolio_association":        resourceAwsServiceCatalogProductPortfolioAssociation(),
 			"aws_service_discovery_http_namespace":                    resourceAwsServiceDiscoveryHttpNamespace(),
 			"aws_service_discovery_private_dns_namespace":             resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":              resourceAwsServiceDiscoveryPublicDnsNamespace(),

--- a/aws/resource_aws_servicecatalog_constraint.go
+++ b/aws/resource_aws_servicecatalog_constraint.go
@@ -117,7 +117,7 @@ func resourceAwsServiceCatalogConstraintCreate(d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating Service Catalog Constraint %v: %w", input, err) // take input out
+		return fmt.Errorf("error creating Service Catalog Constraint: %w", err)
 	}
 
 	if output == nil || output.ConstraintDetail == nil {

--- a/aws/resource_aws_servicecatalog_constraint.go
+++ b/aws/resource_aws_servicecatalog_constraint.go
@@ -101,6 +101,10 @@ func resourceAwsServiceCatalogConstraintCreate(d *schema.ResourceData, meta inte
 			return resource.RetryableError(err)
 		}
 
+		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -113,7 +117,7 @@ func resourceAwsServiceCatalogConstraintCreate(d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating Service Catalog Constraint: %w", err)
+		return fmt.Errorf("error creating Service Catalog Constraint %v: %w", input, err) // take input out
 	}
 
 	if output == nil || output.ConstraintDetail == nil {

--- a/aws/resource_aws_servicecatalog_constraint.go
+++ b/aws/resource_aws_servicecatalog_constraint.go
@@ -1,0 +1,231 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsServiceCatalogConstraint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceCatalogConstraintCreate,
+		Read:   resourceAwsServiceCatalogConstraintRead,
+		Update: resourceAwsServiceCatalogConstraintUpdate,
+		Delete: resourceAwsServiceCatalogConstraintDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parameters": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+			},
+			"portfolio_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.ConstraintType_Values(), false),
+			},
+		},
+	}
+}
+
+func resourceAwsServiceCatalogConstraintCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.CreateConstraintInput{
+		IdempotencyToken: aws.String(resource.UniqueId()),
+		Parameters:       aws.String(d.Get("parameters").(string)),
+		PortfolioId:      aws.String(d.Get("portfolio_id").(string)),
+		ProductId:        aws.String(d.Get("product_id").(string)),
+		Type:             aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	var output *servicecatalog.CreateConstraintOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.CreateConstraint(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateConstraint(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating Service Catalog Constraint: %w", err)
+	}
+
+	if output == nil || output.ConstraintDetail == nil {
+		return fmt.Errorf("error creating Service Catalog Constraint: empty response")
+	}
+
+	d.SetId(aws.StringValue(output.ConstraintDetail.ConstraintId))
+
+	return resourceAwsServiceCatalogConstraintRead(d, meta)
+}
+
+func resourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	output, err := waiter.ConstraintReady(conn, d.Get("accept_language").(string), d.Id())
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Service Catalog Constraint (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Constraint (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Catalog Constraint (%s): empty response", d.Id())
+	}
+
+	d.Set("parameters", output.ConstraintParameters)
+	d.Set("status", output.Status)
+
+	detail := output.ConstraintDetail
+
+	d.Set("description", detail.Description)
+	d.Set("owner", detail.Owner)
+	d.Set("portfolio_id", detail.PortfolioId)
+	d.Set("product_id", detail.ProductId)
+	d.Set("type", detail.Type)
+
+	return nil
+}
+
+func resourceAwsServiceCatalogConstraintUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.UpdateConstraintInput{
+		Id: aws.String(d.Id()),
+	}
+
+	if d.HasChange("accept_language") {
+		input.AcceptLanguage = aws.String(d.Get("accept_language").(string))
+	}
+
+	if d.HasChange("description") {
+		input.Description = aws.String(d.Get("description").(string))
+	}
+
+	if d.HasChange("parameters") {
+		input.Parameters = aws.String(d.Get("parameters").(string))
+	}
+
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		_, err := conn.UpdateConstraint(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.UpdateConstraint(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error updating Service Catalog Constraint (%s): %w", d.Id(), err)
+	}
+
+	return resourceAwsServiceCatalogConstraintRead(d, meta)
+}
+
+func resourceAwsServiceCatalogConstraintDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.DeleteConstraintInput{
+		Id: aws.String(d.Id()),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteConstraint(input)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Service Catalog Constraint (%s): %w", d.Id(), err)
+	}
+
+	if err := waiter.ConstraintDeleted(conn, d.Get("accept_language").(string), d.Id()); err != nil {
+		return fmt.Errorf("error waiting for Service Catalog Constraint (%s) to be deleted: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_servicecatalog_constraint_test.go
+++ b/aws/resource_aws_servicecatalog_constraint_test.go
@@ -1,0 +1,305 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// add sweeper to delete known test servicecat constraints
+func init() {
+	resource.AddTestSweepers("aws_servicecatalog_constraint", &resource.Sweeper{
+		Name:         "aws_servicecatalog_constraint",
+		Dependencies: []string{},
+		F:            testSweepServiceCatalogConstraints,
+	})
+}
+
+func testSweepServiceCatalogConstraints(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).scconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	// no paginator or list operation for constraints directly, have to list portfolios and constraints of portfolios
+
+	input := &servicecatalog.ListPortfoliosInput{}
+
+	err = conn.ListPortfoliosPages(input, func(page *servicecatalog.ListPortfoliosOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, detail := range page.PortfolioDetails {
+			if detail == nil {
+				continue
+			}
+
+			constraintInput := &servicecatalog.ListConstraintsForPortfolioInput{
+				PortfolioId: detail.Id,
+			}
+
+			err = conn.ListConstraintsForPortfolioPages(constraintInput, func(page *servicecatalog.ListConstraintsForPortfolioOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, detail := range page.ConstraintDetails {
+					if detail == nil {
+						continue
+					}
+
+					r := resourceAwsServiceCatalogConstraint()
+					d := r.Data(nil)
+					d.SetId(aws.StringValue(detail.ConstraintId))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Constraints for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Service Catalog Constraints for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Service Catalog Constraints sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func TestAccAWSServiceCatalogConstraint_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_constraint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogConstraintDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogConstraintConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogConstraintExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "description", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "NOTIFICATION"),
+					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", "aws_servicecatalog_portfolio.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
+					resource.TestCheckResourceAttrSet(resourceName, "parameters"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogConstraint_disappears(t *testing.T) {
+	resourceName := "aws_servicecatalog_constraint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogConstraintDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogConstraintConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogConstraintExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogConstraint(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogConstraint_update(t *testing.T) {
+	resourceName := "aws_servicecatalog_constraint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	//rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogConstraintDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogConstraintConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
+					resource.TestCheckResourceAttr(resourceName, "value", "värde ett"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogConstraintDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).scconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_servicecatalog_constraint" {
+			continue
+		}
+
+		input := &servicecatalog.DescribeConstraintInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeConstraint(input)
+
+		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Service Catalog Constraint (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("Service Catalog Constraint (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsServiceCatalogConstraintExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).scconn
+
+		input := &servicecatalog.DescribeConstraintInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeConstraint(input)
+
+		if err != nil {
+			return fmt.Errorf("error describing Service Catalog Constraint (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSServiceCatalogConstraintConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_object" "test" {
+  bucket = aws_s3_bucket.test.id
+  key    = "%[1]s.json"
+
+  content = <<EOF
+{
+  "Resources" : {
+    "MyVPC": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : "10.0.0.0/16",
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  },
+  "Outputs" : {
+    "DefaultSgId" : {
+      "Description": "The ID of default security group",
+      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
+    },
+    "VpcID" : {
+      "Description": "The VPC ID",
+      "Value" : { "Ref" : "MyVPC" }
+    }
+  }
+}
+EOF
+}
+
+resource "aws_servicecatalog_product" "test" {
+  name                = %[1]q
+  owner               = "ägare"
+  type                = "CLOUD_FORMATION_TEMPLATE"
+
+  provisioning_artifact_parameters {
+    disable_template_validation = true
+    name                        = %[1]q
+    template_url                = "s3://${aws_s3_bucket.test.id}/${aws_s3_bucket_object.test.key}"
+    type                        = "CLOUD_FORMATION_TEMPLATE"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_servicecatalog_portfolio" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccAWSServiceCatalogConstraintConfig_basic(rName string) string {
+	return composeConfig(testAccAWSServiceCatalogConstraintConfig_base(rName), fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_servicecatalog_constraint" "test" {
+  description  = %[1]q
+  portfolio_id = aws_servicecatalog_portfolio.test.id
+  product_id   = aws_servicecatalog_product.test.id
+  type         = "NOTIFICATION"
+
+  parameters = jsonencode({"NotificationArns" : ["${aws_sns_topic.test.arn}"]})
+}
+`, rName))
+}

--- a/aws/resource_aws_servicecatalog_constraint_test.go
+++ b/aws/resource_aws_servicecatalog_constraint_test.go
@@ -308,7 +308,7 @@ resource "aws_servicecatalog_constraint" "test" {
   product_id   = aws_servicecatalog_product_portfolio_association.test.product_id
   type         = "NOTIFICATION"
 
-  parameters = jsonencode({"NotificationArns" : ["${aws_sns_topic.test.arn}"]})
+  parameters = jsonencode({ "NotificationArns" : ["${aws_sns_topic.test.arn}"] })
 
   depends_on = [aws_sns_topic.test]
 }

--- a/aws/resource_aws_servicecatalog_constraint_test.go
+++ b/aws/resource_aws_servicecatalog_constraint_test.go
@@ -268,9 +268,9 @@ EOF
 }
 
 resource "aws_servicecatalog_product" "test" {
-  name                = %[1]q
-  owner               = "ägare"
-  type                = "CLOUD_FORMATION_TEMPLATE"
+  name  = %[1]q
+  owner = "ägare"
+  type  = "CLOUD_FORMATION_TEMPLATE"
 
   provisioning_artifact_parameters {
     disable_template_validation = true

--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -53,7 +53,7 @@ func resourceAwsServiceCatalogPortfolio() *schema.Resource {
 			},
 			"provider_name": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 50),
 			},
 			"tags":     tagsSchema(),

--- a/aws/resource_aws_servicecatalog_product_portfolio_association.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association.go
@@ -1,0 +1,173 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsServiceCatalogProductPortfolioAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceCatalogProductPortfolioAssociationCreate,
+		Read:   resourceAwsServiceCatalogProductPortfolioAssociationRead,
+		Delete: resourceAwsServiceCatalogProductPortfolioAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"portfolio_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"source_portfolio_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsServiceCatalogProductPortfolioAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.AssociateProductWithPortfolioInput{
+		PortfolioId: aws.String(d.Get("portfolio_id").(string)),
+		ProductId:   aws.String(d.Get("product_id").(string)),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("source_portfolio_id"); ok {
+		input.SourcePortfolioId = aws.String(v.(string))
+	}
+
+	var output *servicecatalog.AssociateProductWithPortfolioOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.AssociateProductWithPortfolio(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.AssociateProductWithPortfolio(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error associating Service Catalog Product with Portfolio: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error creating Service Catalog Product Portfolio Association: empty response")
+	}
+
+	d.SetId(tfservicecatalog.ProductPortfolioAssociationCreateID(d.Get("accept_language").(string), d.Get("portfolio_id").(string), d.Get("product_id").(string)))
+
+	return resourceAwsServiceCatalogProductPortfolioAssociationRead(d, meta)
+}
+
+func resourceAwsServiceCatalogProductPortfolioAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	acceptLanguage, portfolioID, productID, err := tfservicecatalog.ProductPortfolioAssociationParseID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("could not parse ID (%s): %w", d.Id(), err)
+	}
+
+	output, err := waiter.ProductPortfolioAssociationReady(conn, acceptLanguage, portfolioID, productID)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Service Catalog Product Portfolio Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Product Portfolio Association (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Catalog Product Portfolio Association (%s): empty response", d.Id())
+	}
+
+	d.Set("accept_language", acceptLanguage)
+	d.Set("portfolio_id", output.Id)
+	d.Set("product_id", productID)
+	d.Set("source_portfolio_id", d.Get("source_portfolio_id").(string))
+
+	return nil
+}
+
+func resourceAwsServiceCatalogProductPortfolioAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	acceptLanguage, portfolioID, productID, err := tfservicecatalog.ProductPortfolioAssociationParseID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("could not parse ID (%s): %w", d.Id(), err)
+	}
+
+	input := &servicecatalog.DisassociateProductFromPortfolioInput{
+		PortfolioId: aws.String(portfolioID),
+		ProductId:   aws.String(productID),
+	}
+
+	if acceptLanguage != "" {
+		input.AcceptLanguage = aws.String(acceptLanguage)
+	}
+
+	_, err = conn.DisassociateProductFromPortfolio(input)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error disassociating Service Catalog Product from Portfolio (%s): %w", d.Id(), err)
+	}
+
+	err = waiter.ProductPortfolioAssociationDeleted(conn, acceptLanguage, portfolioID, productID)
+
+	if err != nil && !tfresource.NotFound(err) {
+		return fmt.Errorf("error waiting for Service Catalog Product Portfolio Disassociation (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
@@ -1,0 +1,288 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+// add sweeper to delete known test servicecat product portfolio associations
+func init() {
+	resource.AddTestSweepers("aws_servicecatalog_product_portfolio_association", &resource.Sweeper{
+		Name:         "aws_servicecatalog_product_portfolio_association",
+		Dependencies: []string{},
+		F:            testSweepServiceCatalogProductPortfolioAssociations,
+	})
+}
+
+func testSweepServiceCatalogProductPortfolioAssociations(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).scconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	// no paginator or list operation for associations directly, have to list products and associations of products
+
+	input := &servicecatalog.SearchProductsAsAdminInput{}
+
+	err = conn.SearchProductsAsAdminPages(input, func(page *servicecatalog.SearchProductsAsAdminOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, detail := range page.ProductViewDetails {
+			if detail == nil {
+				continue
+			}
+
+			productARN, err := arn.Parse(aws.StringValue(detail.ProductARN))
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error parsing Product ARN for %s: %w", aws.StringValue(detail.ProductARN), err))
+				continue
+			}
+
+			// arn:aws:catalog:us-west-2:187416307283:product/prod-t5thhvquxw2x2
+
+			resourceParts := strings.SplitN(productARN.Resource, "/", 2)
+
+			if len(resourceParts) != 2 {
+				errs = multierror.Append(errs, fmt.Errorf("error parsing Product ARN resource for %s: %w", aws.StringValue(detail.ProductARN), err))
+				continue
+			}
+
+			productID := resourceParts[1]
+
+			assocInput := &servicecatalog.ListPortfoliosForProductInput{
+				ProductId: aws.String(productID),
+			}
+
+			err = conn.ListPortfoliosForProductPages(assocInput, func(page *servicecatalog.ListPortfoliosForProductOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, detail := range page.PortfolioDetails {
+					if detail == nil {
+						continue
+					}
+
+					r := resourceAwsServiceCatalogProductPortfolioAssociation()
+					d := r.Data(nil)
+					d.SetId(tfservicecatalog.ProductPortfolioAssociationCreateID("en", aws.StringValue(detail.Id), productID))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Product Portfolio Associations for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Service Catalog Product Portfolio Associations for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Service Catalog Product Portfolio Associations sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func TestAccAWSServiceCatalogProductPortfolioAssociation_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_product_portfolio_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogProductPortfolioAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProductPortfolioAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", "aws_servicecatalog_portfolio.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogProductPortfolioAssociation_disappears(t *testing.T) {
+	resourceName := "aws_servicecatalog_product_portfolio_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogProductPortfolioAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogProductPortfolioAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogProductPortfolioAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogProductPortfolioAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).scconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_servicecatalog_product_portfolio_association" {
+			continue
+		}
+
+		acceptLanguage, portfolioID, productID, err := tfservicecatalog.ProductPortfolioAssociationParseID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("could not parse ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		err = waiter.ProductPortfolioAssociationDeleted(conn, acceptLanguage, portfolioID, productID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("waiting for Service Catalog Product Portfolio Association to be destroyed (%s): %w", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsServiceCatalogProductPortfolioAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		acceptLanguage, portfolioID, productID, err := tfservicecatalog.ProductPortfolioAssociationParseID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("could not parse ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).scconn
+
+		_, err = waiter.ProductPortfolioAssociationReady(conn, acceptLanguage, portfolioID, productID)
+
+		if err != nil {
+			return fmt.Errorf("waiting for Service Catalog Product Portfolio Association existence (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
+
+  template_body = <<STACK
+{
+  "Resources" : {
+    "MyVPC": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : "10.0.0.0/16",
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  },
+  "Outputs" : {
+    "DefaultSgId" : {
+      "Description": "The ID of default security group",
+      "Value" : { "Fn::GetAtt" : [ "MyVPC", "DefaultSecurityGroup" ]}
+    },
+    "VpcID" : {
+      "Description": "The VPC ID",
+      "Value" : { "Ref" : "MyVPC" }
+    }
+  }
+}
+STACK
+}
+
+resource "aws_servicecatalog_product" "test" {
+  description         = "beskrivning"
+  distributor         = "distributör"
+  name                = %[1]q
+  owner               = "ägare"
+  type                = "CLOUD_FORMATION_TEMPLATE"
+  support_description = "supportbeskrivning"
+  support_email       = "support@example.com"
+  support_url         = "http://example.com"
+
+  provisioning_artifact_parameters {
+    description          = "artefaktbeskrivning"
+    name                 = %[1]q
+    template_physical_id = aws_cloudformation_stack.test.id
+    type                 = "CLOUD_FORMATION_TEMPLATE"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_servicecatalog_portfolio" "test" {
+  name          = %[1]q
+  provider_name = %[1]q
+}
+`, rName)
+}
+
+func testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName string) string {
+	return composeConfig(testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName), `
+resource "aws_servicecatalog_product_portfolio_association" "test" {
+  portfolio_id = aws_servicecatalog_portfolio.test.id
+  product_id   = aws_servicecatalog_product.test.id
+}
+`)
+}

--- a/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
@@ -93,6 +93,11 @@ func testSweepServiceCatalogProductPortfolioAssociations(region string) error {
 
 				return !lastPage
 			})
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error listing Service Catalog Portfolios for Products %s: %w", region, err))
+				continue
+			}
 		}
 
 		return !lastPage

--- a/website/docs/r/servicecatalog_constraint.html.markdown
+++ b/website/docs/r/servicecatalog_constraint.html.markdown
@@ -90,5 +90,5 @@ In addition to all arguments above, the following attributes are exported:
 `aws_servicecatalog_constraint` can be imported using the constraint ID, e.g.
 
 ```
-$ terraform import aws_servicecatalog_constraint.example constraint-id
+$ terraform import aws_servicecatalog_constraint.example cons-nmdkb6cgxfcrs
 ```

--- a/website/docs/r/servicecatalog_constraint.html.markdown
+++ b/website/docs/r/servicecatalog_constraint.html.markdown
@@ -47,36 +47,32 @@ The following arguments are optional:
 
 The `type` you specify determines what must be included in the `parameters` JSON:
 
-* `LAUNCH`: You are required to specify either the RoleArn or the LocalRoleName but can't use both. If you specify the `LocalRoleName` property, when an account uses the launch constraint, the IAM role with that name in the account will be used. This allows launch-role constraints to be account-agnostic so the administrator can create fewer resources per shared account. The given role name must exist in the account used to create the launch constraint and the account of the user who launches a product with this launch constraint. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `LAUNCH` constraint on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`.
-
-    * Specify the `RoleArn` property as follows:
+* `LAUNCH`: You are required to specify either the RoleArn or the LocalRoleName but can't use both. If you specify the `LocalRoleName` property, when an account uses the launch constraint, the IAM role with that name in the account will be used. This allows launch-role constraints to be account-agnostic so the administrator can create fewer resources per shared account. The given role name must exist in the account used to create the launch constraint and the account of the user who launches a product with this launch constraint. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `LAUNCH` constraint on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Specify the `RoleArn` and `LocalRoleName` properties as follows:
 
 ```json
-{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"}
+{ "RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole" }
 ```
 
-    * Specify the `LocalRoleName` property as follows:
-
 ```json
-{"LocalRoleName": "SCBasicLaunchRole"}
+{ "LocalRoleName" : "SCBasicLaunchRole" }
 ```
 
 * `NOTIFICATION`: Specify the `NotificationArns` property as follows:
 
 ```json
-{"NotificationArns" : ["arn:aws:sns:us-east-1:123456789012:Topic"]}
+{ "NotificationArns" : ["arn:aws:sns:us-east-1:123456789012:Topic"] }
 ```
 
 * `RESOURCE_UPDATE`: Specify the `TagUpdatesOnProvisionedProduct` property as follows. The `TagUpdatesOnProvisionedProduct` property accepts a string value of `ALLOWED` or `NOT_ALLOWED`.
 
 ```json
-{"Version":"2.0","Properties":{"TagUpdateOnProvisionedProduct":"String"}}
+{ "Version" : "2.0","Properties" :{ "TagUpdateOnProvisionedProduct" : "String" }}
 ```
 
 * `STACKSET`: Specify the Parameters property as follows. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `STACKSET` constraint on on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Products with a `STACKSET` constraint will launch an AWS CloudFormation stack set.
 
 ```json
-{"Version": "String", "Properties": {"AccountList": [ "String" ], "RegionList": [ "String" ], "AdminRole": "String", "ExecutionRole": "String"}}
+{ "Version" : "String", "Properties" : { "AccountList" : [ "String" ], "RegionList" : [ "String" ], "AdminRole" : "String", "ExecutionRole" : "String" }}
 ```
 
 * `TEMPLATE`: Specify the Rules property. For more information, see [Template Constraint Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).

--- a/website/docs/r/servicecatalog_constraint.html.markdown
+++ b/website/docs/r/servicecatalog_constraint.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Service Catalog Constraint.
 
-~> **NOTE:** This resource does not associate a Service Catalog product and portfolio. However, the product and portfolio must be associated (see the [`aws_servicecatalog_product_portfolio_association`]((/docs/providers/aws/r/servicecatalog_product_portfolio_association.html)) resource) prior to creating a constraint or you will receive an error.
+~> **NOTE:** This resource does not associate a Service Catalog product and portfolio. However, the product and portfolio must be associated (see the `aws_servicecatalog_product_portfolio_association` resource) prior to creating a constraint or you will receive an error.
 
 ## Example Usage
 

--- a/website/docs/r/servicecatalog_constraint.html.markdown
+++ b/website/docs/r/servicecatalog_constraint.html.markdown
@@ -1,0 +1,92 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_constraint"
+description: |-
+  Manages a Service Catalog Constraint
+---
+
+# Resource: aws_servicecatalog_constraint
+
+Manages a Service Catalog Constraint.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_constraint" "example" {
+  description  = "Back off, man. I'm a scientist."
+  portfolio_id = aws_servicecatalog_portfolio.example.id
+  product_id   = aws_servicecatalog_product.example.id
+  type         = "LAUNCH"
+
+  parameters = jsonencode({
+    "RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `parameters` - (Required) Constraint parameters in JSON format. The syntax depends on the constraint type. See details below.
+* `portfolio_id` - (Required) Portfolio identifier.
+* `product_id` - (Required) Product identifier.
+* `type` - (Required) Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `RESOURCE_UPDATE`, `STACKSET`, and `TEMPLATE`.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+* `description` - (Optional) Description of the constraint.
+
+### `parameters`
+
+The `type` you specify determines what must be included in the `parameters` JSON:
+
+* `LAUNCH`: You are required to specify either the RoleArn or the LocalRoleName but can't use both. If you specify the `LocalRoleName` property, when an account uses the launch constraint, the IAM role with that name in the account will be used. This allows launch-role constraints to be account-agnostic so the administrator can create fewer resources per shared account. The given role name must exist in the account used to create the launch constraint and the account of the user who launches a product with this launch constraint. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `LAUNCH` constraint on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`.
+
+    * Specify the `RoleArn` property as follows:
+
+```json
+{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"}
+```
+
+    * Specify the `LocalRoleName` property as follows:
+
+```json
+{"LocalRoleName": "SCBasicLaunchRole"}
+```
+* `NOTIFICATION`: Specify the `NotificationArns` property as follows:
+
+```json
+{"NotificationArns" : ["arn:aws:sns:us-east-1:123456789012:Topic"]}
+```
+* `RESOURCE_UPDATE`: Specify the `TagUpdatesOnProvisionedProduct` property as follows. The `TagUpdatesOnProvisionedProduct` property accepts a string value of `ALLOWED` or `NOT_ALLOWED`.
+
+```json
+{"Version":"2.0","Properties":{"TagUpdateOnProvisionedProduct":"String"}}
+```
+* `STACKSET`: Specify the Parameters property as follows. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `STACKSET` constraint on on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Products with a `STACKSET` constraint will launch an AWS CloudFormation stack set.
+
+```json
+{"Version": "String", "Properties": {"AccountList": [ "String" ], "RegionList":
+[ "String" ], "AdminRole": "String", "ExecutionRole": "String"}}
+```
+* `TEMPLATE`: Specify the Rules property. For more information, see [Template Constraint Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
+  
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Constraint identifier.
+* `owner` - Owner of the constraint.
+
+## Import
+
+`aws_servicecatalog_constraint` can be imported using the constraint ID, e.g.
+
+```
+$ terraform import aws_servicecatalog_constraint.example constraint-id
+```

--- a/website/docs/r/servicecatalog_constraint.html.markdown
+++ b/website/docs/r/servicecatalog_constraint.html.markdown
@@ -60,24 +60,27 @@ The `type` you specify determines what must be included in the `parameters` JSON
 ```json
 {"LocalRoleName": "SCBasicLaunchRole"}
 ```
+
 * `NOTIFICATION`: Specify the `NotificationArns` property as follows:
 
 ```json
 {"NotificationArns" : ["arn:aws:sns:us-east-1:123456789012:Topic"]}
 ```
+
 * `RESOURCE_UPDATE`: Specify the `TagUpdatesOnProvisionedProduct` property as follows. The `TagUpdatesOnProvisionedProduct` property accepts a string value of `ALLOWED` or `NOT_ALLOWED`.
 
 ```json
 {"Version":"2.0","Properties":{"TagUpdateOnProvisionedProduct":"String"}}
 ```
+
 * `STACKSET`: Specify the Parameters property as follows. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `STACKSET` constraint on on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Products with a `STACKSET` constraint will launch an AWS CloudFormation stack set.
 
 ```json
-{"Version": "String", "Properties": {"AccountList": [ "String" ], "RegionList":
-[ "String" ], "AdminRole": "String", "ExecutionRole": "String"}}
+{"Version": "String", "Properties": {"AccountList": [ "String" ], "RegionList": [ "String" ], "AdminRole": "String", "ExecutionRole": "String"}}
 ```
+
 * `TEMPLATE`: Specify the Rules property. For more information, see [Template Constraint Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
-  
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/servicecatalog_constraint.html.markdown
+++ b/website/docs/r/servicecatalog_constraint.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Service Catalog Constraint.
 
+~> **NOTE:** This resource does not associate a Service Catalog product and portfolio. However, the product and portfolio must be associated (see the [`aws_servicecatalog_product_portfolio_association`]((/docs/providers/aws/r/servicecatalog_product_portfolio_association.html)) resource) prior to creating a constraint or you will receive an error.
+
 ## Example Usage
 
 ### Basic Usage

--- a/website/docs/r/servicecatalog_product_portfolio_association.html.markdown
+++ b/website/docs/r/servicecatalog_product_portfolio_association.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_product_portfolio_association"
+description: |-
+  Manages a Service Catalog Product Portfolio Association
+---
+
+# Resource: aws_servicecatalog_product_portfolio_association
+
+Manages a Service Catalog Product Portfolio Association.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_product_portfolio_association" "example" {
+  portfolio_id = "port-68656c6c6f"
+  product_id   = "prod-dnigbtea24ste"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `portfolio_id` - (Required) Portfolio identifier.
+* `product_id` - (Required) Product identifier.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+* `source_portfolio_id` - (Optional) Identifier of the source portfolio.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Identifier of the association.
+
+## Import
+
+`aws_servicecatalog_product_portfolio_association` can be imported using the accept language, portfolio ID, and product ID, e.g.
+
+```
+$ terraform import aws_servicecatalog_product_portfolio_association.example en:port-68656c6c6f:prod-dnigbtea24ste
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19122

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogConstraint_disappears (30.13s)
--- PASS: TestAccAWSServiceCatalogConstraint_basic (32.54s)
--- PASS: TestAccAWSServiceCatalogConstraint_update (51.03s)

--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_disappears (70.62s)
--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_basic (72.07s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogConstraint_disappears (32.37s)
--- PASS: TestAccAWSServiceCatalogConstraint_basic (35.45s)
--- PASS: TestAccAWSServiceCatalogConstraint_update (56.15s)

--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_disappears (73.96s)
--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_basic (76.10s)
```