### PR TITLE
r/aws_lambda_function: Wait for successful completion of function code update

### DIFF
--- a/.changelog/19386.txt
+++ b/.changelog/19386.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Wait for successful completion of function code update
+```

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -1114,7 +1114,7 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if err := waitForLambdaFunctionUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("error waiting for Lambda Function (%s) update: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for Lambda Function (%s) configuration update: %w", d.Id(), err)
 		}
 	}
 
@@ -1154,6 +1154,10 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		_, err := conn.UpdateFunctionCode(codeReq)
 		if err != nil {
 			return fmt.Errorf("error modifying Lambda Function (%s) Code: %w", d.Id(), err)
+		}
+
+		if err := waitForLambdaFunctionUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error waiting for Lambda Function (%s) code update: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -192,8 +192,11 @@ func TestAccAWSLambdaFunction_disappears(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_codeSigningConfig(t *testing.T) {
-	var conf lambda.GetFunctionOutput
+	if testAccGetPartition() == "aws-us-gov" {
+		t.Skip("Lambda code signing config is not supported in GovCloud partition")
+	}
 
+	var conf lambda.GetFunctionOutput
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_csc_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_csc_%s", rString)
@@ -990,18 +993,17 @@ func TestAccAWSLambdaFunction_imageConfig(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
-	var conf lambda.GetFunctionOutput
+	if testAccGetPartition() == "aws-us-gov" {
+		t.Skip("Lambda tracing config is not supported in GovCloud partition")
+	}
 
+	var conf lambda.GetFunctionOutput
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_tracing_cfg_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tracing_cfg_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_tracing_cfg_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_tracing_cfg_%s", rString)
 	resourceName := "aws_lambda_function.test"
-
-	if testAccGetPartition() == "aws-us-gov" {
-		t.Skip("Lambda tracing config is not supported in GovCloud partition")
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

There are scenarios where failing to wait for successful completion of updates to a Lambda function's code results in Terraform diffs suggesting that the resources needs to be recreated:

```
=== RUN   TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== PAUSE TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
    resource_aws_lambda_function_test.go:1499: Step 3/3 error: After applying this test step, the plan was not empty.
        stdout:
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        Terraform will perform the following actions:
          # aws_lambda_function.test must be replaced
        -/+ resource "aws_lambda_function" "test" {
              ~ arn                            = "arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_local_upd_name_8vus407z" -> (known after apply)
                filename                       = "/var/folders/lx/48ng4y950gv10_x6x1jwk05w0000gq/T/lambda_localUpdate_name_change3548296448"
                function_name                  = "tf_acc_lambda_func_local_upd_name_8vus407z"
                handler                        = "exports.example"
              ~ id                             = "tf_acc_lambda_func_local_upd_name_8vus407z" -> (known after apply)
              ~ invoke_arn                     = "arn:aws:apigateway:eu-south-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_local_upd_name_8vus407z/invocations" -> (known after apply)
              ~ last_modified                  = "2021-05-14T17:25:41.000+0000" -> (known after apply)
              - layers                         = [] -> null
                memory_size                    = 128
              + package_type                   = "Zip"
                publish                        = false
              ~ qualified_arn                  = "arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_local_upd_name_8vus407z:$LATEST" -> (known after apply)
                reserved_concurrent_executions = -1
                role                           = "arn:aws:iam::123456789012:role/tf_acc_role_lambda_func_local_upd_name_8vus407z"
                runtime                        = "nodejs12.x"
              + signing_job_arn                = (known after apply)
              + signing_profile_version_arn    = (known after apply)
              ~ source_code_hash               = "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg=" -> (known after apply)
              ~ source_code_size               = 308 -> (known after apply)
              - tags                           = {} -> null
              ~ tags_all                       = {} -> (known after apply)
                timeout                        = 3
              ~ version                        = "$LATEST" -> (known after apply)
              ~ tracing_config {
                  ~ mode = "PassThrough" -> (known after apply)
                }
            }
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccAWSLambdaFunction_localUpdate_nameOnly (44.95s)
=== CONT  TestAccAWSLambdaFunction_UnpublishedCodeUpdate
    resource_aws_lambda_function_test.go:129: Step 2/3 error: After applying this test step, the plan was not empty.
        stdout:
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        Terraform will perform the following actions:
          # aws_lambda_function.test must be replaced
        -/+ resource "aws_lambda_function" "test" {
              ~ arn                            = "arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_versioned_7ptquycl" -> (known after apply)
                filename                       = "/var/folders/lx/48ng4y950gv10_x6x1jwk05w0000gq/T/lambda_localUpdate1717345776"
                function_name                  = "tf_acc_lambda_func_versioned_7ptquycl"
                handler                        = "exports.example"
              ~ id                             = "tf_acc_lambda_func_versioned_7ptquycl" -> (known after apply)
              ~ invoke_arn                     = "arn:aws:apigateway:eu-south-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_versioned_7ptquycl/invocations" -> (known after apply)
              ~ last_modified                  = "2021-05-14T17:25:52.000+0000" -> (known after apply)
              - layers                         = [] -> null
                memory_size                    = 128
              + package_type                   = "Zip"
                publish                        = false
              ~ qualified_arn                  = "arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_versioned_7ptquycl:$LATEST" -> (known after apply)
                reserved_concurrent_executions = -1
                role                           = "arn:aws:iam::123456789012:role/tf_acc_role_lambda_func_versioned_7ptquycl"
                runtime                        = "nodejs12.x"
              + signing_job_arn                = (known after apply)
              + signing_profile_version_arn    = (known after apply)
              ~ source_code_hash               = "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg=" -> (known after apply)
              ~ source_code_size               = 308 -> (known after apply)
              - tags                           = {} -> null
              ~ tags_all                       = {} -> (known after apply)
                timeout                        = 3
              ~ version                        = "$LATEST" -> (known after apply)
              ~ tracing_config {
                  ~ mode = "PassThrough" -> (known after apply)
                }
            }
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (56.76s)
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
    resource_aws_lambda_function_test.go:1623: Step 3/3 error: After applying this test step, the plan was not empty.
        stdout:
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        Terraform will perform the following actions:
          # aws_lambda_function.test must be replaced
        -/+ resource "aws_lambda_function" "test" {
              ~ arn                            = "arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_s3_upd_unver_o9vpa2j0" -> (known after apply)
                function_name                  = "tf_acc_lambda_func_s3_upd_unver_o9vpa2j0"
                handler                        = "exports.example"
              ~ id                             = "tf_acc_lambda_func_s3_upd_unver_o9vpa2j0" -> (known after apply)
              ~ invoke_arn                     = "arn:aws:apigateway:eu-south-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_s3_upd_unver_o9vpa2j0/invocations" -> (known after apply)
              ~ last_modified                  = "2021-05-14T17:26:07.000+0000" -> (known after apply)
              - layers                         = [] -> null
                memory_size                    = 128
              + package_type                   = "Zip"
                publish                        = false
              ~ qualified_arn                  = "arn:aws:lambda:eu-south-1:123456789012:function:tf_acc_lambda_func_s3_upd_unver_o9vpa2j0:$LATEST" -> (known after apply)
                reserved_concurrent_executions = -1
                role                           = "arn:aws:iam::123456789012:role/tf_acc_role_lambda_func_s3_upd_unver_o9vpa2j0"
                runtime                        = "nodejs12.x"
                s3_bucket                      = "tf-acc-bucket-lambda-func-s3-upd-unver-o9vpa2j0"
                s3_key                         = "lambda-func-modified.zip"
              + signing_job_arn                = (known after apply)
              + signing_profile_version_arn    = (known after apply)
              ~ source_code_hash               = "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg=" -> (known after apply)
              ~ source_code_size               = 308 -> (known after apply)
              - tags                           = {} -> null
              ~ tags_all                       = {} -> (known after apply)
                timeout                        = 3
              ~ version                        = "$LATEST" -> (known after apply)
              ~ tracing_config {
                  ~ mode = "PassThrough" -> (known after apply)
                }
            }
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccAWSLambdaFunction_s3Update_unversioned (72.94s)
```

This PR adds a wait for `LastUpdateStatusSuccessful` after function code update.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

##### Commercial

```console
# A region where this behavior has been observed:
% AWS_DEFAULT_REGION=eu-south-1 make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_' ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 3 -run=TestAccAWSLambdaFunction_ -timeout 180m
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== PAUSE TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== RUN   TestAccAWSLambdaFunction_disappears
=== PAUSE TestAccAWSLambdaFunction_disappears
=== RUN   TestAccAWSLambdaFunction_codeSigningConfig
=== PAUSE TestAccAWSLambdaFunction_codeSigningConfig
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== PAUSE TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_enablePublish
=== PAUSE TestAccAWSLambdaFunction_enablePublish
=== RUN   TestAccAWSLambdaFunction_disablePublish
=== PAUSE TestAccAWSLambdaFunction_disablePublish
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_FileSystemConfig
=== PAUSE TestAccAWSLambdaFunction_FileSystemConfig
=== RUN   TestAccAWSLambdaFunction_imageConfig
=== PAUSE TestAccAWSLambdaFunction_imageConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== PAUSE TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== PAUSE TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimes
=== PAUSE TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_basic
=== CONT  TestAccAWSLambdaFunction_tracingConfig
=== CONT  TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (41.31s)
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
--- PASS: TestAccAWSLambdaFunction_basic (54.91s)
=== CONT  TestAccAWSLambdaFunction_runtimes
--- PASS: TestAccAWSLambdaFunction_tracingConfig (77.73s)
=== CONT  TestAccAWSLambdaFunction_tags
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (39.56s)
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_tags (89.37s)
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (90.18s)
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (54.00s)
=== CONT  TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (92.01s)
=== CONT  TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_localUpdate (54.45s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_s3 (47.24s)
=== CONT  TestAccAWSLambdaFunction_imageConfig
    resource_aws_lambda_function_test.go:922: AWS_LAMBDA_IMAGE_LATEST_ID, AWS_LAMBDA_IMAGE_V1_ID and AWS_LAMBDA_IMAGE_V2_ID env vars must be set for Lambda Container Image Support acceptance tests. 
--- SKIP: TestAccAWSLambdaFunction_imageConfig (0.00s)
=== CONT  TestAccAWSLambdaFunction_FileSystemConfig
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (69.96s)
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (23.76s)
=== CONT  TestAccAWSLambdaFunction_disablePublish
--- PASS: TestAccAWSLambdaFunction_disablePublish (66.78s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_runtimes (542.00s)
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (164.23s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (71.74s)
=== CONT  TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (90.54s)
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (554.98s)
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (194.97s)
=== CONT  TestAccAWSLambdaFunction_Environment_Variables_NoValue
--- PASS: TestAccAWSLambdaFunction_Environment_Variables_NoValue (237.06s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_envVariables (134.06s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (22.13s)
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (606.49s)
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (202.38s)
=== CONT  TestAccAWSLambdaFunction_Layers
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (185.95s)
=== CONT  TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
--- PASS: TestAccAWSLambdaFunction_Layers (38.75s)
=== CONT  TestAccAWSLambdaFunction_enablePublish
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (39.45s)
=== CONT  TestAccAWSLambdaFunction_codeSigningConfig
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (667.10s)
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_concurrency (65.25s)
=== CONT  TestAccAWSLambdaFunction_disappears
--- PASS: TestAccAWSLambdaFunction_enablePublish (90.30s)
=== CONT  TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_codeSigningConfig (78.67s)
=== CONT  TestAccAWSLambdaFunction_UnpublishedCodeUpdate
--- PASS: TestAccAWSLambdaFunction_disappears (35.46s)
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (188.82s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (215.11s)
--- PASS: TestAccAWSLambdaFunction_VPC (432.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2031.735s
# Standard acceptance testing region:
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_'                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_ -timeout 180m
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== PAUSE TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== RUN   TestAccAWSLambdaFunction_disappears
=== PAUSE TestAccAWSLambdaFunction_disappears
=== RUN   TestAccAWSLambdaFunction_codeSigningConfig
=== PAUSE TestAccAWSLambdaFunction_codeSigningConfig
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== PAUSE TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_enablePublish
=== PAUSE TestAccAWSLambdaFunction_enablePublish
=== RUN   TestAccAWSLambdaFunction_disablePublish
=== PAUSE TestAccAWSLambdaFunction_disablePublish
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_FileSystemConfig
=== PAUSE TestAccAWSLambdaFunction_FileSystemConfig
=== RUN   TestAccAWSLambdaFunction_imageConfig
=== PAUSE TestAccAWSLambdaFunction_imageConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== PAUSE TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== PAUSE TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimes
=== PAUSE TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
=== CONT  TestAccAWSLambdaFunction_imageConfig
=== CONT  TestAccAWSLambdaFunction_tags
=== CONT  TestAccAWSLambdaFunction_basic
=== CONT  TestAccAWSLambdaFunction_localUpdate
=== CONT  TestAccAWSLambdaFunction_s3
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
=== CONT  TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
=== CONT  TestAccAWSLambdaFunction_VPC
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
=== CONT  TestAccAWSLambdaFunction_Layers
=== CONT  TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== CONT  TestAccAWSLambdaFunction_tracingConfig
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
=== CONT  TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_imageConfig
    resource_aws_lambda_function_test.go:925: AWS_LAMBDA_IMAGE_LATEST_ID, AWS_LAMBDA_IMAGE_V1_ID and AWS_LAMBDA_IMAGE_V2_ID env vars must be set for Lambda Container Image Support acceptance tests. 
--- SKIP: TestAccAWSLambdaFunction_imageConfig (0.97s)
=== CONT  TestAccAWSLambdaFunction_Environment_Variables_NoValue
--- PASS: TestAccAWSLambdaFunction_s3 (54.25s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_Environment_Variables_NoValue (63.21s)
=== CONT  TestAccAWSLambdaFunction_codeSigningConfig
--- PASS: TestAccAWSLambdaFunction_basic (69.71s)
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (86.16s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (87.68s)
=== CONT  TestAccAWSLambdaFunction_FileSystemConfig
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (98.26s)
=== CONT  TestAccAWSLambdaFunction_disappears
--- PASS: TestAccAWSLambdaFunction_tracingConfig (101.93s)
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (114.06s)
=== CONT  TestAccAWSLambdaFunction_enablePublish
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (123.41s)
=== CONT  TestAccAWSLambdaFunction_disablePublish
--- PASS: TestAccAWSLambdaFunction_Layers (130.90s)
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_tags (143.64s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (150.07s)
=== CONT  TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (15.95s)
=== CONT  TestAccAWSLambdaFunction_UnpublishedCodeUpdate
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (350.61s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_runtimes (470.33s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (534.59s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (871.47s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (1017.32s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (1023.64s)
--- PASS: TestAccAWSLambdaFunction_VPC (1040.36s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (953.23s)
--- PASS: TestAccAWSLambdaFunction_disappears (965.99s)
--- PASS: TestAccAWSLambdaFunction_codeSigningConfig (1005.70s)
--- PASS: TestAccAWSLambdaFunction_concurrency (1000.83s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (999.14s)
--- PASS: TestAccAWSLambdaFunction_versioned (946.67s)
--- PASS: TestAccAWSLambdaFunction_disablePublish (977.23s)
--- PASS: TestAccAWSLambdaFunction_envVariables (1054.61s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (997.16s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (1161.83s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (972.49s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (860.60s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (1206.87s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (2143.71s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (2496.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2587.156s
```

##### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_ -timeout 180m
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== PAUSE TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== RUN   TestAccAWSLambdaFunction_disappears
=== PAUSE TestAccAWSLambdaFunction_disappears
=== RUN   TestAccAWSLambdaFunction_codeSigningConfig
=== PAUSE TestAccAWSLambdaFunction_codeSigningConfig
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== PAUSE TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_enablePublish
=== PAUSE TestAccAWSLambdaFunction_enablePublish
=== RUN   TestAccAWSLambdaFunction_disablePublish
=== PAUSE TestAccAWSLambdaFunction_disablePublish
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_FileSystemConfig
=== PAUSE TestAccAWSLambdaFunction_FileSystemConfig
=== RUN   TestAccAWSLambdaFunction_imageConfig
=== PAUSE TestAccAWSLambdaFunction_imageConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
    resource_aws_lambda_function_test.go:1003: Lambda tracing config is not supported in GovCloud partition
--- SKIP: TestAccAWSLambdaFunction_tracingConfig (0.00s)
=== RUN   TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== PAUSE TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== PAUSE TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimes
=== PAUSE TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_basic
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
=== CONT  TestAccAWSLambdaFunction_imageConfig
=== CONT  TestAccAWSLambdaFunction_codeSigningConfig
=== CONT  TestAccAWSLambdaFunction_concurrency
=== CONT  TestAccAWSLambdaFunction_UnpublishedCodeUpdate
=== CONT  TestAccAWSLambdaFunction_FileSystemConfig
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
=== CONT  TestAccAWSLambdaFunction_disablePublish
=== CONT  TestAccAWSLambdaFunction_enablePublish
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
=== CONT  TestAccAWSLambdaFunction_versioned
=== CONT  TestAccAWSLambdaFunction_envVariables
=== CONT  TestAccAWSLambdaFunction_Environment_Variables_NoValue
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
=== CONT  TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== CONT  TestAccAWSLambdaFunction_imageConfig
    resource_aws_lambda_function_test.go:922: AWS_LAMBDA_IMAGE_LATEST_ID, AWS_LAMBDA_IMAGE_V1_ID and AWS_LAMBDA_IMAGE_V2_ID env vars must be set for Lambda Container Image Support acceptance tests. 
--- SKIP: TestAccAWSLambdaFunction_imageConfig (1.71s)
=== CONT  TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_codeSigningConfig
    resource_aws_lambda_function_test.go:196: Lambda code signing config is not supported in GovCloud partition
--- SKIP: TestAccAWSLambdaFunction_codeSigningConfig (0.00s)
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (33.37s)
=== CONT  TestAccAWSLambdaFunction_tags
--- PASS: TestAccAWSLambdaFunction_versioned (45.30s)
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (45.93s)
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_Environment_Variables_NoValue (60.95s)
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_concurrency (75.35s)
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (92.60s)
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (93.82s)
=== CONT  TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_basic (106.91s)
=== CONT  TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (75.92s)
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (129.96s)
=== CONT  TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (131.31s)
=== CONT  TestAccAWSLambdaFunction_Layers
--- PASS: TestAccAWSLambdaFunction_disablePublish (137.21s)
=== CONT  TestAccAWSLambdaFunction_disappears
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (76.40s)
=== CONT  TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (156.00s)
--- PASS: TestAccAWSLambdaFunction_envVariables (157.77s)
--- PASS: TestAccAWSLambdaFunction_s3 (38.29s)
--- PASS: TestAccAWSLambdaFunction_enablePublish (183.08s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (296.36s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (405.52s)
--- PASS: TestAccAWSLambdaFunction_tags (416.40s)
--- PASS: TestAccAWSLambdaFunction_runtimes (534.39s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (581.41s)
--- PASS: TestAccAWSLambdaFunction_UnpublishedCodeUpdate (976.56s)
--- PASS: TestAccAWSLambdaFunction_Layers (853.00s)
--- PASS: TestAccAWSLambdaFunction_disappears (852.05s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (916.08s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (860.64s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (906.85s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (878.71s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (899.26s)
--- PASS: TestAccAWSLambdaFunction_VPC (974.69s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (1243.50s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2037.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2085.401s
```