### PR TITLE
Expose the default tags configured on a provider as a data source

### DIFF
--- a/.changelog/19391.txt
+++ b/.changelog/19391.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+data-source/aws_default_tags: Add `aws_default_tags` data source to expose the `default_tags` configured on the provider
+```

--- a/.changelog/19391.txt
+++ b/.changelog/19391.txt
@@ -1,3 +1,3 @@
-```release-notes:enhancement
-data-source/aws_default_tags: Add `aws_default_tags` data source to expose the `default_tags` configured on the provider
+```release-notes:new-data-source
+aws_default_tags
 ```

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -18,12 +18,12 @@ func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(meta.(*AWSClient).partition)
 
-	if defaultTagsConfig == nil || defaultTagsConfig.Tags == nil {
-		return nil
-	}
-
-	if err := d.Set("tags", defaultTagsConfig.Tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return err
+	if defaultTagsConfig != nil && defaultTagsConfig.Tags != nil {
+		if err := d.Set("tags", defaultTagsConfig.Tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return err
+		}
+	} else {
+		d.Set("tags", nil)
 	}
 
 	return nil

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -24,12 +24,12 @@ func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) erro
 
 	tags := defaultTagsConfig.GetTags()
 
-	if len(tags) > 0 {
-		tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
-	}
-
-	if err := d.Set("tags", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+	if tags != nil {
+		if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %w", err)
+		}
+	} else {
+		d.Set("tags", nil)
 	}
 
 	return nil

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -13,12 +13,18 @@ func dataSourceAwsDefaultTags() *schema.Resource {
 }
 
 func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).DefaultTagsConfig
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
-	if err := d.Set("tags", conn.Tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+
+	d.SetId(meta.(*AWSClient).partition)
+
+	if defaultTagsConfig == nil || defaultTagsConfig.Tags == nil {
+		return nil
+	}
+
+	if err := d.Set("tags", defaultTagsConfig.Tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return err
 	}
-	d.SetId(meta.(*AWSClient).partition)
 
 	return nil
 }

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -15,7 +15,7 @@ func dataSourceAwsDefaultTags() *schema.Resource {
 func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
-	if err := d.Set("tags", conn.Tags.IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+	if err := d.Set("tags", conn.Tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return err
 	}
 	d.SetId(meta.(*AWSClient).partition)

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -1,0 +1,23 @@
+package aws
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func dataSourceAwsDefaultTags() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDefaultTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).DefaultTagsConfig
+	if err := d.Set("tags", conn.Tags.Map()); err != nil {
+		return err
+	}
+	d.SetId(meta.(*AWSClient).partition)
+
+	return nil
+}

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -14,7 +14,8 @@ func dataSourceAwsDefaultTags() *schema.Resource {
 
 func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).DefaultTagsConfig
-	if err := d.Set("tags", conn.Tags.Map()); err != nil {
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+	if err := d.Set("tags", conn.Tags.IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return err
 	}
 	d.SetId(meta.(*AWSClient).partition)

--- a/aws/data_source_aws_default_tags.go
+++ b/aws/data_source_aws_default_tags.go
@@ -1,6 +1,10 @@
 package aws
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 func dataSourceAwsDefaultTags() *schema.Resource {
 	return &schema.Resource{
@@ -18,12 +22,14 @@ func dataSourceAwsDefaultTagsRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(meta.(*AWSClient).partition)
 
-	if defaultTagsConfig != nil && defaultTagsConfig.Tags != nil {
-		if err := d.Set("tags", defaultTagsConfig.Tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-			return err
-		}
-	} else {
-		d.Set("tags", nil)
+	tags := defaultTagsConfig.GetTags()
+
+	if len(tags) > 0 {
+		tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+	}
+
+	if err := d.Set("tags", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_default_tags_test.go
+++ b/aws/data_source_aws_default_tags_test.go
@@ -33,6 +33,56 @@ func TestAccAWSDefaultTagsDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDefaultTagsDataSource_empty(t *testing.T) {
+	var providers []*schema.Provider
+
+	dataSourceName := "data.aws_default_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccAWSProviderConfigDefaultTags_Tags0(),
+					testAccAWSDefaultTagsDataSource(),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDefaultTagsDataSource_multiple(t *testing.T) {
+	var providers []*schema.Provider
+
+	dataSourceName := "data.aws_default_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccAWSProviderConfigDefaultTags_Tags2("nuera", "hijo", "escalofrios", "calambres"),
+					testAccAWSDefaultTagsDataSource(),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.nuera", "hijo"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.escalofrios", "calambres"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSDefaultTagsDataSource() string {
 	return `data "aws_default_tags" "test" {}`
 }

--- a/aws/data_source_aws_default_tags_test.go
+++ b/aws/data_source_aws_default_tags_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAWSDefaultTagsDataSource_basic(t *testing.T) {
+func TestAccAWSDefaultTagsDataSource_basic(t *testing.T) {
 	var providers []*schema.Provider
 
 	dataSourceName := "data.aws_default_tags.test"

--- a/aws/data_source_aws_default_tags_test.go
+++ b/aws/data_source_aws_default_tags_test.go
@@ -83,6 +83,40 @@ func TestAccAWSDefaultTagsDataSource_multiple(t *testing.T) {
 	})
 }
 
+func TestAccAWSDefaultTagsDataSource_ignore(t *testing.T) {
+	var providers []*schema.Provider
+
+	dataSourceName := "data.aws_default_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccAWSProviderConfigDefaultTags_Tags1("Tabac", "Louis Chiron"),
+					testAccAWSDefaultTagsDataSource(),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.Tabac", "Louis Chiron"),
+				),
+			},
+			{
+				Config: composeConfig(
+					testAccProviderConfigDefaultAndIgnoreTagsKeys1("Tabac", "Louis Chiron"),
+					testAccAWSDefaultTagsDataSource(),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSDefaultTagsDataSource() string {
 	return `data "aws_default_tags" "test" {}`
 }

--- a/aws/data_source_aws_default_tags_test.go
+++ b/aws/data_source_aws_default_tags_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAWSDefaultTagsDataSource_basic(t *testing.T) {
+	var providers []*schema.Provider
+
+	dataSourceName := "data.aws_default_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, ec2.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccAWSProviderConfigDefaultTags_Tags1("first", "value"),
+					testAccAWSDefaultTagsDataSource(),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.first", "value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDefaultTagsDataSource() string {
+	return `data "aws_default_tags" "test" {}`
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -226,6 +226,7 @@ func Provider() *schema.Provider {
 			"aws_codecommit_repository":                      dataSourceAwsCodeCommitRepository(),
 			"aws_codestarconnections_connection":             dataSourceAwsCodeStarConnectionsConnection(),
 			"aws_cur_report_definition":                      dataSourceAwsCurReportDefinition(),
+			"aws_default_tags":                               dataSourceAwsDefaultTags(),
 			"aws_db_cluster_snapshot":                        dataSourceAwsDbClusterSnapshot(),
 			"aws_db_event_categories":                        dataSourceAwsDbEventCategories(),
 			"aws_db_instance":                                dataSourceAwsDbInstance(),

--- a/website/docs/d/default_tags.markdown
+++ b/website/docs/d/default_tags.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to get the default tags configured on the provider.
 
-With this data source, you can apply default tags to resources not _directly_ managed by a Terraform resource, such as the instances underneath an Auto Scaling group or the volumes created for an instance.
+With this data source, you can apply default tags to resources not _directly_ managed by a Terraform resource, such as the instances underneath an Auto Scaling group or the volumes created for an EC2 instance.
 
 ## Example Usage
 

--- a/website/docs/d/default_tags.markdown
+++ b/website/docs/d/default_tags.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: ""
+layout: "aws"
+page_title: "AWS: aws_default_tags"
+description: |-
+Expose the default tags configured on the provider.
+---
+
+# Data Source: aws_default_Tags
+
+Use this data source to get the default tags configured on the provider.
+
+It is intended to be used to optionally add the default tags to resources not _directly_ managed by the Terraform
+resource - such as the instances underneath an autoscaling group or the volumes created for an instance.
+
+## Example Usage
+
+```terraform
+provider "aws" {
+  default_tags {
+    tags = {
+      Environment = "Test"
+      Name = "Provider Tag"
+    }
+  }
+}
+data "aws_default_tags" "tags" {}
+
+resource "aws_autoscaling_group" "group" {
+  # ...
+  dynamic "tag" {
+    for_each = data.aws_default_tags.tags.tags
+    content {
+      key = tag.key
+      value = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `tags` - Any default tags set on the provider.
+    * `tags.#.key` - The key name of the tag.
+    * `tags.#.value` - The value of the tag.

--- a/website/docs/d/default_tags.markdown
+++ b/website/docs/d/default_tags.markdown
@@ -3,7 +3,7 @@ subcategory: ""
 layout: "aws"
 page_title: "AWS: aws_default_tags"
 description: |-
-Expose the default tags configured on the provider.
+  Expose the default tags configured on the provider.
 ---
 
 # Data Source: aws_default_Tags
@@ -20,7 +20,7 @@ provider "aws" {
   default_tags {
     tags = {
       Environment = "Test"
-      Name = "Provider Tag"
+      Name        = "Provider Tag"
     }
   }
 }
@@ -31,8 +31,8 @@ resource "aws_autoscaling_group" "group" {
   dynamic "tag" {
     for_each = data.aws_default_tags.tags.tags
     content {
-      key = tag.key
-      value = tag.value
+      key                 = tag.key
+      value               = tag.value
       propagate_at_launch = true
     }
   }

--- a/website/docs/d/default_tags.markdown
+++ b/website/docs/d/default_tags.markdown
@@ -3,17 +3,24 @@ subcategory: ""
 layout: "aws"
 page_title: "AWS: aws_default_tags"
 description: |-
-  Expose the default tags configured on the provider.
+  Access the default tags configured on the provider.
 ---
 
 # Data Source: aws_default_Tags
 
 Use this data source to get the default tags configured on the provider.
 
-It is intended to be used to optionally add the default tags to resources not _directly_ managed by the Terraform
-resource - such as the instances underneath an autoscaling group or the volumes created for an instance.
+With this data source, you can apply default tags to resources not _directly_ managed by a Terraform resource, such as the instances underneath an Auto Scaling group or the volumes created for an instance.
 
 ## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_default_tags" "example" {}
+```
+
+### Dynamically Apply Default Tags to Auto Scaling Group
 
 ```terraform
 provider "aws" {
@@ -24,12 +31,13 @@ provider "aws" {
     }
   }
 }
-data "aws_default_tags" "tags" {}
 
-resource "aws_autoscaling_group" "group" {
+data "aws_default_tags" "example" {}
+
+resource "aws_autoscaling_group" "example" {
   # ...
   dynamic "tag" {
-    for_each = data.aws_default_tags.tags.tags
+    for_each = data.aws_default_tags.example.tags
     content {
       key                 = tag.key
       value               = tag.value
@@ -41,12 +49,15 @@ resource "aws_autoscaling_group" "group" {
 
 ## Argument Reference
 
-There are no arguments available for this data source.
+This data source has no arguments.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `tags` - Any default tags set on the provider.
-    * `tags.#.key` - The key name of the tag.
-    * `tags.#.value` - The value of the tag.
+* `tags` - Blocks of default tags set on the provider. See details below.
+
+### tags
+
+* `key` - Key name of the tag (i.e., `tags.#.key`).
+* `value` - Value of the tag (i.e., `tags.#.value`).


### PR DESCRIPTION
Allow the provider `default_tags` to be exposed as a data source so that the tags can be added to other areas where they are not automatically applied, like the `volume_tags` of a `aws_instance` or the `tag_specifications` of a `aws_launch_template`.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #19370

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDefaultTagsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDefaultTagsDataSource_basic -timeout 180m
=== RUN   TestAccAWSDefaultTagsDataSource_basic
=== PAUSE TestAccAWSDefaultTagsDataSource_basic
=== CONT  TestAccAWSDefaultTagsDataSource_basic
--- PASS: TestAccAWSDefaultTagsDataSource_basic (5.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       7.710s

```
