### PR TITLE
aws_eks_addon use service_account_role_arn if already provided.

### DIFF
--- a/aws/resource_aws_eks_addon.go
+++ b/aws/resource_aws_eks_addon.go
@@ -241,7 +241,9 @@ func resourceAwsEksAddonUpdate(ctx context.Context, d *schema.ResourceData, meta
 		input.AddonVersion = aws.String(d.Get("addon_version").(string))
 	}
 
-	if d.HasChange("service_account_role_arn") {
+	// If service account role ARN is already provided, use it. Otherwise, the add-on uses
+	// permissions assigned to the node IAM role.
+	if d.HasChange("service_account_role_arn") || d.Get("service_account_role_arn") != nil {
 		input.ServiceAccountRoleArn = aws.String(d.Get("service_account_role_arn").(string))
 	}
 


### PR DESCRIPTION
If there's a service account role already provided, we need to pass that ARN with the add-on's version change. Otherwise, it defaults to the use of node IAM role.

(UpdateAddonInput)[https://docs.aws.amazon.com/sdk-for-go/api/service/eks/#UpdateAddonInput]:
```
    // The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's
    // service account. The role must be assigned the IAM permissions required by
    // the add-on. If you don't specify an existing IAM role, then the add-on uses
    // the permissions assigned to the node IAM role. For more information, see
    // Amazon EKS node IAM role (https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
    // in the Amazon EKS User Guide.
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #19402
