### PR TITLE
Implemented Scope-down statements on WAFv2 Web ACL Managed Rules

### DIFF
--- a/.changelog/19407.txt
+++ b/.changelog/19407.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Support `scope_down_statement` on `managed_rule_group_statement`
+```

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -386,12 +386,12 @@ func wafv2ManagedRuleGroupStatementSchema(level int) *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringLenBetween(1, 128),
 				},
+				"scope_down_statement": wafv2ScopeDownStatementSchema(level - 1),
 				"vendor_name": {
 					Type:         schema.TypeString,
 					Required:     true,
 					ValidateFunc: validation.StringLenBetween(1, 128),
 				},
-				"scope_down_statement": wafv2ScopeDownStatementSchema(level - 1),
 			},
 		},
 	}
@@ -633,8 +633,7 @@ func expandWafv2ManagedRuleGroupStatement(l []interface{}) *wafv2.ManagedRuleGro
 		VendorName:    aws.String(m["vendor_name"].(string)),
 	}
 
-	s := m["scope_down_statement"].([]interface{})
-	if len(s) > 0 && s[0] != nil {
+	if s, ok := m["scope_down_statement"].([]interface{}); ok && len(s) > 0 && s[0] != nil {
 		r.ScopeDownStatement = expandWafv2Statement(s[0].(map[string]interface{}))
 	}
 
@@ -826,41 +825,56 @@ func flattenWafv2DefaultAction(a *wafv2.DefaultAction) interface{} {
 	return []interface{}{m}
 }
 
-func flattenWafv2ManagedRuleGroupStatement(r *wafv2.ManagedRuleGroupStatement) interface{} {
-	if r == nil {
+func flattenWafv2ManagedRuleGroupStatement(apiObject *wafv2.ManagedRuleGroupStatement) interface{} {
+	if apiObject == nil {
 		return []interface{}{}
 	}
 
-	m := map[string]interface{}{
-		"excluded_rule":        flattenWafv2ExcludedRules(r.ExcludedRules),
-		"name":                 aws.StringValue(r.Name),
-		"vendor_name":          aws.StringValue(r.VendorName),
-		"scope_down_statement": nil,
+	tfMap := map[string]interface{}{}
+
+	if apiObject.ExcludedRules != nil {
+		tfMap["excluded_rule"] = flattenWafv2ExcludedRules(apiObject.ExcludedRules)
 	}
 
-if r.ScopeDownStatement != nil {
-		m["scope_down_statement"] = []interface{}{flattenWafv2Statement(r.ScopeDownStatement)}
-}
-	return []interface{}{m}
+	if apiObject.Name != nil {
+		tfMap["name"] = aws.StringValue(apiObject.Name)
+	}
+
+	if apiObject.ScopeDownStatement != nil {
+		tfMap["scope_down_statement"] = []interface{}{flattenWafv2Statement(apiObject.ScopeDownStatement)}
+	}
+
+	if apiObject.VendorName != nil {
+		tfMap["vendor_name"] = aws.StringValue(apiObject.VendorName)
+	}
+
+	return []interface{}{tfMap}
 }
 
-func flattenWafv2RateBasedStatement(r *wafv2.RateBasedStatement) interface{} {
-	if r == nil {
+func flattenWafv2RateBasedStatement(apiObject *wafv2.RateBasedStatement) interface{} {
+	if apiObject == nil {
 		return []interface{}{}
 	}
 
-	m := map[string]interface{}{
-		"limit":                int(aws.Int64Value(r.Limit)),
-		"aggregate_key_type":   aws.StringValue(r.AggregateKeyType),
-		"forwarded_ip_config":  flattenWafv2ForwardedIPConfig(r.ForwardedIPConfig),
-		"scope_down_statement": nil,
+	tfMap := map[string]interface{}{}
+
+	if apiObject.AggregateKeyType != nil {
+		tfMap["aggregate_key_type"] = aws.StringValue(apiObject.AggregateKeyType)
 	}
 
-	if r.ScopeDownStatement != nil {
-		m["scope_down_statement"] = []interface{}{flattenWafv2Statement(r.ScopeDownStatement)}
+	if apiObject.ForwardedIPConfig != nil {
+		tfMap["forwarded_ip_config"] = flattenWafv2ForwardedIPConfig(apiObject.ForwardedIPConfig)
 	}
 
-	return []interface{}{m}
+	if apiObject.Limit != nil {
+		tfMap["limit"] = int(aws.Int64Value(apiObject.Limit))
+	}
+
+	if apiObject.ScopeDownStatement != nil {
+		tfMap["scope_down_statement"] = []interface{}{flattenWafv2Statement(apiObject.ScopeDownStatement)}
+	}
+
+	return []interface{}{tfMap}
 }
 
 func flattenWafv2RuleGroupReferenceStatement(r *wafv2.RuleGroupReferenceStatement) interface{} {

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -838,6 +838,9 @@ func flattenWafv2ManagedRuleGroupStatement(r *wafv2.ManagedRuleGroupStatement) i
 		"scope_down_statement": nil,
 	}
 
+if r.ScopeDownStatement != nil {
+		m["scope_down_statement"] = []interface{}{flattenWafv2Statement(r.ScopeDownStatement)}
+}
 	return []interface{}{m}
 }
 

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -129,7 +129,7 @@ func TestAccAwsWafv2WebACL_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_updateRule(t *testing.T) {
+func TestAccAwsWafv2WebACL_Update_rule(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -260,7 +260,7 @@ func TestAccAwsWafv2WebACL_updateRule(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
+func TestAccAwsWafv2WebACL_Update_ruleProperties(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -466,7 +466,7 @@ func TestAccAwsWafv2WebACL_UpdateRuleProperties(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_ChangeNameForceNew(t *testing.T) {
+func TestAccAwsWafv2WebACL_Update_nameForceNew(t *testing.T) {
 	var before, after wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	ruleGroupNewName := acctest.RandomWithPrefix("tf-acc-test")
@@ -518,7 +518,7 @@ func TestAccAwsWafv2WebACL_ChangeNameForceNew(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_Disappears(t *testing.T) {
+func TestAccAwsWafv2WebACL_disappears(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -541,7 +541,7 @@ func TestAccAwsWafv2WebACL_Disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
+func TestAccAwsWafv2WebACL_managedRuleGroup(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -575,7 +575,7 @@ func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_ManagedRuleGroupStatement_Update(webACLName),
+				Config: testAccAwsWafv2WebACLConfig_ManagedRuleGroupStatement_update(webACLName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -612,7 +612,7 @@ func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_Minimal(t *testing.T) {
+func TestAccAwsWafv2WebACL_minimal(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -645,7 +645,7 @@ func TestAccAwsWafv2WebACL_Minimal(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_RateBasedStatement(t *testing.T) {
+func TestAccAwsWafv2WebACL_RateBased_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -679,7 +679,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_RateBasedStatement_Update(webACLName),
+				Config: testAccAwsWafv2WebACLConfig_RateBasedStatement_update(webACLName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -714,7 +714,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_GeoMatchStatement(t *testing.T) {
+func TestAccAwsWafv2WebACL_GeoMatch_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -806,7 +806,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig(t *testing.T) {
+func TestAccAwsWafv2WebACL_GeoMatch_forwardedIPConfig(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -818,7 +818,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2WebACLConfig_GeoMatchStatement_ForwardedIPConfig(webACLName, "MATCH", "X-Forwarded-For"),
+				Config: testAccAwsWafv2WebACLConfig_GeoMatchStatement_forwardedIPConfig(webACLName, "MATCH", "X-Forwarded-For"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -840,7 +840,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_GeoMatchStatement_ForwardedIPConfig(webACLName, "NO_MATCH", "Updated"),
+				Config: testAccAwsWafv2WebACLConfig_GeoMatchStatement_forwardedIPConfig(webACLName, "NO_MATCH", "Updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -871,7 +871,7 @@ func TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_IPSetReferenceStatement(t *testing.T) {
+func TestAccAwsWafv2WebACL_IPSetReference_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -883,7 +883,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2WebACLConfig_IPSetReferenceStatement(webACLName),
+				Config: testAccAwsWafv2WebACLConfig_IPSetReference(webACLName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -917,7 +917,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *testing.T) {
+func TestAccAwsWafv2WebACL_IPSetReference_forwardedIPConfig(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -929,7 +929,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2WebACLConfig_IPSetReferenceStatement_IPSetForwardedIPConfig(webACLName, "MATCH", "X-Forwarded-For", "FIRST"),
+				Config: testAccAwsWafv2WebACLConfig_IPSetReference_forwardedIPConfig(webACLName, "MATCH", "X-Forwarded-For", "FIRST"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -951,7 +951,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_IPSetReferenceStatement_IPSetForwardedIPConfig(webACLName, "NO_MATCH", "X-Forwarded-For", "LAST"),
+				Config: testAccAwsWafv2WebACLConfig_IPSetReference_forwardedIPConfig(webACLName, "NO_MATCH", "X-Forwarded-For", "LAST"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -973,7 +973,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_IPSetReferenceStatement_IPSetForwardedIPConfig(webACLName, "MATCH", "Updated", "ANY"),
+				Config: testAccAwsWafv2WebACLConfig_IPSetReference_forwardedIPConfig(webACLName, "MATCH", "Updated", "ANY"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -995,7 +995,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_IPSetReferenceStatement(webACLName),
+				Config: testAccAwsWafv2WebACLConfig_IPSetReference(webACLName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -1021,7 +1021,7 @@ func TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig(t *tes
 	})
 }
 
-func TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig(t *testing.T) {
+func TestAccAwsWafv2WebACL_RateBased_forwardedIPConfig(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1033,7 +1033,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2WebACLConfig_RateBasedStatement_ForwardedIPConfig(webACLName, "MATCH", "X-Forwarded-For"),
+				Config: testAccAwsWafv2WebACLConfig_RateBasedStatement_forwardedIPConfig(webACLName, "MATCH", "X-Forwarded-For"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -1057,7 +1057,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_RateBasedStatement_ForwardedIPConfig(webACLName, "NO_MATCH", "Updated"),
+				Config: testAccAwsWafv2WebACLConfig_RateBasedStatement_forwardedIPConfig(webACLName, "NO_MATCH", "Updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -1090,7 +1090,7 @@ func TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
+func TestAccAwsWafv2WebACL_RuleGroupReference_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1123,7 +1123,7 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_RuleGroupReferenceStatement_Update(webACLName),
+				Config: testAccAwsWafv2WebACLConfig_RuleGroupReferenceStatement_update(webACLName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -1155,7 +1155,7 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
+func TestAccAwsWafv2WebACL_Custom_requestHandling(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1167,7 +1167,7 @@ func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2WebACLConfig_CustomRequestHandling_Allow(webACLName, "x-hdr1", "x-hdr2"),
+				Config: testAccAwsWafv2WebACLConfig_CustomRequestHandling_allow(webACLName, "x-hdr1", "x-hdr2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -1198,7 +1198,7 @@ func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2WebACLConfig_CustomRequestHandling_Count(webACLName, "x-hdr1", "x-hdr2"),
+				Config: testAccAwsWafv2WebACLConfig_CustomRequestHandling_count(webACLName, "x-hdr1", "x-hdr2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
@@ -1238,7 +1238,7 @@ func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_CustomResponse(t *testing.T) {
+func TestAccAwsWafv2WebACL_Custom_response(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1323,7 +1323,7 @@ func TestAccAwsWafv2WebACL_CustomResponse(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_Tags(t *testing.T) {
+func TestAccAwsWafv2WebACL_tags(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1373,7 +1373,7 @@ func TestAccAwsWafv2WebACL_Tags(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13862
-func TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements(t *testing.T) {
+func TestAccAwsWafv2WebACL_RateBased_maxNested(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1416,7 +1416,7 @@ func TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_MaxNestedOperatorStatements(t *testing.T) {
+func TestAccAwsWafv2WebACL_Operators_maxNested(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
@@ -1531,8 +1531,8 @@ func testAccCheckAwsWafv2WebACLExists(n string, v *wafv2.WebACL) resource.TestCh
 func testAccAwsWafv2WebACLConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1551,7 +1551,7 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_BasicRule(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
+  name        = %[1]q
   description = "Updated"
   scope       = "REGIONAL"
 
@@ -1607,7 +1607,7 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_UpdateRuleNamePriorityMetric(name, ruleName1, ruleName2 string, priority1, priority2 int) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
+  name        = %[1]q
   description = "Updated"
   scope       = "REGIONAL"
 
@@ -1616,7 +1616,7 @@ resource "aws_wafv2_web_acl" "test" {
   }
 
   rule {
-    name     = "%[2]s"
+    name     = %[2]q
     priority = %[3]d
 
     action {
@@ -1646,13 +1646,13 @@ resource "aws_wafv2_web_acl" "test" {
 
     visibility_config {
       cloudwatch_metrics_enabled = false
-      metric_name                = "%[2]s"
+      metric_name                = %[2]q
       sampled_requests_enabled   = false
     }
   }
 
   rule {
-    name     = "%[4]s"
+    name     = %[4]q
     priority = %[5]d
 
     action {
@@ -1667,7 +1667,7 @@ resource "aws_wafv2_web_acl" "test" {
 
     visibility_config {
       cloudwatch_metrics_enabled = false
-      metric_name                = "%[4]s"
+      metric_name                = %[4]q
       sampled_requests_enabled   = false
     }
   }
@@ -1684,8 +1684,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_GeoMatchStatement(name, countryCodes string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1727,11 +1727,11 @@ resource "aws_wafv2_web_acl" "test" {
 `, name, countryCodes)
 }
 
-func testAccAwsWafv2WebACLConfig_CustomRequestHandling_Count(name, firstHeader string, secondHeader string) string {
+func testAccAwsWafv2WebACLConfig_CustomRequestHandling_count(name, firstHeader string, secondHeader string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1746,12 +1746,12 @@ resource "aws_wafv2_web_acl" "test" {
       count {
         custom_request_handling {
           insert_header {
-            name  = "%[2]s"
+            name  = %[2]q
             value = "test-value-1"
           }
 
           insert_header {
-            name  = "%[3]s"
+            name  = %[3]q
             value = "test-value-2"
           }
         }
@@ -1780,11 +1780,11 @@ resource "aws_wafv2_web_acl" "test" {
 `, name, firstHeader, secondHeader)
 }
 
-func testAccAwsWafv2WebACLConfig_CustomRequestHandling_Allow(name, firstHeader string, secondHeader string) string {
+func testAccAwsWafv2WebACLConfig_CustomRequestHandling_allow(name, firstHeader string, secondHeader string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1799,12 +1799,12 @@ resource "aws_wafv2_web_acl" "test" {
       allow {
         custom_request_handling {
           insert_header {
-            name  = "%[2]s"
+            name  = %[2]q
             value = "test-value-1"
           }
 
           insert_header {
-            name  = "%[3]s"
+            name  = %[3]q
             value = "test-value-2"
           }
         }
@@ -1836,8 +1836,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_CustomResponse(name string, defaultStatusCode int, countryBlockStatusCode int, countryHeaderName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1858,7 +1858,7 @@ resource "aws_wafv2_web_acl" "test" {
           response_code = %[3]d
 
           response_header {
-            name  = "%[4]s"
+            name  = %[4]q
             value = "custom-response-header-value"
           }
         }
@@ -1887,11 +1887,11 @@ resource "aws_wafv2_web_acl" "test" {
 `, name, defaultStatusCode, countryBlockStatusCode, countryHeaderName)
 }
 
-func testAccAwsWafv2WebACLConfig_GeoMatchStatement_ForwardedIPConfig(name, fallbackBehavior, headerName string) string {
+func testAccAwsWafv2WebACLConfig_GeoMatchStatement_forwardedIPConfig(name, fallbackBehavior, headerName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1918,8 +1918,8 @@ resource "aws_wafv2_web_acl" "test" {
           geo_match_statement {
             country_codes = ["CA"]
             forwarded_ip_config {
-              fallback_behavior = "%s"
-              header_name       = "%s"
+              fallback_behavior = %[2]q
+              header_name       = %[3]q
             }
           }
         }
@@ -1942,7 +1942,7 @@ resource "aws_wafv2_web_acl" "test" {
 `, name, fallbackBehavior, headerName)
 }
 
-func testAccAwsWafv2WebACLConfig_IPSetReferenceStatement(name string) string {
+func testAccAwsWafv2WebACLConfig_IPSetReference(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_ip_set" "test" {
   name               = "ip-set-%[1]s"
@@ -1952,8 +1952,8 @@ resource "aws_wafv2_ip_set" "test" {
 }
 
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -1990,7 +1990,7 @@ resource "aws_wafv2_web_acl" "test" {
 `, name)
 }
 
-func testAccAwsWafv2WebACLConfig_IPSetReferenceStatement_IPSetForwardedIPConfig(name, fallbackBehavior, headerName, position string) string {
+func testAccAwsWafv2WebACLConfig_IPSetReference_forwardedIPConfig(name, fallbackBehavior, headerName, position string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_ip_set" "test" {
   name               = "ip-set-%[1]s"
@@ -2000,8 +2000,8 @@ resource "aws_wafv2_ip_set" "test" {
 }
 
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2020,9 +2020,9 @@ resource "aws_wafv2_web_acl" "test" {
       ip_set_reference_statement {
         arn = aws_wafv2_ip_set.test.arn
         ip_set_forwarded_ip_config {
-          fallback_behavior = "%[2]s"
-          header_name       = "%[3]s"
-          position          = "%[4]s"
+          fallback_behavior = %[2]q
+          header_name       = %[3]q
+          position          = %[4]q
         }
       }
     }
@@ -2046,8 +2046,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_ManagedRuleGroupStatement(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2090,11 +2090,11 @@ resource "aws_wafv2_web_acl" "test" {
 `, name)
 }
 
-func testAccAwsWafv2WebACLConfig_ManagedRuleGroupStatement_Update(name string) string {
+func testAccAwsWafv2WebACLConfig_ManagedRuleGroupStatement_update(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2154,8 +2154,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_RateBasedStatement(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2197,11 +2197,11 @@ resource "aws_wafv2_web_acl" "test" {
 `, name)
 }
 
-func testAccAwsWafv2WebACLConfig_RateBasedStatement_ForwardedIPConfig(name, fallbackBehavior, headerName string) string {
+func testAccAwsWafv2WebACLConfig_RateBasedStatement_forwardedIPConfig(name, fallbackBehavior, headerName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2220,8 +2220,8 @@ resource "aws_wafv2_web_acl" "test" {
       rate_based_statement {
         aggregate_key_type = "FORWARDED_IP"
         forwarded_ip_config {
-          fallback_behavior = "%s"
-          header_name       = "%s"
+          fallback_behavior = %[2]q
+          header_name       = %[3]q
         }
         limit = 50000
       }
@@ -2248,11 +2248,11 @@ resource "aws_wafv2_web_acl" "test" {
 `, name, fallbackBehavior, headerName)
 }
 
-func testAccAwsWafv2WebACLConfig_RateBasedStatement_Update(name string) string {
+func testAccAwsWafv2WebACLConfig_RateBasedStatement_update(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2316,7 +2316,7 @@ resource "aws_wafv2_rule_group" "test" {
 }
 
 resource "aws_wafv2_web_acl" "test" {
-  name  = "%[1]s"
+  name  = %[1]q
   scope = "REGIONAL"
 
   default_action {
@@ -2358,7 +2358,7 @@ resource "aws_wafv2_web_acl" "test" {
 `, name)
 }
 
-func testAccAwsWafv2WebACLConfig_RuleGroupReferenceStatement_Update(name string) string {
+func testAccAwsWafv2WebACLConfig_RuleGroupReferenceStatement_update(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 10
@@ -2436,7 +2436,7 @@ resource "aws_wafv2_rule_group" "test" {
 }
 
 resource "aws_wafv2_web_acl" "test" {
-  name  = "%[1]s"
+  name  = %[1]q
   scope = "REGIONAL"
 
   default_action {
@@ -2489,7 +2489,7 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_Minimal(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name  = "%s"
+  name  = %[1]q
   scope = "REGIONAL"
 
   default_action {
@@ -2508,8 +2508,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_OneTag(name, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2523,7 +2523,7 @@ resource "aws_wafv2_web_acl" "test" {
   }
 
   tags = {
-    "%s" = "%s"
+    %[2]q = %[3]q
   }
 }
 `, name, tagKey, tagValue)
@@ -2532,8 +2532,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_TwoTags(name, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2547,8 +2547,8 @@ resource "aws_wafv2_web_acl" "test" {
   }
 
   tags = {
-    "%s" = "%s"
-    "%s" = "%s"
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, name, tag1Key, tag1Value, tag2Key, tag2Value)
@@ -2557,7 +2557,7 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_multipleNestedRateBasedStatements(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name  = "%[1]s"
+  name  = %[1]q
   scope = "REGIONAL"
 
   regular_expression {
@@ -2566,15 +2566,15 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 }
 
 resource "aws_wafv2_ip_set" "test" {
-  name               = "%[1]s"
+  name               = %[1]q
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = ["1.2.3.4/32", "5.6.7.8/32"]
 }
 
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {
@@ -2644,7 +2644,7 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccAwsWafv2WebACLConfig_multipleNestedOperatorStatements(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name  = "%[1]s"
+  name  = %[1]q
   scope = "REGIONAL"
 
   regular_expression {
@@ -2653,15 +2653,15 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 }
 
 resource "aws_wafv2_ip_set" "test" {
-  name               = "%[1]s"
+  name               = %[1]q
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = ["1.2.3.4/32", "5.6.7.8/32"]
 }
 
 resource "aws_wafv2_web_acl" "test" {
-  name        = "%[1]s"
-  description = "%[1]s"
+  name        = %[1]q
+  description = %[1]q
   scope       = "REGIONAL"
 
   default_action {

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -566,10 +566,11 @@ func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
 						"override_action.0.count.#": "0",
 						"override_action.0.none.#":  "1",
 						"statement.#":               "1",
-						"statement.0.managed_rule_group_statement.#":                 "1",
-						"statement.0.managed_rule_group_statement.0.name":            "AWSManagedRulesCommonRuleSet",
-						"statement.0.managed_rule_group_statement.0.vendor_name":     "AWS",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.#": "0",
+						"statement.0.managed_rule_group_statement.#":                        "1",
+						"statement.0.managed_rule_group_statement.0.name":                   "AWSManagedRulesCommonRuleSet",
+						"statement.0.managed_rule_group_statement.0.vendor_name":            "AWS",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.#":        "0",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.#": "0",
 					}),
 				),
 			},
@@ -587,12 +588,17 @@ func TestAccAwsWafv2WebACL_ManagedRuleGroupStatement(t *testing.T) {
 						"override_action.0.count.#": "1",
 						"override_action.0.none.#":  "0",
 						"statement.#":               "1",
-						"statement.0.managed_rule_group_statement.#":                      "1",
-						"statement.0.managed_rule_group_statement.0.name":                 "AWSManagedRulesCommonRuleSet",
-						"statement.0.managed_rule_group_statement.0.vendor_name":          "AWS",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.#":      "2",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.0.name": "SizeRestrictions_QUERYSTRING",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.1.name": "NoUserAgent_HEADER",
+						"statement.0.managed_rule_group_statement.#":                                                              "1",
+						"statement.0.managed_rule_group_statement.0.name":                                                         "AWSManagedRulesCommonRuleSet",
+						"statement.0.managed_rule_group_statement.0.vendor_name":                                                  "AWS",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                              "2",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.0.name":                                         "SizeRestrictions_QUERYSTRING",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.1.name":                                         "NoUserAgent_HEADER",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                       "1",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.0.geo_match_statement.#":                 "1",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.0.geo_match_statement.0.country_codes.#": "2",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.0.geo_match_statement.0.country_codes.0": "US",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.0.geo_match_statement.0.country_codes.1": "NL",
 					}),
 				),
 			},
@@ -2114,6 +2120,12 @@ resource "aws_wafv2_web_acl" "test" {
 
         excluded_rule {
           name = "NoUserAgent_HEADER"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
         }
       }
     }

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -541,7 +541,7 @@ func TestAccAwsWafv2WebACL_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2WebACL_managedRuleGroup(t *testing.T) {
+func TestAccAwsWafv2WebACL_ManagedRuleGroup_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -416,6 +416,7 @@ The `managed_rule_group_statement` block supports the following arguments:
 
 * `excluded_rule` - (Optional) The `rules` whose actions are set to `COUNT` by the web ACL, regardless of the action that is set on the rule. See [Excluded Rule](#excluded-rule) below for details.
 * `name` - (Required) The name of the managed rule group.
+* `scope_down_statement` - Narrows the scope of the statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [Statement](#statement) above for details.
 * `vendor_name` - (Required) The name of the managed rule group vendor.
 
 ### NOT Statement

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -47,6 +47,12 @@ resource "aws_wafv2_web_acl" "example" {
         excluded_rule {
           name = "NoUserAgent_HEADER"
         }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
       }
     }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18584
Closes #19125
Relates #15580

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsWafv2WebACL_ManagedRuleGroupStatement'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWafv2WebACL_ManagedRuleGroupStatement -timeout 180m
=== RUN   TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== PAUSE TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== CONT  TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
    resource_aws_wafv2_web_acl_test.go:534: Step 2/3 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_wafv2_web_acl.test will be updated in-place
          ~ resource "aws_wafv2_web_acl" "test" {
                id          = "38e30f56-fdbf-4622-aedd-c931aa410384"
                name        = "tf-acc-test-1625682019993276028"
                tags        = {
                    "Tag1" = "Value1"
                    "Tag2" = "Value2"
                }
                # (6 unchanged attributes hidden)


              + rule {
                  + name     = "rule-1"
                  + priority = 1

                  + override_action {
                      + count {}
                    }

                  + statement {

                      + managed_rule_group_statement {
                          + name        = "AWSManagedRulesCommonRuleSet"
                          + vendor_name = "AWS"

                          + excluded_rule {
                              + name = "SizeRestrictions_QUERYSTRING"
                            }
                          + excluded_rule {
                              + name = "NoUserAgent_HEADER"
                            }

                          + scope_down_statement {

                              + geo_match_statement {
                                  + country_codes = [
                                      + "US",
                                      + "NL",
                                    ]
                                }
                            }
                        }
                    }

                  + visibility_config {
                      + cloudwatch_metrics_enabled = false
                      + metric_name                = "friendly-rule-metric-name"
                      + sampled_requests_enabled   = false
                    }
                }
              - rule {
                  - name     = "rule-1" -> null
                  - priority = 1 -> null

                  - override_action {
                      - count {}
                    }

                  - statement {

                      - managed_rule_group_statement {
                          - name        = "AWSManagedRulesCommonRuleSet" -> null
                          - vendor_name = "AWS" -> null

                          - excluded_rule {
                              - name = "SizeRestrictions_QUERYSTRING" -> null
                            }
                          - excluded_rule {
                              - name = "NoUserAgent_HEADER" -> null
                            }
                        }
                    }

                  - visibility_config {
                      - cloudwatch_metrics_enabled = false -> null
                      - metric_name                = "friendly-rule-metric-name" -> null
                      - sampled_requests_enabled   = false -> null
                    }
                }

                # (2 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAwsWafv2WebACL_ManagedRuleGroupStatement (52.10s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	52.171s
FAIL
GNUmakefile:27: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
