### PR TITLE
WAFv2: Add support for custom request and responses to rules

### DIFF
--- a/.changelog/19415.txt
+++ b/.changelog/19415.txt
@@ -5,3 +5,7 @@ resource/aws_wafv2_web_acl: Add `custom_request_handling` to `allow` and `count`
 ```release-notes:enhancement
 resource/aws_wafv2_web_acl: Add `custom_response` to `block` actions.
 ```
+
+```release-notes:enhancement
+resource/aws_wafv2_rule_group: Included the above changes to `rule` `allow`, `count`, and `block` actions.
+```

--- a/.changelog/19415.txt
+++ b/.changelog/19415.txt
@@ -1,0 +1,7 @@
+```release-notes:enhancement
+resource/aws_wafv2_web_acl: Add `custom_request_handling` to `allow` and `count` actions.
+```
+
+```release-notes:enhancement
+resource/aws_wafv2_web_acl: Add `custom_response` to `block` actions.
+```

--- a/.changelog/19415.txt
+++ b/.changelog/19415.txt
@@ -7,5 +7,9 @@ resource/aws_wafv2_web_acl: Add `custom_response` to `block` default action and 
 ```
 
 ```release-notes:enhancement
-resource/aws_wafv2_rule_group: Included the above changes to `rule` `allow`, `count`, and `block` actions.
+resource/aws_wafv2_rule_group: Add `custom_request_handling` to `allow` and `count` rule actions.
+```
+
+```release-notes:enhancement
+resource/aws_wafv2_rule_group: Add `custom_response` to `block` rule actions.
 ```

--- a/.changelog/19415.txt
+++ b/.changelog/19415.txt
@@ -1,9 +1,9 @@
 ```release-notes:enhancement
-resource/aws_wafv2_web_acl: Add `custom_request_handling` to `allow` and `count` actions.
+resource/aws_wafv2_web_acl: Add `custom_request_handling` to `allow` and `count` default action and rule actions.
 ```
 
 ```release-notes:enhancement
-resource/aws_wafv2_web_acl: Add `custom_response` to `block` actions.
+resource/aws_wafv2_web_acl: Add `custom_response` to `block` default action and rule actions.
 ```
 
 ```release-notes:enhancement

--- a/aws/resource_aws_wafv2_rule_group.go
+++ b/aws/resource_aws_wafv2_rule_group.go
@@ -86,9 +86,9 @@ func resourceAwsWafv2RuleGroup() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"allow": wafv2EmptySchema(),
-									"block": wafv2EmptySchema(),
-									"count": wafv2EmptySchema(),
+									"allow": wafv2AllowConfigSchema(),
+									"block": wafv2BlockConfigSchema(),
+									"count": wafv2CountConfigSchema(),
 								},
 							},
 						},

--- a/aws/resource_aws_wafv2_rule_group_test.go
+++ b/aws/resource_aws_wafv2_rule_group_test.go
@@ -1241,12 +1241,12 @@ func TestAccAwsWafv2RuleGroup_RuleAction_CustomRequestHandling(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"action.#":         "1",
 						"action.0.allow.#": "1",
-						"action.0.allow.0.custom_request_handling.#":                        "1",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.#":       "2",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.0.value": "test-val1",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.1.value": "test-val2",
+						"action.0.allow.0.custom_request_handling.#":                       "1",
+						"action.0.allow.0.custom_request_handling.0.insert_header.#":       "2",
+						"action.0.allow.0.custom_request_handling.0.insert_header.0.name":  "x-hdr1",
+						"action.0.allow.0.custom_request_handling.0.insert_header.0.value": "test-val1",
+						"action.0.allow.0.custom_request_handling.0.insert_header.1.name":  "x-hdr2",
+						"action.0.allow.0.custom_request_handling.0.insert_header.1.value": "test-val2",
 						"action.0.block.#": "0",
 						"action.0.count.#": "0",
 					}),
@@ -1268,12 +1268,12 @@ func TestAccAwsWafv2RuleGroup_RuleAction_CustomRequestHandling(t *testing.T) {
 						"action.0.allow.#": "0",
 						"action.0.block.#": "0",
 						"action.0.count.#": "1",
-						"action.0.count.0.custom_request_handling.#":                        "1",
-						"action.0.count.0.custom_request_handling.0.insert_headers.#":       "2",
-						"action.0.count.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
-						"action.0.count.0.custom_request_handling.0.insert_headers.0.value": "test-val1",
-						"action.0.count.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
-						"action.0.count.0.custom_request_handling.0.insert_headers.1.value": "test-val2",
+						"action.0.count.0.custom_request_handling.#":                       "1",
+						"action.0.count.0.custom_request_handling.0.insert_header.#":       "2",
+						"action.0.count.0.custom_request_handling.0.insert_header.0.name":  "x-hdr1",
+						"action.0.count.0.custom_request_handling.0.insert_header.0.value": "test-val1",
+						"action.0.count.0.custom_request_handling.0.insert_header.1.name":  "x-hdr2",
+						"action.0.count.0.custom_request_handling.0.insert_header.1.value": "test-val2",
 					}),
 				),
 			},
@@ -1314,12 +1314,12 @@ func TestAccAwsWafv2RuleGroup_RuleAction_CustomResponse(t *testing.T) {
 						"action.0.allow.#":                   "0",
 						"action.0.block.#":                   "1",
 						"action.0.block.0.custom_response.#": "1",
-						"action.0.block.0.custom_response.0.response_code":            "429",
-						"action.0.block.0.custom_response.0.response_headers.#":       "2",
-						"action.0.block.0.custom_response.0.response_headers.0.name":  "x-hdr1",
-						"action.0.block.0.custom_response.0.response_headers.0.value": "test-val1",
-						"action.0.block.0.custom_response.0.response_headers.1.name":  "x-hdr2",
-						"action.0.block.0.custom_response.0.response_headers.1.value": "test-val2",
+						"action.0.block.0.custom_response.0.response_code":           "429",
+						"action.0.block.0.custom_response.0.response_header.#":       "2",
+						"action.0.block.0.custom_response.0.response_header.0.name":  "x-hdr1",
+						"action.0.block.0.custom_response.0.response_header.0.value": "test-val1",
+						"action.0.block.0.custom_response.0.response_header.1.name":  "x-hdr2",
+						"action.0.block.0.custom_response.0.response_header.1.value": "test-val2",
 						"action.0.count.#": "0",
 					}),
 				),
@@ -1888,12 +1888,12 @@ resource "aws_wafv2_rule_group" "test" {
     action {
       allow {
         custom_request_handling {
-          insert_headers {
+          insert_header {
             name  = "x-hdr1"
             value = "test-val1"
           }
 
-          insert_headers {
+          insert_header {
             name  = "x-hdr2"
             value = "test-val2"
           }
@@ -1975,12 +1975,12 @@ resource "aws_wafv2_rule_group" "test" {
       block {
         custom_response {
           response_code = 429
-          response_headers {
+          response_header {
             name  = "x-hdr1"
             value = "test-val1"
           }
 
-          response_headers {
+          response_header {
             name  = "x-hdr2"
             value = "test-val2"
           }
@@ -2061,12 +2061,12 @@ resource "aws_wafv2_rule_group" "test" {
     action {
       count {
         custom_request_handling {
-          insert_headers {
+          insert_header {
             name  = "x-hdr1"
             value = "test-val1"
           }
 
-          insert_headers {
+          insert_header {
             name  = "x-hdr2"
             value = "test-val2"
           }

--- a/aws/resource_aws_wafv2_rule_group_test.go
+++ b/aws/resource_aws_wafv2_rule_group_test.go
@@ -1160,8 +1160,9 @@ func TestAccAwsWafv2RuleGroup_RuleAction(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"action.#":         "1",
 						"action.0.allow.#": "1",
-						"action.0.block.#": "0",
-						"action.0.count.#": "0",
+						"action.0.allow.0.custom_request_handling.#": "0",
+						"action.0.block.#":                           "0",
+						"action.0.count.#":                           "0",
 					}),
 				),
 			},
@@ -1177,10 +1178,11 @@ func TestAccAwsWafv2RuleGroup_RuleAction(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
-						"action.#":         "1",
-						"action.0.allow.#": "0",
-						"action.0.block.#": "1",
-						"action.0.count.#": "0",
+						"action.#":                           "1",
+						"action.0.allow.#":                   "0",
+						"action.0.block.#":                   "1",
+						"action.0.block.0.custom_response.#": "0",
+						"action.0.count.#":                   "0",
 					}),
 				),
 			},
@@ -1200,6 +1202,125 @@ func TestAccAwsWafv2RuleGroup_RuleAction(t *testing.T) {
 						"action.0.allow.#": "0",
 						"action.0.block.#": "0",
 						"action.0.count.#": "1",
+						"action.0.count.0.custom_request_handling.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAwsWafv2RuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccAwsWafv2RuleGroup_RuleAction_CustomRequestHandling(t *testing.T) {
+	var v wafv2.RuleGroup
+	ruleGroupName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWafv2ScopeRegional(t) },
+		ErrorCheck:   testAccErrorCheck(t, wafv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2RuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2RuleGroupConfig_RuleActionAllow_CustomRequestHandling(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"action.#":         "1",
+						"action.0.allow.#": "1",
+						"action.0.allow.0.custom_request_handling.#":                        "1",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.#":       "2",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.0.value": "test-val1",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.1.value": "test-val2",
+						"action.0.block.#": "0",
+						"action.0.count.#": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccAwsWafv2RuleGroupConfig_RuleActionCount_CustomRequestHandling(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"action.#":         "1",
+						"action.0.allow.#": "0",
+						"action.0.block.#": "0",
+						"action.0.count.#": "1",
+						"action.0.count.0.custom_request_handling.#":                        "1",
+						"action.0.count.0.custom_request_handling.0.insert_headers.#":       "2",
+						"action.0.count.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
+						"action.0.count.0.custom_request_handling.0.insert_headers.0.value": "test-val1",
+						"action.0.count.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
+						"action.0.count.0.custom_request_handling.0.insert_headers.1.value": "test-val2",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAwsWafv2RuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccAwsWafv2RuleGroup_RuleAction_CustomResponse(t *testing.T) {
+	var v wafv2.RuleGroup
+	ruleGroupName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWafv2ScopeRegional(t) },
+		ErrorCheck:   testAccErrorCheck(t, wafv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2RuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2RuleGroupConfig_RuleActionBlock_CustomResponse(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2RuleGroupExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"action.#":                           "1",
+						"action.0.allow.#":                   "0",
+						"action.0.block.#":                   "1",
+						"action.0.block.0.custom_response.#": "1",
+						"action.0.block.0.custom_response.0.response_code":            "429",
+						"action.0.block.0.custom_response.0.response_headers.#":       "2",
+						"action.0.block.0.custom_response.0.response_headers.0.name":  "x-hdr1",
+						"action.0.block.0.custom_response.0.response_headers.0.value": "test-val1",
+						"action.0.block.0.custom_response.0.response_headers.1.name":  "x-hdr2",
+						"action.0.block.0.custom_response.0.response_headers.1.value": "test-val2",
+						"action.0.count.#": "0",
 					}),
 				),
 			},
@@ -1753,6 +1874,55 @@ resource "aws_wafv2_rule_group" "test" {
 `, name)
 }
 
+func testAccAwsWafv2RuleGroupConfig_RuleActionAllow_CustomRequestHandling(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 2
+  name     = "%s"
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {
+        custom_request_handling {
+          insert_headers {
+            name  = "x-hdr1"
+            value = "test-val1"
+          }
+
+          insert_headers {
+            name  = "x-hdr2"
+            value = "test-val2"
+          }
+        }
+      }
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US", "NL"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name)
+}
+
 func testAccAwsWafv2RuleGroupConfig_RuleActionBlock(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
@@ -1790,6 +1960,56 @@ resource "aws_wafv2_rule_group" "test" {
 `, name)
 }
 
+func testAccAwsWafv2RuleGroupConfig_RuleActionBlock_CustomResponse(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 2
+  name     = "%s"
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+          response_headers {
+            name  = "x-hdr1"
+            value = "test-val1"
+          }
+
+          response_headers {
+            name  = "x-hdr2"
+            value = "test-val2"
+          }
+        }
+      }
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US", "NL"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name)
+}
+
 func testAccAwsWafv2RuleGroupConfig_RuleActionCount(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
@@ -1803,6 +2023,55 @@ resource "aws_wafv2_rule_group" "test" {
 
     action {
       count {}
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US", "NL"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name)
+}
+
+func testAccAwsWafv2RuleGroupConfig_RuleActionCount_CustomRequestHandling(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 2
+  name     = "%s"
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {
+        custom_request_handling {
+          insert_headers {
+            name  = "x-hdr1"
+            value = "test-val1"
+          }
+
+          insert_headers {
+            name  = "x-hdr2"
+            value = "test-val2"
+          }
+        }
+      }
     }
 
     statement {

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -119,7 +119,7 @@ func resourceAwsWafv2WebACL() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"count": wafv2CountConfigSchema(),
+									"count": wafv2EmptySchema(),
 									"none":  wafv2EmptySchema(),
 								},
 							},
@@ -519,7 +519,7 @@ func expandWafv2OverrideAction(l []interface{}) *wafv2.OverrideAction {
 	action := &wafv2.OverrideAction{}
 
 	if v, ok := m["count"]; ok && len(v.([]interface{})) > 0 {
-		action.Count = expandWafv2CountAction(v.([]interface{}))
+		action.Count = &wafv2.CountAction{}
 	}
 
 	if v, ok := m["none"]; ok && len(v.([]interface{})) > 0 {
@@ -790,7 +790,7 @@ func flattenWafv2OverrideAction(a *wafv2.OverrideAction) interface{} {
 	m := map[string]interface{}{}
 
 	if a.Count != nil {
-		m["count"] = flattenWafv2Count(a.Count)
+		m["count"] = make([]map[string]interface{}, 1)
 	}
 
 	if a.None != nil {

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -59,8 +59,8 @@ func resourceAwsWafv2WebACL() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"allow": wafv2EmptySchema(),
-						"block": wafv2EmptySchema(),
+						"allow": wafv2AllowConfigSchema(),
+						"block": wafv2BlockConfigSchema(),
 					},
 				},
 			},
@@ -102,9 +102,9 @@ func resourceAwsWafv2WebACL() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"allow": wafv2EmptySchema(),
-									"block": wafv2EmptySchema(),
-									"count": wafv2EmptySchema(),
+									"allow": wafv2AllowConfigSchema(),
+									"block": wafv2BlockConfigSchema(),
+									"count": wafv2CountConfigSchema(),
 								},
 							},
 						},
@@ -119,7 +119,7 @@ func resourceAwsWafv2WebACL() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"count": wafv2EmptySchema(),
+									"count": wafv2CountConfigSchema(),
 									"none":  wafv2EmptySchema(),
 								},
 							},
@@ -519,7 +519,7 @@ func expandWafv2OverrideAction(l []interface{}) *wafv2.OverrideAction {
 	action := &wafv2.OverrideAction{}
 
 	if v, ok := m["count"]; ok && len(v.([]interface{})) > 0 {
-		action.Count = &wafv2.CountAction{}
+		action.Count = expandWafv2CountAction(v.([]interface{}))
 	}
 
 	if v, ok := m["none"]; ok && len(v.([]interface{})) > 0 {
@@ -538,11 +538,11 @@ func expandWafv2DefaultAction(l []interface{}) *wafv2.DefaultAction {
 	action := &wafv2.DefaultAction{}
 
 	if v, ok := m["allow"]; ok && len(v.([]interface{})) > 0 {
-		action.Allow = &wafv2.AllowAction{}
+		action.Allow = expandWafv2AllowAction(v.([]interface{}))
 	}
 
 	if v, ok := m["block"]; ok && len(v.([]interface{})) > 0 {
-		action.Block = &wafv2.BlockAction{}
+		action.Block = expandWafv2BlockAction(v.([]interface{}))
 	}
 
 	return action
@@ -790,7 +790,7 @@ func flattenWafv2OverrideAction(a *wafv2.OverrideAction) interface{} {
 	m := map[string]interface{}{}
 
 	if a.Count != nil {
-		m["count"] = make([]map[string]interface{}, 1)
+		m["count"] = flattenWafv2Count(a.Count)
 	}
 
 	if a.None != nil {
@@ -808,11 +808,11 @@ func flattenWafv2DefaultAction(a *wafv2.DefaultAction) interface{} {
 	m := map[string]interface{}{}
 
 	if a.Allow != nil {
-		m["allow"] = make([]map[string]interface{}, 1)
+		m["allow"] = flattenWafv2Allow(a.Allow)
 	}
 
 	if a.Block != nil {
-		m["block"] = make([]map[string]interface{}, 1)
+		m["block"] = flattenWafv2Block(a.Block)
 	}
 
 	return []interface{}{m}

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -1160,12 +1160,12 @@ func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
 						"name":             "rule-1",
 						"action.#":         "1",
 						"action.0.allow.#": "1",
-						"action.0.allow.0.custom_request_handling.#":                        "1",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.#":       "2",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.0.value": "test-value-1",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
-						"action.0.allow.0.custom_request_handling.0.insert_headers.1.value": "test-value-2",
+						"action.0.allow.0.custom_request_handling.#":                       "1",
+						"action.0.allow.0.custom_request_handling.0.insert_header.#":       "2",
+						"action.0.allow.0.custom_request_handling.0.insert_header.0.name":  "x-hdr1",
+						"action.0.allow.0.custom_request_handling.0.insert_header.0.value": "test-value-1",
+						"action.0.allow.0.custom_request_handling.0.insert_header.1.name":  "x-hdr2",
+						"action.0.allow.0.custom_request_handling.0.insert_header.1.value": "test-value-2",
 						"action.0.block.#": "0",
 						"action.0.count.#": "0",
 						"priority":         "1",
@@ -1193,12 +1193,12 @@ func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
 						"action.0.allow.#": "0",
 						"action.0.block.#": "0",
 						"action.0.count.#": "1",
-						"action.0.count.0.custom_request_handling.#":                        "1",
-						"action.0.count.0.custom_request_handling.0.insert_headers.#":       "2",
-						"action.0.count.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
-						"action.0.count.0.custom_request_handling.0.insert_headers.0.value": "test-value-1",
-						"action.0.count.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
-						"action.0.count.0.custom_request_handling.0.insert_headers.1.value": "test-value-2",
+						"action.0.count.0.custom_request_handling.#":                       "1",
+						"action.0.count.0.custom_request_handling.0.insert_header.#":       "2",
+						"action.0.count.0.custom_request_handling.0.insert_header.0.name":  "x-hdr1",
+						"action.0.count.0.custom_request_handling.0.insert_header.0.value": "test-value-1",
+						"action.0.count.0.custom_request_handling.0.insert_header.1.name":  "x-hdr2",
+						"action.0.count.0.custom_request_handling.0.insert_header.1.value": "test-value-2",
 						"priority": "1",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
@@ -1247,10 +1247,10 @@ func TestAccAwsWafv2WebACL_CustomResponse(t *testing.T) {
 						"action.0.allow.#":                   "0",
 						"action.0.block.#":                   "1",
 						"action.0.block.0.custom_response.#": "1",
-						"action.0.block.0.custom_response.0.response_code":            "403",
-						"action.0.block.0.custom_response.0.response_headers.#":       "1",
-						"action.0.block.0.custom_response.0.response_headers.0.name":  "x-hdr1",
-						"action.0.block.0.custom_response.0.response_headers.0.value": "custom-response-header-value",
+						"action.0.block.0.custom_response.0.response_code":           "403",
+						"action.0.block.0.custom_response.0.response_header.#":       "1",
+						"action.0.block.0.custom_response.0.response_header.0.name":  "x-hdr1",
+						"action.0.block.0.custom_response.0.response_header.0.value": "custom-response-header-value",
 						"action.0.count.#": "0",
 						"priority":         "1",
 					}),
@@ -1279,10 +1279,10 @@ func TestAccAwsWafv2WebACL_CustomResponse(t *testing.T) {
 						"action.0.allow.#":                   "0",
 						"action.0.block.#":                   "1",
 						"action.0.block.0.custom_response.#": "1",
-						"action.0.block.0.custom_response.0.response_code":            "429",
-						"action.0.block.0.custom_response.0.response_headers.#":       "1",
-						"action.0.block.0.custom_response.0.response_headers.0.name":  "x-hdr2",
-						"action.0.block.0.custom_response.0.response_headers.0.value": "custom-response-header-value",
+						"action.0.block.0.custom_response.0.response_code":           "429",
+						"action.0.block.0.custom_response.0.response_header.#":       "1",
+						"action.0.block.0.custom_response.0.response_header.0.name":  "x-hdr2",
+						"action.0.block.0.custom_response.0.response_header.0.value": "custom-response-header-value",
 						"action.0.count.#": "0",
 						"priority":         "1",
 					}),
@@ -1724,12 +1724,12 @@ resource "aws_wafv2_web_acl" "test" {
     action {
       count {
         custom_request_handling {
-          insert_headers {
+          insert_header {
             name  = "%[2]s"
             value = "test-value-1"
           }
 
-          insert_headers {
+          insert_header {
             name  = "%[3]s"
             value = "test-value-2"
           }
@@ -1777,12 +1777,12 @@ resource "aws_wafv2_web_acl" "test" {
     action {
       allow {
         custom_request_handling {
-          insert_headers {
+          insert_header {
             name  = "%[2]s"
             value = "test-value-1"
           }
 
-          insert_headers {
+          insert_header {
             name  = "%[3]s"
             value = "test-value-2"
           }
@@ -1836,7 +1836,7 @@ resource "aws_wafv2_web_acl" "test" {
         custom_response {
           response_code = %[3]d
 
-          response_headers {
+          response_header {
             name  = "%[4]s"
             value = "custom-response-header-value"
           }

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -1134,6 +1134,174 @@ func TestAccAwsWafv2WebACL_RuleGroupReferenceStatement(t *testing.T) {
 	})
 }
 
+func TestAccAwsWafv2WebACL_CustomRequestHandling(t *testing.T) {
+	var v wafv2.WebACL
+	webACLName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWafv2ScopeRegional(t) },
+		ErrorCheck:   testAccErrorCheck(t, wafv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLConfig_CustomRequestHandling(webACLName, "allow", "x-hdr1", "x-hdr2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.allow.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scope", "REGIONAL"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"name":             "rule-1",
+						"action.#":         "1",
+						"action.0.allow.#": "1",
+						"action.0.allow.0.custom_request_handling.#":                        "1",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.#":       "2",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.0.value": "test-value-1",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
+						"action.0.allow.0.custom_request_handling.0.insert_headers.1.value": "test-value-2",
+						"action.0.block.#": "0",
+						"action.0.count.#": "0",
+						"priority":         "1",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLConfig_CustomRequestHandling(webACLName, "count", "x-hdr1", "x-hdr2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.allow.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scope", "REGIONAL"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"name":             "rule-1",
+						"action.#":         "1",
+						"action.0.allow.#": "0",
+						"action.0.block.#": "0",
+						"action.0.count.#": "1",
+						"action.0.count.0.custom_request_handling.#":                        "1",
+						"action.0.count.0.custom_request_handling.0.insert_headers.#":       "2",
+						"action.0.count.0.custom_request_handling.0.insert_headers.0.name":  "x-hdr1",
+						"action.0.count.0.custom_request_handling.0.insert_headers.0.value": "test-value-1",
+						"action.0.count.0.custom_request_handling.0.insert_headers.1.name":  "x-hdr2",
+						"action.0.count.0.custom_request_handling.0.insert_headers.1.value": "test-value-2",
+						"priority": "1",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAwsWafv2WebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccAwsWafv2WebACL_CustomResponse(t *testing.T) {
+	var v wafv2.WebACL
+	webACLName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWafv2ScopeRegional(t) },
+		ErrorCheck:   testAccErrorCheck(t, wafv2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWafv2WebACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLConfig_CustomResponse(webACLName, 401, 403, "x-hdr1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.allow.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.0.custom_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.0.custom_response.0.response_code", "401"),
+					resource.TestCheckResourceAttr(resourceName, "scope", "REGIONAL"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"name":                               "rule-1",
+						"action.#":                           "1",
+						"action.0.allow.#":                   "0",
+						"action.0.block.#":                   "1",
+						"action.0.block.0.custom_response.#": "1",
+						"action.0.block.0.custom_response.0.response_code":            "403",
+						"action.0.block.0.custom_response.0.response_headers.#":       "1",
+						"action.0.block.0.custom_response.0.response_headers.0.name":  "x-hdr1",
+						"action.0.block.0.custom_response.0.response_headers.0.value": "custom-response-header-value",
+						"action.0.count.#": "0",
+						"priority":         "1",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAwsWafv2WebACLConfig_CustomResponse(webACLName, 404, 429, "x-hdr2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWafv2WebACLExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", webACLName),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.allow.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.0.custom_response.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.0.custom_response.0.response_code", "404"),
+					resource.TestCheckResourceAttr(resourceName, "scope", "REGIONAL"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"name":                               "rule-1",
+						"action.#":                           "1",
+						"action.0.allow.#":                   "0",
+						"action.0.block.#":                   "1",
+						"action.0.block.0.custom_response.#": "1",
+						"action.0.block.0.custom_response.0.response_code":            "429",
+						"action.0.block.0.custom_response.0.response_headers.#":       "1",
+						"action.0.block.0.custom_response.0.response_headers.0.name":  "x-hdr2",
+						"action.0.block.0.custom_response.0.response_headers.0.value": "custom-response-header-value",
+						"action.0.count.#": "0",
+						"priority":         "1",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAwsWafv2WebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccAwsWafv2WebACL_Tags(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1536,6 +1704,113 @@ resource "aws_wafv2_web_acl" "test" {
   }
 }
 `, name, countryCodes)
+}
+
+func testAccAwsWafv2WebACLConfig_CustomRequestHandling(name, actionName string, firstHeader string, secondHeader string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = "%[1]s"
+  description = "%[1]s"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      %[2]s {
+	    custom_request_handling {
+          insert_headers {
+            name = "%[3]s"
+            value = "test-value-1"
+          }
+
+          insert_headers {
+            name = "%[4]s"
+            value = "test-value-2"
+          }
+        }
+      }
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US", "CA"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name, actionName, firstHeader, secondHeader)
+}
+
+func testAccAwsWafv2WebACLConfig_CustomResponse(name string, defaultStatusCode int, countryBlockStatusCode int, countryHeaderName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = "%[1]s"
+  description = "%[1]s"
+  scope       = "REGIONAL"
+
+  default_action {
+    block {
+      custom_response {
+        response_code = %[2]d
+      }
+    }
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      block {
+	    custom_response {
+          response_code = %[3]d
+          
+          response_headers {
+            name = "%[4]s"
+            value = "custom-response-header-value"
+          }
+        }
+      }
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US", "CA"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, name, defaultStatusCode, countryBlockStatusCode, countryHeaderName)
 }
 
 func testAccAwsWafv2WebACLConfig_GeoMatchStatement_ForwardedIPConfig(name, fallbackBehavior, headerName string) string {

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -497,14 +497,6 @@ func wafv2CustomResponseSchema() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"custom_response_body_key": {
-					Type:     schema.TypeString,
-					Optional: true,
-					ValidateFunc: validation.All(
-						validation.StringLenBetween(0, 128),
-						validation.StringMatch(regexp.MustCompile(`^[\w\-]+$`), "must contain only alphanumeric or hyphen characters"),
-					),
-				},
 				"response_code": {
 					Type:         schema.TypeInt,
 					Required:     true,
@@ -645,9 +637,6 @@ func expandWafv2CustomResponse(l []interface{}) *wafv2.CustomResponse {
 	}
 	if v, ok := m["response_header"]; ok && len(v.([]interface{})) > 0 {
 		customResponse.ResponseHeaders = expandWafv2CustomHeaders(v.([]interface{}))
-	}
-	if v, ok := m["custom_response_body_key"]; ok && len(v.(string)) > 0 {
-		customResponse.CustomResponseBodyKey = aws.String(v.(string))
 	}
 
 	return customResponse
@@ -1152,9 +1141,8 @@ func flattenWafv2CustomResponse(r *wafv2.CustomResponse) interface{} {
 	}
 
 	m := map[string]interface{}{
-		"custom_response_body_key": aws.StringValue(r.CustomResponseBodyKey),
-		"response_code":            int(aws.Int64Value(r.ResponseCode)),
-		"response_header":          flattenWafv2CustomHeaders(r.ResponseHeaders),
+		"response_code":   int(aws.Int64Value(r.ResponseCode)),
+		"response_header": flattenWafv2CustomHeaders(r.ResponseHeaders),
 	}
 
 	return []interface{}{m}

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -1098,8 +1098,10 @@ func flattenWafv2Allow(a *wafv2.AllowAction) interface{} {
 	if a == nil {
 		return map[string]interface{}{}
 	}
-	m := map[string]interface{}{
-		"custom_request_handling": flattenWafv2CustomRequestHandling(a.CustomRequestHandling),
+	m := map[string]interface{}{}
+
+	if a.CustomRequestHandling != nil {
+		m["custom_request_handling"] = flattenWafv2CustomRequestHandling(a.CustomRequestHandling)
 	}
 
 	return []interface{}{m}
@@ -1109,8 +1111,11 @@ func flattenWafv2Block(a *wafv2.BlockAction) interface{} {
 	if a == nil {
 		return map[string]interface{}{}
 	}
-	m := map[string]interface{}{
-		"custom_response": flattenWafv2CustomResponse(a.CustomResponse),
+
+	m := map[string]interface{}{}
+
+	if a.CustomResponse != nil {
+		m["custom_response"] = flattenWafv2CustomResponse(a.CustomResponse)
 	}
 
 	return []interface{}{m}
@@ -1120,8 +1125,10 @@ func flattenWafv2Count(a *wafv2.CountAction) interface{} {
 	if a == nil {
 		return map[string]interface{}{}
 	}
-	m := map[string]interface{}{
-		"custom_request_handling": flattenWafv2CustomRequestHandling(a.CustomRequestHandling),
+	m := map[string]interface{}{}
+
+	if a.CustomRequestHandling != nil {
+		m["custom_request_handling"] = flattenWafv2CustomRequestHandling(a.CustomRequestHandling)
 	}
 
 	return []interface{}{m}
@@ -1172,7 +1179,7 @@ func flattenWafv2CustomHeader(h *wafv2.CustomHTTPHeader) interface{} {
 		"value": aws.StringValue(h.Value),
 	}
 
-	return []interface{}{m}
+	return m
 }
 
 func flattenWafv2RootStatement(s *wafv2.Statement) interface{} {

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -463,8 +463,8 @@ func wafv2CustomRequestHandlingSchema() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"insert_headers": {
-					Type:     schema.TypeList,
+				"insert_header": {
+					Type:     schema.TypeSet,
 					Required: true,
 					MinItems: 1,
 					Elem: &schema.Resource{
@@ -510,8 +510,8 @@ func wafv2CustomResponseSchema() *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.IntBetween(200, 599),
 				},
-				"response_headers": {
-					Type:     schema.TypeList,
+				"response_header": {
+					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -643,7 +643,7 @@ func expandWafv2CustomResponse(l []interface{}) *wafv2.CustomResponse {
 	if v, ok := m["response_code"]; ok && v.(int) > 0 {
 		customResponse.ResponseCode = aws.Int64(int64(v.(int)))
 	}
-	if v, ok := m["response_headers"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := m["response_header"]; ok && len(v.([]interface{})) > 0 {
 		customResponse.ResponseHeaders = expandWafv2CustomHeaders(v.([]interface{}))
 	}
 	if v, ok := m["custom_response_body_key"]; ok && len(v.(string)) > 0 {
@@ -661,7 +661,7 @@ func expandWafv2CustomRequestHandling(l []interface{}) *wafv2.CustomRequestHandl
 	m := l[0].(map[string]interface{})
 	requestHandling := &wafv2.CustomRequestHandling{}
 
-	if v, ok := m["insert_headers"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := m["insert_header"]; ok && len(v.([]interface{})) > 0 {
 		requestHandling.InsertHeaders = expandWafv2CustomHeaders(v.([]interface{}))
 	}
 
@@ -1140,7 +1140,7 @@ func flattenWafv2CustomRequestHandling(c *wafv2.CustomRequestHandling) interface
 	}
 
 	m := map[string]interface{}{
-		"insert_headers": flattenWafv2CustomHeaders(c.InsertHeaders),
+		"insert_header": flattenWafv2CustomHeaders(c.InsertHeaders),
 	}
 
 	return []interface{}{m}
@@ -1154,7 +1154,7 @@ func flattenWafv2CustomResponse(r *wafv2.CustomResponse) interface{} {
 	m := map[string]interface{}{
 		"custom_response_body_key": aws.StringValue(r.CustomResponseBodyKey),
 		"response_code":            int(aws.Int64Value(r.ResponseCode)),
-		"response_headers":         flattenWafv2CustomHeaders(r.ResponseHeaders),
+		"response_header":          flattenWafv2CustomHeaders(r.ResponseHeaders),
 	}
 
 	return []interface{}{m}

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -635,8 +635,8 @@ func expandWafv2CustomResponse(l []interface{}) *wafv2.CustomResponse {
 	if v, ok := m["response_code"]; ok && v.(int) > 0 {
 		customResponse.ResponseCode = aws.Int64(int64(v.(int)))
 	}
-	if v, ok := m["response_header"]; ok && len(v.([]interface{})) > 0 {
-		customResponse.ResponseHeaders = expandWafv2CustomHeaders(v.([]interface{}))
+	if v, ok := m["response_header"]; ok && len(v.(*schema.Set).List()) > 0 {
+		customResponse.ResponseHeaders = expandWafv2CustomHeaders(v.(*schema.Set).List())
 	}
 
 	return customResponse
@@ -650,8 +650,8 @@ func expandWafv2CustomRequestHandling(l []interface{}) *wafv2.CustomRequestHandl
 	m := l[0].(map[string]interface{})
 	requestHandling := &wafv2.CustomRequestHandling{}
 
-	if v, ok := m["insert_header"]; ok && len(v.([]interface{})) > 0 {
-		requestHandling.InsertHeaders = expandWafv2CustomHeaders(v.([]interface{}))
+	if v, ok := m["insert_header"]; ok && len(v.(*schema.Set).List()) > 0 {
+		requestHandling.InsertHeaders = expandWafv2CustomHeaders(v.(*schema.Set).List())
 	}
 
 	return requestHandling

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -583,16 +583,16 @@ func expandWafv2RuleAction(l []interface{}) *wafv2.RuleAction {
 }
 
 func expandWafv2AllowAction(l []interface{}) *wafv2.AllowAction {
+	action := &wafv2.AllowAction{}
+
 	if len(l) == 0 || l[0] == nil {
-		return nil
+		return action
 	}
 
 	m, ok := l[0].(map[string]interface{})
 	if !ok {
-		return nil
+		return action
 	}
-
-	action := &wafv2.AllowAction{}
 
 	if v, ok := m["custom_request_handling"].([]interface{}); ok && len(v) > 0 {
 		action.CustomRequestHandling = expandWafv2CustomRequestHandling(v)
@@ -602,16 +602,16 @@ func expandWafv2AllowAction(l []interface{}) *wafv2.AllowAction {
 }
 
 func expandWafv2CountAction(l []interface{}) *wafv2.CountAction {
+	action := &wafv2.CountAction{}
+
 	if len(l) == 0 || l[0] == nil {
-		return nil
+		return action
 	}
 
 	m, ok := l[0].(map[string]interface{})
 	if !ok {
-		return nil
+		return action
 	}
-
-	action := &wafv2.CountAction{}
 
 	if v, ok := m["custom_request_handling"].([]interface{}); ok && len(v) > 0 {
 		action.CustomRequestHandling = expandWafv2CustomRequestHandling(v)
@@ -621,16 +621,16 @@ func expandWafv2CountAction(l []interface{}) *wafv2.CountAction {
 }
 
 func expandWafv2BlockAction(l []interface{}) *wafv2.BlockAction {
+	action := &wafv2.BlockAction{}
+
 	if len(l) == 0 || l[0] == nil {
-		return nil
+		return action
 	}
 
 	m, ok := l[0].(map[string]interface{})
 	if !ok {
-		return nil
+		return action
 	}
-
-	action := &wafv2.BlockAction{}
 
 	if v, ok := m["custom_response"].([]interface{}); ok && len(v) > 0 {
 		action.CustomResponse = expandWafv2CustomResponse(v)

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -307,11 +307,49 @@ Each `rule` supports the following arguments:
 
 The `action` block supports the following arguments:
 
-~> **NOTE:** One of `allow`, `block`, or `count`, expressed as an empty configuration block `{}`, is required when specifying an `action`
+~> **NOTE:** One of `allow`, `block`, or `count`, is required when specifying an `action`.
 
-* `allow` - (Optional) Instructs AWS WAF to allow the web request.
-* `block` - (Optional) Instructs AWS WAF to block the web request.
-* `count` - (Optional) Instructs AWS WAF to count the web request and allow it.
+* `allow` - (Optional) Instructs AWS WAF to allow the web request. See [Allow](#action) below for details.
+* `block` - (Optional) Instructs AWS WAF to block the web request. See [Block](#block) below for details.
+* `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [Count](#count) below for details.
+
+### Allow
+
+The `allow` block supports the following arguments:
+
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [Custom Request Handling](#custom-request-handling) below for details.
+
+### Block
+
+The `block` block supports the following arguments:
+
+* `custom_response` - (Optional) Defines a custom response for the web request. See [Custom Response](#custom-response) below for details.
+
+### Count
+
+The `count` block supports the following arguments:
+
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [Custom Request Handling](#custom-request-handling) below for details.
+
+### Custom Request Handling
+
+The `custom_request_handling` block supports the following arguments:
+
+* `insert_header` - (Required) The `insert_header` blocks used to define HTTP headers added to the request. See [Custom HTTP Header](#custom-http-header) below for details.
+
+### Custom Response
+
+The `custom_response` block supports the following arguments:
+
+* `response_code` - (Optional) The HTTP status code to return to the client.
+* `response_header` - (Optional) The `response_header` blocks used to define the HTTP response headers added to the response. See [Custom HTTP Header](#custom-http-header) below for details.
+
+### Custom HTTP Header
+
+Each block supports the following arguments. Duplicate header names are not allowed:
+
+* `name` - The name of the custom header. For custom request header insertion, when AWS WAF inserts the header into the request, it prefixes this name `x-amzn-waf-`, to avoid confusion with the headers that are already in the request. For example, for the header name `sample`, AWS WAF inserts the header `x-amzn-waf-sample`.
+* `value` - The value of the custom header.
 
 ### Statement
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -269,8 +269,8 @@ The `default_action` block supports the following arguments:
 
 ~> **NOTE:** One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
 
-* `allow` - (Optional) Specifies that AWS WAF should allow requests by default.
-* `block` - (Optional) Specifies that AWS WAF should block requests by default.
+* `allow` - (Optional) Specifies that AWS WAF should allow requests by default. See [Allow](#action) below for details.
+* `block` - (Optional) Specifies that AWS WAF should block requests by default. See [Block](#block) below for details.
 
 ### Rules
 
@@ -289,11 +289,11 @@ Each `rule` supports the following arguments:
 
 The `action` block supports the following arguments:
 
-~> **NOTE:** One of `allow`, `block`, or `count`, expressed as an empty configuration block `{}`, is required when specifying an `action`
+~> **NOTE:** One of `allow`, `block`, or `count`, is required when specifying an `action`.
 
-* `allow` - (Optional) Instructs AWS WAF to allow the web request. Configure as an empty block `{}`.
-* `block` - (Optional) Instructs AWS WAF to block the web request. Configure as an empty block `{}`.
-* `count` - (Optional) Instructs AWS WAF to count the web request and allow it. Configure as an empty block `{}`.
+* `allow` - (Optional) Instructs AWS WAF to allow the web request. See [Allow](#action) below for details.
+* `block` - (Optional) Instructs AWS WAF to block the web request. See [Block](#block) below for details.
+* `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [Count](#count) below for details.
 
 ### Override Action
 
@@ -303,6 +303,44 @@ The `override_action` block supports the following arguments:
 
 * `count` - (Optional) Override the rule action setting to count (i.e. only count matches). Configured as an empty block `{}`.
 * `none` - (Optional) Don't override the rule action setting. Configured as an empty block `{}`.
+
+### Allow
+
+The `allow` block supports the following arguments:
+
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [Custom Request Handling](#custom-request-handling) below for details.
+
+### Block
+
+The `block` block supports the following arguments:
+
+* `custom_response` - (Optional) Defines a custom response for the web request. See [Custom Response](#custom-response) below for details.
+
+### Count
+
+The `count` block supports the following arguments:
+
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [Custom Request Handling](#custom-request-handling) below for details.
+
+### Custom Request Handling
+
+The `custom_request_handling` block supports the following arguments:
+
+* `insert_header` - (Required) The `insert_header` blocks used to define HTTP headers added to the request. See [Custom HTTP Header](#custom-http-header) below for details.
+
+### Custom Response
+
+The `custom_response` block supports the following arguments:
+
+* `response_code` - (Optional) The HTTP status code to return to the client.
+* `response_header` - (Optional) The `response_header` blocks used to define the HTTP response headers added to the response. See [Custom HTTP Header](#custom-http-header) below for details.
+
+### Custom HTTP Header
+
+Each block supports the following arguments. Duplicate header names are not allowed:
+
+* `name` - The name of the custom header. For custom request header insertion, when AWS WAF inserts the header into the request, it prefixes this name `x-amzn-waf-`, to avoid confusion with the headers that are already in the request. For example, for the header name `sample`, AWS WAF inserts the header `x-amzn-waf-sample`.
+* `value` - The value of the custom header.
 
 ### Statement
 


### PR DESCRIPTION
This adds support for `custom_request_handling` on allow and count actions, and `custom_response` on block actions.

Notes:
 - I'm a first time contributor new to golang, so am learning as I go. Will accept suggestions/feedback.
 - I have added two acceptance tests to cover these changes. One for `custom_request_handling` and one for `custom_response`.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18754

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsWafv2WebACL_.+'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWafv2WebACL_.+ -timeout 180m
=== RUN   TestAccAwsWafv2WebACL_basic
=== PAUSE TestAccAwsWafv2WebACL_basic
=== RUN   TestAccAwsWafv2WebACL_updateRule
=== PAUSE TestAccAwsWafv2WebACL_updateRule
=== RUN   TestAccAwsWafv2WebACL_UpdateRuleProperties
=== PAUSE TestAccAwsWafv2WebACL_UpdateRuleProperties
=== RUN   TestAccAwsWafv2WebACL_ChangeNameForceNew
=== PAUSE TestAccAwsWafv2WebACL_ChangeNameForceNew
=== RUN   TestAccAwsWafv2WebACL_Disappears
=== PAUSE TestAccAwsWafv2WebACL_Disappears
=== RUN   TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== PAUSE TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== RUN   TestAccAwsWafv2WebACL_Minimal
=== PAUSE TestAccAwsWafv2WebACL_Minimal
=== RUN   TestAccAwsWafv2WebACL_RateBasedStatement
=== PAUSE TestAccAwsWafv2WebACL_RateBasedStatement
=== RUN   TestAccAwsWafv2WebACL_GeoMatchStatement
=== PAUSE TestAccAwsWafv2WebACL_GeoMatchStatement
=== RUN   TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig
=== PAUSE TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig
=== RUN   TestAccAwsWafv2WebACL_IPSetReferenceStatement
=== PAUSE TestAccAwsWafv2WebACL_IPSetReferenceStatement
=== RUN   TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig
=== PAUSE TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig
=== RUN   TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig
=== PAUSE TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig
=== RUN   TestAccAwsWafv2WebACL_RuleGroupReferenceStatement
=== PAUSE TestAccAwsWafv2WebACL_RuleGroupReferenceStatement
=== RUN   TestAccAwsWafv2WebACL_CustomRequestHandling
=== PAUSE TestAccAwsWafv2WebACL_CustomRequestHandling
=== RUN   TestAccAwsWafv2WebACL_CustomResponse
=== PAUSE TestAccAwsWafv2WebACL_CustomResponse
=== RUN   TestAccAwsWafv2WebACL_Tags
=== PAUSE TestAccAwsWafv2WebACL_Tags
=== RUN   TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements
=== PAUSE TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements
=== RUN   TestAccAwsWafv2WebACL_MaxNestedOperatorStatements
=== PAUSE TestAccAwsWafv2WebACL_MaxNestedOperatorStatements
=== CONT  TestAccAwsWafv2WebACL_basic
=== CONT  TestAccAwsWafv2WebACL_IPSetReferenceStatement
=== CONT  TestAccAwsWafv2WebACL_MaxNestedOperatorStatements
=== CONT  TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements
=== CONT  TestAccAwsWafv2WebACL_Tags
=== CONT  TestAccAwsWafv2WebACL_CustomResponse
=== CONT  TestAccAwsWafv2WebACL_CustomRequestHandling
=== CONT  TestAccAwsWafv2WebACL_UpdateRuleProperties
=== CONT  TestAccAwsWafv2WebACL_ManagedRuleGroupStatement
=== CONT  TestAccAwsWafv2WebACL_updateRule
=== CONT  TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig
=== CONT  TestAccAwsWafv2WebACL_GeoMatchStatement
=== CONT  TestAccAwsWafv2WebACL_RateBasedStatement
=== CONT  TestAccAwsWafv2WebACL_Minimal
=== CONT  TestAccAwsWafv2WebACL_ChangeNameForceNew
=== CONT  TestAccAwsWafv2WebACL_Disappears
=== CONT  TestAccAwsWafv2WebACL_RuleGroupReferenceStatement
=== CONT  TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig
=== CONT  TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig
--- PASS: TestAccAwsWafv2WebACL_Minimal (68.69s)
--- PASS: TestAccAwsWafv2WebACL_Disappears (76.45s)
--- PASS: TestAccAwsWafv2WebACL_ChangeNameForceNew (92.42s)
--- PASS: TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements (94.38s)
--- PASS: TestAccAwsWafv2WebACL_RuleGroupReferenceStatement (97.20s)
--- PASS: TestAccAwsWafv2WebACL_ManagedRuleGroupStatement (108.29s)
--- PASS: TestAccAwsWafv2WebACL_CustomResponse (109.22s)
--- PASS: TestAccAwsWafv2WebACL_MaxNestedOperatorStatements (114.64s)
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig (115.85s)
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement (132.15s)
--- PASS: TestAccAwsWafv2WebACL_Tags (133.90s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement (141.10s)
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement (142.37s)
--- PASS: TestAccAwsWafv2WebACL_CustomRequestHandling (143.13s)
--- PASS: TestAccAwsWafv2WebACL_basic (144.91s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig (145.64s)
--- PASS: TestAccAwsWafv2WebACL_updateRule (154.38s)
--- PASS: TestAccAwsWafv2WebACL_UpdateRuleProperties (163.60s)
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig (258.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       259.649s
```
