### PR TITLE
Default limits on backends per Virtual Node to 50

### DIFF
--- a/.changelog/19423.txt
+++ b/.changelog/19423.txt
@@ -1,0 +1,3 @@
+```release-notes:note
+resource/aws_appmesh_virtual_node: Number of default backends per virtual node increased up to 50
+```

--- a/aws/resource_aws_appmesh_virtual_node.go
+++ b/aws/resource_aws_appmesh_virtual_node.go
@@ -65,7 +65,7 @@ func resourceAwsAppmeshVirtualNode() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							MinItems: 0,
-							MaxItems: 25,
+							MaxItems: 50,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"virtual_service": {


### PR DESCRIPTION
Increase the number of default limits on backends per AppMesh Virtual
Node from 25 to 50, as it was announced on Nov 15, 2019 [1]

[1]: https://aws.amazon.com/about-aws/whats-new/2019/11/aws-app-mesh-increases-default-limits-on-several-resources/


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #10917

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=AppmeshVirtualNode'
```
