### PR TITLE
resource/networkfirewall_rule_group: check configuration changes in rules when determining update input

### DIFF
--- a/.changelog/19430.txt
+++ b/.changelog/19430.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_networkfirewall_rule_group: Correctly update resource on `rules` change
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19414 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateRules (163.26s)

--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rules (166.65s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_rulesSourceList (166.88s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statelessRuleWithCustomAction (178.55s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statefulRule (178.77s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_basic_statelessRule (178.78s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_disappears (193.26s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateRulesSourceList (266.68s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatelessRule (312.36s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_header (312.82s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateStatefulRule (329.79s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_tags (339.96s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_updateMultipleStatefulRules (386.25s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_statefulRule_action (393.60s)
--- PASS: TestAccAwsNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (405.81s)
```
