### PR TITLE
r/servicecatalog_budget_resource_association: New resource

### DIFF
--- a/.changelog/19452.txt
+++ b/.changelog/19452.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicecatalog_budget_resource_association
+```

--- a/.changelog/19454.txt
+++ b/.changelog/19454.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_addon: Use `service_account_role_arn`, if set, on updates
+```

--- a/aws/internal/service/servicecatalog/finder/finder.go
+++ b/aws/internal/service/servicecatalog/finder/finder.go
@@ -69,3 +69,32 @@ func ProductPortfolioAssociation(conn *servicecatalog.ServiceCatalog, acceptLang
 
 	return result, err
 }
+
+func BudgetResourceAssociation(conn *servicecatalog.ServiceCatalog, budgetName, resourceID string) (*servicecatalog.BudgetDetail, error) {
+	input := &servicecatalog.ListBudgetsForResourceInput{
+		ResourceId: aws.String(resourceID),
+	}
+
+	var result *servicecatalog.BudgetDetail
+
+	err := conn.ListBudgetsForResourcePages(input, func(page *servicecatalog.ListBudgetsForResourceOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, budget := range page.Budgets {
+			if budget == nil {
+				continue
+			}
+
+			if aws.StringValue(budget.BudgetName) == budgetName {
+				result = budget
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}

--- a/aws/internal/service/servicecatalog/id.go
+++ b/aws/internal/service/servicecatalog/id.go
@@ -32,3 +32,17 @@ func ProductPortfolioAssociationParseID(id string) (string, string, string, erro
 func ProductPortfolioAssociationCreateID(acceptLanguage, portfolioID, productID string) string {
 	return strings.Join([]string{acceptLanguage, portfolioID, productID}, ":")
 }
+
+func BudgetResourceAssociationParseID(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), budgetName:resourceID", id)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func BudgetResourceAssociationID(budgetName, resourceID string) string {
+	return strings.Join([]string{budgetName, resourceID}, ":")
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1021,6 +1021,7 @@ func Provider() *schema.Provider {
 			"aws_securityhub_organization_admin_account":              resourceAwsSecurityHubOrganizationAdminAccount(),
 			"aws_securityhub_product_subscription":                    resourceAwsSecurityHubProductSubscription(),
 			"aws_securityhub_standards_subscription":                  resourceAwsSecurityHubStandardsSubscription(),
+			"aws_servicecatalog_budget_resource_association":          resourceAwsServiceCatalogBudgetResourceAssociation(),
 			"aws_servicecatalog_constraint":                           resourceAwsServiceCatalogConstraint(),
 			"aws_servicecatalog_organizations_access":                 resourceAwsServiceCatalogOrganizationsAccess(),
 			"aws_servicecatalog_portfolio":                            resourceAwsServiceCatalogPortfolio(),

--- a/aws/resource_aws_servicecatalog_budget_resource_association.go
+++ b/aws/resource_aws_servicecatalog_budget_resource_association.go
@@ -1,0 +1,146 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsServiceCatalogBudgetResourceAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceCatalogBudgetResourceAssociationCreate,
+		Read:   resourceAwsServiceCatalogBudgetResourceAssociationRead,
+		Delete: resourceAwsServiceCatalogBudgetResourceAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"budget_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsServiceCatalogBudgetResourceAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.AssociateBudgetWithResourceInput{
+		BudgetName: aws.String(d.Get("budget_name").(string)),
+		ResourceId: aws.String(d.Get("resource_id").(string)),
+	}
+
+	var output *servicecatalog.AssociateBudgetWithResourceOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.AssociateBudgetWithResource(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.AssociateBudgetWithResource(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error associating Service Catalog Budget with Resource: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error creating Service Catalog Budget Resource Association: empty response")
+	}
+
+	d.SetId(tfservicecatalog.BudgetResourceAssociationID(d.Get("budget_name").(string), d.Get("resource_id").(string)))
+
+	return resourceAwsServiceCatalogBudgetResourceAssociationRead(d, meta)
+}
+
+func resourceAwsServiceCatalogBudgetResourceAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	budgetName, resourceID, err := tfservicecatalog.BudgetResourceAssociationParseID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("could not parse ID (%s): %w", d.Id(), err)
+	}
+
+	output, err := waiter.BudgetResourceAssociationReady(conn, budgetName, resourceID)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Service Catalog Budget Resource Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Budget Resource Association (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Catalog Budget Resource Association (%s): empty response", d.Id())
+	}
+
+	d.Set("resource_id", resourceID)
+	d.Set("budget_name", output.BudgetName)
+
+	return nil
+}
+
+func resourceAwsServiceCatalogBudgetResourceAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	budgetName, resourceID, err := tfservicecatalog.BudgetResourceAssociationParseID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("could not parse ID (%s): %w", d.Id(), err)
+	}
+
+	input := &servicecatalog.DisassociateBudgetFromResourceInput{
+		ResourceId: aws.String(resourceID),
+		BudgetName: aws.String(budgetName),
+	}
+
+	_, err = conn.DisassociateBudgetFromResource(input)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error disassociating Service Catalog Budget from Resource (%s): %w", d.Id(), err)
+	}
+
+	err = waiter.BudgetResourceAssociationDeleted(conn, budgetName, resourceID)
+
+	if err != nil && !tfresource.NotFound(err) {
+		return fmt.Errorf("error waiting for Service Catalog Budget Resource Disassociation (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_servicecatalog_budget_resource_association_test.go
+++ b/aws/resource_aws_servicecatalog_budget_resource_association_test.go
@@ -1,0 +1,268 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+// add sweeper to delete known test servicecat budget resource associations
+func init() {
+	resource.AddTestSweepers("aws_servicecatalog_budget_resource_association", &resource.Sweeper{
+		Name:         "aws_servicecatalog_budget_resource_association",
+		Dependencies: []string{},
+		F:            testSweepServiceCatalogBudgetResourceAssociations,
+	})
+}
+
+func testSweepServiceCatalogBudgetResourceAssociations(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).scconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &servicecatalog.ListPortfoliosInput{}
+
+	err = conn.ListPortfoliosPages(input, func(page *servicecatalog.ListPortfoliosOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, port := range page.PortfolioDetails {
+			if port == nil {
+				continue
+			}
+
+			resInput := &servicecatalog.ListBudgetsForResourceInput{
+				ResourceId: port.Id,
+			}
+
+			err = conn.ListBudgetsForResourcePages(resInput, func(page *servicecatalog.ListBudgetsForResourceOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, budget := range page.Budgets {
+					if budget == nil {
+						continue
+					}
+
+					r := resourceAwsServiceCatalogBudgetResourceAssociation()
+					d := r.Data(nil)
+					d.SetId(tfservicecatalog.BudgetResourceAssociationID(aws.StringValue(budget.BudgetName), aws.StringValue(port.Id)))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Budget Resource (Portfolio) Associations for %s: %w", region, err))
+	}
+
+	prodInput := &servicecatalog.SearchProductsAsAdminInput{}
+
+	err = conn.SearchProductsAsAdminPages(prodInput, func(page *servicecatalog.SearchProductsAsAdminOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, pvd := range page.ProductViewDetails {
+			if pvd == nil || pvd.ProductViewSummary == nil {
+				continue
+			}
+
+			resInput := &servicecatalog.ListBudgetsForResourceInput{
+				ResourceId: pvd.ProductViewSummary.ProductId,
+			}
+
+			err = conn.ListBudgetsForResourcePages(resInput, func(page *servicecatalog.ListBudgetsForResourceOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, budget := range page.Budgets {
+					if budget == nil {
+						continue
+					}
+
+					r := resourceAwsServiceCatalogBudgetResourceAssociation()
+					d := r.Data(nil)
+					d.SetId(tfservicecatalog.BudgetResourceAssociationID(aws.StringValue(budget.BudgetName), aws.StringValue(pvd.ProductViewSummary.ProductId)))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Budget Resource (Product) Associations for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Service Catalog Budget Resource Associations for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Service Catalog Budget Resource Associations sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func TestAccAWSServiceCatalogBudgetResourceAssociation_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_budget_resource_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogBudgetResourceAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogBudgetResourceAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogBudgetResourceAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "aws_servicecatalog_portfolio.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "budget_name", "aws_budgets_budget.test", "name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogBudgetResourceAssociation_disappears(t *testing.T) {
+	resourceName := "aws_servicecatalog_budget_resource_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogBudgetResourceAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogBudgetResourceAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogBudgetResourceAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogBudgetResourceAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogBudgetResourceAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).scconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_servicecatalog_budget_resource_association" {
+			continue
+		}
+
+		budgetName, resourceID, err := tfservicecatalog.BudgetResourceAssociationParseID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("could not parse ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		err = waiter.BudgetResourceAssociationDeleted(conn, budgetName, resourceID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("waiting for Service Catalog Budget Resource Association to be destroyed (%s): %w", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsServiceCatalogBudgetResourceAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		budgetName, resourceID, err := tfservicecatalog.BudgetResourceAssociationParseID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("could not parse ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).scconn
+
+		_, err = waiter.BudgetResourceAssociationReady(conn, budgetName, resourceID)
+
+		if err != nil {
+			return fmt.Errorf("waiting for Service Catalog Budget Resource Association existence (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSServiceCatalogBudgetResourceAssociationConfig_base(rName, budgetType, limitAmount, limitUnit, timePeriodStart, timeUnit string) string {
+	return fmt.Sprintf(`
+resource "aws_servicecatalog_portfolio" "test" {
+  name          = %[1]q
+  description   = %[1]q
+  provider_name = %[1]q
+}
+
+resource "aws_budgets_budget" "test" {
+  name              = %[1]q
+  budget_type       = %[2]q
+  limit_amount      = %[3]q
+  limit_unit        = %[4]q
+  time_period_start = %[5]q
+  time_unit         = %[6]q
+}
+`, rName, budgetType, limitAmount, limitUnit, timePeriodStart, timeUnit)
+}
+
+func testAccAWSServiceCatalogBudgetResourceAssociationConfig_basic(rName string) string {
+	return composeConfig(testAccAWSServiceCatalogBudgetResourceAssociationConfig_base(rName, "COST", "100.0", "USD", "2017-01-01_12:00", "MONTHLY"), fmt.Sprintf(`
+resource "aws_servicecatalog_budget_resource_association" "test" {
+  resource_id = aws_servicecatalog_portfolio.test.id
+  budget_name = %[1]q
+}
+`, rName))
+}

--- a/aws/resource_aws_servicecatalog_budget_resource_association_test.go
+++ b/aws/resource_aws_servicecatalog_budget_resource_association_test.go
@@ -141,8 +141,8 @@ func TestAccAWSServiceCatalogBudgetResourceAssociation_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("budgets", t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID, "budgets"),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceCatalogBudgetResourceAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -168,8 +168,8 @@ func TestAccAWSServiceCatalogBudgetResourceAssociation_disappears(t *testing.T) 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("budgets", t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID, "budgets"),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceCatalogBudgetResourceAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/servicecatalog_budget_resource_association.html.markdown
+++ b/website/docs/r/servicecatalog_budget_resource_association.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_budget_resource_association"
+description: |-
+  Manages a Service Catalog Budget Resource Association
+---
+
+# Resource: aws_servicecatalog_budget_resource_association
+
+Manages a Service Catalog Budget Resource Association.
+
+-> A "resource" is either a Service Catalog portfolio or product.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_budget_resource_association" "example" {
+  budget_name = "budget-pjtvyakdlyo3m"
+  resource_id = "prod-dnigbtea24ste"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `budget_name` - (Required) Budget name.
+* `resource_id` - (Required) Resource identifier.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Identifier of the association.
+
+## Import
+
+`aws_servicecatalog_budget_resource_association` can be imported using the budget name and resource ID, e.g.
+
+```
+$ terraform import aws_servicecatalog_budget_resource_association.example budget-pjtvyakdlyo3m:prod-dnigbtea24ste
+```

--- a/website/docs/r/servicecatalog_budget_resource_association.html.markdown
+++ b/website/docs/r/servicecatalog_budget_resource_association.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Service Catalog Budget Resource Association.
 
--> A "resource" is either a Service Catalog portfolio or product.
+-> **Tip:** A "resource" is either a Service Catalog portfolio or product.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19122

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogBudgetResourceAssociation_disappears (13.24s)
--- PASS: TestAccAWSServiceCatalogBudgetResourceAssociation_basic (15.21s)
```

Output from acceptance testing (GovCloud):

(partition `aws-us-gov` does not support budgets service)

```
--- SKIP: TestAccAWSServiceCatalogBudgetResourceAssociation_basic (1.23s)
--- SKIP: TestAccAWSServiceCatalogBudgetResourceAssociation_disappears (1.23s)
```
