### PR TITLE
r/eks_addon: Use service account

### DIFF
--- a/aws/resource_aws_eks_addon.go
+++ b/aws/resource_aws_eks_addon.go
@@ -243,7 +243,7 @@ func resourceAwsEksAddonUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	// If service account role ARN is already provided, use it. Otherwise, the add-on uses
 	// permissions assigned to the node IAM role.
-	if d.HasChange("service_account_role_arn") || d.Get("service_account_role_arn") != nil {
+	if d.HasChange("service_account_role_arn") || d.Get("service_account_role_arn").(string) != "" {
 		input.ServiceAccountRoleArn = aws.String(d.Get("service_account_role_arn").(string))
 	}
 

--- a/aws/resource_aws_eks_addon.go
+++ b/aws/resource_aws_eks_addon.go
@@ -241,7 +241,9 @@ func resourceAwsEksAddonUpdate(ctx context.Context, d *schema.ResourceData, meta
 		input.AddonVersion = aws.String(d.Get("addon_version").(string))
 	}
 
-	if d.HasChange("service_account_role_arn") {
+	// If service account role ARN is already provided, use it. Otherwise, the add-on uses
+	// permissions assigned to the node IAM role.
+	if d.HasChange("service_account_role_arn") || d.Get("service_account_role_arn") != nil {
 		input.ServiceAccountRoleArn = aws.String(d.Get("service_account_role_arn").(string))
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19403
Closes #19402

Output from acceptance testing (`us-west-2`):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_duplicateTag (4.37s)
--- PASS: TestAccAWSEksAddon_ServiceAccountRoleArn (823.69s)
--- PASS: TestAccAWSEksAddon_defaultTags_updateToProviderOnly (873.03s)
--- PASS: TestAccAWSEksAddon_defaultAndIgnoreTags (877.86s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerOnly (891.51s)
--- PASS: TestAccAWSEksAddon_disappears (897.03s)
--- PASS: TestAccAWSEksAddon_Tags (906.19s)
--- PASS: TestAccAWSEksAddon_ignoreTags (920.50s)
--- PASS: TestAccAWSEksAddon_defaultTags_updateToResourceOnly (949.72s)
--- PASS: TestAccAWSEksAddon_disappears_Cluster (988.40s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_overlappingTag (1005.13s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_nonOverlappingTag (1011.28s)
--- PASS: TestAccAWSEksAddon_ResolveConflicts (1032.76s)
--- PASS: TestAccAWSEksAddon_AddonVersion (1149.38s)
--- PASS: TestAccAWSEksAddon_basic (1164.05s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_duplicateTag (5.15s)
--- PASS: TestAccAWSEksAddon_disappears_Cluster (647.59s)
--- PASS: TestAccAWSEksAddon_defaultTags_updateToProviderOnly (663.42s)
--- PASS: TestAccAWSEksAddon_ResolveConflicts (681.14s)
--- PASS: TestAccAWSEksAddon_basic (714.48s)
--- PASS: TestAccAWSEksAddon_AddonVersion (825.23s)
--- PASS: TestAccAWSEksAddon_ignoreTags (728.63s)
--- PASS: TestAccAWSEksAddonDataSource_basic (738.06s)
--- PASS: TestAccAWSEksAddon_defaultAndIgnoreTags (738.26s)
--- PASS: TestAccAWSEksAddon_disappears (747.06s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerOnly (754.51s)
--- PASS: TestAccAWSEksAddon_ServiceAccountRoleArn (762.98s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_overlappingTag (763.24s)
--- PASS: TestAccAWSEksAddon_Tags (810.54s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_nonOverlappingTag (821.32s)
--- PASS: TestAccAWSEksAddon_defaultTags_updateToResourceOnly (831.51s)
```