### PR TITLE
[WIP] Bugfix update resource aws_ssm_document attachments_source

### DIFF
--- a/.changelog/19458.txt
+++ b/.changelog/19458.txt
@@ -1,3 +1,3 @@
 ```release-note:bugfix
-resource/aws_ssm_docment: Fix Attachments error on update:wq
+resource/aws_ssm_docment: Fix Attachments error on update
 ```

--- a/.changelog/19458.txt
+++ b/.changelog/19458.txt
@@ -1,0 +1,3 @@
+```release-note:bugfix
+resource/aws_ssm_docment: Fix Attachments error on update:wq
+```

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -382,7 +382,6 @@ func resourceAwsSsmDocumentUpdate(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error validating Permissions: %v", errors)
 		}
 	}
-
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
@@ -670,8 +669,8 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 		updateDocInput.VersionName = aws.String(v.(string))
 	}
 
-	if d.HasChange("attachments_source") {
-		updateDocInput.Attachments = expandSsmAttachmentsSources(d.Get("attachments_source").([]interface{}))
+	if v, ok := d.GetOk("attachments_source"); ok {
+		updateDocInput.Attachments = expandSsmAttachmentsSources(v.([]interface{}))
 	}
 
 	newDefaultVersion := d.Get("default_version").(string)


### PR DESCRIPTION
Fix aws_ssm_document Package Update. 

While updating the document with the same attachments_source the resource gives the following error:
InvalidParameterValueException: AttachmentSource not provided in the input request.

When the filename is different it works, because the attachments_source is only added when changed.
However this parameter is obligated in the API .

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18913

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
