### PR TITLE
Documentation: fixed import parameter in aws_dms_certificate

### DIFF
--- a/website/docs/r/dms_certificate.html.markdown
+++ b/website/docs/r/dms_certificate.html.markdown
@@ -42,8 +42,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Certificates can be imported using the `certificate_arn`, e.g.
+Certificates can be imported using the `certificate_id`, e.g.
 
 ```
-$ terraform import aws_dms_certificate.test arn:aws:dms:us-west-2:123456789:cert:xxxxxxxxxx
+$ terraform import aws_dms_certificate.test test-dms-certificate-tf
 ```


### PR DESCRIPTION
When importing `aws_dms_certificate`, the argument listed in the documentation is `certificate_arn`, but `certificate_id` is correct.

https://github.com/kangaechu/terraform-provider-aws/blob/7900b33d47fe9f26c0fb23f9672f3354dce7b734/aws/resource_aws_dms_certificate.go#L88-L95

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Closes #19460 


