### PR TITLE
r/servicecatalog_principal_portfolio_association: New resource

### DIFF
--- a/.changelog/19470.txt
+++ b/.changelog/19470.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_servicecatalog_principal_portfolio_association
+```

--- a/aws/data_source_aws_servicecatalog_constraint.go
+++ b/aws/data_source_aws_servicecatalog_constraint.go
@@ -18,7 +18,7 @@ func dataSourceAwsServiceCatalogConstraint() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"description": {

--- a/aws/internal/service/servicecatalog/enum.go
+++ b/aws/internal/service/servicecatalog/enum.go
@@ -3,9 +3,9 @@ package servicecatalog
 const (
 	// If AWS adds these to the API, we should use those and remove these.
 
-	ServiceCatalogAcceptLanguageEnglish  = "en"
-	ServiceCatalogAcceptLanguageJapanese = "jp"
-	ServiceCatalogAcceptLanguageChinese  = "zh"
+	AcceptLanguageEnglish  = "en"
+	AcceptLanguageJapanese = "jp"
+	AcceptLanguageChinese  = "zh"
 
 	ConstraintTypeLaunch         = "LAUNCH"
 	ConstraintTypeNotification   = "NOTIFICATION"
@@ -16,9 +16,9 @@ const (
 
 func AcceptLanguage_Values() []string {
 	return []string{
-		ServiceCatalogAcceptLanguageEnglish,
-		ServiceCatalogAcceptLanguageJapanese,
-		ServiceCatalogAcceptLanguageChinese,
+		AcceptLanguageEnglish,
+		AcceptLanguageJapanese,
+		AcceptLanguageChinese,
 	}
 }
 

--- a/aws/internal/service/servicecatalog/finder/finder.go
+++ b/aws/internal/service/servicecatalog/finder/finder.go
@@ -1,6 +1,7 @@
 package finder
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -124,6 +125,47 @@ func TagOptionResourceAssociation(conn *servicecatalog.ServiceCatalog, tagOption
 
 		return !lastPage
 	})
+
+	return result, err
+}
+
+func PrincipalPortfolioAssociation(conn *servicecatalog.ServiceCatalog, acceptLanguage, principalARN, portfolioID string) (*servicecatalog.Principal, error) {
+	input := &servicecatalog.ListPrincipalsForPortfolioInput{
+		PortfolioId: aws.String(portfolioID),
+	}
+
+	if acceptLanguage != "" {
+		input.AcceptLanguage = aws.String(acceptLanguage)
+	}
+
+	arns := make([]string, 3)
+
+	var result *servicecatalog.Principal
+
+	err := conn.ListPrincipalsForPortfolioPages(input, func(page *servicecatalog.ListPrincipalsForPortfolioOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, deet := range page.Principals {
+			if deet == nil {
+				continue
+			}
+
+			arns = append(arns, aws.StringValue(deet.PrincipalARN))
+
+			if aws.StringValue(deet.PrincipalARN) == principalARN {
+				result = deet
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if true {
+		return nil, fmt.Errorf("wut?? %v\narn: %s\narns: %v", input, principalARN, arns)
+	}
 
 	return result, err
 }

--- a/aws/internal/service/servicecatalog/finder/finder.go
+++ b/aws/internal/service/servicecatalog/finder/finder.go
@@ -1,7 +1,6 @@
 package finder
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -138,8 +137,6 @@ func PrincipalPortfolioAssociation(conn *servicecatalog.ServiceCatalog, acceptLa
 		input.AcceptLanguage = aws.String(acceptLanguage)
 	}
 
-	arns := make([]string, 3)
-
 	var result *servicecatalog.Principal
 
 	err := conn.ListPrincipalsForPortfolioPages(input, func(page *servicecatalog.ListPrincipalsForPortfolioOutput, lastPage bool) bool {
@@ -152,8 +149,6 @@ func PrincipalPortfolioAssociation(conn *servicecatalog.ServiceCatalog, acceptLa
 				continue
 			}
 
-			arns = append(arns, aws.StringValue(deet.PrincipalARN))
-
 			if aws.StringValue(deet.PrincipalARN) == principalARN {
 				result = deet
 				return false
@@ -162,10 +157,6 @@ func PrincipalPortfolioAssociation(conn *servicecatalog.ServiceCatalog, acceptLa
 
 		return !lastPage
 	})
-
-	if true {
-		return nil, fmt.Errorf("wut?? %v\narn: %s\narns: %v", input, principalARN, arns)
-	}
 
 	return result, err
 }

--- a/aws/internal/service/servicecatalog/id.go
+++ b/aws/internal/service/servicecatalog/id.go
@@ -73,3 +73,17 @@ func ProvisioningArtifactParseID(id string) (string, string, error) {
 	}
 	return parts[0], parts[1], nil
 }
+
+func PrincipalPortfolioAssociationParseID(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, ",", 3)
+
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%s), expected acceptLanguage,principalARN,portfolioID", id)
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}
+
+func PrincipalPortfolioAssociationID(acceptLanguage, principalARN, portfolioID string) string {
+	return strings.Join([]string{acceptLanguage, principalARN, portfolioID}, ",")
+}

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -305,9 +305,7 @@ func PrincipalPortfolioAssociationStatus(conn *servicecatalog.ServiceCatalog, ac
 		output, err := finder.PrincipalPortfolioAssociation(conn, acceptLanguage, principalARN, portfolioID)
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
-			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("principal portfolio association not found (%s): %s", tfservicecatalog.PrincipalPortfolioAssociationID(acceptLanguage, principalARN, portfolioID), err),
-			}
+			return nil, StatusNotFound, err
 		}
 
 		if err != nil {
@@ -315,9 +313,7 @@ func PrincipalPortfolioAssociationStatus(conn *servicecatalog.ServiceCatalog, ac
 		}
 
 		if output == nil {
-			return nil, StatusNotFound, &resource.NotFoundError{
-				Message: fmt.Sprintf("finding principal portfolio association (%s): empty response", tfservicecatalog.PrincipalPortfolioAssociationID(acceptLanguage, principalARN, portfolioID)),
-			}
+			return nil, StatusNotFound, err
 		}
 
 		return output, servicecatalog.StatusAvailable, err

--- a/aws/internal/service/servicecatalog/waiter/waiter.go
+++ b/aws/internal/service/servicecatalog/waiter/waiter.go
@@ -413,10 +413,12 @@ func ProvisioningArtifactDeleted(conn *servicecatalog.ServiceCatalog, id, produc
 
 func PrincipalPortfolioAssociationReady(conn *servicecatalog.ServiceCatalog, acceptLanguage, principalARN, portfolioID string) (*servicecatalog.Principal, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{StatusNotFound, StatusUnavailable},
-		Target:  []string{servicecatalog.StatusAvailable},
-		Refresh: PrincipalPortfolioAssociationStatus(conn, acceptLanguage, principalARN, portfolioID),
-		Timeout: PrincipalPortfolioAssociationReadyTimeout,
+		Pending:        []string{StatusNotFound, StatusUnavailable},
+		Target:         []string{servicecatalog.StatusAvailable},
+		Refresh:        PrincipalPortfolioAssociationStatus(conn, acceptLanguage, principalARN, portfolioID),
+		Timeout:        PrincipalPortfolioAssociationReadyTimeout,
+		NotFoundChecks: 5,
+		MinTimeout:     10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -430,10 +432,11 @@ func PrincipalPortfolioAssociationReady(conn *servicecatalog.ServiceCatalog, acc
 
 func PrincipalPortfolioAssociationDeleted(conn *servicecatalog.ServiceCatalog, acceptLanguage, principalARN, portfolioID string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{servicecatalog.StatusAvailable},
-		Target:  []string{StatusNotFound, StatusUnavailable},
-		Refresh: PrincipalPortfolioAssociationStatus(conn, acceptLanguage, principalARN, portfolioID),
-		Timeout: PrincipalPortfolioAssociationDeleteTimeout,
+		Pending:        []string{servicecatalog.StatusAvailable},
+		Target:         []string{StatusNotFound, StatusUnavailable},
+		Refresh:        PrincipalPortfolioAssociationStatus(conn, acceptLanguage, principalARN, portfolioID),
+		Timeout:        PrincipalPortfolioAssociationDeleteTimeout,
+		NotFoundChecks: 1,
 	}
 
 	_, err := stateConf.WaitForState()

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1040,6 +1040,7 @@ func Provider() *schema.Provider {
 			"aws_servicecatalog_service_action":                       resourceAwsServiceCatalogServiceAction(),
 			"aws_servicecatalog_tag_option":                           resourceAwsServiceCatalogTagOption(),
 			"aws_servicecatalog_tag_option_resource_association":      resourceAwsServiceCatalogTagOptionResourceAssociation(),
+			"aws_servicecatalog_principal_portfolio_association":      resourceAwsServiceCatalogPrincipalPortfolioAssociation(),
 			"aws_servicecatalog_product_portfolio_association":        resourceAwsServiceCatalogProductPortfolioAssociation(),
 			"aws_servicecatalog_provisioning_artifact":                resourceAwsServiceCatalogProvisioningArtifact(),
 			"aws_service_discovery_http_namespace":                    resourceAwsServiceDiscoveryHttpNamespace(),

--- a/aws/resource_aws_servicecatalog_constraint.go
+++ b/aws/resource_aws_servicecatalog_constraint.go
@@ -30,7 +30,7 @@ func resourceAwsServiceCatalogConstraint() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"description": {
@@ -151,7 +151,7 @@ func resourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta interf
 	acceptLanguage := d.Get("accept_language").(string)
 
 	if acceptLanguage == "" {
-		acceptLanguage = "en"
+		acceptLanguage = tfservicecatalog.AcceptLanguageEnglish
 	}
 
 	d.Set("accept_language", acceptLanguage)

--- a/aws/resource_aws_servicecatalog_constraint_test.go
+++ b/aws/resource_aws_servicecatalog_constraint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 )
 
 // add sweeper to delete known test servicecat constraints
@@ -106,7 +107,7 @@ func TestAccAWSServiceCatalogConstraint_basic(t *testing.T) {
 				Config: testAccAWSServiceCatalogConstraintConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogConstraintExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "NOTIFICATION"),
 					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", "aws_servicecatalog_portfolio.test", "id"),

--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 )
 
 func resourceAwsServiceCatalogPortfolio() *schema.Resource {
@@ -68,7 +69,7 @@ func resourceAwsServiceCatalogPortfolioCreate(d *schema.ResourceData, meta inter
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 	input := servicecatalog.CreatePortfolioInput{
-		AcceptLanguage:   aws.String("en"),
+		AcceptLanguage:   aws.String(tfservicecatalog.AcceptLanguageEnglish),
 		DisplayName:      aws.String(d.Get("name").(string)),
 		IdempotencyToken: aws.String(resource.UniqueId()),
 		Tags:             tags.IgnoreAws().ServicecatalogTags(),
@@ -98,7 +99,7 @@ func resourceAwsServiceCatalogPortfolioRead(d *schema.ResourceData, meta interfa
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := servicecatalog.DescribePortfolioInput{
-		AcceptLanguage: aws.String("en"),
+		AcceptLanguage: aws.String(tfservicecatalog.AcceptLanguageEnglish),
 	}
 	input.Id = aws.String(d.Id())
 
@@ -138,7 +139,7 @@ func resourceAwsServiceCatalogPortfolioRead(d *schema.ResourceData, meta interfa
 func resourceAwsServiceCatalogPortfolioUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).scconn
 	input := servicecatalog.UpdatePortfolioInput{
-		AcceptLanguage: aws.String("en"),
+		AcceptLanguage: aws.String(tfservicecatalog.AcceptLanguageEnglish),
 		Id:             aws.String(d.Id()),
 	}
 

--- a/aws/resource_aws_servicecatalog_portfolio_share.go
+++ b/aws/resource_aws_servicecatalog_portfolio_share.go
@@ -32,7 +32,7 @@ func resourceAwsServiceCatalogPortfolioShare() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"accepted": {

--- a/aws/resource_aws_servicecatalog_portfolio_share_test.go
+++ b/aws/resource_aws_servicecatalog_portfolio_share_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/finder"
 )
 
@@ -34,7 +35,7 @@ func TestAccAWSServiceCatalogPortfolioShare_basic(t *testing.T) {
 				Config: testAccAWSServiceCatalogPortfolioShareConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogPortfolioShareExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "accepted", "false"),
 					resource.TestCheckResourceAttrPair(resourceName, "principal_id", dataSourceName, "account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", compareName, "id"),
@@ -74,7 +75,7 @@ func TestAccAWSServiceCatalogPortfolioShare_organizationalUnit(t *testing.T) {
 				Config: testAccAWSServiceCatalogPortfolioShareConfig_organizationalUnit(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogPortfolioShareExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "accepted", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "principal_id", "aws_organizations_organizational_unit.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", compareName, "id"),

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association.go
@@ -1,0 +1,185 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsServiceCatalogPrincipalPortfolioAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceCatalogPrincipalPortfolioAssociationCreate,
+		Read:   resourceAwsServiceCatalogPrincipalPortfolioAssociationRead,
+		Delete: resourceAwsServiceCatalogPrincipalPortfolioAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"portfolio_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"principal_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"principal_unique_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"principal_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      servicecatalog.PrincipalTypeIam,
+				ValidateFunc: validation.StringInSlice(servicecatalog.PrincipalType_Values(), false),
+			},
+		},
+	}
+}
+
+func resourceAwsServiceCatalogPrincipalPortfolioAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.AssociatePrincipalWithPortfolioInput{
+		PortfolioId:  aws.String(d.Get("portfolio_id").(string)),
+		PrincipalARN: aws.String(d.Get("principal_arn").(string)),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("principal_type"); ok {
+		input.PrincipalType = aws.String(v.(string))
+	}
+
+	var output *servicecatalog.AssociatePrincipalWithPortfolioOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.AssociatePrincipalWithPortfolio(input)
+
+		if tfawserr.ErrMessageContains(err, servicecatalog.ErrCodeInvalidParametersException, "profile does not exist") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.AssociatePrincipalWithPortfolio(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error associating Service Catalog Principal with Portfolio: %w", err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error creating Service Catalog Principal Portfolio Association: empty response")
+	}
+
+	d.SetId(tfservicecatalog.PrincipalPortfolioAssociationID(d.Get("accept_language").(string), d.Get("principal_arn").(string), d.Get("portfolio_id").(string)))
+
+	return resourceAwsServiceCatalogPrincipalPortfolioAssociationRead(d, meta)
+}
+
+func resourceAwsServiceCatalogPrincipalPortfolioAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	acceptLanguage, principalARN, portfolioID, err := tfservicecatalog.PrincipalPortfolioAssociationParseID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("could not parse ID (%s): %w", d.Id(), err)
+	}
+
+	if acceptLanguage == "" {
+		acceptLanguage = tfservicecatalog.ServiceCatalogAcceptLanguageEnglish
+	}
+
+	output, err := waiter.PrincipalPortfolioAssociationReady(conn, acceptLanguage, principalARN, portfolioID)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Service Catalog Principal Portfolio Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Principal Portfolio Association (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Catalog Principal Portfolio Association (%s): empty response", d.Id())
+	}
+
+	d.Set("accept_language", acceptLanguage)
+	d.Set("portfolio_id", portfolioID)
+	d.Set("principal_arn", output.PrincipalARN)
+	d.Set("principal_type", output.PrincipalType)
+
+	return nil
+}
+
+func resourceAwsServiceCatalogPrincipalPortfolioAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	acceptLanguage, principalARN, portfolioID, err := tfservicecatalog.PrincipalPortfolioAssociationParseID(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("could not parse ID (%s): %w", d.Id(), err)
+	}
+
+	if acceptLanguage == "" {
+		acceptLanguage = tfservicecatalog.ServiceCatalogAcceptLanguageEnglish
+	}
+
+	input := &servicecatalog.DisassociatePrincipalFromPortfolioInput{
+		PortfolioId:    aws.String(portfolioID),
+		PrincipalARN:   aws.String(principalARN),
+		AcceptLanguage: aws.String(acceptLanguage),
+	}
+
+	_, err = conn.DisassociatePrincipalFromPortfolio(input)
+
+	if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error disassociating Service Catalog Principal from Portfolio (%s): %w", d.Id(), err)
+	}
+
+	err = waiter.PrincipalPortfolioAssociationDeleted(conn, acceptLanguage, principalARN, portfolioID)
+
+	if err != nil && !tfresource.NotFound(err) {
+		return fmt.Errorf("error waiting for Service Catalog Principal Portfolio Disassociation (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association.go
@@ -30,7 +30,7 @@ func resourceAwsServiceCatalogPrincipalPortfolioAssociation() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.ServiceCatalogAcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"portfolio_id": {

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association.go
@@ -30,7 +30,7 @@ func resourceAwsServiceCatalogPrincipalPortfolioAssociation() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				Default:      tfservicecatalog.ServiceCatalogAcceptLanguageEnglish,
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"portfolio_id": {
@@ -114,7 +114,7 @@ func resourceAwsServiceCatalogPrincipalPortfolioAssociationRead(d *schema.Resour
 	}
 
 	if acceptLanguage == "" {
-		acceptLanguage = tfservicecatalog.ServiceCatalogAcceptLanguageEnglish
+		acceptLanguage = tfservicecatalog.AcceptLanguageEnglish
 	}
 
 	output, err := waiter.PrincipalPortfolioAssociationReady(conn, acceptLanguage, principalARN, portfolioID)
@@ -151,7 +151,7 @@ func resourceAwsServiceCatalogPrincipalPortfolioAssociationDelete(d *schema.Reso
 	}
 
 	if acceptLanguage == "" {
-		acceptLanguage = tfservicecatalog.ServiceCatalogAcceptLanguageEnglish
+		acceptLanguage = tfservicecatalog.AcceptLanguageEnglish
 	}
 
 	input := &servicecatalog.DisassociatePrincipalFromPortfolioInput{

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association.go
@@ -43,13 +43,6 @@ func resourceAwsServiceCatalogPrincipalPortfolioAssociation() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			/*
-				"principal_unique_id": {
-					Type:     schema.TypeString,
-					Required: true,
-					ForceNew: true,
-				},
-			*/
 			"principal_type": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association_test.go
@@ -1,0 +1,237 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+// add sweeper to delete known test servicecat principal portfolio associations
+func init() {
+	resource.AddTestSweepers("aws_servicecatalog_principal_portfolio_association", &resource.Sweeper{
+		Name:         "aws_servicecatalog_principal_portfolio_association",
+		Dependencies: []string{},
+		F:            testSweepServiceCatalogPrincipalPortfolioAssociations,
+	})
+}
+
+func testSweepServiceCatalogPrincipalPortfolioAssociations(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).scconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &servicecatalog.ListPortfoliosInput{}
+
+	err = conn.ListPortfoliosPages(input, func(page *servicecatalog.ListPortfoliosOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, detail := range page.PortfolioDetails {
+			if detail == nil {
+				continue
+			}
+
+			pInput := &servicecatalog.ListPrincipalsForPortfolioInput{
+				PortfolioId: detail.Id,
+			}
+
+			err = conn.ListPrincipalsForPortfolioPages(pInput, func(page *servicecatalog.ListPrincipalsForPortfolioOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, principal := range page.Principals {
+					if principal == nil {
+						continue
+					}
+
+					r := resourceAwsServiceCatalogPrincipalPortfolioAssociation()
+					d := r.Data(nil)
+					d.SetId(tfservicecatalog.PrincipalPortfolioAssociationID("en", aws.StringValue(principal.PrincipalARN), aws.StringValue(detail.Id)))
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error listing Service Catalog Portfolios for Principals %s: %w", region, err))
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing Service Catalog Principal Portfolio Associations for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Service Catalog Principal Portfolio Associations for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Service Catalog Principal Portfolio Associations sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func TestAccAWSServiceCatalogPrincipalPortfolioAssociation_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_principal_portfolio_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", "aws_servicecatalog_portfolio.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "principal_arn", "aws_servicecatalog_principal.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogPrincipalPortfolioAssociation_disappears(t *testing.T) {
+	resourceName := "aws_servicecatalog_principal_portfolio_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogPrincipalPortfolioAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).scconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_servicecatalog_principal_portfolio_association" {
+			continue
+		}
+
+		acceptLanguage, principalARN, portfolioID, err := tfservicecatalog.PrincipalPortfolioAssociationParseID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("could not parse ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		err = waiter.PrincipalPortfolioAssociationDeleted(conn, acceptLanguage, principalARN, portfolioID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("waiting for Service Catalog Principal Portfolio Association to be destroyed (%s): %w", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		acceptLanguage, principalARN, portfolioID, err := tfservicecatalog.PrincipalPortfolioAssociationParseID(rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("could not parse ID (%s): %w", rs.Primary.ID, err)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).scconn
+
+		_, err = waiter.PrincipalPortfolioAssociationReady(conn, acceptLanguage, principalARN, portfolioID)
+
+		if err != nil {
+			return fmt.Errorf("waiting for Service Catalog Principal Portfolio Association existence (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_base(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "servicecatalog.${data.aws_partition.current.dns_suffix}"
+      }
+      Sid = ""
+    }]
+  })
+}
+
+resource "aws_servicecatalog_portfolio" "test" {
+  name          = %[1]q
+  provider_name = %[1]q
+}
+`, rName)
+}
+
+func testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_basic(rName string) string {
+	return composeConfig(testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_base(rName), `
+resource "aws_servicecatalog_principal_portfolio_association" "test" {
+  portfolio_id  = aws_servicecatalog_portfolio.test.id
+  principal_arn = aws_iam_role.test.unique_id
+}
+`)
+}

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association_test.go
@@ -65,7 +65,7 @@ func testSweepServiceCatalogPrincipalPortfolioAssociations(region string) error 
 
 					r := resourceAwsServiceCatalogPrincipalPortfolioAssociation()
 					d := r.Data(nil)
-					d.SetId(tfservicecatalog.PrincipalPortfolioAssociationID("en", aws.StringValue(principal.PrincipalARN), aws.StringValue(detail.Id)))
+					d.SetId(tfservicecatalog.PrincipalPortfolioAssociationID(tfservicecatalog.AcceptLanguageEnglish, aws.StringValue(principal.PrincipalARN), aws.StringValue(detail.Id)))
 
 					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 				}

--- a/aws/resource_aws_servicecatalog_principal_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_principal_portfolio_association_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -112,7 +113,7 @@ func TestAccAWSServiceCatalogPrincipalPortfolioAssociation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", "aws_servicecatalog_portfolio.test", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "principal_arn", "aws_servicecatalog_principal.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "principal_arn", "aws_iam_role.test", "arn"),
 				),
 			},
 			{
@@ -162,7 +163,7 @@ func testAccCheckAwsServiceCatalogPrincipalPortfolioAssociationDestroy(s *terraf
 
 		err = waiter.PrincipalPortfolioAssociationDeleted(conn, acceptLanguage, principalARN, portfolioID)
 
-		if tfresource.NotFound(err) {
+		if tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
 			continue
 		}
 
@@ -231,7 +232,7 @@ func testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_basic(rName str
 	return composeConfig(testAccAWSServiceCatalogPrincipalPortfolioAssociationConfig_base(rName), `
 resource "aws_servicecatalog_principal_portfolio_association" "test" {
   portfolio_id  = aws_servicecatalog_portfolio.test.id
-  principal_arn = aws_iam_role.test.unique_id
+  principal_arn = aws_iam_role.test.arn
 }
 `)
 }

--- a/aws/resource_aws_servicecatalog_product.go
+++ b/aws/resource_aws_servicecatalog_product.go
@@ -36,7 +36,7 @@ func resourceAwsServiceCatalogProduct() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"created_time": {

--- a/aws/resource_aws_servicecatalog_product_portfolio_association.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association.go
@@ -30,7 +30,7 @@ func resourceAwsServiceCatalogProductPortfolioAssociation() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"portfolio_id": {

--- a/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
@@ -86,7 +86,7 @@ func testSweepServiceCatalogProductPortfolioAssociations(region string) error {
 
 					r := resourceAwsServiceCatalogProductPortfolioAssociation()
 					d := r.Data(nil)
-					d.SetId(tfservicecatalog.ProductPortfolioAssociationCreateID("en", aws.StringValue(detail.Id), productID))
+					d.SetId(tfservicecatalog.ProductPortfolioAssociationCreateID(tfservicecatalog.AcceptLanguageEnglish, aws.StringValue(detail.Id), productID))
 
 					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 				}

--- a/aws/resource_aws_servicecatalog_product_test.go
+++ b/aws/resource_aws_servicecatalog_product_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
 )
 
@@ -93,7 +94,7 @@ func TestAccAWSServiceCatalogProduct_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "catalog", regexp.MustCompile(`product/prod-.*`)),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					testAccCheckResourceAttrRfc3339(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "description", "beskrivning"),
 					resource.TestCheckResourceAttr(resourceName, "distributor", "distributör"),

--- a/aws/resource_aws_servicecatalog_provisioning_artifact.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact.go
@@ -31,7 +31,7 @@ func resourceAwsServiceCatalogProvisioningArtifact() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"active": {

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -119,7 +119,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_basic(t *testing.T) {
 				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "disable_template_validation", "true"),
@@ -181,7 +181,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
 				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "guidance", servicecatalog.ProvisioningArtifactGuidanceDefault),
@@ -226,7 +226,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_physicalID(t *testing.T) {
 				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "disable_template_validation", "false"),

--- a/aws/resource_aws_servicecatalog_service_action.go
+++ b/aws/resource_aws_servicecatalog_service_action.go
@@ -30,7 +30,7 @@ func resourceAwsServiceCatalogServiceAction() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"definition": {

--- a/aws/resource_aws_servicecatalog_service_action_test.go
+++ b/aws/resource_aws_servicecatalog_service_action_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 )
 
 // add sweeper to delete known test servicecat service actions
@@ -88,7 +89,7 @@ func TestAccAWSServiceCatalogServiceAction_basic(t *testing.T) {
 				Config: testAccAWSServiceCatalogServiceActionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogServiceActionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.name", "AWS-RestartEC2Instance"),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
@@ -144,7 +145,7 @@ func TestAccAWSServiceCatalogServiceAction_update(t *testing.T) {
 				Config: testAccAWSServiceCatalogServiceActionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogServiceActionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.name", "AWS-RestartEC2Instance"),
 					resource.TestCheckResourceAttr(resourceName, "definition.0.version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
@@ -155,7 +156,7 @@ func TestAccAWSServiceCatalogServiceAction_update(t *testing.T) {
 				Config: testAccAWSServiceCatalogServiceActionConfig_update(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogServiceActionExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
 					resource.TestCheckResourceAttrPair(resourceName, "definition.0.assume_role", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "description", rName2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),

--- a/website/docs/r/servicecatalog_principal_portfolio_association.html.markdown
+++ b/website/docs/r/servicecatalog_principal_portfolio_association.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_principal_portfolio_association"
+description: |-
+  Manages a Service Catalog Principal Portfolio Association
+---
+
+# Resource: aws_servicecatalog_principal_portfolio_association
+
+Manages a Service Catalog Principal Portfolio Association.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_principal_portfolio_association" "example" {
+  portfolio_id  = "port-68656c6c6f"
+  principal_arn = "arn:aws:iam::123456789012:user/Eleanor"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `portfolio_id` - (Required) Portfolio identifier.
+* `principal_arn` - (Required) Principal ARN.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+* `principal_type` - (Optional) Principal type. Setting this argument empty (e.g., `principal_type = ""`) will result in an error. Valid value is `IAM`. Default is `IAM`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Identifier of the association.
+
+## Import
+
+`aws_servicecatalog_principal_portfolio_association` can be imported using the accept language, principal ARN, and portfolio ID, separated by a comma, e.g.
+
+```
+$ terraform import aws_servicecatalog_principal_portfolio_association.example en,arn:aws:iam::123456789012:user/Eleanor,port-68656c6c6f
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19122

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogPrincipalPortfolioAssociation_basic (29.80s)
--- PASS: TestAccAWSServiceCatalogPrincipalPortfolioAssociation_disappears (79.08s)
```

Output from acceptance testing (GovCloud):

(partition `aws-us-gov` does not support budgets service)

```
--- PASS: TestAccAWSServiceCatalogPrincipalPortfolioAssociation_basic (33.07s)
--- PASS: TestAccAWSServiceCatalogPrincipalPortfolioAssociation_disappears (81.99s)
```

### References:
* Unusual IAM behavior for rapidly creating IAM role and calling API: aws/aws-sdk-go#3920 (resolved by using the retry to wait until IAM returns an ARN rather than a unique ID for the role, note: that is also why the disappears test takes a bit longer than the basic test, distinguishing between not found because IAM is returning unique IDs and not found because it doesn't exist)