### PR TITLE
resource/apprunner_service: add missing arguments in expansion methods

### DIFF
--- a/.changelog/19471.txt
+++ b/.changelog/19471.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_service: Correctly configure `authentication_configuration`, `code_configuration`, and `image_configuration` nested arguments in API requests
+```

--- a/aws/resource_aws_apprunner_service.go
+++ b/aws/resource_aws_apprunner_service.go
@@ -680,6 +680,10 @@ func expandAppRunnerServiceAuthenticationConfiguration(l []interface{}) *apprunn
 		result.AccessRoleArn = aws.String(v)
 	}
 
+	if v, ok := tfMap["connection_arn"].(string); ok && v != "" {
+		result.ConnectionArn = aws.String(v)
+	}
+
 	return result
 }
 
@@ -698,6 +702,14 @@ func expandAppRunnerServiceImageConfiguration(l []interface{}) *apprunner.ImageC
 
 	if v, ok := tfMap["port"].(string); ok && v != "" {
 		result.Port = aws.String(v)
+	}
+
+	if v, ok := tfMap["runtime_environment_variables"].(map[string]interface{}); ok && len(v) > 0 {
+		result.RuntimeEnvironmentVariables = expandStringMap(v)
+	}
+
+	if v, ok := tfMap["start_command"].(string); ok && v != "" {
+		result.StartCommand = aws.String(v)
 	}
 
 	return result
@@ -806,6 +818,10 @@ func expandAppRunnerServiceCodeConfigurationValues(l []interface{}) *apprunner.C
 
 	if v, ok := tfMap["runtime"].(string); ok && v != "" {
 		result.Runtime = aws.String(v)
+	}
+
+	if v, ok := tfMap["runtime_environment_variables"].(map[string]interface{}); ok && len(v) > 0 {
+		result.RuntimeEnvironmentVariables = expandStringMap(v)
 	}
 
 	if v, ok := tfMap["start_command"].(string); ok && v != "" {

--- a/aws/resource_aws_apprunner_service_test.go
+++ b/aws/resource_aws_apprunner_service_test.go
@@ -281,6 +281,37 @@ func TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration(t *testing
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19469
+func TestAccAwsAppRunnerService_ImageRepository_RuntimeEnvironmentVars(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_apprunner_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAppRunner(t) },
+		ErrorCheck:   testAccErrorCheck(t, apprunner.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppRunnerServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRunnerService_imageRepository_runtimeEnvVars(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppRunnerServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.0.runtime_environment_variables.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.0.runtime_environment_variables.APP_NAME", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsAppRunnerService_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_apprunner_service.test"
@@ -434,6 +465,27 @@ resource "aws_apprunner_service" "test" {
     image_repository {
       image_configuration {
         port = "8000"
+      }
+      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_repository_type = "ECR_PUBLIC"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAppRunnerService_imageRepository_runtimeEnvVars(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apprunner_service" "test" {
+  service_name = %[1]q
+  source_configuration {
+    auto_deployments_enabled = false
+    image_repository {
+      image_configuration {
+        port = "8000"
+        runtime_environment_variables = {
+          APP_NAME = %[1]q
+        }
       }
       image_identifier      = "public.ecr.aws/jg/hello:latest"
       image_repository_type = "ECR_PUBLIC"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19469 

Output from acceptance testing (commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsAppRunnerService_ImageRepository_RuntimeEnvironmentVars (302.57s)

--- FAIL: TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration (8.46s) --> known failure (will create an issue for this one)
--- PASS: TestAccAwsAppRunnerService_disappears (206.59s)
--- PASS: TestAccAwsAppRunnerService_tags (239.63s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_basic (317.41s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_AutoScalingConfiguration (351.27s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_HealthCheckConfiguration (440.80s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_EncryptionConfiguration (459.00s)
```

Output from acceptance testing (gov cloud):

``` 
--- SKIP: TestAccAwsAppRunnerService_ImageRepository_HealthCheckConfiguration (19.62s)
--- SKIP: TestAccAwsAppRunnerService_ImageRepository_basic (19.79s)
--- SKIP: TestAccAwsAppRunnerService_ImageRepository_RuntimeEnvironmentVars (21.95s)
--- SKIP: TestAccAwsAppRunnerService_ImageRepository_EncryptionConfiguration (22.92s)
--- SKIP: TestAccAwsAppRunnerService_disappears (23.32s)
--- SKIP: TestAccAwsAppRunnerService_tags (25.92s)
--- SKIP: TestAccAwsAppRunnerService_ImageRepository_AutoScalingConfiguration (26.65s)
--- SKIP: TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration (26.73s)
```