### PR TITLE
resource/apprunner_service: fix resource creation with instance role and instance_configuration

### DIFF
--- a/.changelog/19483.txt
+++ b/.changelog/19483.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_apprunner_service: Handle asynchronous IAM eventual consistency error on creation
+```
+
+```release-note:bug
+resource/aws_apprunner_service: Suppress `instance_configuration` `cpu` and `memory` differences
+```

--- a/aws/resource_aws_apprunner_service_test.go
+++ b/aws/resource_aws_apprunner_service_test.go
@@ -93,6 +93,21 @@ func TestAccAwsAppRunnerService_ImageRepository_basic(t *testing.T) {
 					testAccCheckAwsAppRunnerServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_name", rName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`service/%s/.+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "auto_scaling_configuration_arn", "apprunner", regexp.MustCompile(`autoscalingconfiguration/DefaultConfiguration/1/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "health_check_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_configuration.0.protocol", apprunner.HealthCheckProtocolTcp),
+					resource.TestCheckResourceAttr(resourceName, "health_check_configuration.0.path", "/"),
+					// Only check the following attribute values for health_check and instance configurations
+					// are set as their defaults differ in the API documentation and API itself
+					resource.TestCheckResourceAttrSet(resourceName, "health_check_configuration.0.interval"),
+					resource.TestCheckResourceAttrSet(resourceName, "health_check_configuration.0.timeout"),
+					resource.TestCheckResourceAttrSet(resourceName, "health_check_configuration.0.healthy_threshold"),
+					resource.TestCheckResourceAttrSet(resourceName, "health_check_configuration.0.unhealthy_threshold"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.cpu"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.memory"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_url"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.auto_deployments_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.#", "1"),
@@ -100,6 +115,8 @@ func TestAccAwsAppRunnerService_ImageRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.0.port", "8000"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_identifier", "public.ecr.aws/jg/hello:latest"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_repository_type", apprunner.ImageRepositoryTypeEcrPublic),
+					resource.TestCheckResourceAttr(resourceName, "status", apprunner.ServiceStatusRunning),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -245,9 +262,9 @@ func TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration(t *testing
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppRunnerServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.cpu", "1 vCPU"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.cpu", "1024"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_configuration.0.instance_role_arn", roleResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.memory", "3 GB"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.memory", "3072"),
 				),
 			},
 			{
@@ -260,7 +277,7 @@ func TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration(t *testing
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppRunnerServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.cpu", "2 vCPU"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.cpu", "2048"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_configuration.0.instance_role_arn", roleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.memory", "4096"),
 				),
@@ -274,7 +291,9 @@ func TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration(t *testing
 				Config: testAccAppRunnerService_imageRepository(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppRunnerServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.cpu"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.memory"),
 				),
 			},
 		},
@@ -560,47 +579,13 @@ resource "aws_iam_role" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": [
-          "apprunner.${data.aws_partition.current.dns_suffix}"
-        ]
+        "Service": "tasks.apprunner.${data.aws_partition.current.dns_suffix}"
       },
-      "Action": [
-        "sts:AssumeRole"
-      ]
+      "Action": "sts:AssumeRole"
     }
   ]
 }
 EOF
-}
-
-resource "aws_iam_policy" "test" {
-  name        = %[1]q
-  path        = "/"
-  description = "App Runner PassRole Policy"
-
-  policy = <<EOF
-{
- "Version": "2012-10-17",
- "Statement": [
-   {
-     "Effect": "Allow",
-     "Action": [
-       "iam:PassRole",
-       "apprunner:*"
-     ],
-     "Resource": [
-       "*"
-     ]
-   }
- ]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test" {
-  name       = %[1]q
-  roles      = [aws_iam_role.test.name]
-  policy_arn = aws_iam_policy.test.arn
 }
 `, rName)
 }
@@ -642,7 +627,7 @@ resource "aws_apprunner_service" "test" {
   instance_configuration {
     cpu               = "2 vCPU"
     instance_role_arn = aws_iam_role.test.arn
-    memory            = "4096"
+    memory            = "4 GB"
   }
 
   source_configuration {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19484 

### Notes:
* AccTest _TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration_ was previously failing due to failure to assume role (iam eventual consistency 🤦‍♀️), so retry handling has been added. 
* While fixing the mentioned test, it became apparent that the `instance_configuration` `cpu` and `memory` values returned from API and set in state did not match original values if configured in `vCPU` or `GB`, respectively. Thus `DiffSuppressFuncs` have been added to address these. 
 
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsAppRunnerService_ImageRepository_basic (241.08s)
--- PASS: TestAccAwsAppRunnerService_disappears (246.84s)
--- PASS: TestAccAwsAppRunnerService_tags (278.58s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_AutoScalingConfiguration (315.06s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration (361.75s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_HealthCheckConfiguration (484.59s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_EncryptionConfiguration (533.10s)
```
