### PR TITLE
r/aws_lb_listener_rule: Allow empty string for `action.redirect.query`

### DIFF
--- a/.changelog/19496.txt
+++ b/.changelog/19496.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb_listener_rule: Allow blank string for `action.redirect.query` nested argument
+```

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -168,7 +168,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Default:      "#{query}",
-										ValidateFunc: validation.StringLenBetween(1, 128),
+										ValidateFunc: validation.StringLenBetween(0, 128),
 									},
 
 									"status_code": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19376.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBListenerRule_' ACCTEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSLBListenerRule_ -timeout 180m
=== RUN   TestAccAWSLBListenerRule_basic
=== PAUSE TestAccAWSLBListenerRule_basic
=== RUN   TestAccAWSLBListenerRule_tags
=== PAUSE TestAccAWSLBListenerRule_tags
=== RUN   TestAccAWSLBListenerRule_forwardWeighted
=== PAUSE TestAccAWSLBListenerRule_forwardWeighted
=== RUN   TestAccAWSLBListenerRule_BackwardsCompatibility
=== PAUSE TestAccAWSLBListenerRule_BackwardsCompatibility
=== RUN   TestAccAWSLBListenerRule_redirect
=== PAUSE TestAccAWSLBListenerRule_redirect
=== RUN   TestAccAWSLBListenerRule_fixedResponse
=== PAUSE TestAccAWSLBListenerRule_fixedResponse
=== RUN   TestAccAWSLBListenerRule_updateFixedResponse
=== PAUSE TestAccAWSLBListenerRule_updateFixedResponse
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
=== PAUSE TestAccAWSLBListenerRule_updateRulePriority
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== PAUSE TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== RUN   TestAccAWSLBListenerRule_priority
=== PAUSE TestAccAWSLBListenerRule_priority
=== RUN   TestAccAWSLBListenerRule_cognito
=== PAUSE TestAccAWSLBListenerRule_cognito
=== RUN   TestAccAWSLBListenerRule_oidc
=== PAUSE TestAccAWSLBListenerRule_oidc
=== RUN   TestAccAWSLBListenerRule_Action_Order
=== PAUSE TestAccAWSLBListenerRule_Action_Order
=== RUN   TestAccAWSLBListenerRule_Action_Order_Recreates
=== PAUSE TestAccAWSLBListenerRule_Action_Order_Recreates
=== RUN   TestAccAWSLBListenerRule_conditionAttributesCount
=== PAUSE TestAccAWSLBListenerRule_conditionAttributesCount
=== RUN   TestAccAWSLBListenerRule_conditionHostHeader
=== PAUSE TestAccAWSLBListenerRule_conditionHostHeader
=== RUN   TestAccAWSLBListenerRule_conditionHttpHeader
=== PAUSE TestAccAWSLBListenerRule_conditionHttpHeader
=== RUN   TestAccAWSLBListenerRule_conditionHttpHeader_invalid
=== PAUSE TestAccAWSLBListenerRule_conditionHttpHeader_invalid
=== RUN   TestAccAWSLBListenerRule_conditionHttpRequestMethod
=== PAUSE TestAccAWSLBListenerRule_conditionHttpRequestMethod
=== RUN   TestAccAWSLBListenerRule_conditionPathPattern
=== PAUSE TestAccAWSLBListenerRule_conditionPathPattern
=== RUN   TestAccAWSLBListenerRule_conditionQueryString
=== PAUSE TestAccAWSLBListenerRule_conditionQueryString
=== RUN   TestAccAWSLBListenerRule_conditionSourceIp
=== PAUSE TestAccAWSLBListenerRule_conditionSourceIp
=== RUN   TestAccAWSLBListenerRule_conditionUpdateMixed
=== PAUSE TestAccAWSLBListenerRule_conditionUpdateMixed
=== RUN   TestAccAWSLBListenerRule_conditionMultiple
=== PAUSE TestAccAWSLBListenerRule_conditionMultiple
=== RUN   TestAccAWSLBListenerRule_conditionUpdateMultiple
=== PAUSE TestAccAWSLBListenerRule_conditionUpdateMultiple
=== CONT  TestAccAWSLBListenerRule_basic
=== CONT  TestAccAWSLBListenerRule_Action_Order_Recreates
=== CONT  TestAccAWSLBListenerRule_conditionUpdateMultiple
=== CONT  TestAccAWSLBListenerRule_conditionMultiple
=== CONT  TestAccAWSLBListenerRule_conditionUpdateMixed
=== CONT  TestAccAWSLBListenerRule_conditionSourceIp
=== CONT  TestAccAWSLBListenerRule_conditionQueryString
=== CONT  TestAccAWSLBListenerRule_conditionHttpHeader
=== CONT  TestAccAWSLBListenerRule_conditionHostHeader
=== CONT  TestAccAWSLBListenerRule_conditionHttpHeader_invalid
=== CONT  TestAccAWSLBListenerRule_conditionAttributesCount
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (3.06s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (19.97s)
=== CONT  TestAccAWSLBListenerRule_conditionPathPattern
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (195.47s)
=== CONT  TestAccAWSLBListenerRule_conditionHttpRequestMethod
--- PASS: TestAccAWSLBListenerRule_basic (202.24s)
=== CONT  TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (202.97s)
=== CONT  TestAccAWSLBListenerRule_Action_Order
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (186.34s)
=== CONT  TestAccAWSLBListenerRule_oidc
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (213.54s)
=== CONT  TestAccAWSLBListenerRule_cognito
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (213.55s)
=== CONT  TestAccAWSLBListenerRule_priority
=== CONT  TestAccAWSLBListenerRule_Action_Order_Recreates
    testing_new.go:63: Error running post-test destroy, there may be dangling resources: exit status 1
        2021/05/24 11:45:05 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: AccessDenied: User: <ARN> is not authorized to perform: iam:DeleteServerCertificate on resource: server certificate tf-acc-test-3585884939490358602
        	status code: 403, request id: de70dfb6-9f10-4284-87f5-31af84df97cd
        
        
--- FAIL: TestAccAWSLBListenerRule_Action_Order_Recreates (214.32s)
=== CONT  TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (216.27s)
=== CONT  TestAccAWSLBListenerRule_redirect
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (223.82s)
=== CONT  TestAccAWSLBListenerRule_fixedResponse
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (269.36s)
=== CONT  TestAccAWSLBListenerRule_forwardWeighted
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (186.92s)
=== CONT  TestAccAWSLBListenerRule_BackwardsCompatibility
=== CONT  TestAccAWSLBListenerRule_Action_Order
    testing_new.go:63: Error running post-test destroy, there may be dangling resources: exit status 1
        2021/05/24 11:48:21 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: AccessDenied: User: <ARN> is not authorized to perform: iam:DeleteServerCertificate on resource: server certificate tf-acc-test-7705779240479493019
        	status code: 403, request id: e9038774-1ab0-4b45-a825-0df4b55e7c9d
        
        
--- FAIL: TestAccAWSLBListenerRule_Action_Order (195.64s)
=== CONT  TestAccAWSLBListenerRule_tags
=== CONT  TestAccAWSLBListenerRule_oidc
    testing_new.go:63: Error running post-test destroy, there may be dangling resources: exit status 1
        2021/05/24 11:48:37 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: AccessDenied: User: <ARN> is not authorized to perform: iam:DeleteServerCertificate on resource: server certificate tf-acc-test-8961799291599779974
        	status code: 403, request id: 04a699ce-1173-41ff-b0fc-58eca4094030
        
        
--- FAIL: TestAccAWSLBListenerRule_oidc (205.98s)
=== CONT  TestAccAWSLBListenerRule_updateFixedResponse
=== CONT  TestAccAWSLBListenerRule_cognito
    testing_new.go:63: Error running post-test destroy, there may be dangling resources: exit status 1
        2021/05/24 11:48:32 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: AccessDenied: User: <ARN> is not authorized to perform: iam:DeleteServerCertificate on resource: server certificate tf-acc-test-1811524195052031819
        	status code: 403, request id: 395a0eaa-36ef-4ffa-ae83-dc9b3945be5f
        
        
--- FAIL: TestAccAWSLBListenerRule_cognito (207.64s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (218.06s)
--- PASS: TestAccAWSLBListenerRule_redirect (241.61s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (265.00s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (253.82s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (230.14s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (185.88s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (206.89s)
--- PASS: TestAccAWSLBListenerRule_priority (431.97s)
--- PASS: TestAccAWSLBListenerRule_tags (253.64s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	655.876s
FAIL
make: *** [testacc] Error 1
```

Failures are unrelated to this change.

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBListenerRule_' ACCTEST_PARALLELISM=6
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 6 -run=TestAccAWSLBListenerRule_ -timeout 180m
=== RUN   TestAccAWSLBListenerRule_basic
=== PAUSE TestAccAWSLBListenerRule_basic
=== RUN   TestAccAWSLBListenerRule_tags
=== PAUSE TestAccAWSLBListenerRule_tags
=== RUN   TestAccAWSLBListenerRule_forwardWeighted
=== PAUSE TestAccAWSLBListenerRule_forwardWeighted
=== RUN   TestAccAWSLBListenerRule_BackwardsCompatibility
=== PAUSE TestAccAWSLBListenerRule_BackwardsCompatibility
=== RUN   TestAccAWSLBListenerRule_redirect
=== PAUSE TestAccAWSLBListenerRule_redirect
=== RUN   TestAccAWSLBListenerRule_fixedResponse
=== PAUSE TestAccAWSLBListenerRule_fixedResponse
=== RUN   TestAccAWSLBListenerRule_updateFixedResponse
=== PAUSE TestAccAWSLBListenerRule_updateFixedResponse
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
=== PAUSE TestAccAWSLBListenerRule_updateRulePriority
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== PAUSE TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== RUN   TestAccAWSLBListenerRule_priority
=== PAUSE TestAccAWSLBListenerRule_priority
=== RUN   TestAccAWSLBListenerRule_cognito
=== PAUSE TestAccAWSLBListenerRule_cognito
=== RUN   TestAccAWSLBListenerRule_oidc
=== PAUSE TestAccAWSLBListenerRule_oidc
=== RUN   TestAccAWSLBListenerRule_Action_Order
=== PAUSE TestAccAWSLBListenerRule_Action_Order
=== RUN   TestAccAWSLBListenerRule_Action_Order_Recreates
=== PAUSE TestAccAWSLBListenerRule_Action_Order_Recreates
=== RUN   TestAccAWSLBListenerRule_conditionAttributesCount
=== PAUSE TestAccAWSLBListenerRule_conditionAttributesCount
=== RUN   TestAccAWSLBListenerRule_conditionHostHeader
=== PAUSE TestAccAWSLBListenerRule_conditionHostHeader
=== RUN   TestAccAWSLBListenerRule_conditionHttpHeader
=== PAUSE TestAccAWSLBListenerRule_conditionHttpHeader
=== RUN   TestAccAWSLBListenerRule_conditionHttpHeader_invalid
=== PAUSE TestAccAWSLBListenerRule_conditionHttpHeader_invalid
=== RUN   TestAccAWSLBListenerRule_conditionHttpRequestMethod
=== PAUSE TestAccAWSLBListenerRule_conditionHttpRequestMethod
=== RUN   TestAccAWSLBListenerRule_conditionPathPattern
=== PAUSE TestAccAWSLBListenerRule_conditionPathPattern
=== RUN   TestAccAWSLBListenerRule_conditionQueryString
=== PAUSE TestAccAWSLBListenerRule_conditionQueryString
=== RUN   TestAccAWSLBListenerRule_conditionSourceIp
=== PAUSE TestAccAWSLBListenerRule_conditionSourceIp
=== RUN   TestAccAWSLBListenerRule_conditionUpdateMixed
=== PAUSE TestAccAWSLBListenerRule_conditionUpdateMixed
=== RUN   TestAccAWSLBListenerRule_conditionMultiple
=== PAUSE TestAccAWSLBListenerRule_conditionMultiple
=== RUN   TestAccAWSLBListenerRule_conditionUpdateMultiple
=== PAUSE TestAccAWSLBListenerRule_conditionUpdateMultiple
=== CONT  TestAccAWSLBListenerRule_basic
=== CONT  TestAccAWSLBListenerRule_Action_Order_Recreates
=== CONT  TestAccAWSLBListenerRule_conditionHttpRequestMethod
=== CONT  TestAccAWSLBListenerRule_conditionHttpHeader_invalid
=== CONT  TestAccAWSLBListenerRule_conditionHttpHeader
=== CONT  TestAccAWSLBListenerRule_conditionPathPattern
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (2.84s)
=== CONT  TestAccAWSLBListenerRule_conditionHostHeader
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (172.95s)
=== CONT  TestAccAWSLBListenerRule_conditionAttributesCount
--- PASS: TestAccAWSLBListenerRule_basic (172.93s)
=== CONT  TestAccAWSLBListenerRule_cognito
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (175.72s)
=== CONT  TestAccAWSLBListenerRule_Action_Order
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (180.37s)
=== CONT  TestAccAWSLBListenerRule_oidc
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (181.47s)
=== CONT  TestAccAWSLBListenerRule_redirect
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (183.12s)
=== CONT  TestAccAWSLBListenerRule_updateFixedResponse
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (25.48s)
=== CONT  TestAccAWSLBListenerRule_fixedResponse
=== CONT  TestAccAWSLBListenerRule_cognito
    provider_test.go:1103: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/05/24 11:31:03 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: Error creating LB Listener Rule: ValidationError: Action type 'authenticate-cognito' must be one of 'redirect,fixed-response,forward,authenticate-oidc'
        	status code: 400, request id: a1a3ded7-2b12-44f1-8fc1-9acd50d63aee
        
          on terraform_plugin_test.tf line 2, in resource "aws_lb_listener_rule" "cognito":
           2: resource "aws_lb_listener_rule" "cognito" {
        
        
--- PASS: TestAccAWSLBListenerRule_Action_Order (158.74s)
=== CONT  TestAccAWSLBListenerRule_updateRulePriority
--- SKIP: TestAccAWSLBListenerRule_cognito (174.60s)
=== CONT  TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_oidc (167.72s)
=== CONT  TestAccAWSLBListenerRule_priority
--- PASS: TestAccAWSLBListenerRule_fixedResponse (169.30s)
=== CONT  TestAccAWSLBListenerRule_conditionUpdateMixed
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (202.58s)
=== CONT  TestAccAWSLBListenerRule_conditionUpdateMultiple
--- PASS: TestAccAWSLBListenerRule_redirect (236.69s)
=== CONT  TestAccAWSLBListenerRule_conditionMultiple
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (196.91s)
=== CONT  TestAccAWSLBListenerRule_conditionSourceIp
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (217.22s)
=== CONT  TestAccAWSLBListenerRule_conditionQueryString
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (199.28s)
=== CONT  TestAccAWSLBListenerRule_tags
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (168.93s)
=== CONT  TestAccAWSLBListenerRule_BackwardsCompatibility
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (228.90s)
=== CONT  TestAccAWSLBListenerRule_forwardWeighted
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (168.76s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (188.33s)
--- PASS: TestAccAWSLBListenerRule_priority (399.44s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (164.84s)
--- PASS: TestAccAWSLBListenerRule_tags (215.32s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (218.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	818.055s
```
