### PR TITLE
r/aws_elasticsearch_domain_saml_options: New resource

### DIFF
--- a/.changelog/19497.txt
+++ b/.changelog/19497.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_elasticsearch_domain_saml_options
+```

--- a/aws/elasticsearch_domain_structure.go
+++ b/aws/elasticsearch_domain_structure.go
@@ -45,8 +45,12 @@ func expandAdvancedSecurityOptions(m []interface{}) *elasticsearch.AdvancedSecur
 }
 
 func expandESSAMLOptions(data []interface{}) *elasticsearch.SAMLOptionsInput {
-	if len(data) == 0 || data[0] == nil {
+	if len(data) == 0 {
 		return nil
+	}
+
+	if data[0] == nil {
+		return &elasticsearch.SAMLOptionsInput{}
 	}
 
 	options := elasticsearch.SAMLOptionsInput{}
@@ -119,15 +123,9 @@ func flattenESSAMLOptions(d *schema.ResourceData, samlOptions *elasticsearch.SAM
 		"idp":     flattenESSAMLIdpOptions(samlOptions.Idp),
 	}
 
-	if samlOptions.RolesKey != nil {
-		m["roles_key"] = aws.StringValue(samlOptions.RolesKey)
-	}
-	if samlOptions.SessionTimeoutMinutes != nil {
-		m["session_timeout_minutes"] = aws.Int64Value(samlOptions.SessionTimeoutMinutes)
-	}
-	if samlOptions.SubjectKey != nil {
-		m["subject_key"] = aws.StringValue(samlOptions.SubjectKey)
-	}
+	m["roles_key"] = aws.StringValue(samlOptions.RolesKey)
+	m["session_timeout_minutes"] = aws.Int64Value(samlOptions.SessionTimeoutMinutes)
+	m["subject_key"] = aws.StringValue(samlOptions.SubjectKey)
 
 	// samlOptions.master_backend_role and samlOptions.master_user_name will be added to the
 	// all_access role in kibana's security manager.  These values cannot be read or

--- a/aws/elasticsearch_domain_structure.go
+++ b/aws/elasticsearch_domain_structure.go
@@ -44,6 +44,57 @@ func expandAdvancedSecurityOptions(m []interface{}) *elasticsearch.AdvancedSecur
 	return &config
 }
 
+func expandESSAMLOptions(data []interface{}) *elasticsearch.SAMLOptionsInput {
+	if len(data) == 0 || data[0] == nil {
+		return nil
+	}
+
+	options := elasticsearch.SAMLOptionsInput{}
+	group := data[0].(map[string]interface{})
+
+	if SAMLEnabled, ok := group["enabled"]; ok {
+		options.Enabled = aws.Bool(SAMLEnabled.(bool))
+
+		if SAMLEnabled.(bool) {
+			options.Idp = expandSAMLOptionsIdp(group["idp"].([]interface{}))
+			if v, ok := group["master_backend_role"].(string); ok && v != "" {
+				options.MasterBackendRole = aws.String(v)
+			}
+			if v, ok := group["master_user_name"].(string); ok && v != "" {
+				options.MasterUserName = aws.String(v)
+			}
+			if v, ok := group["roles_key"].(string); ok {
+				options.RolesKey = aws.String(v)
+			}
+			if v, ok := group["session_timeout_minutes"].(int); ok {
+				options.SessionTimeoutMinutes = aws.Int64(int64(v))
+			}
+			if v, ok := group["subject_key"].(string); ok {
+				options.SubjectKey = aws.String(v)
+			}
+		}
+	}
+
+	return &options
+}
+
+func expandSAMLOptionsIdp(l []interface{}) *elasticsearch.SAMLIdp {
+	if len(l) == 0 {
+		return nil
+	}
+
+	if l[0] == nil {
+		return &elasticsearch.SAMLIdp{}
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &elasticsearch.SAMLIdp{
+		EntityId:        aws.String(m["entity_id"].(string)),
+		MetadataContent: aws.String(m["metadata_content"].(string)),
+	}
+}
+
 func flattenAdvancedSecurityOptions(advancedSecurityOptions *elasticsearch.AdvancedSecurityOptions) []map[string]interface{} {
 	if advancedSecurityOptions == nil {
 		return []map[string]interface{}{}
@@ -56,6 +107,49 @@ func flattenAdvancedSecurityOptions(advancedSecurityOptions *elasticsearch.Advan
 	}
 
 	return []map[string]interface{}{m}
+}
+
+func flattenESSAMLOptions(d *schema.ResourceData, samlOptions *elasticsearch.SAMLOptionsOutput) []interface{} {
+	if samlOptions == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"enabled": aws.BoolValue(samlOptions.Enabled),
+		"idp":     flattenESSAMLIdpOptions(samlOptions.Idp),
+	}
+
+	if samlOptions.RolesKey != nil {
+		m["roles_key"] = aws.StringValue(samlOptions.RolesKey)
+	}
+	if samlOptions.SessionTimeoutMinutes != nil {
+		m["session_timeout_minutes"] = aws.Int64Value(samlOptions.SessionTimeoutMinutes)
+	}
+	if samlOptions.SubjectKey != nil {
+		m["subject_key"] = aws.StringValue(samlOptions.SubjectKey)
+	}
+
+	// samlOptions.master_backend_role and samlOptions.master_user_name will be added to the
+	// all_access role in kibana's security manager.  These values cannot be read or
+	// modified by the elasticsearch API.  So, we ignore it on read and let persist
+	// the value already in the state.
+	m["master_backend_role"] = d.Get("saml_options.0.master_backend_role").(string)
+	m["master_user_name"] = d.Get("saml_options.0.master_user_name").(string)
+
+	return []interface{}{m}
+}
+
+func flattenESSAMLIdpOptions(SAMLIdp *elasticsearch.SAMLIdp) []interface{} {
+	if SAMLIdp == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"entity_id":        aws.StringValue(SAMLIdp.EntityId),
+		"metadata_content": aws.StringValue(SAMLIdp.MetadataContent),
+	}
+
+	return []interface{}{m}
 }
 
 func getMasterUserOptions(d *schema.ResourceData) []interface{} {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -723,6 +723,7 @@ func Provider() *schema.Provider {
 			"aws_elastic_beanstalk_environment":                       resourceAwsElasticBeanstalkEnvironment(),
 			"aws_elasticsearch_domain":                                resourceAwsElasticSearchDomain(),
 			"aws_elasticsearch_domain_policy":                         resourceAwsElasticSearchDomainPolicy(),
+			"aws_elasticsearch_domain_saml_options":                   resourceAwsElasticSearchDomainSAMLOptions(),
 			"aws_elastictranscoder_pipeline":                          resourceAwsElasticTranscoderPipeline(),
 			"aws_elastictranscoder_preset":                            resourceAwsElasticTranscoderPreset(),
 			"aws_elb":                                                 resourceAwsElb(),

--- a/aws/resource_aws_elasticsearch_domain_saml_options.go
+++ b/aws/resource_aws_elasticsearch_domain_saml_options.go
@@ -1,0 +1,218 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsElasticSearchDomainSAMLOptions() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElasticSearchDomainSAMLOptionsPut,
+		Read:   resourceAwsElasticSearchDomainSAMLOptionsRead,
+		Update: resourceAwsElasticSearchDomainSAMLOptionsPut,
+		Delete: resourceAwsElasticSearchDomainSAMLOptionsDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"saml_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"idp": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"entity_id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"metadata_content": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+						"master_backend_role": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"master_user_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"roles_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"session_timeout_minutes": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      60,
+							ValidateFunc: validation.IntBetween(1, 1440),
+						},
+						"subject_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsElasticSearchDomainSAMLOptionsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).esconn
+
+	input := &elasticsearch.DescribeElasticsearchDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	domain, err := conn.DescribeElasticsearchDomain(input)
+
+	if err != nil {
+		if !d.IsNewResource() {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+				log.Printf("[WARN] ElasticSearch Domain %q not found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] Received ElasticSearch domain: %s", domain)
+
+	ds := domain.DomainStatus
+	options := ds.AdvancedSecurityOptions.SAMLOptions
+
+	if err := d.Set("saml_options", flattenESSAMLOptions(d, options)); err != nil {
+		return fmt.Errorf("error setting saml_options for ElasticSearch Configuration: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsElasticSearchDomainSAMLOptionsPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).esconn
+
+	domainName := d.Get("domain_name").(string)
+	config := elasticsearch.AdvancedSecurityOptionsInput{}
+	config.SetSAMLOptions(expandESSAMLOptions(d.Get("saml_options").([]interface{})))
+
+	log.Printf("[DEBUG] Updating ElasticSearch domain SAML Options %s", config)
+
+	_, err := conn.UpdateElasticsearchDomainConfig(&elasticsearch.UpdateElasticsearchDomainConfigInput{
+		DomainName:              aws.String(domainName),
+		AdvancedSecurityOptions: &config,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("esd-saml-options-" + domainName)
+
+	input := &elasticsearch.DescribeElasticsearchDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+	var out *elasticsearch.DescribeElasticsearchDomainOutput
+	err = resource.Retry(50*time.Minute, func() *resource.RetryError {
+		var err error
+		out, err = conn.DescribeElasticsearchDomain(input)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if !*out.DomainStatus.Processing {
+			return nil
+		}
+
+		return resource.RetryableError(
+			fmt.Errorf("%q: Timeout while waiting for changes to be processed", d.Id()))
+	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.DescribeElasticsearchDomain(input)
+		if err == nil && !*out.DomainStatus.Processing {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error updating Elasticsearch domain SAML Options: %s", err)
+	}
+
+	return resourceAwsElasticSearchDomainSAMLOptionsRead(d, meta)
+}
+
+func resourceAwsElasticSearchDomainSAMLOptionsDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).esconn
+
+	domainName := d.Get("domain_name").(string)
+	config := elasticsearch.AdvancedSecurityOptionsInput{}
+	config.SetSAMLOptions(nil)
+
+	_, err := conn.UpdateElasticsearchDomainConfig(&elasticsearch.UpdateElasticsearchDomainConfigInput{
+		DomainName:              aws.String(domainName),
+		AdvancedSecurityOptions: &config,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Waiting for ElasticSearch domain SAML Options %q to be deleted", d.Get("domain_name").(string))
+
+	input := &elasticsearch.DescribeElasticsearchDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+	var out *elasticsearch.DescribeElasticsearchDomainOutput
+	err = resource.Retry(60*time.Minute, func() *resource.RetryError {
+		var err error
+		out, err = conn.DescribeElasticsearchDomain(input)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if !*out.DomainStatus.Processing {
+			return nil
+		}
+
+		return resource.RetryableError(
+			fmt.Errorf("%q: Timeout while waiting for SAML Options to be deleted", d.Id()))
+	})
+	if isResourceTimeoutError(err) {
+		out, err := conn.DescribeElasticsearchDomain(input)
+		if err == nil && !*out.DomainStatus.Processing {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting Elasticsearch domain SAML Options: %s", err)
+	}
+	return nil
+}

--- a/aws/resource_aws_elasticsearch_domain_saml_options_test.go
+++ b/aws/resource_aws_elasticsearch_domain_saml_options_test.go
@@ -373,7 +373,7 @@ resource "aws_elasticsearch_domain_saml_options" "main" {
   domain_name = aws_elasticsearch_domain.example.domain_name
 
   saml_options {
-    enabled                 = false
+    enabled = false
   }
 }
 `, userName, domainName)

--- a/aws/resource_aws_elasticsearch_domain_saml_options_test.go
+++ b/aws/resource_aws_elasticsearch_domain_saml_options_test.go
@@ -32,7 +32,15 @@ func TestAccAWSElasticSearchDomainSAMLOptions_basic(t *testing.T) {
 					testAccCheckESDomainExists(esDomainResourceName, &domain),
 					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.idp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.idp.0.entity_id", "https://terraform-dev-ed.my.salesforce.com"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -110,6 +118,38 @@ func TestAccAWSElasticSearchDomainSAMLOptions_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "180"),
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticSearchDomainSAMLOptions_Disabled(t *testing.T) {
+	rName := acctest.RandomWithPrefix("acc-test")
+	rUserName := acctest.RandomWithPrefix("es-master-user")
+	resourceName := "aws_elasticsearch_domain_saml_options.main"
+	esDomainResourceName := "aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticsearch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainSAMLOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainSAMLOptionsConfig(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "60"),
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+				),
+			},
+			{
+				Config: testAccESDomainSAMLOptionsConfigDisabled(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "0"),
 					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
 				),
 			},
@@ -281,6 +321,59 @@ resource "aws_elasticsearch_domain_saml_options" "main" {
       metadata_content = file("./test-fixtures/saml-metadata.xml")
     }
     session_timeout_minutes = 180
+  }
+}
+`, userName, domainName)
+}
+
+func testAccESDomainSAMLOptionsConfigDisabled(userName string, domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "es_master_user" {
+  name = "%s"
+}
+
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "%s"
+  elasticsearch_version = "7.10"
+
+  cluster_config {
+    instance_type = "r5.large.elasticsearch"
+  }
+
+  # Advanced security option must be enabled to configure SAML.
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = false
+    master_user_options {
+      master_user_arn = aws_iam_user.es_master_user.arn
+    }
+  }
+
+  # You must enable node-to-node encryption to use advanced security options.
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+
+resource "aws_elasticsearch_domain_saml_options" "main" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  saml_options {
+    enabled                 = false
   }
 }
 `, userName, domainName)

--- a/aws/resource_aws_elasticsearch_domain_saml_options_test.go
+++ b/aws/resource_aws_elasticsearch_domain_saml_options_test.go
@@ -1,0 +1,311 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSElasticSearchDomainSAMLOptions_basic(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+
+	rName := acctest.RandomWithPrefix("acc-test")
+	rUserName := acctest.RandomWithPrefix("es-master-user")
+	resourceName := "aws_elasticsearch_domain_saml_options.main"
+	esDomainResourceName := "aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticsearch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainSAMLOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainSAMLOptionsConfig(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists(esDomainResourceName, &domain),
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticSearchDomainSAMLOptions_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("acc-test")
+	rUserName := acctest.RandomWithPrefix("es-master-user")
+	resourceName := "aws_elasticsearch_domain_saml_options.main"
+	esDomainResourceName := "aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticsearch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainSAMLOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainSAMLOptionsConfig(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsElasticSearchDomainSAMLOptions(), resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticSearchDomainSAMLOptions_disappears_Domain(t *testing.T) {
+	rName := acctest.RandomWithPrefix("acc-test")
+	rUserName := acctest.RandomWithPrefix("es-master-user")
+	resourceName := "aws_elasticsearch_domain_saml_options.main"
+	esDomainResourceName := "aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticsearch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainSAMLOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainSAMLOptionsConfig(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsElasticSearchDomain(), esDomainResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticSearchDomainSAMLOptions_Update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("acc-test")
+	rUserName := acctest.RandomWithPrefix("es-master-user")
+	resourceName := "aws_elasticsearch_domain_saml_options.main"
+	esDomainResourceName := "aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticsearch.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainSAMLOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainSAMLOptionsConfig(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "60"),
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+				),
+			},
+			{
+				Config: testAccESDomainSAMLOptionsConfigUpdate(rUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout_minutes", "180"),
+					testAccCheckESDomainSAMLOptions(esDomainResourceName, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckESDomainSAMLOptionsDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).esconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticsearch_domain_saml_options" {
+			continue
+		}
+
+		resp, err := conn.DescribeElasticsearchDomain(&elasticsearch.DescribeElasticsearchDomainInput{
+			DomainName: aws.String(rs.Primary.Attributes["domain_name"]),
+		})
+
+		if err == nil {
+			return fmt.Errorf("Elasticsearch Domain still exists %s", resp)
+		}
+
+		awsErr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if awsErr.Code() != "ResourceNotFoundException" {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckESDomainSAMLOptionsDisappears(domainName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).esconn
+
+		input := elasticsearch.AdvancedSecurityOptionsInput{}
+		input.SetSAMLOptions(nil)
+		_, err := conn.UpdateElasticsearchDomainConfig(&elasticsearch.UpdateElasticsearchDomainConfigInput{
+			DomainName:              aws.String(domainName),
+			AdvancedSecurityOptions: &input,
+		})
+
+		return err
+	}
+}
+
+func testAccCheckESDomainSAMLOptions(esResource string, samlOptionsResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[esResource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", esResource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		options, ok := s.RootModule().Resources[samlOptionsResource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", samlOptionsResource)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).esconn
+		_, err := conn.DescribeElasticsearchDomain(&elasticsearch.DescribeElasticsearchDomainInput{
+			DomainName: aws.String(options.Primary.Attributes["domain_name"]),
+		})
+
+		return err
+	}
+}
+
+func testAccESDomainSAMLOptionsConfig(userName string, domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "es_master_user" {
+  name = "%s"
+}
+
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "%s"
+  elasticsearch_version = "7.10"
+
+  cluster_config {
+    instance_type = "r5.large.elasticsearch"
+  }
+
+  # Advanced security option must be enabled to configure SAML.
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = false
+    master_user_options {
+      master_user_arn = aws_iam_user.es_master_user.arn
+    }
+  }
+
+  # You must enable node-to-node encryption to use advanced security options.
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+
+resource "aws_elasticsearch_domain_saml_options" "main" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  saml_options {
+	# enabled  = true
+    idp {
+        entity_id = "https://terraform-dev-ed.my.salesforce.com"
+        metadata_content = file("./test-fixtures/saml-metadata.xml")
+    }
+	# master_backend_role = "my-idp-group-or-role"
+	# master_user_name = "my-idp-user"
+	# roles_key = "optional-roles-key"
+	# session_timeout_minutes = 60
+	# subject_key = "optional-subject-key"
+  }
+}
+`, userName, domainName)
+}
+
+func testAccESDomainSAMLOptionsConfigUpdate(userName string, domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "es_master_user" {
+  name = "%s"
+}
+
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "%s"
+  elasticsearch_version = "7.10"
+
+  cluster_config {
+    instance_type = "r5.large.elasticsearch"
+  }
+
+  # Advanced security option must be enabled to configure SAML.
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = false
+    master_user_options {
+      master_user_arn = aws_iam_user.es_master_user.arn
+    }
+  }
+
+  # You must enable node-to-node encryption to use advanced security options.
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+
+resource "aws_elasticsearch_domain_saml_options" "main" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  saml_options {
+	# enabled  = true
+    idp {
+        entity_id = "https://terraform-dev-ed.my.salesforce.com"
+        metadata_content = file("./test-fixtures/saml-metadata.xml")
+    }
+	# master_backend_role = "my-idp-group-or-role"
+	# master_user_name = "my-idp-user"
+	# roles_key = "optional-roles-key"
+	session_timeout_minutes = 180
+	# subject_key = "optional-subject-key"
+  }
+}
+`, userName, domainName)
+}

--- a/aws/resource_aws_elasticsearch_domain_saml_options_test.go
+++ b/aws/resource_aws_elasticsearch_domain_saml_options_test.go
@@ -146,21 +146,6 @@ func testAccCheckESDomainSAMLOptionsDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckESDomainSAMLOptionsDisappears(domainName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).esconn
-
-		input := elasticsearch.AdvancedSecurityOptionsInput{}
-		input.SetSAMLOptions(nil)
-		_, err := conn.UpdateElasticsearchDomainConfig(&elasticsearch.UpdateElasticsearchDomainConfigInput{
-			DomainName:              aws.String(domainName),
-			AdvancedSecurityOptions: &input,
-		})
-
-		return err
-	}
-}
-
 func testAccCheckESDomainSAMLOptions(esResource string, samlOptionsResource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[esResource]

--- a/aws/resource_aws_elasticsearch_domain_saml_options_test.go
+++ b/aws/resource_aws_elasticsearch_domain_saml_options_test.go
@@ -218,16 +218,11 @@ resource "aws_elasticsearch_domain_saml_options" "main" {
   domain_name = aws_elasticsearch_domain.example.domain_name
 
   saml_options {
-	# enabled  = true
+    enabled = true
     idp {
-        entity_id = "https://terraform-dev-ed.my.salesforce.com"
-        metadata_content = file("./test-fixtures/saml-metadata.xml")
+      entity_id        = "https://terraform-dev-ed.my.salesforce.com"
+      metadata_content = file("./test-fixtures/saml-metadata.xml")
     }
-	# master_backend_role = "my-idp-group-or-role"
-	# master_user_name = "my-idp-user"
-	# roles_key = "optional-roles-key"
-	# session_timeout_minutes = 60
-	# subject_key = "optional-subject-key"
   }
 }
 `, userName, domainName)
@@ -280,16 +275,12 @@ resource "aws_elasticsearch_domain_saml_options" "main" {
   domain_name = aws_elasticsearch_domain.example.domain_name
 
   saml_options {
-	# enabled  = true
+    enabled = true
     idp {
-        entity_id = "https://terraform-dev-ed.my.salesforce.com"
-        metadata_content = file("./test-fixtures/saml-metadata.xml")
+      entity_id        = "https://terraform-dev-ed.my.salesforce.com"
+      metadata_content = file("./test-fixtures/saml-metadata.xml")
     }
-	# master_backend_role = "my-idp-group-or-role"
-	# master_user_name = "my-idp-user"
-	# roles_key = "optional-roles-key"
-	session_timeout_minutes = 180
-	# subject_key = "optional-subject-key"
+    session_timeout_minutes = 180
   }
 }
 `, userName, domainName)

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/iam"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -1454,6 +1454,18 @@ func testAccPreCheckIamServiceLinkedRoleEs(t *testing.T) {
 
 	if role == nil {
 		t.Fatalf("missing IAM Service Linked Role (es.%s), please create it in the AWS account and retry", dnsSuffix)
+	}
+}
+
+func testAccCheckESDomainDisappears(domainName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).esconn
+
+		_, err := conn.DeleteElasticsearchDomain(&elasticsearch.DeleteElasticsearchDomainInput{
+			DomainName: aws.String(domainName),
+		})
+
+		return err
 	}
 }
 

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1457,18 +1457,6 @@ func testAccPreCheckIamServiceLinkedRoleEs(t *testing.T) {
 	}
 }
 
-func testAccCheckESDomainDisappears(domainName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).esconn
-
-		_, err := conn.DeleteElasticsearchDomain(&elasticsearch.DeleteElasticsearchDomainInput{
-			DomainName: aws.String(domainName),
-		})
-
-		return err
-	}
-}
-
 func testAccESDomainConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {

--- a/website/docs/r/elasticsearch_domain_saml_options.html.markdown
+++ b/website/docs/r/elasticsearch_domain_saml_options.html.markdown
@@ -32,13 +32,16 @@ resource "aws_elasticsearch_domain" "example" {
   }
 }
 
-saml_options {                                                                 
-  enabled = true                                                               
-  idp {                                                                        
-    entity_id        = "https://example.com"            
-    metadata_content = file("./saml-metadata.xml")               
-  }                                                                            
-}                                                                              
+resource "aws_elasticsearch_domain_saml_options" "example" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+  saml_options {
+    enabled = true
+    idp {
+      entity_id        = "https://example.com"
+      metadata_content = file("./saml-metadata.xml")
+    }
+  }
+}
 ```
 
 ## Argument Reference
@@ -67,10 +70,16 @@ The following arguments are optional:
 * `entity_id` - (Required) The unique Entity ID of the application in SAML Identity Provider.
 * `metadata_content` - (Required) The Metadata of the SAML application in xml format.
 
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the domain the SAML options are associated with.
+
 ## Import
 
 Elasticsearch domains can be imported using the `domain_name`, e.g.
 
 ```
-$ terraform import aws_elasticsearch_domain.example domain_name
+$ terraform import aws_elasticsearch_domain_saml_options.example domain_name
 ```

--- a/website/docs/r/elasticsearch_domain_saml_options.html.markdown
+++ b/website/docs/r/elasticsearch_domain_saml_options.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "ElasticSearch"
+layout: "aws"
+page_title: "AWS: aws_elasticsearch_domain_saml_options"
+description: |-
+  Terraform resource for managing SAML authentication options for an AWS Elasticsearch Domain.
+---
+
+# Resource: aws_elasticsearch_domain_saml_options
+
+Manages SAML authentication options for an AWS Elasticsearch Domain.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  cluster_config {
+    instance_type = "r4.large.elasticsearch"
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags = {
+    Domain = "TestDomain"
+  }
+}
+
+saml_options {                                                                 
+  enabled = true                                                               
+  idp {                                                                        
+    entity_id        = "https://example.com"            
+    metadata_content = file("./saml-metadata.xml")               
+  }                                                                            
+}                                                                              
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `domain_name` - (Required) Name of the domain.
+
+The following arguments are optional:
+
+* `saml_options` - (Optional) The SAML authentication options for an AWS Elasticsearch Domain.
+
+### saml_options
+
+* `enabled` - (Required) Whether SAML authentication is enabled.
+* `idp` - (Optional) Information from your identity provider.
+* `master_backend_role` - (Optional) This backend role from the SAML IdP receives full permissions to the cluster, equivalent to a new master user.
+* `master_user_name` - (Options) This username from the SAML IdP receives full permissions to the cluster, equivalent to a new master user.
+* `roles_key` - (Optional) Element of the SAML assertion to use for backend roles. Default is roles.
+* `session_timeout_minutes` - (Optional) Duration of a session in minutes after a user logs in. Default is 60. Maximum value is 1,440.
+* `subject_key` - (Optional) Element of the SAML assertion to use for username. Default is NameID.
+
+
+#### idp
+
+* `entity_id` - (Required) The unique Entity ID of the application in SAML Identity Provider.
+* `metadata_content` - (Required) The Metadata of the SAML application in xml format.
+
+## Import
+
+Elasticsearch domains can be imported using the `domain_name`, e.g.
+
+```
+$ terraform import aws_elasticsearch_domain.example domain_name
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes #16259
Relates #16424

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticSearchDomainSAMLOptions*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticSearchDomainSAMLOptions* -timeout 180m
=== RUN   TestAccAWSElasticSearchDomainSAMLOptions_basic
=== PAUSE TestAccAWSElasticSearchDomainSAMLOptions_basic
=== RUN   TestAccAWSElasticSearchDomainSAMLOptions_disappears
=== PAUSE TestAccAWSElasticSearchDomainSAMLOptions_disappears
=== RUN   TestAccAWSElasticSearchDomainSAMLOptions_disappears_Domain
=== PAUSE TestAccAWSElasticSearchDomainSAMLOptions_disappears_Domain
=== RUN   TestAccAWSElasticSearchDomainSAMLOptions_Update
=== PAUSE TestAccAWSElasticSearchDomainSAMLOptions_Update
=== CONT  TestAccAWSElasticSearchDomainSAMLOptions_basic
=== CONT  TestAccAWSElasticSearchDomainSAMLOptions_Update
=== CONT  TestAccAWSElasticSearchDomainSAMLOptions_disappears
=== CONT  TestAccAWSElasticSearchDomainSAMLOptions_disappears_Domain
--- PASS: TestAccAWSElasticSearchDomainSAMLOptions_disappears (1050.52s)
--- PASS: TestAccAWSElasticSearchDomainSAMLOptions_Update (1237.55s)
--- PASS: TestAccAWSElasticSearchDomainSAMLOptions_basic (1310.63s)
--- PASS: TestAccAWSElasticSearchDomainSAMLOptions_disappears_Domain (1453.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1453.830s
```
