### PR TITLE
ds/servicecatalog_constraint: New data source

### DIFF
--- a/.changelog/19499.txt
+++ b/.changelog/19499.txt
@@ -1,0 +1,3 @@
+```release-notes:new-data-source
+aws_servicecatalog_constraint
+```

--- a/aws/data_source_aws_servicecatalog_constraint.go
+++ b/aws/data_source_aws_servicecatalog_constraint.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func dataSourceAwsServiceCatalogConstraint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsServiceCatalogConstraintRead,
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parameters": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"portfolio_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	output, err := waiter.ConstraintReady(conn, d.Get("accept_language").(string), d.Get("id").(string))
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Service Catalog Constraint (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Constraint (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Catalog Constraint (%s): empty response", d.Id())
+	}
+
+	acceptLanguage := d.Get("accept_language").(string)
+
+	if acceptLanguage == "" {
+		acceptLanguage = "en"
+	}
+
+	d.Set("accept_language", acceptLanguage)
+
+	d.Set("parameters", output.ConstraintParameters)
+	d.Set("status", output.Status)
+
+	detail := output.ConstraintDetail
+
+	d.Set("description", detail.Description)
+	d.Set("owner", detail.Owner)
+	d.Set("portfolio_id", detail.PortfolioId)
+	d.Set("product_id", detail.ProductId)
+	d.Set("type", detail.Type)
+
+	d.SetId(aws.StringValue(detail.ConstraintId))
+
+	return nil
+}

--- a/aws/data_source_aws_servicecatalog_constraint.go
+++ b/aws/data_source_aws_servicecatalog_constraint.go
@@ -2,14 +2,12 @@ package aws
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func dataSourceAwsServiceCatalogConstraint() *schema.Resource {
@@ -65,18 +63,12 @@ func dataSourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta inte
 
 	output, err := waiter.ConstraintReady(conn, d.Get("accept_language").(string), d.Get("id").(string))
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] Service Catalog Constraint (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
-		return fmt.Errorf("error describing Service Catalog Constraint (%s): %w", d.Id(), err)
+		return fmt.Errorf("error describing Service Catalog Constraint: %w", err)
 	}
 
 	if output == nil {
-		return fmt.Errorf("error getting Service Catalog Constraint (%s): empty response", d.Id())
+		return fmt.Errorf("error getting Service Catalog Constraint: empty response")
 	}
 
 	acceptLanguage := d.Get("accept_language").(string)

--- a/aws/data_source_aws_servicecatalog_constraint.go
+++ b/aws/data_source_aws_servicecatalog_constraint.go
@@ -67,17 +67,11 @@ func dataSourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error describing Service Catalog Constraint: %w", err)
 	}
 
-	if output == nil {
+	if output == nil || output.ConstraintDetail == nil {
 		return fmt.Errorf("error getting Service Catalog Constraint: empty response")
 	}
 
-	acceptLanguage := d.Get("accept_language").(string)
-
-	if acceptLanguage == "" {
-		acceptLanguage = "en"
-	}
-
-	d.Set("accept_language", acceptLanguage)
+	d.Set("accept_language", d.Get("accept_language").(string))
 
 	d.Set("parameters", output.ConstraintParameters)
 	d.Set("status", output.Status)

--- a/aws/data_source_aws_servicecatalog_constraint_test.go
+++ b/aws/data_source_aws_servicecatalog_constraint_test.go
@@ -39,7 +39,7 @@ func TestAccAWSServiceCatalogConstraintDataSource_basic(t *testing.T) {
 func testAccAWSServiceCatalogConstraintDataSourceConfig_basic(rName, description string) string {
 	return composeConfig(testAccAWSServiceCatalogConstraintConfig_basic(rName, description), `
 data "aws_servicecatalog_constraint" "test" {
-  id  = aws_servicecatalog_constraint.test.id
+  id = aws_servicecatalog_constraint.test.id
 }
 `)
 }

--- a/aws/data_source_aws_servicecatalog_constraint_test.go
+++ b/aws/data_source_aws_servicecatalog_constraint_test.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSServiceCatalogConstraintDataSource_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_constraint.test"
+	dataSourceName := "data.aws_servicecatalog_constraint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceCatalogConstraintDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogConstraintDataSourceConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceCatalogConstraintExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "owner", dataSourceName, "owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "parameters", dataSourceName, "parameters"),
+					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", dataSourceName, "portfolio_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", dataSourceName, "product_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
+					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSServiceCatalogConstraintDataSourceConfig_basic(rName, description string) string {
+	return composeConfig(testAccAWSServiceCatalogConstraintConfig_basic(rName, description), `
+data "aws_servicecatalog_constraint" "test" {
+  id  = aws_servicecatalog_constraint.test.id
+}
+`)
+}

--- a/aws/data_source_aws_servicecatalog_constraint_test.go
+++ b/aws/data_source_aws_servicecatalog_constraint_test.go
@@ -23,6 +23,7 @@ func TestAccAWSServiceCatalogConstraintDataSource_basic(t *testing.T) {
 				Config: testAccAWSServiceCatalogConstraintDataSourceConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogConstraintExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "acceptLanguage", dataSourceName, "acceptLanguage"),
 					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
 					resource.TestCheckResourceAttrPair(resourceName, "owner", dataSourceName, "owner"),
 					resource.TestCheckResourceAttrPair(resourceName, "parameters", dataSourceName, "parameters"),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -386,6 +386,7 @@ func Provider() *schema.Provider {
 			"aws_secretsmanager_secret":                      dataSourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_rotation":             dataSourceAwsSecretsManagerSecretRotation(),
 			"aws_secretsmanager_secret_version":              dataSourceAwsSecretsManagerSecretVersion(),
+			"aws_servicecatalog_constraint":                  dataSourceAwsServiceCatalogConstraint(),
 			"aws_servicequotas_service":                      dataSourceAwsServiceQuotasService(),
 			"aws_servicequotas_service_quota":                dataSourceAwsServiceQuotasServiceQuota(),
 			"aws_service_discovery_dns_namespace":            dataSourceServiceDiscoveryDnsNamespace(),

--- a/website/docs/d/servicecatalog_constraint.html.markdown
+++ b/website/docs/d/servicecatalog_constraint.html.markdown
@@ -3,29 +3,21 @@ subcategory: "Service Catalog"
 layout: "aws"
 page_title: "AWS: aws_servicecatalog_constraint"
 description: |-
-  Manages a Service Catalog Constraint
+  Provides information on a Service Catalog Constraint
 ---
 
 # Data source: aws_servicecatalog_constraint
 
-Manages a Service Catalog Constraint.
-
-~> **NOTE:** This resource does not associate a Service Catalog product and portfolio. However, the product and portfolio must be associated (see the `aws_servicecatalog_product_portfolio_association` resource) prior to creating a constraint or you will receive an error.
+Provides information on a Service Catalog Constraint.
 
 ## Example Usage
 
 ### Basic Usage
 
 ```terraform
-resource "aws_servicecatalog_constraint" "example" {
-  description  = "Back off, man. I'm a scientist."
-  portfolio_id = aws_servicecatalog_portfolio.example.id
-  product_id   = aws_servicecatalog_product.example.id
-  type         = "LAUNCH"
-
-  parameters = jsonencode({
-    "RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"
-  })
+data "aws_servicecatalog_constraint" "example" {
+  accept_language = "en"
+  id              = "cons-hrvy0335"
 }
 ```
 
@@ -33,61 +25,20 @@ resource "aws_servicecatalog_constraint" "example" {
 
 The following arguments are required:
 
-* `parameters` - (Required) Constraint parameters in JSON format. The syntax depends on the constraint type. See details below.
-* `portfolio_id` - (Required) Portfolio identifier.
-* `product_id` - (Required) Product identifier.
-* `type` - (Required) Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `RESOURCE_UPDATE`, `STACKSET`, and `TEMPLATE`.
+* `id` - Constraint identifier.
 
 The following arguments are optional:
 
 * `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
-* `description` - (Optional) Description of the constraint.
-
-### `parameters`
-
-The `type` you specify determines what must be included in the `parameters` JSON:
-
-* `LAUNCH`: You are required to specify either the RoleArn or the LocalRoleName but can't use both. If you specify the `LocalRoleName` property, when an account uses the launch constraint, the IAM role with that name in the account will be used. This allows launch-role constraints to be account-agnostic so the administrator can create fewer resources per shared account. The given role name must exist in the account used to create the launch constraint and the account of the user who launches a product with this launch constraint. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `LAUNCH` constraint on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Specify the `RoleArn` and `LocalRoleName` properties as follows:
-
-```json
-{ "RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole" }
-```
-
-```json
-{ "LocalRoleName" : "SCBasicLaunchRole" }
-```
-
-* `NOTIFICATION`: Specify the `NotificationArns` property as follows:
-
-```json
-{ "NotificationArns" : ["arn:aws:sns:us-east-1:123456789012:Topic"] }
-```
-
-* `RESOURCE_UPDATE`: Specify the `TagUpdatesOnProvisionedProduct` property as follows. The `TagUpdatesOnProvisionedProduct` property accepts a string value of `ALLOWED` or `NOT_ALLOWED`.
-
-```json
-{ "Version" : "2.0","Properties" :{ "TagUpdateOnProvisionedProduct" : "String" }}
-```
-
-* `STACKSET`: Specify the Parameters property as follows. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `STACKSET` constraint on on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Products with a `STACKSET` constraint will launch an AWS CloudFormation stack set.
-
-```json
-{ "Version" : "String", "Properties" : { "AccountList" : [ "String" ], "RegionList" : [ "String" ], "AdminRole" : "String", "ExecutionRole" : "String" }}
-```
-
-* `TEMPLATE`: Specify the Rules property. For more information, see [Template Constraint Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Constraint identifier.
+* `description` - Description of the constraint.
 * `owner` - Owner of the constraint.
-
-## Import
-
-`aws_servicecatalog_constraint` can be imported using the constraint ID, e.g.
-
-```
-$ terraform import aws_servicecatalog_constraint.example cons-nmdkb6cgxfcrs
-```
+* `parameters` - Constraint parameters in JSON format.
+* `portfolio_id` - Portfolio identifier.
+* `product_id` - Product identifier.
+* `status` - Constraint status.
+* `type` - Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `RESOURCE_UPDATE`, `STACKSET`, and `TEMPLATE`.

--- a/website/docs/d/servicecatalog_constraint.html.markdown
+++ b/website/docs/d/servicecatalog_constraint.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_constraint"
+description: |-
+  Manages a Service Catalog Constraint
+---
+
+# Data source: aws_servicecatalog_constraint
+
+Manages a Service Catalog Constraint.
+
+~> **NOTE:** This resource does not associate a Service Catalog product and portfolio. However, the product and portfolio must be associated (see the `aws_servicecatalog_product_portfolio_association` resource) prior to creating a constraint or you will receive an error.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_servicecatalog_constraint" "example" {
+  description  = "Back off, man. I'm a scientist."
+  portfolio_id = aws_servicecatalog_portfolio.example.id
+  product_id   = aws_servicecatalog_product.example.id
+  type         = "LAUNCH"
+
+  parameters = jsonencode({
+    "RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `parameters` - (Required) Constraint parameters in JSON format. The syntax depends on the constraint type. See details below.
+* `portfolio_id` - (Required) Portfolio identifier.
+* `product_id` - (Required) Product identifier.
+* `type` - (Required) Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `RESOURCE_UPDATE`, `STACKSET`, and `TEMPLATE`.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+* `description` - (Optional) Description of the constraint.
+
+### `parameters`
+
+The `type` you specify determines what must be included in the `parameters` JSON:
+
+* `LAUNCH`: You are required to specify either the RoleArn or the LocalRoleName but can't use both. If you specify the `LocalRoleName` property, when an account uses the launch constraint, the IAM role with that name in the account will be used. This allows launch-role constraints to be account-agnostic so the administrator can create fewer resources per shared account. The given role name must exist in the account used to create the launch constraint and the account of the user who launches a product with this launch constraint. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `LAUNCH` constraint on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Specify the `RoleArn` and `LocalRoleName` properties as follows:
+
+```json
+{ "RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole" }
+```
+
+```json
+{ "LocalRoleName" : "SCBasicLaunchRole" }
+```
+
+* `NOTIFICATION`: Specify the `NotificationArns` property as follows:
+
+```json
+{ "NotificationArns" : ["arn:aws:sns:us-east-1:123456789012:Topic"] }
+```
+
+* `RESOURCE_UPDATE`: Specify the `TagUpdatesOnProvisionedProduct` property as follows. The `TagUpdatesOnProvisionedProduct` property accepts a string value of `ALLOWED` or `NOT_ALLOWED`.
+
+```json
+{ "Version" : "2.0","Properties" :{ "TagUpdateOnProvisionedProduct" : "String" }}
+```
+
+* `STACKSET`: Specify the Parameters property as follows. You cannot have both a `LAUNCH` and a `STACKSET` constraint. You also cannot have more than one `STACKSET` constraint on on an `aws_servicecatalog_product` and `aws_servicecatalog_portfolio`. Products with a `STACKSET` constraint will launch an AWS CloudFormation stack set.
+
+```json
+{ "Version" : "String", "Properties" : { "AccountList" : [ "String" ], "RegionList" : [ "String" ], "AdminRole" : "String", "ExecutionRole" : "String" }}
+```
+
+* `TEMPLATE`: Specify the Rules property. For more information, see [Template Constraint Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Constraint identifier.
+* `owner` - Owner of the constraint.
+
+## Import
+
+`aws_servicecatalog_constraint` can be imported using the constraint ID, e.g.
+
+```
+$ terraform import aws_servicecatalog_constraint.example cons-nmdkb6cgxfcrs
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19385

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogConstraintDataSource_basic (32.17s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogConstraintDataSource_basic (35.02s)
```