### PR TITLE
ds/servicecatalog_portfolio: New data source

### DIFF
--- a/.changelog/19500.txt
+++ b/.changelog/19500.txt
@@ -1,0 +1,3 @@
+```release-notes:new-data-source
+ aws_servicecatalog_portfolio
+ ```

--- a/.changelog/19500.txt
+++ b/.changelog/19500.txt
@@ -1,3 +1,3 @@
-```release-notes:new-data-source
+```release-note:new-data-source
  aws_servicecatalog_portfolio
  ```

--- a/aws/data_source_aws_servicecatalog_portfolio.go
+++ b/aws/data_source_aws_servicecatalog_portfolio.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+)
+
+func dataSourceAwsServiceCatalogPortfolio() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsServiceCatalogPortfolioRead,
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"provider_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceAwsServiceCatalogPortfolioRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	input := &servicecatalog.DescribePortfolioInput{
+		Id: aws.String(d.Get("id").(string)),
+	}
+
+	if v, ok := d.GetOk("accept_language"); ok {
+		input.AcceptLanguage = aws.String(v.(string))
+	}
+
+	output, err := conn.DescribePortfolio(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Service Catalog Portfolio: %w", err)
+	}
+
+	if output == nil || output.PortfolioDetail == nil {
+		return fmt.Errorf("error getting Service Catalog Portfolio: empty response")
+	}
+
+	detail := output.PortfolioDetail
+
+	d.SetId(aws.StringValue(detail.Id))
+
+	if err := d.Set("created_time", detail.CreatedTime.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting created_time: %s", err)
+	}
+
+	d.Set("arn", detail.ARN)
+	d.Set("description", detail.Description)
+	d.Set("name", detail.DisplayName)
+	d.Set("provider_name", detail.ProviderName)
+
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+	tags := keyvaluetags.ServicecatalogKeyValueTags(output.Tags)
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_servicecatalog_portfolio.go
+++ b/aws/data_source_aws_servicecatalog_portfolio.go
@@ -32,6 +32,10 @@ func dataSourceAwsServiceCatalogPortfolio() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -40,15 +44,11 @@ func dataSourceAwsServiceCatalogPortfolio() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"provider_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tagsSchema(),
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }

--- a/aws/data_source_aws_servicecatalog_portfolio.go
+++ b/aws/data_source_aws_servicecatalog_portfolio.go
@@ -67,18 +67,18 @@ func dataSourceAwsServiceCatalogPortfolioRead(d *schema.ResourceData, meta inter
 	output, err := conn.DescribePortfolio(input)
 
 	if err != nil {
-		return fmt.Errorf("error getting Service Catalog Portfolio: %w", err)
+		return fmt.Errorf("error getting Service Catalog Portfolio (%s): %w", d.Get("id").(string), err)
 	}
 
 	if output == nil || output.PortfolioDetail == nil {
-		return fmt.Errorf("error getting Service Catalog Portfolio: empty response")
+		return fmt.Errorf("error getting Service Catalog Portfolio (%s): empty response", d.Get("id").(string))
 	}
 
 	detail := output.PortfolioDetail
 
 	d.SetId(aws.StringValue(detail.Id))
 
-	if err := d.Set("created_time", detail.CreatedTime.Format(time.RFC3339)); err != nil {
+	if err := d.Set("created_time", aws.TimeValue(detail.CreatedTime).Format(time.RFC3339)); err != nil {
 		log.Printf("[DEBUG] Error setting created_time: %s", err)
 	}
 

--- a/aws/data_source_aws_servicecatalog_portfolio_test.go
+++ b/aws/data_source_aws_servicecatalog_portfolio_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSServiceCatalogPortfolioDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_servicecatalog_portfolio.test"
+	resourceName := "aws_servicecatalog_portfolio.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceCatlaogPortfolioDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsServiceCatalogPortfolioDataSourceConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_time", dataSourceName, "created_time"),
+					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "provider_name", dataSourceName, "provider_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.Chicane", dataSourceName, "tags.Chicane"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceCatalogPortfolioDataSourceConfigBasic(rName string) string {
+	return composeConfig(testAccCheckAwsServiceCatalogPortfolioResourceConfigTags1(rName, "Chicane", "Nick"), `
+data "aws_servicecatalog_portfolio" "test" {
+  id = aws_servicecatalog_portfolio.test.id
+}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -391,6 +391,7 @@ func Provider() *schema.Provider {
 			"aws_secretsmanager_secret_rotation":             dataSourceAwsSecretsManagerSecretRotation(),
 			"aws_secretsmanager_secret_version":              dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_servicecatalog_constraint":                  dataSourceAwsServiceCatalogConstraint(),
+			"aws_servicecatalog_portfolio":                   dataSourceAwsServiceCatalogPortfolio(),
 			"aws_servicequotas_service":                      dataSourceAwsServiceQuotasService(),
 			"aws_servicequotas_service_quota":                dataSourceAwsServiceQuotasServiceQuota(),
 			"aws_service_discovery_dns_namespace":            dataSourceServiceDiscoveryDnsNamespace(),

--- a/website/docs/d/servicecatalog_portfolio.html.markdown
+++ b/website/docs/d/servicecatalog_portfolio.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_portfolio"
+description: |-
+  Provides information for a Service Catalog Portfolio.
+---
+
+# Data source: aws_servicecatalog_portfolio
+
+Provides information for a Service Catalog Portfolio.
+
+## Example Usage
+
+```terraform
+data "aws_servicecatalog_portfolio" "portfolio" {
+  id = "port-07052002"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `id` - (Optional) Portfolio identifier.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Portfolio ARN.
+* `created_time` - Time the portfolio was created.
+* `description` - Description of the portfolio
+* `name` - Portfolio name.
+* `provider_name` - Name of the person or organization who owns the portfolio.
+* `tags` - Tags applied to the portfolio.

--- a/website/docs/d/servicecatalog_portfolio.html.markdown
+++ b/website/docs/d/servicecatalog_portfolio.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides information for a Service Catalog Portfolio.
 ---
 
-# Data source: aws_servicecatalog_portfolio
+# Data Source: aws_servicecatalog_portfolio
 
 Provides information for a Service Catalog Portfolio.
 
@@ -22,7 +22,7 @@ data "aws_servicecatalog_portfolio" "portfolio" {
 
 The following arguments are required:
 
-* `id` - (Optional) Portfolio identifier.
+* `id` - (Required) Portfolio identifier.
 
 The following arguments are optional:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #1694

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogPortfolioDataSource_basic (13.60s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogPortfolioDataSource_basic (16.36s)
```