### PR TITLE
d/aws_mq_broker: `logs.audit` is TypeString (NullableBool)

### DIFF
--- a/.changelog/19502.txt
+++ b/.changelog/19502.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_mq_broker: Correct type for `logs.audit` attribute
+```

--- a/aws/data_source_aws_mq_broker.go
+++ b/aws/data_source_aws_mq_broker.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/experimental/nullable"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -162,15 +163,7 @@ func dataSourceAwsMqBroker() *schema.Resource {
 			},
 			"logs": {
 				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				// Ignore missing configuration block
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "1" && new == "0" {
-						return true
-					}
-					return false
-				},
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"general": {
@@ -178,7 +171,7 @@ func dataSourceAwsMqBroker() *schema.Resource {
 							Computed: true,
 						},
 						"audit": {
-							Type:     schema.TypeBool,
+							Type:     nullable.TypeNullableBool,
 							Computed: true,
 						},
 					},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19494.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSMqBroker_'     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSMqBroker_ -timeout 180m
=== RUN   TestAccDataSourceAWSMqBroker_basic
=== PAUSE TestAccDataSourceAWSMqBroker_basic
=== CONT  TestAccDataSourceAWSMqBroker_basic
--- PASS: TestAccDataSourceAWSMqBroker_basic (1180.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1183.527s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSMqBroker_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSMqBroker_ -timeout 180m
=== RUN   TestAccDataSourceAWSMqBroker_basic
=== PAUSE TestAccDataSourceAWSMqBroker_basic
=== CONT  TestAccDataSourceAWSMqBroker_basic
    provider_test.go:734: skipping tests; partition aws-us-gov does not support mq service
--- SKIP: TestAccDataSourceAWSMqBroker_basic (1.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.399s
```

