### PR TITLE
r/aws_batch_job_definition: Don't crash when setting `timeout.attempt_duration_seconds` to `null`

### DIFF
--- a/.changelog/19505.txt
+++ b/.changelog/19505.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Don't crash when setting `timeout.attempt_duration_seconds` to `null`
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18066.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition_'                                  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_ -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_disappears
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (21.64s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (23.18s)
--- PASS: TestAccAWSBatchJobDefinition_disappears (23.34s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (24.22s)
--- PASS: TestAccAWSBatchJobDefinition_basic (24.44s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (26.09s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (26.66s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (38.46s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (42.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.168s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_ -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_disappears
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
--- PASS: TestAccAWSBatchJobDefinition_disappears (20.97s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (26.93s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (27.25s)
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (27.65s)
--- PASS: TestAccAWSBatchJobDefinition_basic (29.52s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (31.44s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (33.98s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (42.38s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (50.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.393s
```
