### PR TITLE
resource/aws_synthetics_canary: fix minimum timeout_in_seconds

### DIFF
--- a/.changelog/19515.txt
+++ b/.changelog/19515.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_synthetics_canary: Change minimum `timeout_in_seconds` in `run_config` from `60` to `3`
+```

--- a/aws/resource_aws_synthetics_canary.go
+++ b/aws/resource_aws_synthetics_canary.go
@@ -96,7 +96,7 @@ func resourceAwsSyntheticsCanary() *schema.Resource {
 						"timeout_in_seconds": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(60, 14*60),
+							ValidateFunc: validation.IntBetween(3, 14*60),
 							Default:      840,
 						},
 					},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/19289

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
-
```
