### PR TITLE
r/aws_ec2_managed_prefix_list: Fix crash with multiple description-only changes

### DIFF
--- a/.changelog/19517.txt
+++ b/.changelog/19517.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_managed_prefix_list: Fix crash with multiple description-only updates
+```

--- a/aws/resource_aws_ec2_managed_prefix_list_test.go
+++ b/aws/resource_aws_ec2_managed_prefix_list_test.go
@@ -170,9 +170,13 @@ func TestAccAwsEc2ManagedPrefixList_Entry_Description(t *testing.T) {
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAwsEc2ManagedPrefixListExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "entry.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "entry.*", map[string]string{
 						"cidr":        "1.0.0.0/8",
+						"description": "description1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "entry.*", map[string]string{
+						"cidr":        "2.0.0.0/8",
 						"description": "description1",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -188,9 +192,13 @@ func TestAccAwsEc2ManagedPrefixList_Entry_Description(t *testing.T) {
 				ResourceName: resourceName,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccAwsEc2ManagedPrefixListExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "entry.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "entry.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "entry.*", map[string]string{
 						"cidr":        "1.0.0.0/8",
+						"description": "description2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "entry.*", map[string]string{
+						"cidr":        "2.0.0.0/8",
 						"description": "description2",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "version", "3"), // description-only updates require two operations
@@ -414,6 +422,11 @@ resource "aws_ec2_managed_prefix_list" "test" {
 
   entry {
     cidr        = "1.0.0.0/8"
+    description = %[2]q
+  }
+
+  entry {
+    cidr        = "2.0.0.0/8"
     description = %[2]q
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19421.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAwsEc2ManagedPrefixList_'                 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsEc2ManagedPrefixList_ -timeout 180m
=== RUN   TestAccAwsEc2ManagedPrefixList_basic
=== PAUSE TestAccAwsEc2ManagedPrefixList_basic
=== RUN   TestAccAwsEc2ManagedPrefixList_disappears
=== PAUSE TestAccAwsEc2ManagedPrefixList_disappears
=== RUN   TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6
=== PAUSE TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6
=== RUN   TestAccAwsEc2ManagedPrefixList_Entry_Cidr
=== PAUSE TestAccAwsEc2ManagedPrefixList_Entry_Cidr
=== RUN   TestAccAwsEc2ManagedPrefixList_Entry_Description
=== PAUSE TestAccAwsEc2ManagedPrefixList_Entry_Description
=== RUN   TestAccAwsEc2ManagedPrefixList_Name
=== PAUSE TestAccAwsEc2ManagedPrefixList_Name
=== RUN   TestAccAwsEc2ManagedPrefixList_Tags
=== PAUSE TestAccAwsEc2ManagedPrefixList_Tags
=== CONT  TestAccAwsEc2ManagedPrefixList_basic
=== CONT  TestAccAwsEc2ManagedPrefixList_Entry_Description
=== CONT  TestAccAwsEc2ManagedPrefixList_Tags
=== CONT  TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6
=== CONT  TestAccAwsEc2ManagedPrefixList_Entry_Cidr
=== CONT  TestAccAwsEc2ManagedPrefixList_disappears
=== CONT  TestAccAwsEc2ManagedPrefixList_Name
--- PASS: TestAccAwsEc2ManagedPrefixList_disappears (21.89s)
--- PASS: TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6 (26.80s)
--- PASS: TestAccAwsEc2ManagedPrefixList_basic (28.43s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Entry_Description (39.82s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Name (40.13s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Entry_Cidr (43.77s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Tags (47.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.693s
```
