### PR TITLE
r/sns_topic - add firehose args

### DIFF
--- a/.changelog/19528.txt
+++ b/.changelog/19528.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_sns_topic: Add `firehose_success_feedback_role_arn`, `firehose_success_feedback_sample_rate` and `firehose_failure_feedback_role_arn` arguments.
+```
+
+```release-note:enhancement
+resource/aws_sns_topic: Add plan time validation for `application_success_feedback_role_arn`, `application_failure_feedback_role_arn`, `http_success_feedback_role_arn`, `http_failure_feedback_role_arn`, `lambda_success_feedback_role_arn`, `lambda_failure_feedback_role_arn`, `sqs_success_feedback_role_arn`, `sqs_failure_feedback_role_arn`.
+```
+
+```release-note:enhancement
+resource/aws_sns_topic: Add `owner` attribute.
+```

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -75,8 +75,9 @@ func resourceAwsSnsTopic() *schema.Resource {
 				},
 			},
 			"application_success_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"application_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
@@ -84,12 +85,14 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"application_failure_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"http_success_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"http_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
@@ -97,8 +100,9 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"http_failure_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"kms_master_key_id": {
 				Type:     schema.TypeString,
@@ -115,9 +119,25 @@ func resourceAwsSnsTopic() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"firehose_success_feedback_role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
+			"firehose_success_feedback_sample_rate": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
+			},
+			"firehose_failure_feedback_role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
 			"lambda_success_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"lambda_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
@@ -125,12 +145,14 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"lambda_failure_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"sqs_success_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"sqs_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
@@ -138,10 +160,15 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"sqs_failure_feedback_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -298,6 +325,24 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+	if d.HasChange("firehose_failure_feedback_role_arn") {
+		_, v := d.GetChange("firehose_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "FirehoseFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("firehose_success_feedback_role_arn") {
+		_, v := d.GetChange("firehose_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "FirehoseSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("firehose_success_feedback_sample_rate") {
+		_, v := d.GetChange("firehose_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "FirehoseSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
 
 	return resourceAwsSnsTopicRead(d, meta)
 }
@@ -414,6 +459,24 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+	if d.HasChange("firehose_failure_feedback_role_arn") {
+		_, v := d.GetChange("firehose_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "FirehoseFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("firehose_success_feedback_role_arn") {
+		_, v := d.GetChange("firehose_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "FirehoseSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("firehose_success_feedback_sample_rate") {
+		_, v := d.GetChange("firehose_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "FirehoseSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
@@ -463,6 +526,9 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("policy", attributeOutput.Attributes["Policy"])
 		d.Set("sqs_failure_feedback_role_arn", attributeOutput.Attributes["SQSFailureFeedbackRoleArn"])
 		d.Set("sqs_success_feedback_role_arn", attributeOutput.Attributes["SQSSuccessFeedbackRoleArn"])
+		d.Set("firehose_success_feedback_role_arn", attributeOutput.Attributes["FirehoseSuccessFeedbackRoleArn"])
+		d.Set("firehose_failure_feedback_role_arn", attributeOutput.Attributes["FirehoseFailureFeedbackRoleArn"])
+		d.Set("owner", attributeOutput.Attributes["Owner"])
 
 		// set the boolean values
 		if v, ok := attributeOutput.Attributes["FifoTopic"]; ok && aws.StringValue(v) == "true" {
@@ -513,6 +579,15 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 			}
 			d.Set("sqs_success_feedback_sample_rate", v)
 		}
+
+		vStr = aws.StringValue(attributeOutput.Attributes["FirehoseSuccessFeedbackSampleRate"])
+		if vStr != "" {
+			v, err = strconv.ParseInt(vStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing integer attribute 'FirehoseSuccessFeedbackSampleRate': %w", err)
+			}
+			d.Set("firehose_success_feedback_sample_rate", v)
+		}
 	}
 
 	d.Set("fifo_topic", fifoTopic)
@@ -560,6 +635,9 @@ func resourceAwsSnsTopicDelete(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
+		if isAWSErr(err, sns.ErrCodeNotFoundException, "") {
+			return nil
+		}
 		return fmt.Errorf("error deleting SNS Topic (%s): %w", d.Id(), err)
 	}
 

--- a/website/docs/r/sns_topic.html.markdown
+++ b/website/docs/r/sns_topic.html.markdown
@@ -92,6 +92,9 @@ The following arguments are supported:
 * `sqs_success_feedback_role_arn` - (Optional) The IAM role permitted to receive success feedback for this topic
 * `sqs_success_feedback_sample_rate` - (Optional) Percentage of success to sample
 * `sqs_failure_feedback_role_arn` - (Optional) IAM role for failure feedback
+* `firehose_success_feedback_role_arn` - (Optional) The IAM role permitted to receive success feedback for this topic
+* `firehose_success_feedback_sample_rate` - (Optional) Percentage of success to sample
+* `firehose_failure_feedback_role_arn` - (Optional) IAM role for failure feedback
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
@@ -100,6 +103,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ARN of the SNS topic
 * `arn` - The ARN of the SNS topic, as a more obvious property (clone of id)
+* `owner` - The AWS Account ID of the SNS topic owner
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19491

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=estAccAWSSNSTopic_'
--- PASS: TestAccAWSSNSTopic_FIFOExpectContentBasedDeduplicationError (27.21s)
--- PASS: TestAccAWSSNSTopic_disappears (79.28s)
--- PASS: TestAccAWSSNSTopic_NamePrefix_FIFOTopic (91.97s)
--- PASS: TestAccAWSSNSTopic_Name (95.23s)
--- PASS: TestAccAWSSNSTopic_Name_Generated_FIFOTopic (100.60s)
--- PASS: TestAccAWSSNSTopic_basic (101.00s)
--- PASS: TestAccAWSSNSTopic_policy (101.56s)
--- PASS: TestAccAWSSNSTopic_Name_FIFOTopic (101.80s)
--- PASS: TestAccAWSSNSTopic_NamePrefix (102.29s)
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (102.33s)
--- PASS: TestAccAWSSNSTopic_withIAMRole (107.71s)
--- PASS: TestAccAWSSNSTopic_deliveryStatus (119.73s)
--- PASS: TestAccAWSSNSTopic_encryption (135.00s)
--- PASS: TestAccAWSSNSTopic_FIFOWithContentBasedDeduplication (139.15s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (163.18s)
--- PASS: TestAccAWSSNSTopic_tags (173.28s)


```
