### PR TITLE
r/iam_role - add plan time validations

### DIFF
--- a/.changelog/19532.txt
+++ b/.changelog/19532.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_role: Add plan time validation for `path`, `permissions_boundary`, `managed_policy_arns`.
+```

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -63,16 +63,17 @@ func resourceAwsIamRole() *schema.Resource {
 			},
 
 			"path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "/",
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "/",
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 512),
 			},
 
 			"permissions_boundary": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 2048),
+				ValidateFunc: validateArn,
 			},
 
 			"description": {
@@ -141,8 +142,10 @@ func resourceAwsIamRole() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
 			},
 		},
 

--- a/aws/resource_aws_iam_role_policy_attachment_test.go
+++ b/aws/resource_aws_iam_role_policy_attachment_test.go
@@ -109,7 +109,7 @@ func TestAccAWSRolePolicyAttachment_disappears_Role(t *testing.T) {
 					testAccCheckAWSRolePolicyAttachmentExists(resourceName, 1, &attachedRolePolicies),
 					// DeleteConflict: Cannot delete entity, must detach all policies first.
 					testAccCheckAWSIAMRolePolicyAttachmentDisappears(resourceName),
-					testAccCheckAWSRoleDisappears(&role),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsIamRole(), iamRoleResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -319,7 +319,7 @@ func TestAccAWSIAMRole_disappears(t *testing.T) {
 				Config: testAccAWSIAMRoleConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists(resourceName, &role),
-					testAccCheckAWSRoleDisappears(&role),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsIamRole(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -948,23 +948,6 @@ func testAccCheckAWSRoleExists(n string, res *iam.GetRoleOutput) resource.TestCh
 		}
 
 		*res = *resp
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRoleDisappears(getRoleOutput *iam.GetRoleOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
-
-		roleName := aws.StringValue(getRoleOutput.Role.RoleName)
-
-		_, err := iamconn.DeleteRole(&iam.DeleteRoleInput{
-			RoleName: aws.String(roleName),
-		})
-		if err != nil {
-			return fmt.Errorf("error deleting role %q: %s", roleName, err)
-		}
 
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIAMRole_'
--- PASS: TestAccAWSIAMRole_badJSON (19.51s)
--- PASS: TestAccAWSIAMRole_disappears (52.30s)
--- PASS: TestAccAWSIAMRole_policyBasicInlineEmpty (54.28s)
--- PASS: TestAccAWSIAMRole_basic (56.15s)
--- PASS: TestAccAWSIAMRole_namePrefix (58.30s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (66.71s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_managedNonExistent (85.92s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedEmpty (90.30s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineEmpty (91.42s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_inlineNonEmpty (92.20s)
--- PASS: TestAccAWSIAMRole_tags (93.65s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_inlineNonEmpty (97.30s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (98.48s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionRemoved_managedNonEmpty (101.40s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandRemovalAddedBack_managedNonEmpty (101.58s)
--- PASS: TestAccAWSIAMRole_testNameChange (111.15s)
--- PASS: TestAccAWSIAMRole_policyOutOfBandAdditionIgnored_inlineNonExistent (115.37s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (111.60s)
--- PASS: TestAccAWSIAMRole_policyBasicManaged (134.77s)
--- PASS: TestAccAWSIAMRole_policyBasicInline (134.87s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (171.22s)
```
