### PR TITLE
added single condition values handling

### DIFF
--- a/.changelog/19533.txt
+++ b/.changelog/19533.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_policy_document: fix single conditiona value that cause always update
+```

--- a/.changelog/19533.txt
+++ b/.changelog/19533.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_iam_policy_document: fix single conditiona value that cause always update
+data-source/aws_iam_policy_document: No longer show changes when there's a single condition
 ```

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -317,6 +317,10 @@ func dataSourcePolicyDocumentMakeConditions(in []interface{}, version string) (I
 		if err != nil {
 			return nil, fmt.Errorf("error reading values: %w", err)
 		}
+		itemValues := out[i].Values.([]string)
+		if len(itemValues) == 1 {
+			out[i].Values = itemValues[0]
+		}
 	}
 	return IAMPolicyStatementConditionSet(out), nil
 }


### PR DESCRIPTION
when the conditional values is single value it always cause an update. added the single condition values handling.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #18005

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
╰─ make testacc  TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument_ -timeout 180m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_basic
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_basic
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_source
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_source
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceList
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceList
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_override
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_override
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_overrideList
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_overrideList
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_version20081017
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_version20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_basic
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceList
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_source
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_override
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_overrideList
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_version20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov
    provider_test.go:779: skipping tests; current partition (aws) does not equal aws-us-gov
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipalsGov (4.19s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting (33.23s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceList (180.82s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (182.57s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_multiplePrincipals (184.01s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_statementPrincipalIdentifiers_stringAndSlice (184.52s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (185.19s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (196.51s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (200.84s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (201.96s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_overrideList (213.69s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (220.10s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_version20081017 (264.72s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (306.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       310.091s

...
```
