### PR TITLE
Add tags argument to resource/aws_elasticache_parameter_group

### DIFF
--- a/.changelog/19551.txt
+++ b/.changelog/19551.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_parameter_group: Add `tags` argument and `arn` and `tags_all` attributes
+```

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsElasticacheParameterGroup() *schema.Resource {
@@ -45,6 +46,10 @@ func resourceAwsElasticacheParameterGroup() *schema.Resource {
 				ForceNew: true,
 				Default:  "Managed by Terraform",
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"parameter": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -62,17 +67,23 @@ func resourceAwsElasticacheParameterGroup() *schema.Resource {
 				},
 				Set: resourceAwsElasticacheParameterHash,
 			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
 		},
+		CustomizeDiff: SetTagsDiff,
 	}
 }
 
 func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
 	createOpts := elasticache.CreateCacheParameterGroupInput{
 		CacheParameterGroupName:   aws.String(d.Get("name").(string)),
 		CacheParameterGroupFamily: aws.String(d.Get("family").(string)),
 		Description:               aws.String(d.Get("description").(string)),
+		Tags:                      tags.IgnoreAws().ElasticacheTags(),
 	}
 
 	log.Printf("[DEBUG] Create ElastiCache Parameter Group: %#v", createOpts)
@@ -82,6 +93,7 @@ func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta int
 	}
 
 	d.SetId(aws.StringValue(resp.CacheParameterGroup.CacheParameterGroupName))
+	d.Set("arn", aws.StringValue(resp.CacheParameterGroup.ARN))
 	log.Printf("[INFO] ElastiCache Parameter Group ID: %s", d.Id())
 
 	return resourceAwsElasticacheParameterGroupUpdate(d, meta)
@@ -89,6 +101,8 @@ func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta int
 
 func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	describeOpts := elasticache.DescribeCacheParameterGroupsInput{
 		CacheParameterGroupName: aws.String(d.Id()),
@@ -107,6 +121,24 @@ func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta inter
 	d.Set("name", describeResp.CacheParameterGroups[0].CacheParameterGroupName)
 	d.Set("family", describeResp.CacheParameterGroups[0].CacheParameterGroupFamily)
 	d.Set("description", describeResp.CacheParameterGroups[0].Description)
+	d.Set("arn", describeResp.CacheParameterGroups[0].ARN)
+
+	tags, err := keyvaluetags.ElasticacheListTags(conn, aws.StringValue(describeResp.CacheParameterGroups[0].ARN))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for ElastiCache Parameter Group (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
 
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := elasticache.DescribeCacheParametersInput{
@@ -126,6 +158,14 @@ func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta inter
 
 func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := keyvaluetags.ElasticacheUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating ElastiCache Parameter Group (%s) tags: %w", d.Get("arn").(string), err)
+		}
+	}
 
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -93,7 +93,7 @@ func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta int
 	}
 
 	d.SetId(aws.StringValue(resp.CacheParameterGroup.CacheParameterGroupName))
-	d.Set("arn", aws.StringValue(resp.CacheParameterGroup.ARN))
+	d.Set("arn", resp.CacheParameterGroup.ARN)
 	log.Printf("[INFO] ElastiCache Parameter Group ID: %s", d.Id())
 
 	return resourceAwsElasticacheParameterGroupUpdate(d, meta)

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -597,7 +597,7 @@ resource "aws_elasticache_parameter_group" "test" {
   name   = %[2]q
 
   tags = {
-	%[3]s  = %[4]q
+    %[3]s = %[4]q
   }
 }
 `, family, rName, tagName1, tagValue1)
@@ -610,8 +610,8 @@ resource "aws_elasticache_parameter_group" "test" {
   name   = %[2]q
 
   tags = {
-    %[3]s  = %[4]q
-    %[5]s  = %[6]q
+    %[3]s = %[4]q
+    %[5]s = %[6]q
   }
 }
 `, family, rName, tagName1, tagValue1, tagName2, tagValue2)

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -87,6 +87,7 @@ func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(resourceName, "family", "redis2.8"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -413,6 +414,50 @@ func TestAccAWSElasticacheParameterGroup_Description(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticacheParameterGroup_Tags(t *testing.T) {
+	var cacheParameterGroup1 elasticache.CacheParameterGroup
+	resourceName := "aws_elasticache_parameter_group.test"
+	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheParameterGroupConfigTags1(rName, "redis2.8", "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheParameterGroupConfigTags2(rName, "redis2.8", "key1", "updatedvalue1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "updatedvalue1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheParameterGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists(resourceName, &cacheParameterGroup1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSElasticacheParameterGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
 
@@ -543,6 +588,33 @@ resource "aws_elasticache_parameter_group" "test" {
   }
 }
 `, family, rName, parameterName1, parameterValue1, parameterName2, parameterValue2)
+}
+
+func testAccAWSElasticacheParameterGroupConfigTags1(rName, family, tagName1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_parameter_group" "test" {
+  family = %[1]q
+  name   = %[2]q
+
+  tags = {
+	%[3]s  = %[4]q
+  }
+}
+`, family, rName, tagName1, tagValue1)
+}
+
+func testAccAWSElasticacheParameterGroupConfigTags2(rName, family, tagName1, tagValue1, tagName2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_parameter_group" "test" {
+  family = %[1]q
+  name   = %[2]q
+
+  tags = {
+    %[3]s  = %[4]q
+    %[5]s  = %[6]q
+  }
+}
+`, family, rName, tagName1, tagValue1, tagName2, tagValue2)
 }
 
 func TestFlattenElasticacheParameters(t *testing.T) {

--- a/website/docs/r/elasticache_parameter_group.html.markdown
+++ b/website/docs/r/elasticache_parameter_group.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `family` - (Required) The family of the ElastiCache parameter group.
 * `description` - (Optional) The description of the ElastiCache parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of ElastiCache parameters to apply.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 Parameter blocks support the following:
 
@@ -50,6 +51,8 @@ Parameter blocks support the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ElastiCache parameter group name.
+* `arn` - The AWS ARN associated with the parameter group.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19550 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticacheParameterGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheParameterGroup -timeout 180m
=== RUN   TestAccAWSElasticacheParameterGroup_basic
=== PAUSE TestAccAWSElasticacheParameterGroup_basic
=== RUN   TestAccAWSElasticacheParameterGroup_addParameter
=== PAUSE TestAccAWSElasticacheParameterGroup_addParameter
=== RUN   TestAccAWSElasticacheParameterGroup_removeAllParameters
=== PAUSE TestAccAWSElasticacheParameterGroup_removeAllParameters
=== RUN   TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters
=== PAUSE TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters
=== RUN   TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters
=== PAUSE TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters
=== RUN   TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter
=== PAUSE TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter
=== RUN   TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter
=== PAUSE TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter
=== RUN   TestAccAWSElasticacheParameterGroup_UppercaseName
=== PAUSE TestAccAWSElasticacheParameterGroup_UppercaseName
=== RUN   TestAccAWSElasticacheParameterGroup_Description
=== PAUSE TestAccAWSElasticacheParameterGroup_Description
=== RUN   TestAccAWSElasticacheParameterGroup_Tags
=== PAUSE TestAccAWSElasticacheParameterGroup_Tags
=== CONT  TestAccAWSElasticacheParameterGroup_basic
=== CONT  TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter
=== CONT  TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters
=== CONT  TestAccAWSElasticacheParameterGroup_addParameter
=== CONT  TestAccAWSElasticacheParameterGroup_Tags
=== CONT  TestAccAWSElasticacheParameterGroup_Description
=== CONT  TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter
=== CONT  TestAccAWSElasticacheParameterGroup_UppercaseName
=== CONT  TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters
=== CONT  TestAccAWSElasticacheParameterGroup_removeAllParameters
--- PASS: TestAccAWSElasticacheParameterGroup_Description (35.70s)
--- PASS: TestAccAWSElasticacheParameterGroup_UppercaseName (35.79s)
--- PASS: TestAccAWSElasticacheParameterGroup_basic (36.07s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeAllParameters (55.63s)
--- PASS: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (56.21s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_RemainingParameters (57.95s)
--- PASS: TestAccAWSElasticacheParameterGroup_addParameter (59.18s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter_AllParameters (60.88s)
--- PASS: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (60.99s)
--- PASS: TestAccAWSElasticacheParameterGroup_Tags (74.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       74.755s
```
