### PR TITLE
Allow empty string as valid setting for launch_type in CloudWatchEventTarget

### DIFF
--- a/.changelog/19555.txt
+++ b/.changelog/19555.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Fix ecs_target.launch_type not allowing empty string values.
+```

--- a/.changelog/19555.txt
+++ b/.changelog/19555.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cloudwatch_event_target: Fix ecs_target.launch_type not allowing empty string values.
+resource/aws_cloudwatch_event_target: Fix `ecs_target.launch_type` not allowing empty string values.
 ```

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -146,7 +146,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      events.LaunchTypeEc2,
-							ValidateFunc: validation.StringInSlice(events.LaunchType_Values(), false),
+							ValidateFunc: validation.StringInSlice(append(events.LaunchType_Values(), []string{""}...), false),
 						},
 						"network_configuration": {
 							Type:     schema.TypeList,

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -146,7 +146,10 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      events.LaunchTypeEc2,
-							ValidateFunc: validation.StringInSlice(append(events.LaunchType_Values(), []string{""}...), false),
+							ValidateFunc: validation.Any(
+								validation.StringIsEmpty,
+								validation.StringInSlice(events.LaunchType_Values(), false),
+							),
 						},
 						"network_configuration": {
 							Type:     schema.TypeList,

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -143,9 +143,9 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							ValidateFunc: validation.StringLenBetween(1, 255),
 						},
 						"launch_type": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      events.LaunchTypeEc2,
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  events.LaunchTypeEc2,
 							ValidateFunc: validation.Any(
 								validation.StringIsEmpty,
 								validation.StringInSlice(events.LaunchType_Values(), false),

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -447,13 +447,6 @@ func TestAccAWSCloudWatchEventTarget_ecs(t *testing.T) {
 				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccAWSCloudWatchEventTargetConfigEcsWithBlankLaunchType(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", ""),
-				),
-			},
 		},
 	})
 }
@@ -489,6 +482,26 @@ func TestAccAWSCloudWatchEventTarget_ecsWithBlankLaunchType(t *testing.T) {
 				ImportState:       true,
 				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCloudWatchEventTargetConfigEcs(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", "FARGATE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCloudWatchEventTargetConfigEcsWithBlankLaunchType(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", ""),
+				),
 			},
 		},
 	})

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -447,6 +447,49 @@ func TestAccAWSCloudWatchEventTarget_ecs(t *testing.T) {
 				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAWSCloudWatchEventTargetConfigEcsWithBlankLaunchType(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventTarget_ecsWithBlankLaunchType(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
+	iamRoleResourceName := "aws_iam_role.test"
+	ecsTaskDefinitionResourceName := "aws_ecs_task_definition.task"
+	var v events.Target
+	rName := acctest.RandomWithPrefix("tf_ecs_target")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventTargetConfigEcsWithBlankLaunchType(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.task_count", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "ecs_target.0.task_definition_arn", ecsTaskDefinitionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.network_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.network_configuration.0.subnets.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1198,6 +1241,110 @@ resource "aws_cloudwatch_event_target" "test" {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.task.arn
     launch_type         = "FARGATE"
+
+    network_configuration {
+      subnets = [aws_subnet.subnet.id]
+    }
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecs:RunTask"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_task_definition" "task" {
+  family                   = %[1]q
+  cpu                      = 256
+  memory                   = 512
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+
+  container_definitions = <<EOF
+[
+  {
+    "name": "first",
+    "image": "service-first",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true
+  }
+]
+EOF
+}
+
+data "aws_partition" "current" {}
+`, rName)
+}
+
+func testAccAWSCloudWatchEventTargetConfigEcsWithBlankLaunchType(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "test" {
+  name        = %[1]q
+  description = "schedule_ecs_test"
+
+  schedule_expression = "rate(5 minutes)"
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id     = aws_vpc.vpc.id
+  cidr_block = "10.1.1.0/24"
+}
+
+resource "aws_cloudwatch_event_target" "test" {
+  arn      = aws_ecs_cluster.test.id
+  rule     = aws_cloudwatch_event_rule.test.id
+  role_arn = aws_iam_role.test.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.task.arn
+    launch_type         = ""
 
     network_configuration {
       subnets = [aws_subnet.subnet.id]

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -352,7 +352,7 @@ The following arguments are supported:
 `ecs_target` support the following:
 
 * `group` - (Optional) Specifies an ECS task group for the task. The maximum length is 255 characters.
-* `launch_type` - (Optional) Specifies the launch type on which your task is running. The launch type that you specify here must match one of the launch type (compatibilities) of the target task. Valid values are `EC2` or `FARGATE`.
+* `launch_type` - (Optional) Specifies the launch type on which your task is running. The launch type that you specify here must match one of the launch type (compatibilities) of the target task. Valid values include: an empty string `""` (to specify no launch type), `EC2`, or `FARGATE`.
 * `network_configuration` - (Optional) Use this if the ECS task uses the awsvpc network mode. This specifies the VPC subnets and security groups associated with the task, and whether a public IP address is to be used. Required if launch_type is FARGATE because the awsvpc mode is required for Fargate tasks.
 * `platform_version` - (Optional) Specifies the platform version for the task. Specify only the numeric portion of the platform version, such as 1.1.0. This is used only if LaunchType is FARGATE. For more information about valid platform versions, see [AWS Fargate Platform Versions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html).
 * `task_count` - (Optional) The number of tasks to create based on the TaskDefinition. The default is 1.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16078

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchEventTarget_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventTarget_ -timeout 180m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
=== PAUSE TestAccAWSCloudWatchEventTarget_basic
=== RUN   TestAccAWSCloudWatchEventTarget_EventBusName
=== PAUSE TestAccAWSCloudWatchEventTarget_EventBusName
=== RUN   TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== PAUSE TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== RUN   TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== PAUSE TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== RUN   TestAccAWSCloudWatchEventTarget_full
=== PAUSE TestAccAWSCloudWatchEventTarget_full
=== RUN   TestAccAWSCloudWatchEventTarget_disappears
=== PAUSE TestAccAWSCloudWatchEventTarget_disappears
=== RUN   TestAccAWSCloudWatchEventTarget_ssmDocument
=== PAUSE TestAccAWSCloudWatchEventTarget_ssmDocument
=== RUN   TestAccAWSCloudWatchEventTarget_http
=== PAUSE TestAccAWSCloudWatchEventTarget_http
=== RUN   TestAccAWSCloudWatchEventTarget_ecs
=== PAUSE TestAccAWSCloudWatchEventTarget_ecs
=== RUN   TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== PAUSE TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== RUN   TestAccAWSCloudWatchEventTarget_batch
=== PAUSE TestAccAWSCloudWatchEventTarget_batch
=== RUN   TestAccAWSCloudWatchEventTarget_kinesis
=== PAUSE TestAccAWSCloudWatchEventTarget_kinesis
=== RUN   TestAccAWSCloudWatchEventTarget_sqs
=== PAUSE TestAccAWSCloudWatchEventTarget_sqs
=== RUN   TestAccAWSCloudWatchEventTarget_input_transformer
=== PAUSE TestAccAWSCloudWatchEventTarget_input_transformer
=== RUN   TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== PAUSE TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== RUN   TestAccAWSCloudWatchEventTarget_PartnerEventBus
    resource_aws_cloudwatch_event_target_test.go:673: Environment variable EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME is not set
--- SKIP: TestAccAWSCloudWatchEventTarget_PartnerEventBus (0.00s)
=== CONT  TestAccAWSCloudWatchEventTarget_basic
=== CONT  TestAccAWSCloudWatchEventTarget_ecs
=== CONT  TestAccAWSCloudWatchEventTarget_kinesis
=== CONT  TestAccAWSCloudWatchEventTarget_full
=== CONT  TestAccAWSCloudWatchEventTarget_http
=== CONT  TestAccAWSCloudWatchEventTarget_ssmDocument
=== CONT  TestAccAWSCloudWatchEventTarget_disappears
=== CONT  TestAccAWSCloudWatchEventTarget_sqs
=== CONT  TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== CONT  TestAccAWSCloudWatchEventTarget_input_transformer
=== CONT  TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== CONT  TestAccAWSCloudWatchEventTarget_EventBusName
=== CONT  TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== CONT  TestAccAWSCloudWatchEventTarget_batch
=== CONT  TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
--- PASS: TestAccAWSCloudWatchEventTarget_GeneratedTargetId (59.81s)
--- PASS: TestAccAWSCloudWatchEventTarget_http (93.22s)
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (141.61s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (156.11s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (160.64s)
--- PASS: TestAccAWSCloudWatchEventTarget_disappears (162.59s)
--- PASS: TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig (163.23s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (163.35s)
--- PASS: TestAccAWSCloudWatchEventTarget_inputTransformerJsonString (166.32s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (167.78s)
--- PASS: TestAccAWSCloudWatchEventTarget_EventBusName (168.02s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (174.26s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (177.12s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (186.24s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (248.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	251.042s
```
