### PR TITLE
r/cloudtrail: Add DynamoDB as data_resource

### DIFF
--- a/.changelog/19559.txt
+++ b/.changelog/19559.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudtrail: Add `AWS::DynamoDB::Table` as an option for `event_selector`.`data_resource`.`type`
+```

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -110,7 +110,7 @@ func resourceAwsCloudTrail() *schema.Resource {
 									"type": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"AWS::S3::Object", "AWS::Lambda::Function"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"AWS::S3::Object", "AWS::Lambda::Function", "AWS::DynamoDB::Table"}, false),
 									},
 									"values": {
 										Type:     schema.TypeList,

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -93,18 +93,18 @@ func testSweepCloudTrails(region string) error {
 func TestAccAWSCloudTrail_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Trail": {
-			"basic":                      testAccAWSCloudTrail_basic,
-			"cloudwatch":                 testAccAWSCloudTrail_cloudwatch,
-			"enableLogging":              testAccAWSCloudTrail_enable_logging,
-			"includeGlobalServiceEvents": testAccAWSCloudTrail_include_global_service_events,
-			"isMultiRegion":              testAccAWSCloudTrail_is_multi_region,
-			"isOrganization":             testAccAWSCloudTrail_is_organization,
-			"logValidation":              testAccAWSCloudTrail_logValidation,
-			"kmsKey":                     testAccAWSCloudTrail_kmsKey,
-			"tags":                       testAccAWSCloudTrail_tags,
-			"eventSelector":              testAccAWSCloudTrail_event_selector,
-			"eventSelectorDynamoDB":      testAccAWSCloudTrail_eventSelectorDynamoDB,
-			"insightSelector":            testAccAWSCloudTrail_insight_selector,
+			"basic":                 testAccAWSCloudTrail_basic,
+			"cloudwatch":            testAccAWSCloudTrail_cloudwatch,
+			"enableLogging":         testAccAWSCloudTrail_enableLogging,
+			"globalServiceEvents":   testAccAWSCloudTrail_globalServiceEvents,
+			"multiRegion":           testAccAWSCloudTrail_multiRegion,
+			"organization":          testAccAWSCloudTrail_organization,
+			"logValidation":         testAccAWSCloudTrail_logValidation,
+			"kmsKey":                testAccAWSCloudTrail_kmsKey,
+			"tags":                  testAccAWSCloudTrail_tags,
+			"eventSelector":         testAccAWSCloudTrail_eventSelector,
+			"eventSelectorDynamoDB": testAccAWSCloudTrail_eventSelectorDynamoDB,
+			"insightSelector":       testAccAWSCloudTrail_insightSelector,
 		},
 	}
 
@@ -123,8 +123,8 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 
 func testAccAWSCloudTrail_basic(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -133,7 +133,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
@@ -148,7 +148,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailModifiedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", "prefix"),
@@ -163,7 +163,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 
 func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 	var trail cloudtrail.Trail
-	randInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -173,7 +173,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfigCloudWatch(randInt),
+				Config: testAccAWSCloudTrailCloudWatchConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttrSet(resourceName, "cloud_watch_logs_group_arn"),
@@ -186,7 +186,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfigCloudWatchModified(randInt),
+				Config: testAccAWSCloudTrailCloudWatchModifiedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttrSet(resourceName, "cloud_watch_logs_group_arn"),
@@ -197,10 +197,10 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_enable_logging(t *testing.T) {
+func testAccAWSCloudTrail_enableLogging(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -209,7 +209,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					// AWS will create the trail with logging turned off.
@@ -225,7 +225,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailModifiedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailLoggingEnabled(resourceName, false),
@@ -234,7 +234,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailLoggingEnabled(resourceName, true),
@@ -246,10 +246,10 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
+func testAccAWSCloudTrail_multiRegion(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -258,7 +258,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "false"),
@@ -267,7 +267,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfigMultiRegion(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailMultiRegionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "true"),
@@ -281,7 +281,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "false"),
@@ -293,10 +293,10 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_is_organization(t *testing.T) {
+func testAccAWSCloudTrail_organization(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -305,7 +305,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfigOrganization(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailOrganizationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "true"),
@@ -319,7 +319,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "false"),
@@ -333,8 +333,8 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 
 func testAccAWSCloudTrail_logValidation(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -343,7 +343,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_logValidation(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailLogValidationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
@@ -358,7 +358,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailLogValidationModifiedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
@@ -373,10 +373,10 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 
 func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resourceName := "aws_cloudtrail.foobar"
-	kmsResourceName := "aws_kms_key.foo"
+	resourceName := "aws_cloudtrail.test"
+	kmsResourceName := "aws_kms_key.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -385,7 +385,7 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_kmsKey(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailKMSKeyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
@@ -407,8 +407,8 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 	var trail cloudtrail.Trail
 	var trailTags []*cloudtrail.Tag
 	var trailTagsModified []*cloudtrail.Tag
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -417,7 +417,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_tags(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailTagsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -434,7 +434,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailTagsModifiedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -447,7 +447,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailTagsModifiedAgainConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -460,10 +460,10 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
+func testAccAWSCloudTrail_globalServiceEvents(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -472,7 +472,7 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_include_global_service_events(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailGlobalServiceEventsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "false"),
@@ -487,9 +487,9 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_event_selector(t *testing.T) {
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+func testAccAWSCloudTrail_eventSelector(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -498,14 +498,14 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailEventSelectorConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/foobar$`)),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/foobar", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/baz", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 				),
@@ -516,7 +516,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorReadWriteType(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailEventSelectorReadWriteTypeConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
@@ -524,30 +524,30 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailEventSelectorModifiedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/foobar$`)),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/foobar", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/baz", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.0.values.#", "2"),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.1.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/tf1$`)),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.1.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/tf2$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.1.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/tf1", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.1.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/tf2", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.type", "AWS::Lambda::Function"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.values.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "event_selector.1.data_resource.1.values.0", regexp.MustCompile(`^arn:[^:]+:lambda:.+:tf-test-trail-event-select-\d+$`)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "event_selector.1.data_resource.1.values.0", "lambda", fmt.Sprintf("function:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.read_write_type", "All"),
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorNone(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailEventSelectorNoneConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "0"),
 				),
@@ -558,7 +558,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 
 func testAccAWSCloudTrail_eventSelectorDynamoDB(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -567,7 +567,7 @@ func testAccAWSCloudTrail_eventSelectorDynamoDB(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorDynamoDB(rName),
+				Config: testAccAWSCloudTrailEventSelectorDynamoDBConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
@@ -582,7 +582,7 @@ func testAccAWSCloudTrail_eventSelectorDynamoDB(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_insight_selector(t *testing.T) {
+func testAccAWSCloudTrail_insightSelector(t *testing.T) {
 	resourceName := "aws_cloudtrail.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -593,7 +593,7 @@ func testAccAWSCloudTrail_insight_selector(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_insightSelector(rName),
+				Config: testAccAWSCloudTrailInsightSelectorConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "insight_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "insight_selector.0.insight_type", "ApiCallRateInsight"),
@@ -731,650 +731,293 @@ func testAccCheckCloudTrailLoadTags(trail *cloudtrail.Trail, tags *[]*cloudtrail
 	}
 }
 
-func testAccAWSCloudTrailConfig(cloudTrailRandInt int) string {
+func testAccAWSCloudTrailBaseConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%[1]d"
-  s3_bucket_name = aws_s3_bucket.foo.id
-}
-
 data "aws_partition" "current" {}
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
   force_destroy = true
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AWSCloudTrailAclCheck"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetBucketAcl"
+      Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
     },
     {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
+      Sid       = "AWSCloudTrailWrite"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:PutObject"
+      Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
+      Condition = {
+        StringEquals = {
+          "s3:x-amz-acl" = "bucket-owner-full-control"
         }
       }
-    }
-  ]
+    }]
+  })
 }
-POLICY
-}
-`, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfigModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-trail-foobar-%[1]d"
-  s3_bucket_name                = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
+}
+`, rName))
+}
+
+func testAccAWSCloudTrailModifiedConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name                          = %[1]q
+  s3_bucket_name                = aws_s3_bucket.test.id
   s3_key_prefix                 = "prefix"
   include_global_service_events = false
   enable_logging                = false
 }
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfigCloudWatch(randInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailCloudWatchConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-acc-test-%[1]d"
+  name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
   cloud_watch_logs_role_arn  = aws_iam_role.test.arn
 }
 
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "test" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
 resource "aws_cloudwatch_log_group" "test" {
-  name = "tf-acc-test-cloudtrail-%[1]d"
+  name = %[1]q
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-cloudtrail-%[1]d"
+  name = %[1]q
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "cloudtrail.${data.aws_partition.current.dns_suffix}"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{
+      Sid    = ""
+      Effect = "Allow"
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = "cloudtrail.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+  })
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-cloudtrail-%[1]d"
+  name = %[1]q
   role = aws_iam_role.test.id
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailCreateLogStream",
-      "Effect": "Allow",
-      "Action": [
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{
+      Sid      = "AWSCloudTrailCreateLogStream"
+      Effect   = "Allow"
+      Resource = "${aws_cloudwatch_log_group.test.arn}:*"
+      Action = [
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "${aws_cloudwatch_log_group.test.arn}:*"
-    }
-  ]
+        "logs:PutLogEvents",
+      ]
+    }]
+  })
 }
-POLICY
-}
-`, randInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfigCloudWatchModified(randInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailCloudWatchModifiedConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-acc-test-%[1]d"
+  name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
-  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.second.arn}:*"
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.test2.arn}:*"
   cloud_watch_logs_role_arn  = aws_iam_role.test.arn
 }
 
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "test" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
 resource "aws_cloudwatch_log_group" "test" {
-  name = "tf-acc-test-cloudtrail-%[1]d"
+  name = %[1]q
 }
 
-resource "aws_cloudwatch_log_group" "second" {
-  name = "tf-acc-test-cloudtrail-second-%[1]d"
+resource "aws_cloudwatch_log_group" "test2" {
+  name = "%[1]s-2"
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-cloudtrail-%[1]d"
+  name = %[1]q
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "cloudtrail.${data.aws_partition.current.dns_suffix}"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = ""
+      Effect = "Allow"
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = "cloudtrail.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+  })
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-cloudtrail-%[1]d"
+  name = %[1]q
   role = aws_iam_role.test.id
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailCreateLogStream",
-      "Effect": "Allow",
-      "Action": [
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "AWSCloudTrailCreateLogStream"
+      Effect   = "Allow"
+      Resource = "${aws_cloudwatch_log_group.test2.arn}:*"
+      Action = [
         "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "${aws_cloudwatch_log_group.second.arn}:*"
-    }
-  ]
+        "logs:PutLogEvents",
+      ]
+    }]
+  })
 }
-POLICY
-}
-`, randInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfigMultiRegion(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                  = "tf-trail-foobar-%[1]d"
-  s3_bucket_name        = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailMultiRegionConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name                  = %[1]q
+  s3_bucket_name        = aws_s3_bucket.test.id
   is_multi_region_trail = true
 }
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfigOrganization(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-data "aws_partition" "current" {}
-
+func testAccAWSCloudTrailOrganizationConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {
   aws_service_access_principals = ["cloudtrail.${data.aws_partition.current.dns_suffix}"]
 }
 
-resource "aws_cloudtrail" "foobar" {
+resource "aws_cloudtrail" "test" {
   is_organization_trail = true
-  name                  = "tf-trail-foobar-%[1]d"
-  s3_bucket_name        = aws_s3_bucket.foo.id
+  name                  = %[1]q
+  s3_bucket_name        = aws_s3_bucket.test.id
+}
+`, rName))
 }
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
-}
-
-func testAccAWSCloudTrailConfig_logValidation(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-acc-trail-log-validation-test-%[1]d"
-  s3_bucket_name                = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailLogValidationConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name                          = %[1]q
+  s3_bucket_name                = aws_s3_bucket.test.id
   is_multi_region_trail         = true
   include_global_service_events = true
   enable_log_file_validation    = true
 }
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-acc-trail-log-validation-test-%[1]d"
-  s3_bucket_name                = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailLogValidationModifiedConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name                          = %[1]q
+  s3_bucket_name                = aws_s3_bucket.test.id
   include_global_service_events = true
 }
+`, rName))
+}
 
-data "aws_partition" "current" {}
+func testAccAWSCloudTrailKMSKeyConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = %[1]q
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Id        = %[1]q
+    Statement = [{
+      Sid       = "Enable IAM User Permissions"
+      Effect    = "Allow"
+      Action    = "kms:*"
+      Resource  = "*"
+      Principal = {
+        AWS = "*"
       }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
+    }]
+  })
 }
 
-func testAccAWSCloudTrailConfig_kmsKey(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %[1]d"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "kms-tf-1",
-  "Statement": [
-    {
-      "Sid": "Enable IAM User Permissions",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "kms:*",
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-}
-
-data "aws_partition" "current" {}
-
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-acc-trail-log-validation-test-%[1]d"
-  s3_bucket_name                = aws_s3_bucket.foo.id
+resource "aws_cloudtrail" "test" {
+  name                          = %[1]q
+  s3_bucket_name                = aws_s3_bucket.test.id
   include_global_service_events = true
-  kms_key_id                    = aws_kms_key.foo.arn
+  kms_key_id                    = aws_kms_key.test.arn
+}
+`, rName))
 }
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
-}
-
-var testAccAWSCloudTrailConfig_tags_tpl = `
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-acc-trail-log-validation-test-%[1]d"
-  s3_bucket_name = aws_s3_bucket.foo.id
-  %[2]s
-}
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`
-
-func testAccAWSCloudTrailConfig_include_global_service_events(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-trail-foobar-%[1]d"
-  s3_bucket_name                = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailGlobalServiceEventsConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name                          = %[1]q
+  s3_bucket_name                = aws_s3_bucket.test.id
   include_global_service_events = false
 }
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_tags(cloudTrailRandInt int) string {
-	tagsString := `
-tags = {
-  Foo  = "moo"
-  Pooh = "hi"
-}
-`
+func testAccAWSCloudTrailTagsConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
 
-	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl, cloudTrailRandInt, tagsString)
+  tags = {
+    Foo  = "moo"
+    Pooh = "hi"
+  }
 }
-
-func testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt int) string {
-	tagsString := `
-tags = {
-  Foo  = "moo"
-  Pooh = "hi"
-  Moo  = "boom"
-}
-`
-
-	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl, cloudTrailRandInt, tagsString)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt int) string {
-	return fmt.Sprintf(testAccAWSCloudTrailConfig_tags_tpl, cloudTrailRandInt, "")
+func testAccAWSCloudTrailTagsModifiedConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
+
+  tags = {
+    Foo  = "moo"
+    Pooh = "hi"
+    Moo  = "boom"
+  }
+}
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%[1]d"
-  s3_bucket_name = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailTagsModifiedAgainConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
+}
+`, rName))
+}
+
+func testAccAWSCloudTrailEventSelectorConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
 
   event_selector {
     read_write_type           = "ReadOnly"
@@ -1384,107 +1027,39 @@ resource "aws_cloudtrail" "foobar" {
       type = "AWS::S3::Object"
 
       values = [
-        "${aws_s3_bucket.bar.arn}/foobar",
-        "${aws_s3_bucket.bar.arn}/baz",
+        "${aws_s3_bucket.test2.arn}/foobar",
+        "${aws_s3_bucket.test2.arn}/baz",
       ]
     }
   }
 }
 
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_s3_bucket" "bar" {
-  bucket        = "tf-test-trail-event-select-%[1]d"
+resource "aws_s3_bucket" "test2" {
+  bucket        = "%[1]s-2"
   force_destroy = true
 }
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_eventSelectorReadWriteType(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%[1]d"
-  s3_bucket_name = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailEventSelectorReadWriteTypeConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
 
   event_selector {
     read_write_type           = "WriteOnly"
     include_management_events = true
   }
 }
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_eventSelectorModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%[1]d"
-  s3_bucket_name = aws_s3_bucket.foo.id
+func testAccAWSCloudTrailEventSelectorModifiedConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
 
   event_selector {
     read_write_type           = "ReadOnly"
@@ -1494,8 +1069,8 @@ resource "aws_cloudtrail" "foobar" {
       type = "AWS::S3::Object"
 
       values = [
-        "${aws_s3_bucket.bar.arn}/foobar",
-        "${aws_s3_bucket.bar.arn}/baz",
+        "${aws_s3_bucket.test2.arn}/foobar",
+        "${aws_s3_bucket.test2.arn}/baz",
       ]
     }
   }
@@ -1508,8 +1083,8 @@ resource "aws_cloudtrail" "foobar" {
       type = "AWS::S3::Object"
 
       values = [
-        "${aws_s3_bucket.bar.arn}/tf1",
-        "${aws_s3_bucket.bar.arn}/tf2",
+        "${aws_s3_bucket.test2.arn}/tf1",
+        "${aws_s3_bucket.test2.arn}/tf2",
       ]
     }
 
@@ -1517,129 +1092,57 @@ resource "aws_cloudtrail" "foobar" {
       type = "AWS::Lambda::Function"
 
       values = [
-        aws_lambda_function.lambda_function_test.arn,
+        aws_lambda_function.test.arn,
       ]
     }
   }
 }
 
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
+resource "aws_s3_bucket" "test2" {
+  bucket        = "%[1]s-2"
   force_destroy = true
+}
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{
+      Sid       = ""
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = {
+        Service = "lambda.${data.aws_partition.current.dns_suffix}"
       }
-    }
-  ]
-}
-POLICY
+    }]
+  })
 }
 
-resource "aws_s3_bucket" "bar" {
-  bucket        = "tf-test-trail-event-select-%[1]d"
-  force_destroy = true
-}
-
-resource "aws_iam_role" "iam_for_lambda" {
-  name = "tf-test-trail-event-select-%[1]d"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = "tf-test-trail-event-select-%[1]d"
-  role          = aws_iam_role.iam_for_lambda.arn
+  function_name = %[1]q
+  role          = aws_iam_role.test.arn
   handler       = "exports.example"
   runtime       = "nodejs12.x"
 }
-`, cloudTrailRandInt)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_eventSelectorNone(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%[1]d"
-  s3_bucket_name = aws_s3_bucket.foo.id
-}
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%[1]d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-trail-%[1]d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt)
-}
-
-func testAccAWSCloudTrailConfig_eventSelectorDynamoDB(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
+func testAccAWSCloudTrailEventSelectorNoneConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
   name           = %[1]q
-  s3_bucket_name = aws_s3_bucket.foo.id
+  s3_bucket_name = aws_s3_bucket.test.id
+}
+`, rName))
+}
+
+func testAccAWSCloudTrailEventSelectorDynamoDBConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = aws_s3_bucket.test.id
 
   event_selector {
     read_write_type           = "All"
@@ -1655,40 +1158,6 @@ resource "aws_cloudtrail" "foobar" {
   }
 }
 
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = %[1]q
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
 resource "aws_dynamodb_table" "test" {
   name           = %[1]q
   read_capacity  = 1
@@ -1700,11 +1169,11 @@ resource "aws_dynamodb_table" "test" {
     type = "S"
   }
 }
-`, rName)
+`, rName))
 }
 
-func testAccAWSCloudTrailConfig_insightSelector(rName string) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailInsightSelectorConfig(rName string) string {
+	return composeConfig(testAccAWSCloudTrailBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
@@ -1714,39 +1183,5 @@ resource "aws_cloudtrail" "test" {
     insight_type = "ApiCallRateInsight"
   }
 }
-
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "test" {
-  bucket        = %[1]q
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, rName)
+`, rName))
 }

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -422,8 +422,8 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					testAccCheckCloudTrailLoadTags(&trail, &trailTags),
-					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "moo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Pooh", "hi"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Yak", "milk"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Fox", "tail"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
@@ -439,9 +439,9 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					testAccCheckCloudTrailLoadTags(&trail, &trailTagsModified),
-					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "moo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Moo", "boom"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Pooh", "hi"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Yak", "milk"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Emu", "toes"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Fox", "tail"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
@@ -504,8 +504,8 @@ func testAccAWSCloudTrail_eventSelector(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/foobar", rName)),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/baz", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/isen", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/ko", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 				),
@@ -530,8 +530,8 @@ func testAccAWSCloudTrail_eventSelector(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/foobar", rName)),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/baz", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s-2/isen", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s-2/ko", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.#", "2"),
@@ -741,25 +741,27 @@ resource "aws_s3_bucket" "test" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Sid       = "AWSCloudTrailAclCheck"
-      Effect    = "Allow"
-      Principal = "*"
-      Action    = "s3:GetBucketAcl"
-      Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
-    },
-    {
-      Sid       = "AWSCloudTrailWrite"
-      Effect    = "Allow"
-      Principal = "*"
-      Action    = "s3:PutObject"
-      Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
-      Condition = {
-        StringEquals = {
-          "s3:x-amz-acl" = "bucket-owner-full-control"
+    Statement = [
+      {
+        Sid       = "AWSCloudTrailAclCheck"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetBucketAcl"
+        Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
+      },
+      {
+        Sid       = "AWSCloudTrailWrite"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:PutObject"
+        Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
         }
       }
-    }]
+    ]
   })
 }
 `, rName)
@@ -804,11 +806,13 @@ resource "aws_iam_role" "test" {
   name = %[1]q
 
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
+
     Statement = [{
       Sid    = ""
       Effect = "Allow"
       Action = "sts:AssumeRole"
+
       Principal = {
         Service = "cloudtrail.${data.aws_partition.current.dns_suffix}"
       }
@@ -821,11 +825,13 @@ resource "aws_iam_role_policy" "test" {
   role = aws_iam_role.test.id
 
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
+
     Statement = [{
       Sid      = "AWSCloudTrailCreateLogStream"
       Effect   = "Allow"
       Resource = "${aws_cloudwatch_log_group.test.arn}:*"
+
       Action = [
         "logs:CreateLogStream",
         "logs:PutLogEvents",
@@ -859,10 +865,12 @@ resource "aws_iam_role" "test" {
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
+
     Statement = [{
       Sid    = ""
       Effect = "Allow"
       Action = "sts:AssumeRole"
+
       Principal = {
         Service = "cloudtrail.${data.aws_partition.current.dns_suffix}"
       }
@@ -876,10 +884,12 @@ resource "aws_iam_role_policy" "test" {
 
   policy = jsonencode({
     Version = "2012-10-17"
+
     Statement = [{
       Sid      = "AWSCloudTrailCreateLogStream"
       Effect   = "Allow"
       Resource = "${aws_cloudwatch_log_group.test2.arn}:*"
+
       Action = [
         "logs:CreateLogStream",
         "logs:PutLogEvents",
@@ -942,13 +952,15 @@ resource "aws_kms_key" "test" {
   description = %[1]q
 
   policy = jsonencode({
-    Version   = "2012-10-17"
-    Id        = %[1]q
+    Version = "2012-10-17"
+    Id      = %[1]q
+
     Statement = [{
-      Sid       = "Enable IAM User Permissions"
-      Effect    = "Allow"
-      Action    = "kms:*"
-      Resource  = "*"
+      Sid      = "Enable IAM User Permissions"
+      Effect   = "Allow"
+      Action   = "kms:*"
+      Resource = "*"
+
       Principal = {
         AWS = "*"
       }
@@ -982,8 +994,8 @@ resource "aws_cloudtrail" "test" {
   s3_bucket_name = aws_s3_bucket.test.id
 
   tags = {
-    Foo  = "moo"
-    Pooh = "hi"
+    Yak = "milk"
+    Fox = "tail"
   }
 }
 `, rName))
@@ -996,9 +1008,9 @@ resource "aws_cloudtrail" "test" {
   s3_bucket_name = aws_s3_bucket.test.id
 
   tags = {
-    Foo  = "moo"
-    Pooh = "hi"
-    Moo  = "boom"
+    Yak = "milk"
+    Fox = "tail"
+    Emu = "toes"
   }
 }
 `, rName))
@@ -1027,8 +1039,8 @@ resource "aws_cloudtrail" "test" {
       type = "AWS::S3::Object"
 
       values = [
-        "${aws_s3_bucket.test2.arn}/foobar",
-        "${aws_s3_bucket.test2.arn}/baz",
+        "${aws_s3_bucket.test2.arn}/isen",
+        "${aws_s3_bucket.test2.arn}/ko",
       ]
     }
   }
@@ -1069,8 +1081,8 @@ resource "aws_cloudtrail" "test" {
       type = "AWS::S3::Object"
 
       values = [
-        "${aws_s3_bucket.test2.arn}/foobar",
-        "${aws_s3_bucket.test2.arn}/baz",
+        "${aws_s3_bucket.test2.arn}/isen",
+        "${aws_s3_bucket.test2.arn}/ko",
       ]
     }
   }
@@ -1107,11 +1119,13 @@ resource "aws_iam_role" "test" {
   name = %[1]q
 
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
+
     Statement = [{
-      Sid       = ""
-      Effect    = "Allow"
-      Action    = "sts:AssumeRole"
+      Sid    = ""
+      Effect = "Allow"
+      Action = "sts:AssumeRole"
+
       Principal = {
         Service = "lambda.${data.aws_partition.current.dns_suffix}"
       }

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -185,8 +185,8 @@ For **event_selector** the following attributes are supported.
 #### Data Resource Arguments
 For **data_resource** the following attributes are supported.
 
-* `type` (Required) - The resource type in which you want to log data events. You can specify only the following value: "AWS::S3::Object", "AWS::Lambda::Function"
-* `values` (Required) - A list of ARN for the specified S3 buckets and object prefixes..
+* `type` (Required) - The resource type in which you want to log data events. You can specify only the following value: "AWS::S3::Object", "AWS::Lambda::Function" and "AWS::DynamoDB::Table".
+* `values` (Required) - A list of ARN for the specified S3 buckets and object prefixes.
 
 ### Insight Selector Arguments
 

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -186,7 +186,13 @@ For **event_selector** the following attributes are supported.
 For **data_resource** the following attributes are supported.
 
 * `type` (Required) - The resource type in which you want to log data events. You can specify only the following value: "AWS::S3::Object", "AWS::Lambda::Function" and "AWS::DynamoDB::Table".
-* `values` (Required) - A list of ARN for the specified S3 buckets and object prefixes.
+* `values` (Required) - A list of ARN strings or partial ARN strings to specify selectors for data audit events over data resources. ARN list is specific to single-valued `type`.
+    * `arn:aws:s3:::<bucket_name>/` - all objects in bucket
+    * `arn:aws:s3:::<bucket_name>/key` - specific key(s)
+    * `arn:aws:lambda` - all lambda events within account
+    * `arn:aws:lambda:us-west-2:111111111111:function:helloworld` - events for exact arn
+    * `arn:aws:dynamodb` - all DDB events for all tables within account
+
 
 ### Insight Selector Arguments
 

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 Provides a CloudTrail resource.
 
-~> *NOTE:* For a multi-region trail, this resource must be in the home region of the trail.
+-> **Tip:** For a multi-region trail, this resource must be in the home region of the trail.
 
-~> *NOTE:* For an organization trail, this resource must be in the master account of the organization.
+-> **Tip:** For an organization trail, this resource must be in the master account of the organization.
 
 ## Example Usage
 
@@ -149,65 +149,57 @@ resource "aws_cloudtrail" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `name` - (Required) Specifies the name of the trail.
-* `s3_bucket_name` - (Required) Specifies the name of the S3 bucket designated for publishing log files.
-* `s3_key_prefix` - (Optional) Specifies the S3 key prefix that follows
-    the name of the bucket you have designated for log file delivery.
-* `cloud_watch_logs_role_arn` - (Optional) Specifies the role for the CloudWatch Logs
-    endpoint to assume to write to a user’s log group.
-* `cloud_watch_logs_group_arn` - (Optional) Specifies a log group name using an Amazon Resource Name (ARN),
-    that represents the log group to which CloudTrail logs will be delivered. Note that CloudTrail requires the Log Stream wildcard.
-* `enable_logging` - (Optional) Enables logging for the trail. Defaults to `true`.
-    Setting this to `false` will pause logging.
-* `include_global_service_events` - (Optional) Specifies whether the trail is publishing events
-    from global services such as IAM to the log files. Defaults to `true`.
-* `is_multi_region_trail` - (Optional) Specifies whether the trail is created in the current
-    region or in all regions. Defaults to `false`.
-* `is_organization_trail` - (Optional) Specifies whether the trail is an AWS Organizations trail. Organization trails log events for the master account and all member accounts. Can only be created in the organization master account. Defaults to `false`.
-* `sns_topic_name` - (Optional) Specifies the name of the Amazon SNS topic
-    defined for notification of log file delivery.
-* `enable_log_file_validation` - (Optional) Specifies whether log file integrity validation is enabled.
-    Defaults to `false`.
-* `kms_key_id` - (Optional) Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail.
-* `event_selector` - (Optional) Specifies an event selector for enabling data event logging. Fields documented below. Please note the [CloudTrail limits](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html) when configuring these.
-* `insight_selector` - (Optional) Specifies an insight selector for identifying unusual operational activity. Fields documented below.
-* `tags` - (Optional) A map of tags to assign to the trail. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `name` - (Required) Name of the trail.
+* `s3_bucket_name` - (Required) Name of the S3 bucket designated for publishing log files.
 
-### Event Selector Arguments
-For **event_selector** the following attributes are supported.
+The following arguments are optional:
 
-* `read_write_type` (Optional) - Specify if you want your trail to log read-only events, write-only events, or all. By default, the value is All. You can specify only the following value: "ReadOnly", "WriteOnly", "All". Defaults to `All`.
-* `include_management_events` (Optional) - Specify if you want your event selector to include management events for your trail.
-* `data_resource` (Optional) - Specifies logging data events. Fields documented below.
+* `cloud_watch_logs_group_arn` - (Optional) Log group name using an ARN that represents the log group to which CloudTrail logs will be delivered. Note that CloudTrail requires the Log Stream wildcard.
+* `cloud_watch_logs_role_arn` - (Optional) Role for the CloudWatch Logs endpoint to assume to write to a user’s log group.
+* `enable_log_file_validation` - (Optional) Whether log file integrity validation is enabled. Defaults to `false`.
+* `enable_logging` - (Optional) Enables logging for the trail. Defaults to `true`. Setting this to `false` will pause logging.
+* `event_selector` - (Optional) Configuration block of an event selector for enabling data event logging. See details below. Please note the [CloudTrail limits](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html) when configuring these.
+* `include_global_service_events` - (Optional) Whether the trail is publishing events from global services such as IAM to the log files. Defaults to `true`.
+* `insight_selector` - (Optional) Configuration block for identifying unusual operational activity. See details below.
+* `is_multi_region_trail` - (Optional) Whether the trail is created in the current region or in all regions. Defaults to `false`.
+* `is_organization_trail` - (Optional) Whether the trail is an AWS Organizations trail. Organization trails log events for the master account and all member accounts. Can only be created in the organization master account. Defaults to `false`.
+* `kms_key_id` - (Optional) KMS key ARN to use to encrypt the logs delivered by CloudTrail.
+* `s3_key_prefix` - (Optional) S3 key prefix that follows the name of the bucket you have designated for log file delivery.
+* `sns_topic_name` - (Optional) Name of the Amazon SNS topic defined for notification of log file delivery.
+* `tags` - (Optional) Map of tags to assign to the trail. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-#### Data Resource Arguments
-For **data_resource** the following attributes are supported.
+### event_selector
 
-* `type` (Required) - The resource type in which you want to log data events. You can specify only the following value: "AWS::S3::Object", "AWS::Lambda::Function" and "AWS::DynamoDB::Table".
-* `values` (Required) - A list of ARN strings or partial ARN strings to specify selectors for data audit events over data resources. ARN list is specific to single-valued `type`.
-    * `arn:aws:s3:::<bucket_name>/` - all objects in bucket
-    * `arn:aws:s3:::<bucket_name>/key` - specific key(s)
-    * `arn:aws:lambda` - all lambda events within account
-    * `arn:aws:lambda:us-west-2:111111111111:function:helloworld` - events for exact arn
-    * `arn:aws:dynamodb` - all DDB events for all tables within account
+This configuration block supports the following attributes:
+
+* `data_resource` - (Optional) Configuration block for data events. See details below.
+* `include_management_events` - (Optional) Whether to include management events for your trail.
+* `read_write_type` - (Optional) Type of events to log. Valid values are `ReadOnly`, `WriteOnly`, `All`. Default value is `All`.
+
+#### data_resource
+
+This configuration block supports the following attributes:
+
+* `type` - (Required) Resource type in which you want to log data events. You can specify only the following value: "AWS::S3::Object", "AWS::Lambda::Function" and "AWS::DynamoDB::Table".
+* `values` - (Required) List of ARN strings or partial ARN strings to specify selectors for data audit events over data resources. ARN list is specific to single-valued `type`. For example, `arn:aws:s3:::<bucket name>/` for all objects in a bucket, `arn:aws:s3:::<bucket name>/key` for specific objects, `arn:aws:lambda` for all lambda events within an account, `arn:aws:lambda:<region>:<account number>:function:<function name>` for a specific Lambda function, `arn:aws:dynamodb` for all DDB events for all tables within an account, or `arn:aws:dynamodb:<region>:<account number>:table/<table name>` for a specific DynamoDB table.
 
 
-### Insight Selector Arguments
+### insight_selector
 
-For **insight_selector** the following attributes are supported.
+This configuration block supports the following attributes:
 
-* `insight_type` (Optional) - The type of insights to log on a trail. In this release, only `ApiCallRateInsight` is supported as an insight type.
+* `insight_type` - (Optional) Type of insights to log on a trail. The valid value is `ApiCallRateInsight`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The name of the trail.
-* `home_region` - The region in which the trail was created.
-* `arn` - The Amazon Resource Name of the trail.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of the trail.
+* `home_region` - Region in which the trail was created.
+* `id` - Name of the trail.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18420 (supercedes)
Closes #18394

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSCloudTrail_serial (650.96s)
    --- PASS: TestAccAWSCloudTrail_serial/Trail (650.96s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/logValidation (53.82s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/tags (78.76s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/insightSelector (30.12s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/globalServiceEvents (30.77s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/multiRegion (77.79s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/enableLogging (76.99s)
        --- SKIP: TestAccAWSCloudTrail_serial/Trail/organization (0.17s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/kmsKey (30.12s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/eventSelector (115.19s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/eventSelectorDynamoDB (27.34s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/basic (53.45s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/cloudwatch (76.43s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSCloudTrail_serial (683.67s)
    --- PASS: TestAccAWSCloudTrail_serial/Trail (683.67s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/enableLogging (86.19s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/globalServiceEvents (32.68s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/logValidation (57.99s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/tags (83.77s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/eventSelector (126.22s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/insightSelector (33.18s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/basic (57.35s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/multiRegion (81.52s)
        --- SKIP: TestAccAWSCloudTrail_serial/Trail/organization (0.55s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/kmsKey (31.90s)
        --- SKIP: TestAccAWSCloudTrail_serial/Trail/eventSelectorDynamoDB (21.34s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/cloudwatch (70.98s)
```
