### PR TITLE
Fix invalid example: session_number is required

### DIFF
--- a/website/docs/r/ec2_traffic_mirror_session.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_session.html.markdown
@@ -28,6 +28,7 @@ resource "aws_ec2_traffic_mirror_target" "target" {
 resource "aws_ec2_traffic_mirror_session" "session" {
   description              = "traffic mirror session - terraform example"
   network_interface_id     = aws_instance.test.primary_network_interface_id
+  session_number           = 1
   traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
   traffic_mirror_target_id = aws_ec2_traffic_mirror_target.target.id
 }


### PR DESCRIPTION
Otherwise the error is:
```
The argument "session_number" is required, but no definition was found.
```
