### PR TITLE
r/cloudwatch_metric_alarm - add validation to `metric_query.metric.stat` + refactor to use expanded/flatteners

### DIFF
--- a/.changelog/19571.txt
+++ b/.changelog/19571.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Add plan time validation to `metric_query.metric.stat`.
+```

--- a/aws/internal/service/cloudwatch/finder/finder.go
+++ b/aws/internal/service/cloudwatch/finder/finder.go
@@ -24,3 +24,21 @@ func CompositeAlarmByName(ctx context.Context, conn *cloudwatch.CloudWatch, name
 
 	return output.CompositeAlarms[0], nil
 }
+
+func MetricAlarmByName(conn *cloudwatch.CloudWatch, name string) (*cloudwatch.MetricAlarm, error) {
+	input := cloudwatch.DescribeAlarmsInput{
+		AlarmNames: []*string{aws.String(name)},
+		AlarmTypes: aws.StringSlice([]string{cloudwatch.AlarmTypeMetricAlarm}),
+	}
+
+	output, err := conn.DescribeAlarms(&input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.MetricAlarms) != 1 {
+		return nil, nil
+	}
+
+	return output.MetricAlarms[0], nil
+}

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -553,7 +553,7 @@ func expandCloudWatchMetricAlarmMetrics(v *schema.Set) []*cloudwatch.MetricDataQ
 		if v, ok := metricQueryResource["return_data"]; ok {
 			metricQuery.ReturnData = aws.Bool(v.(bool))
 		}
-		if v := metricQueryResource["metric"]; v != nil {
+		if v := metricQueryResource["metric"]; v != nil && len(v.([]interface{})) > 0 {
 			metricQuery.MetricStat = expandCloudWatchMetricAlarmMetricsMetric(v.([]interface{}))
 		}
 		metrics = append(metrics, &metricQuery)

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatch/finder"
 )
 
 func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
@@ -98,8 +99,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 										Required: true,
 									},
 									"stat": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(cloudwatch.Statistic_Values(), false),
 									},
 									"unit": {
 										Type:         schema.TypeString,
@@ -143,6 +145,7 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"extended_statistic", "metric_query"},
+				ExactlyOneOf:  []string{"extended_statistic", "statistic"},
 				ValidateFunc:  validation.StringInSlice(cloudwatch.Statistic_Values(), false),
 			},
 			"threshold": {
@@ -222,6 +225,7 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"statistic", "metric_query"},
+				ExactlyOneOf:  []string{"extended_statistic", "statistic"},
 				ValidateFunc:  validation.StringMatch(regexp.MustCompile(`p(\d{1,2}(\.\d{0,2})?|100)`), "must specify a value between p0.0 and p100"),
 			},
 			"treat_missing_data": {
@@ -246,14 +250,6 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 }
 
 func validateResourceAwsCloudWatchMetricAlarm(d *schema.ResourceData) error {
-	_, metricNameOk := d.GetOk("metric_name")
-	_, statisticOk := d.GetOk("statistic")
-	_, extendedStatisticOk := d.GetOk("extended_statistic")
-
-	if metricNameOk && ((!statisticOk && !extendedStatisticOk) || (statisticOk && extendedStatisticOk)) {
-		return fmt.Errorf("One of `statistic` or `extended_statistic` must be set for a cloudwatch metric alarm")
-	}
-
 	if v := d.Get("metric_query"); v != nil {
 		for _, v := range v.(*schema.Set).List() {
 			metricQueryResource := v.(map[string]interface{})
@@ -282,7 +278,7 @@ func resourceAwsCloudWatchMetricAlarmCreate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Creating CloudWatch Metric Alarm: %#v", params)
 	_, err = conn.PutMetricAlarm(&params)
 	if err != nil {
-		return fmt.Errorf("Creating metric alarm failed: %s", err)
+		return fmt.Errorf("Creating metric alarm failed: %w", err)
 	}
 	d.SetId(d.Get("alarm_name").(string))
 	log.Println("[INFO] CloudWatch Metric Alarm created")
@@ -295,7 +291,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	resp, err := getAwsCloudWatchMetricAlarm(d, meta)
+	resp, err := finder.MetricAlarmByName(conn, d.Id())
 	if err != nil {
 		return err
 	}
@@ -304,12 +300,12 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 		return nil
 	}
 
-	log.Printf("[DEBUG] Reading CloudWatch Metric Alarm: %s", d.Get("alarm_name"))
+	log.Printf("[DEBUG] Reading CloudWatch Metric Alarm: %s", d.Id())
 
 	d.Set("actions_enabled", resp.ActionsEnabled)
 
 	if err := d.Set("alarm_actions", flattenStringSet(resp.AlarmActions)); err != nil {
-		log.Printf("[WARN] Error setting Alarm Actions: %s", err)
+		return fmt.Errorf("error setting Alarm Actions: %w", err)
 	}
 	arn := aws.StringValue(resp.AlarmArn)
 	d.Set("alarm_description", resp.AlarmDescription)
@@ -317,47 +313,27 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	d.Set("arn", arn)
 	d.Set("comparison_operator", resp.ComparisonOperator)
 	d.Set("datapoints_to_alarm", resp.DatapointsToAlarm)
-	if err := d.Set("dimensions", flattenDimensions(resp.Dimensions)); err != nil {
-		return err
+	if err := d.Set("dimensions", flattenAwsCloudWatchMetricAlarmDimensions(resp.Dimensions)); err != nil {
+		return fmt.Errorf("error setting dimensions: %w", err)
 	}
 	d.Set("evaluation_periods", resp.EvaluationPeriods)
 
 	if err := d.Set("insufficient_data_actions", flattenStringSet(resp.InsufficientDataActions)); err != nil {
-		log.Printf("[WARN] Error setting Insufficient Data Actions: %s", err)
+		return fmt.Errorf("error setting Insufficient Data Actions: %w", err)
 	}
 	d.Set("metric_name", resp.MetricName)
 	d.Set("namespace", resp.Namespace)
 
 	if resp.Metrics != nil && len(resp.Metrics) > 0 {
-		metricQueries := make([]interface{}, len(resp.Metrics))
-		for i, mq := range resp.Metrics {
-			metricQuery := map[string]interface{}{
-				"expression":  aws.StringValue(mq.Expression),
-				"id":          aws.StringValue(mq.Id),
-				"label":       aws.StringValue(mq.Label),
-				"return_data": aws.BoolValue(mq.ReturnData),
-			}
-			if mq.MetricStat != nil {
-				metric := map[string]interface{}{
-					"metric_name": aws.StringValue(mq.MetricStat.Metric.MetricName),
-					"namespace":   aws.StringValue(mq.MetricStat.Metric.Namespace),
-					"period":      int(aws.Int64Value(mq.MetricStat.Period)),
-					"stat":        aws.StringValue(mq.MetricStat.Stat),
-					"unit":        aws.StringValue(mq.MetricStat.Unit),
-					"dimensions":  flattenDimensions(mq.MetricStat.Metric.Dimensions),
-				}
-				metricQuery["metric"] = []interface{}{metric}
-			}
-			metricQueries[i] = metricQuery
-		}
-		if err := d.Set("metric_query", metricQueries); err != nil {
-			return fmt.Errorf("error setting metric_query: %s", err)
+		if err := d.Set("metric_query", flattenAwsCloudWatchMetricAlarmMetrics(resp.Metrics)); err != nil {
+			return fmt.Errorf("error setting metric_query: %w", err)
 		}
 	}
 
 	if err := d.Set("ok_actions", flattenStringSet(resp.OKActions)); err != nil {
-		log.Printf("[WARN] Error setting OK Actions: %s", err)
+		return fmt.Errorf("error setting OK Actions: %w", err)
 	}
+
 	d.Set("period", resp.Period)
 	d.Set("statistic", resp.Statistic)
 	d.Set("threshold", resp.Threshold)
@@ -370,7 +346,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	tags, err := keyvaluetags.CloudwatchListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for CloudWatch Metric Alarm (%s): %s", arn, err)
+		return fmt.Errorf("error listing tags for CloudWatch Metric Alarm (%s): %w", arn, err)
 	}
 
 	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -394,7 +370,7 @@ func resourceAwsCloudWatchMetricAlarmUpdate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Updating CloudWatch Metric Alarm: %#v", params)
 	_, err := conn.PutMetricAlarm(&params)
 	if err != nil {
-		return fmt.Errorf("Updating metric alarm failed: %s", err)
+		return fmt.Errorf("Updating metric alarm failed: %w", err)
 	}
 	log.Println("[INFO] CloudWatch Metric Alarm updated")
 
@@ -403,7 +379,7 @@ func resourceAwsCloudWatchMetricAlarmUpdate(d *schema.ResourceData, meta interfa
 		o, n := d.GetChange("tags_all")
 
 		if err := keyvaluetags.CloudwatchUpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating CloudWatch Metric Alarm (%s) tags: %s", arn, err)
+			return fmt.Errorf("error updating CloudWatch Metric Alarm (%s) tags: %w", arn, err)
 		}
 	}
 
@@ -422,7 +398,7 @@ func resourceAwsCloudWatchMetricAlarmDelete(d *schema.ResourceData, meta interfa
 		if isAWSErr(err, cloudwatch.ErrCodeResourceNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("Error deleting CloudWatch Metric Alarm: %s", err)
+		return fmt.Errorf("Error deleting CloudWatch Metric Alarm: %w", err)
 	}
 	log.Println("[INFO] CloudWatch Metric Alarm deleted")
 
@@ -494,105 +470,128 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData, meta interface{
 		params.InsufficientDataActions = expandStringSet(v.(*schema.Set))
 	}
 
-	var metrics []*cloudwatch.MetricDataQuery
 	if v := d.Get("metric_query"); v != nil {
-		for _, v := range v.(*schema.Set).List() {
-			metricQueryResource := v.(map[string]interface{})
-			id := metricQueryResource["id"].(string)
-			if id == "" {
-				continue
-			}
-			metricQuery := cloudwatch.MetricDataQuery{
-				Id: aws.String(id),
-			}
-			if v, ok := metricQueryResource["expression"]; ok && v.(string) != "" {
-				metricQuery.Expression = aws.String(v.(string))
-			}
-			if v, ok := metricQueryResource["label"]; ok && v.(string) != "" {
-				metricQuery.Label = aws.String(v.(string))
-			}
-			if v, ok := metricQueryResource["return_data"]; ok {
-				metricQuery.ReturnData = aws.Bool(v.(bool))
-			}
-			if v := metricQueryResource["metric"]; v != nil {
-				for _, v := range v.([]interface{}) {
-					metricResource := v.(map[string]interface{})
-					metric := cloudwatch.Metric{
-						MetricName: aws.String(metricResource["metric_name"].(string)),
-					}
-					metricStat := cloudwatch.MetricStat{
-						Metric: &metric,
-						Stat:   aws.String(metricResource["stat"].(string)),
-					}
-					if v, ok := metricResource["namespace"]; ok && v.(string) != "" {
-						metric.Namespace = aws.String(v.(string))
-					}
-					if v, ok := metricResource["period"]; ok {
-						metricStat.Period = aws.Int64(int64(v.(int)))
-					}
-					if v, ok := metricResource["unit"]; ok && v.(string) != "" {
-						metricStat.Unit = aws.String(v.(string))
-					}
-					a := metricResource["dimensions"].(map[string]interface{})
-					dimensions := make([]*cloudwatch.Dimension, 0, len(a))
-					for k, v := range a {
-						dimensions = append(dimensions, &cloudwatch.Dimension{
-							Name:  aws.String(k),
-							Value: aws.String(v.(string)),
-						})
-					}
-					metric.Dimensions = dimensions
-					metricQuery.MetricStat = &metricStat
-				}
-			}
-			metrics = append(metrics, &metricQuery)
-		}
-		params.Metrics = metrics
+		params.Metrics = expandCloudWatchMetricAlarmMetrics(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("ok_actions"); ok {
 		params.OKActions = expandStringSet(v.(*schema.Set))
 	}
 
-	a := d.Get("dimensions").(map[string]interface{})
-	var dimensions []*cloudwatch.Dimension
+	if v, ok := d.GetOk("dimensions"); ok {
+		params.Dimensions = expandAwsCloudWatchMetricAlarmDimensions(v.(map[string]interface{}))
+	}
+
+	return params
+}
+
+func flattenAwsCloudWatchMetricAlarmDimensions(dims []*cloudwatch.Dimension) map[string]interface{} {
+	flatDims := make(map[string]interface{})
+	for _, d := range dims {
+		flatDims[aws.StringValue(d.Name)] = aws.StringValue(d.Value)
+	}
+	return flatDims
+}
+
+func flattenAwsCloudWatchMetricAlarmMetrics(metrics []*cloudwatch.MetricDataQuery) []map[string]interface{} {
+	metricQueries := make([]map[string]interface{}, 0)
+	for _, mq := range metrics {
+		metricQuery := map[string]interface{}{
+			"expression":  aws.StringValue(mq.Expression),
+			"id":          aws.StringValue(mq.Id),
+			"label":       aws.StringValue(mq.Label),
+			"return_data": aws.BoolValue(mq.ReturnData),
+		}
+		if mq.MetricStat != nil {
+			metric := flattenAwsCloudWatchMetricAlarmMetricsMetricStat(mq.MetricStat)
+			metricQuery["metric"] = []interface{}{metric}
+		}
+		metricQueries = append(metricQueries, metricQuery)
+	}
+
+	return metricQueries
+}
+
+func flattenAwsCloudWatchMetricAlarmMetricsMetricStat(ms *cloudwatch.MetricStat) map[string]interface{} {
+	msm := ms.Metric
+	metric := map[string]interface{}{
+		"metric_name": aws.StringValue(msm.MetricName),
+		"namespace":   aws.StringValue(msm.Namespace),
+		"period":      int(aws.Int64Value(ms.Period)),
+		"stat":        aws.StringValue(ms.Stat),
+		"unit":        aws.StringValue(ms.Unit),
+		"dimensions":  flattenAwsCloudWatchMetricAlarmDimensions(msm.Dimensions),
+	}
+
+	return metric
+}
+
+func expandCloudWatchMetricAlarmMetrics(v *schema.Set) []*cloudwatch.MetricDataQuery {
+	var metrics []*cloudwatch.MetricDataQuery
+
+	for _, v := range v.List() {
+		metricQueryResource := v.(map[string]interface{})
+		id := metricQueryResource["id"].(string)
+		if id == "" {
+			continue
+		}
+		metricQuery := cloudwatch.MetricDataQuery{
+			Id: aws.String(id),
+		}
+		if v, ok := metricQueryResource["expression"]; ok && v.(string) != "" {
+			metricQuery.Expression = aws.String(v.(string))
+		}
+		if v, ok := metricQueryResource["label"]; ok && v.(string) != "" {
+			metricQuery.Label = aws.String(v.(string))
+		}
+		if v, ok := metricQueryResource["return_data"]; ok {
+			metricQuery.ReturnData = aws.Bool(v.(bool))
+		}
+		if v := metricQueryResource["metric"]; v != nil {
+			metricQuery.MetricStat = expandCloudWatchMetricAlarmMetricsMetric(v.([]interface{}))
+		}
+		metrics = append(metrics, &metricQuery)
+	}
+	return metrics
+}
+
+func expandCloudWatchMetricAlarmMetricsMetric(v []interface{}) *cloudwatch.MetricStat {
+	metricResource := v[0].(map[string]interface{})
+	metric := cloudwatch.Metric{
+		MetricName: aws.String(metricResource["metric_name"].(string)),
+	}
+	metricStat := cloudwatch.MetricStat{
+		Metric: &metric,
+		Stat:   aws.String(metricResource["stat"].(string)),
+	}
+	if v, ok := metricResource["namespace"]; ok && v.(string) != "" {
+		metric.Namespace = aws.String(v.(string))
+	}
+	if v, ok := metricResource["period"]; ok {
+		metricStat.Period = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := metricResource["unit"]; ok && v.(string) != "" {
+		metricStat.Unit = aws.String(v.(string))
+	}
+	a := metricResource["dimensions"].(map[string]interface{})
+	dimensions := make([]*cloudwatch.Dimension, 0, len(a))
 	for k, v := range a {
 		dimensions = append(dimensions, &cloudwatch.Dimension{
 			Name:  aws.String(k),
 			Value: aws.String(v.(string)),
 		})
 	}
-	params.Dimensions = dimensions
-
-	return params
+	metric.Dimensions = dimensions
+	return &metricStat
 }
 
-func getAwsCloudWatchMetricAlarm(d *schema.ResourceData, meta interface{}) (*cloudwatch.MetricAlarm, error) {
-	conn := meta.(*AWSClient).cloudwatchconn
-
-	params := cloudwatch.DescribeAlarmsInput{
-		AlarmNames: []*string{aws.String(d.Id())},
+func expandAwsCloudWatchMetricAlarmDimensions(dims map[string]interface{}) []*cloudwatch.Dimension {
+	var dimensions []*cloudwatch.Dimension
+	for k, v := range dims {
+		dimensions = append(dimensions, &cloudwatch.Dimension{
+			Name:  aws.String(k),
+			Value: aws.String(v.(string)),
+		})
 	}
-
-	resp, err := conn.DescribeAlarms(&params)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find it and return it
-	for idx, ma := range resp.MetricAlarms {
-		if aws.StringValue(ma.AlarmName) == d.Id() {
-			return resp.MetricAlarms[idx], nil
-		}
-	}
-
-	return nil, nil
-}
-
-func flattenDimensions(dims []*cloudwatch.Dimension) map[string]interface{} {
-	flatDims := make(map[string]interface{})
-	for _, d := range dims {
-		flatDims[aws.StringValue(d.Name)] = aws.StringValue(d.Value)
-	}
-	return flatDims
+	return dimensions
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
OR Closes #19567

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_'
--- PASS: TestAccAWSCloudWatchMetricAlarm_disappears (29.46s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (34.08s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (40.03s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (49.40s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (54.08s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (57.11s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (73.35s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (80.53s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_tags (114.83s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (443.02s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (12.16s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (144.62s)
```
