### PR TITLE
ds/servicecatalog_launch_paths: New data source

### DIFF
--- a/.changelog/19572.txt
+++ b/.changelog/19572.txt
@@ -1,0 +1,3 @@
+```release-notes:new-data-source
+aws_servicecatalog_launch_paths
+```

--- a/aws/data_source_aws_servicecatalog_launch_paths.go
+++ b/aws/data_source_aws_servicecatalog_launch_paths.go
@@ -1,0 +1,164 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+)
+
+func dataSourceAwsServiceCatalogLaunchPaths() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsServiceCatalogLaunchPathsRead,
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"summaries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"constraint_summaries": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"path_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": tagsSchemaComputed(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsServiceCatalogLaunchPathsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	summaries, err := waiter.LaunchPathsReady(conn, d.Get("accept_language").(string), d.Get("product_id").(string))
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Launch Paths: %w", err)
+	}
+
+	if err := d.Set("summaries", flattenServiceCatalogLaunchPathSummaries(summaries, ignoreTagsConfig)); err != nil {
+		return fmt.Errorf("error setting summaries: %w", err)
+	}
+
+	d.SetId(d.Get("product_id").(string))
+
+	return nil
+}
+
+func flattenServiceCatalogLaunchPathSummary(apiObject *servicecatalog.LaunchPathSummary, ignoreTagsConfig *keyvaluetags.IgnoreConfig) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if len(apiObject.ConstraintSummaries) > 0 {
+		tfMap["constraint_summaries"] = flattenServiceCatalogConstraintSummaries(apiObject.ConstraintSummaries)
+	}
+
+	if apiObject.Id != nil {
+		tfMap["path_id"] = aws.StringValue(apiObject.Id)
+	}
+
+	if apiObject.Name != nil {
+		tfMap["name"] = aws.StringValue(apiObject.Name)
+	}
+
+	tags := keyvaluetags.ServicecatalogKeyValueTags(apiObject.Tags)
+
+	tfMap["tags"] = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()
+
+	return tfMap
+}
+
+func flattenServiceCatalogLaunchPathSummaries(apiObjects []*servicecatalog.LaunchPathSummary, ignoreTagsConfig *keyvaluetags.IgnoreConfig) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenServiceCatalogLaunchPathSummary(apiObject, ignoreTagsConfig))
+	}
+
+	return tfList
+}
+
+func flattenServiceCatalogConstraintSummary(apiObject *servicecatalog.ConstraintSummary) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if apiObject.Description != nil {
+		tfMap["description"] = aws.StringValue(apiObject.Description)
+	}
+
+	if apiObject.Type != nil {
+		tfMap["type"] = aws.StringValue(apiObject.Type)
+	}
+
+	return tfMap
+}
+
+func flattenServiceCatalogConstraintSummaries(apiObjects []*servicecatalog.ConstraintSummary) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenServiceCatalogConstraintSummary(apiObject))
+	}
+
+	return tfList
+}

--- a/aws/data_source_aws_servicecatalog_launch_paths_test.go
+++ b/aws/data_source_aws_servicecatalog_launch_paths_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// THIS IS A HARD CODED TEST TO TEST FUNCTIONALITY WHILE WORKING THROUGH BLOCKED CODE
+
+// !!FIX THIS!! BEFORE MERGING
+
+func TestAccAWSServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_servicecatalog_launch_paths.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "accept_language", "en"),
+					resource.TestCheckResourceAttr(dataSourceName, "product_id", "prod-nui42zvkjm52a"),
+					resource.TestCheckResourceAttr(dataSourceName, "summaries.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "summaries.0.path_id", "lpv2-5aftplaxgosvk"),
+					resource.TestCheckResourceAttr(dataSourceName, "summaries.0.name", "satsuki-11221122"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName, description string) string {
+	return `
+data "aws_servicecatalog_launch_paths" "test" {
+  product_id = "prod-nui42zvkjm52a"
+}
+`
+}

--- a/aws/data_source_aws_servicecatalog_launch_paths_test.go
+++ b/aws/data_source_aws_servicecatalog_launch_paths_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
@@ -8,12 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// THIS IS A HARD CODED TEST TO TEST FUNCTIONALITY WHILE WORKING THROUGH BLOCKED CODE
-
-// !!FIX THIS!! BEFORE MERGING
-
 func TestAccAWSServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_servicecatalog_launch_paths.test"
+	resourceNameProduct := "aws_servicecatalog_product.test"
+	resourceNamePortfolio := "aws_servicecatalog_portfolio.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,23 +21,112 @@ func TestAccAWSServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName, rName),
+				Config: testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "accept_language", "en"),
-					resource.TestCheckResourceAttr(dataSourceName, "product_id", "prod-nui42zvkjm52a"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "product_id", resourceNameProduct, "id"),
 					resource.TestCheckResourceAttr(dataSourceName, "summaries.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "summaries.0.path_id", "lpv2-5aftplaxgosvk"),
-					resource.TestCheckResourceAttr(dataSourceName, "summaries.0.name", "satsuki-11221122"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "summaries.0.name", resourceNamePortfolio, "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "summaries.0.path_id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName, description string) string {
-	return `
-data "aws_servicecatalog_launch_paths" "test" {
-  product_id = "prod-nui42zvkjm52a"
+func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
+
+  template_body = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+
+    Resources = {
+      MyVPC = {
+        Type = "AWS::EC2::VPC"
+        Properties = {
+          CidrBlock = "10.1.0.0/16"
+        }
+      }
+    }
+
+    Outputs = {
+      VpcID = {
+        Description = "VPC ID"
+        Value = {
+          Ref = "MyVPC"
+        }
+      }
+    }
+  })
 }
-`
+
+resource "aws_servicecatalog_product" "test" {
+  description         = "beskrivning"
+  distributor         = "distributör"
+  name                = %[1]q
+  owner               = "ägare"
+  type                = "CLOUD_FORMATION_TEMPLATE"
+  support_description = "supportbeskrivning"
+  support_email       = "support@example.com"
+  support_url         = "http://example.com"
+
+  provisioning_artifact_parameters {
+    description          = "artefaktbeskrivning"
+    name                 = %[1]q
+    template_physical_id = aws_cloudformation_stack.test.id
+    type                 = "CLOUD_FORMATION_TEMPLATE"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_servicecatalog_portfolio" "test" {
+  name          = %[1]q
+  provider_name = %[1]q
+}
+
+resource "aws_servicecatalog_product_portfolio_association" "test" {
+  portfolio_id = aws_servicecatalog_portfolio.test.id
+  product_id   = aws_servicecatalog_product.test.id
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "servicecatalog.${data.aws_partition.current.dns_suffix}"
+      }
+      Sid = ""
+    }]
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_servicecatalog_principal_portfolio_association" "test" {
+  portfolio_id  = aws_servicecatalog_portfolio.test.id
+  principal_arn = data.aws_caller_identity.current.arn
+}
+`, rName)
+}
+
+func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName string) string {
+	return composeConfig(testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName), `
+data "aws_servicecatalog_launch_paths" "test" {
+  product_id = aws_servicecatalog_product_portfolio_association.test.product_id
+
+  depends_on = [aws_servicecatalog_principal_portfolio_association.test]
+}
+`)
 }

--- a/aws/internal/service/servicecatalog/waiter/status.go
+++ b/aws/internal/service/servicecatalog/waiter/status.go
@@ -346,7 +346,7 @@ func LaunchPathsStatus(conn *servicecatalog.ServiceCatalog, acceptLanguage, prod
 		})
 
 		if tfawserr.ErrCodeEquals(err, servicecatalog.ErrCodeResourceNotFoundException) {
-			return nil, StatusNotFound, err
+			return nil, StatusNotFound, nil
 		}
 
 		if err != nil {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -391,6 +391,7 @@ func Provider() *schema.Provider {
 			"aws_secretsmanager_secret_rotation":             dataSourceAwsSecretsManagerSecretRotation(),
 			"aws_secretsmanager_secret_version":              dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_servicecatalog_constraint":                  dataSourceAwsServiceCatalogConstraint(),
+			"aws_servicecatalog_launch_paths":                dataSourceAwsServiceCatalogLaunchPaths(),
 			"aws_servicecatalog_portfolio":                   dataSourceAwsServiceCatalogPortfolio(),
 			"aws_servicecatalog_product":                     dataSourceAwsServiceCatalogProduct(),
 			"aws_servicequotas_service":                      dataSourceAwsServiceQuotasService(),

--- a/website/docs/d/servicecatalog_launch_paths.html.markdown
+++ b/website/docs/d/servicecatalog_launch_paths.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_constraint"
+description: |-
+  Provides information on a Service Catalog Constraint
+---
+
+# Data source: aws_servicecatalog_constraint
+
+Provides information on a Service Catalog Constraint.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_servicecatalog_constraint" "example" {
+  accept_language = "en"
+  id              = "cons-hrvy0335"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `id` - Constraint identifier.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - Description of the constraint.
+* `owner` - Owner of the constraint.
+* `parameters` - Constraint parameters in JSON format.
+* `portfolio_id` - Portfolio identifier.
+* `product_id` - Product identifier.
+* `status` - Constraint status.
+* `type` - Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `RESOURCE_UPDATE`, `STACKSET`, and `TEMPLATE`.

--- a/website/docs/d/servicecatalog_launch_paths.html.markdown
+++ b/website/docs/d/servicecatalog_launch_paths.html.markdown
@@ -24,7 +24,7 @@ data "aws_servicecatalog_launch_paths" "example" {
 
 The following arguments are required:
 
-* `product_id` - Product identifier.
+* `product_id` - (Required) Product identifier.
 
 The following arguments are optional:
 

--- a/website/docs/d/servicecatalog_launch_paths.html.markdown
+++ b/website/docs/d/servicecatalog_launch_paths.html.markdown
@@ -1,23 +1,22 @@
 ---
 subcategory: "Service Catalog"
 layout: "aws"
-page_title: "AWS: aws_servicecatalog_constraint"
+page_title: "AWS: aws_servicecatalog_launch_paths"
 description: |-
-  Provides information on a Service Catalog Constraint
+  Provides information on Service Catalog Launch Paths
 ---
 
-# Data source: aws_servicecatalog_constraint
+# Data Source: aws_servicecatalog_launch_paths
 
-Provides information on a Service Catalog Constraint.
+Lists the paths to the specified product. A path is how the user has access to a specified product, and is necessary when provisioning a product. A path also determines the constraints put on the product.
 
 ## Example Usage
 
 ### Basic Usage
 
 ```terraform
-data "aws_servicecatalog_constraint" "example" {
-  accept_language = "en"
-  id              = "cons-hrvy0335"
+data "aws_servicecatalog_launch_paths" "example" {
+  product_id = "prod-yakog5pdriver"
 }
 ```
 
@@ -25,7 +24,7 @@ data "aws_servicecatalog_constraint" "example" {
 
 The following arguments are required:
 
-* `id` - Constraint identifier.
+* `product_id` - Product identifier.
 
 The following arguments are optional:
 
@@ -35,10 +34,16 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `summaries` - Block with information about the launch path. See details below.
+
+### summaries
+
+* `constraint_summaries` - Block for constraints on the portfolio-product relationship. See details below.
+* `path_id` - Identifier of the product path.
+* `name` - Name of the portfolio to which the path was assigned.
+* `tags` - Tags associated with this product path.
+
+### constraint_summaries
+
 * `description` - Description of the constraint.
-* `owner` - Owner of the constraint.
-* `parameters` - Constraint parameters in JSON format.
-* `portfolio_id` - Portfolio identifier.
-* `product_id` - Product identifier.
-* `status` - Constraint status.
-* `type` - Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `RESOURCE_UPDATE`, `STACKSET`, and `TEMPLATE`.
+* `type` - Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `STACKSET`, and `TEMPLATE`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

#19459 depends on this

Acceptance testing requires a non-assumed role. See #19958

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogLaunchPathsDataSource_basic (75.66s)
```

### References:

* aws/aws-sdk-go#3920
* https://stackoverflow.com/a/67713362/2121526