### PR TITLE
tests/ds/servicecat_constraint: Fix test

### DIFF
--- a/aws/data_source_aws_servicecatalog_constraint_test.go
+++ b/aws/data_source_aws_servicecatalog_constraint_test.go
@@ -23,7 +23,7 @@ func TestAccAWSServiceCatalogConstraintDataSource_basic(t *testing.T) {
 				Config: testAccAWSServiceCatalogConstraintDataSourceConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogConstraintExists(resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "acceptLanguage", dataSourceName, "acceptLanguage"),
+					resource.TestCheckResourceAttrPair(resourceName, "accept_language", dataSourceName, "accept_language"),
 					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
 					resource.TestCheckResourceAttrPair(resourceName, "owner", dataSourceName, "owner"),
 					resource.TestCheckResourceAttrPair(resourceName, "parameters", dataSourceName, "parameters"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogConstraintDataSource_basic (31.68s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogConstraintDataSource_basic (34.47s)
```
