### PR TITLE
r/devicefarm_project - add `default_job_timeout_minutes` and `tags` arguments

### DIFF
--- a/.changelog/19574.txt
+++ b/.changelog/19574.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_devicefarm_project: Add `default_job_timeout_minutes` argument
+```
+
+```release-note:enhancement
+resource/aws_devicefarm_project: Add plan time validation for `name`
+```

--- a/.changelog/19574.txt
+++ b/.changelog/19574.txt
@@ -1,5 +1,5 @@
 ```release-note:enhancement
-resource/aws_devicefarm_project: Add `default_job_timeout_minutes` argument
+resource/aws_devicefarm_project: Add `default_job_timeout_minutes` and `tags` argument
 ```
 
 ```release-note:enhancement

--- a/aws/resource_aws_devicefarm_project.go
+++ b/aws/resource_aws_devicefarm_project.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsDevicefarmProject() *schema.Resource {
@@ -35,12 +36,17 @@ func resourceAwsDevicefarmProject() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
 		},
+		CustomizeDiff: SetTagsDiff,
 	}
 }
 
 func resourceAwsDevicefarmProjectCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).devicefarmconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &devicefarm.CreateProjectInput{
@@ -61,11 +67,19 @@ func resourceAwsDevicefarmProjectCreate(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Successsfully Created DeviceFarm Project: %s", arn)
 	d.SetId(arn)
 
+	if len(tags) > 0 {
+		if err := keyvaluetags.DevicefarmUpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error updating DeviceFarm Project (%s) tags: %w", arn, err)
+		}
+	}
+
 	return resourceAwsDevicefarmProjectRead(d, meta)
 }
 
 func resourceAwsDevicefarmProjectRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).devicefarmconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &devicefarm.GetProjectInput{
 		Arn: aws.String(d.Id()),
@@ -83,9 +97,27 @@ func resourceAwsDevicefarmProjectRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	project := out.Project
+	arn := aws.StringValue(project.Arn)
 	d.Set("name", project.Name)
-	d.Set("arn", project.Arn)
+	d.Set("arn", arn)
 	d.Set("default_job_timeout_minutes", project.DefaultJobTimeoutMinutes)
+
+	tags, err := keyvaluetags.DevicefarmListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for DeviceFarm Project (%s): %w", arn, err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
 
 	return nil
 }
@@ -93,22 +125,32 @@ func resourceAwsDevicefarmProjectRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsDevicefarmProjectUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).devicefarmconn
 
-	input := &devicefarm.UpdateProjectInput{
-		Arn: aws.String(d.Id()),
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &devicefarm.UpdateProjectInput{
+			Arn: aws.String(d.Id()),
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("default_job_timeout_minutes") {
+			input.DefaultJobTimeoutMinutes = aws.Int64(int64(d.Get("default_job_timeout_minutes").(int)))
+		}
+
+		log.Printf("[DEBUG] Updating DeviceFarm Project: %s", d.Id())
+		_, err := conn.UpdateProject(input)
+		if err != nil {
+			return fmt.Errorf("Error Updating DeviceFarm Project: %w", err)
+		}
 	}
 
-	if d.HasChange("name") {
-		input.Name = aws.String(d.Get("name").(string))
-	}
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
 
-	if d.HasChange("default_job_timeout_minutes") {
-		input.DefaultJobTimeoutMinutes = aws.Int64(int64(d.Get("default_job_timeout_minutes").(int)))
-	}
-
-	log.Printf("[DEBUG] Updating DeviceFarm Project: %s", d.Id())
-	_, err := conn.UpdateProject(input)
-	if err != nil {
-		return fmt.Errorf("Error Updating DeviceFarm Project: %w", err)
+		if err := keyvaluetags.DevicefarmUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating DeviceFarm Project (%s) tags: %w", d.Get("arn").(string), err)
+		}
 	}
 
 	return resourceAwsDevicefarmProjectRead(d, meta)
@@ -124,6 +166,9 @@ func resourceAwsDevicefarmProjectDelete(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Deleting DeviceFarm Project: %s", d.Id())
 	_, err := conn.DeleteProject(input)
 	if err != nil {
+		if isAWSErr(err, devicefarm.ErrCodeNotFoundException, "") {
+			return nil
+		}
 		return fmt.Errorf("Error deleting DeviceFarm Project: %w", err)
 	}
 

--- a/aws/resource_aws_devicefarm_project.go
+++ b/aws/resource_aws_devicefarm_project.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsDevicefarmProject() *schema.Resource {
@@ -26,8 +27,13 @@ func resourceAwsDevicefarmProject() *schema.Resource {
 			},
 
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"default_job_timeout_minutes": {
+				Type:     schema.TypeInt,
+				Optional: true,
 			},
 		},
 	}
@@ -36,18 +42,24 @@ func resourceAwsDevicefarmProject() *schema.Resource {
 func resourceAwsDevicefarmProjectCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).devicefarmconn
 
+	name := d.Get("name").(string)
 	input := &devicefarm.CreateProjectInput{
-		Name: aws.String(d.Get("name").(string)),
+		Name: aws.String(name),
 	}
 
-	log.Printf("[DEBUG] Creating DeviceFarm Project: %s", d.Get("name").(string))
+	if v, ok := d.GetOk("default_job_timeout_minutes"); ok {
+		input.DefaultJobTimeoutMinutes = aws.Int64(int64(v.(int)))
+	}
+
+	log.Printf("[DEBUG] Creating DeviceFarm Project: %s", name)
 	out, err := conn.CreateProject(input)
 	if err != nil {
-		return fmt.Errorf("Error creating DeviceFarm Project: %s", err)
+		return fmt.Errorf("Error creating DeviceFarm Project: %w", err)
 	}
 
-	log.Printf("[DEBUG] Successsfully Created DeviceFarm Project: %s", *out.Project.Arn)
-	d.SetId(aws.StringValue(out.Project.Arn))
+	arn := aws.StringValue(out.Project.Arn)
+	log.Printf("[DEBUG] Successsfully Created DeviceFarm Project: %s", arn)
+	d.SetId(arn)
 
 	return resourceAwsDevicefarmProjectRead(d, meta)
 }
@@ -67,11 +79,13 @@ func resourceAwsDevicefarmProjectRead(d *schema.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading DeviceFarm Project: %s", err)
+		return fmt.Errorf("Error reading DeviceFarm Project: %w", err)
 	}
 
-	d.Set("name", out.Project.Name)
-	d.Set("arn", out.Project.Arn)
+	project := out.Project
+	d.Set("name", project.Name)
+	d.Set("arn", project.Arn)
+	d.Set("default_job_timeout_minutes", project.DefaultJobTimeoutMinutes)
 
 	return nil
 }
@@ -79,18 +93,22 @@ func resourceAwsDevicefarmProjectRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsDevicefarmProjectUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).devicefarmconn
 
+	input := &devicefarm.UpdateProjectInput{
+		Arn: aws.String(d.Id()),
+	}
+
 	if d.HasChange("name") {
-		input := &devicefarm.UpdateProjectInput{
-			Arn:  aws.String(d.Id()),
-			Name: aws.String(d.Get("name").(string)),
-		}
+		input.Name = aws.String(d.Get("name").(string))
+	}
 
-		log.Printf("[DEBUG] Updating DeviceFarm Project: %s", d.Id())
-		_, err := conn.UpdateProject(input)
-		if err != nil {
-			return fmt.Errorf("Error Updating DeviceFarm Project: %s", err)
-		}
+	if d.HasChange("default_job_timeout_minutes") {
+		input.DefaultJobTimeoutMinutes = aws.Int64(int64(d.Get("default_job_timeout_minutes").(int)))
+	}
 
+	log.Printf("[DEBUG] Updating DeviceFarm Project: %s", d.Id())
+	_, err := conn.UpdateProject(input)
+	if err != nil {
+		return fmt.Errorf("Error Updating DeviceFarm Project: %w", err)
 	}
 
 	return resourceAwsDevicefarmProjectRead(d, meta)
@@ -106,7 +124,7 @@ func resourceAwsDevicefarmProjectDelete(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Deleting DeviceFarm Project: %s", d.Id())
 	_, err := conn.DeleteProject(input)
 	if err != nil {
-		return fmt.Errorf("Error deleting DeviceFarm Project: %s", err)
+		return fmt.Errorf("Error deleting DeviceFarm Project: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_devicefarm_project_test.go
+++ b/aws/resource_aws_devicefarm_project_test.go
@@ -36,6 +36,7 @@ func TestAccAWSDeviceFarmProject_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFarmProjectExists(resourceName, &proj),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`project:.+`)),
 				),
 			},
@@ -92,6 +93,57 @@ func TestAccAWSDeviceFarmProject_timeout(t *testing.T) {
 					testAccCheckDeviceFarmProjectExists(resourceName, &proj),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "default_job_timeout_minutes", "20"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDeviceFarmProject_tags(t *testing.T) {
+	var proj devicefarm.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_devicefarm_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			testAccRegionPreCheck(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   testAccErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDeviceFarmProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmProjectConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmProjectExists(resourceName, &proj),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmProjectConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmProjectExists(resourceName, &proj),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDeviceFarmProjectConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmProjectExists(resourceName, &proj),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -196,4 +248,29 @@ resource "aws_devicefarm_project" "test" {
   default_job_timeout_minutes = %[2]d
 }
 `, rName, timeout)
+}
+
+func testAccDeviceFarmProjectConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_devicefarm_project" "test" {
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }  
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccDeviceFarmProjectConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_devicefarm_project" "test" {
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }  
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_devicefarm_project_test.go
+++ b/aws/resource_aws_devicefarm_project_test.go
@@ -257,7 +257,7 @@ resource "aws_devicefarm_project" "test" {
 
   tags = {
     %[2]q = %[3]q
-  }  
+  }
 }
 `, rName, tagKey1, tagValue1)
 }
@@ -270,7 +270,7 @@ resource "aws_devicefarm_project" "test" {
   tags = {
     %[2]q = %[3]q
     %[4]q = %[5]q
-  }  
+  }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/devicefarm_project.html.markdown
+++ b/website/docs/r/devicefarm_project.html.markdown
@@ -28,12 +28,14 @@ resource "aws_devicefarm_project" "awesome_devices" {
 
 * `name` - (Required) The name of the project
 * `default_job_timeout_minutes` - (Optional) Sets the execution timeout value (in minutes) for a project. All test runs in this project use the specified execution timeout value unless overridden when scheduling a run.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name of this project
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 [aws-get-project]: http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_GetProject.html
 

--- a/website/docs/r/devicefarm_project.html.markdown
+++ b/website/docs/r/devicefarm_project.html.markdown
@@ -27,6 +27,7 @@ resource "aws_devicefarm_project" "awesome_devices" {
 ## Argument Reference
 
 * `name` - (Required) The name of the project
+* `default_job_timeout_minutes` - (Optional) Sets the execution timeout value (in minutes) for a project. All test runs in this project use the specified execution timeout value unless overridden when scheduling a run.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #8745.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDeviceFarmProject_'
--- PASS: TestAccAWSDeviceFarmProject_disappears (25.35s)
--- PASS: TestAccAWSDeviceFarmProject_basic (59.77s)
--- PASS: TestAccAWSDeviceFarmProject_timeout (60.49s)
--- PASS: TestAccAWSDeviceFarmProject_tags (87.44s)
```
