### PR TITLE
F data source aws appmesh mesh create

### DIFF
--- a/.changelog/19577.txt
+++ b/.changelog/19577.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_appmesh_mesh
+```

--- a/aws/data_source_aws_appmesh_mesh.go
+++ b/aws/data_source_aws_appmesh_mesh.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsAppmeshMesh() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAppmeshMeshRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"spec": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"egress_filter": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"last_updated_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"mesh_owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"resource_owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsAppmeshMeshRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appmeshconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	meshName := d.Get("name").(string)
+
+	req := &appmesh.DescribeMeshInput{
+		MeshName: aws.String(meshName),
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	resp, err := conn.DescribeMesh(req)
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		return fmt.Errorf("App Mesh Mesh (%s) not found", meshName)
+	}
+	if err != nil {
+		return fmt.Errorf("error reading App Mesh service mesh: %s", err)
+	}
+	if aws.StringValue(resp.Mesh.Status.Status) == appmesh.MeshStatusCodeDeleted {
+		return fmt.Errorf("App Mesh Mesh (%s) has status: 'DELETED'", meshName)
+	}
+
+	arn := aws.StringValue(resp.Mesh.Metadata.Arn)
+
+	d.SetId(aws.StringValue(resp.Mesh.MeshName))
+	d.Set("arn", arn)
+	d.Set("created_date", resp.Mesh.Metadata.CreatedAt.Format(time.RFC3339))
+	d.Set("last_updated_date", resp.Mesh.Metadata.LastUpdatedAt.Format(time.RFC3339))
+	d.Set("mesh_owner", resp.Mesh.Metadata.MeshOwner)
+	d.Set("resource_owner", resp.Mesh.Metadata.ResourceOwner)
+	err = d.Set("spec", flattenAppmeshMeshSpec(resp.Mesh.Spec))
+	if err != nil {
+		return fmt.Errorf("error setting spec: %s", err)
+	}
+
+	tags, err := keyvaluetags.AppmeshListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for App Mesh service mesh (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_appmesh_mesh.go
+++ b/aws/data_source_aws_appmesh_mesh.go
@@ -15,35 +15,6 @@ func dataSourceAwsAppmeshMesh() *schema.Resource {
 		Read: dataSourceAwsAppmeshMeshRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"spec": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"egress_filter": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -62,11 +33,38 @@ func dataSourceAwsAppmeshMesh() *schema.Resource {
 			"mesh_owner": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 
 			"resource_owner": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+
+			"spec": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"egress_filter": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 
 			"tags": tagsSchemaComputed(),
@@ -88,9 +86,6 @@ func dataSourceAwsAppmeshMeshRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	resp, err := conn.DescribeMesh(req)
-	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
-		return fmt.Errorf("App Mesh Mesh (%s) not found", meshName)
-	}
 	if err != nil {
 		return fmt.Errorf("error reading App Mesh service mesh: %s", err)
 	}

--- a/aws/data_source_aws_appmesh_mesh_test.go
+++ b/aws/data_source_aws_appmesh_mesh_test.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSAppmeshMeshDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appmesh_mesh.test"
+	dataSourceName := "data.aws_appmesh_mesh.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAppmeshMeshDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_date", dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "last_updated_date", dataSourceName, "last_updated_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "mesh_owner", dataSourceName, "mesh_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_owner", dataSourceName, "resource_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "spec.0.egress_filter.0.type", dataSourceName, "spec.0.egress_filter.0.type"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAppmeshMeshDataSource_meshOwner(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appmesh_mesh.test"
+	dataSourceName := "data.aws_appmesh_mesh.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAppmeshMeshDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_date", dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "last_updated_date", dataSourceName, "last_updated_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "mesh_owner", dataSourceName, "mesh_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_owner", dataSourceName, "resource_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "spec.0.egress_filter.0.type", dataSourceName, "spec.0.egress_filter.0.type"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAppmeshMeshDataSource_specAndTagsSet(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appmesh_mesh.test"
+	dataSourceName := "data.aws_appmesh_mesh.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAppmeshMeshDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_date", dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "last_updated_date", dataSourceName, "last_updated_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "mesh_owner", dataSourceName, "mesh_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_owner", dataSourceName, "resource_owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "spec.0.egress_filter.0.type", dataSourceName, "spec.0.egress_filter.0.type"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAppmeshMeshDataSource_nonExistent(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshMeshDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckAwsAppmeshMeshDataSourceConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`not found`),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsAppmeshMeshDataSourceConfig_NonExistent = `
+data "aws_appmesh_mesh" "test" {
+  name = "tf-acc-test-non-existent"
+}
+`
+
+func testAccCheckAwsAppmeshMeshDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_appmesh_mesh" "test" {
+	name = %q
+}
+
+data "aws_appmesh_mesh" "test" {
+    name = aws_appmesh_mesh.test.name
+}
+`, rName)
+}
+
+func testAccCheckAwsAppmeshMeshDataSourceConfig_meshOwner(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_appmesh_mesh" "test" {
+	name = %q
+}
+
+data "aws_appmesh_mesh" "test" {
+  name = aws_appmesh_mesh.test.name
+  mesh_owner = data.aws_caller_identity.current.account_id
+}
+`, rName)
+}
+
+func testAccCheckAwsAppmeshMeshDataSourceConfig_specAndTagsSet(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_appmesh_mesh" "test" {
+	name = %q
+
+  spec {
+    egress_filter {
+      type = "DROP_ALL"
+    }
+  }
+
+  tags = {
+    foo  = "bar"
+    good = "bad"
+  }
+}
+
+data "aws_appmesh_mesh" "test" {
+  name = aws_appmesh_mesh.test.name
+}
+`, rName)
+}

--- a/aws/data_source_aws_appmesh_mesh_test.go
+++ b/aws/data_source_aws_appmesh_mesh_test.go
@@ -46,7 +46,7 @@ func TestAccAWSAppmeshMeshDataSource_meshOwner(t *testing.T) {
 		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsAppmeshMeshDataSourceConfig(rName),
+				Config: testAccCheckAwsAppmeshMeshDataSourceConfig_meshOwner(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_date", dataSourceName, "created_date"),
@@ -73,7 +73,7 @@ func TestAccAWSAppmeshMeshDataSource_specAndTagsSet(t *testing.T) {
 		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsAppmeshMeshDataSourceConfig(rName),
+				Config: testAccCheckAwsAppmeshMeshDataSourceConfig_specAndTagsSet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_date", dataSourceName, "created_date"),

--- a/aws/data_source_aws_appmesh_mesh_test.go
+++ b/aws/data_source_aws_appmesh_mesh_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -15,7 +16,7 @@ func TestAccAWSAppmeshMeshDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_appmesh_mesh.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -41,7 +42,7 @@ func TestAccAWSAppmeshMeshDataSource_meshOwner(t *testing.T) {
 	dataSourceName := "data.aws_appmesh_mesh.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{
@@ -68,7 +69,7 @@ func TestAccAWSAppmeshMeshDataSource_specAndTagsSet(t *testing.T) {
 	dataSourceName := "data.aws_appmesh_mesh.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{
@@ -88,26 +89,6 @@ func TestAccAWSAppmeshMeshDataSource_specAndTagsSet(t *testing.T) {
 		},
 	})
 }
-
-func TestAccAWSAppmeshMeshDataSource_nonExistent(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAppmeshMeshDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccCheckAwsAppmeshMeshDataSourceConfig_NonExistent,
-				ExpectError: regexp.MustCompile(`not found`),
-			},
-		},
-	})
-}
-
-const testAccCheckAwsAppmeshMeshDataSourceConfig_NonExistent = `
-data "aws_appmesh_mesh" "test" {
-  name = "tf-acc-test-non-existent"
-}
-`
 
 func testAccCheckAwsAppmeshMeshDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`

--- a/aws/data_source_aws_appmesh_mesh_test.go
+++ b/aws/data_source_aws_appmesh_mesh_test.go
@@ -96,11 +96,11 @@ func TestAccAWSAppmeshMeshDataSource_specAndTagsSet(t *testing.T) {
 func testAccCheckAwsAppmeshMeshDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
-	name = %q
+  name = %[1]q
 }
 
 data "aws_appmesh_mesh" "test" {
-    name = aws_appmesh_mesh.test.name
+  name = aws_appmesh_mesh.test.name
 }
 `, rName)
 }
@@ -110,11 +110,11 @@ func testAccCheckAwsAppmeshMeshDataSourceConfig_meshOwner(rName string) string {
 data "aws_caller_identity" "current" {}
 
 resource "aws_appmesh_mesh" "test" {
-	name = %q
+  name = %[1]q
 }
 
 data "aws_appmesh_mesh" "test" {
-  name = aws_appmesh_mesh.test.name
+  name       = aws_appmesh_mesh.test.name
   mesh_owner = data.aws_caller_identity.current.account_id
 }
 `, rName)
@@ -125,7 +125,7 @@ func testAccCheckAwsAppmeshMeshDataSourceConfig_specAndTagsSet(rName string) str
 data "aws_caller_identity" "current" {}
 
 resource "aws_appmesh_mesh" "test" {
-	name = %q
+  name = %[1]q
 
   spec {
     egress_filter {

--- a/aws/data_source_aws_appmesh_mesh_test.go
+++ b/aws/data_source_aws_appmesh_mesh_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/appmesh"
@@ -16,8 +15,10 @@ func TestAccAWSAppmeshMeshDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_appmesh_mesh.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, appmesh.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAwsAppmeshMeshDataSourceConfig(rName),
@@ -43,6 +44,7 @@ func TestAccAWSAppmeshMeshDataSource_meshOwner(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, appmesh.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{
@@ -70,6 +72,7 @@ func TestAccAWSAppmeshMeshDataSource_specAndTagsSet(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(appmesh.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, appmesh.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppmeshMeshDestroy,
 		Steps: []resource.TestStep{

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -196,6 +196,7 @@ func Provider() *schema.Provider {
 			"aws_api_gateway_vpc_link":                       dataSourceAwsApiGatewayVpcLink(),
 			"aws_apigatewayv2_api":                           dataSourceAwsApiGatewayV2Api(),
 			"aws_apigatewayv2_apis":                          dataSourceAwsApiGatewayV2Apis(),
+			"aws_appmesh_mesh":                               dataSourceAwsAppmeshMesh(),
 			"aws_arn":                                        dataSourceAwsArn(),
 			"aws_autoscaling_group":                          dataSourceAwsAutoscalingGroup(),
 			"aws_autoscaling_groups":                         dataSourceAwsAutoscalingGroups(),

--- a/website/docs/d/appmesh_mesh.html.markdown
+++ b/website/docs/d/appmesh_mesh.html.markdown
@@ -51,4 +51,4 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Egress Filter
 
-* `type` - The egress filter type. By default, the type is `DROP_ALL`, but if the resource was created by Terraform without this value set, this will return `None`.
+* `type` - The egress filter type.

--- a/website/docs/d/appmesh_mesh.html.markdown
+++ b/website/docs/d/appmesh_mesh.html.markdown
@@ -22,7 +22,7 @@ data "aws_appmesh_mesh" "simple" {
 data "aws_caller_identity" "current" {}
 
 data "aws_appmesh_mesh" "simple" {
-  name = "simpleapp"
+  name       = "simpleapp"
   mesh_owner = data.aws_caller_identity.current.account_id
 }
 ```

--- a/website/docs/d/appmesh_mesh.html.markdown
+++ b/website/docs/d/appmesh_mesh.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "AppMesh"
+layout: "aws"
+page_title: "AWS: aws_appmesh_mesh"
+description: |-
+    Provides details about an App Mesh Mesh service mesh resource.
+---
+
+# Data Source: aws_appmesh_mesh
+
+The App Mesh Mesh data source allows details of an App Mesh Mesh to be retrieved by it's name and/or mesh_owner.
+
+## Example Usage
+
+```hcl
+data "aws_appmesh_mesh" "simple" {
+  name = "simpleapp"
+}
+```
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+data "aws_appmesh_mesh" "simple" {
+  name = "simpleapp"
+  mesh_owner = data.aws_caller_identity.current.account_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the service mesh.
+* `mesh_owner` - (Optional) The AWS account ID of the service mesh's owner.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the service mesh.
+* `created_date` - The creation date of the service mesh.
+* `last_updated_date` - The last update date of the service mesh.
+* `resource_owner` - The resource owner's AWS account ID.
+* `spec` - The service mesh specification.
+* `tags` - A map of tags.
+
+### Spec
+
+* `egress_filter` - The egress filter rules for the service mesh.
+
+### Egress Filter
+
+* `type` - The egress filter type. By default, the type is `DROP_ALL`, but if the resource was created by Terraform without this value set, this will return `None`.

--- a/website/docs/d/appmesh_mesh.html.markdown
+++ b/website/docs/d/appmesh_mesh.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_appmesh_mesh
 
-The App Mesh Mesh data source allows details of an App Mesh Mesh to be retrieved by it's name and/or mesh_owner.
+The App Mesh Mesh data source allows details of an App Mesh Mesh to be retrieved by its name and optionally the mesh_owner.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17590 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSAppmeshMeshDataSource_ -timeout=30m
=== RUN   TestAccAWSAppmeshMeshDataSource_basic
=== PAUSE TestAccAWSAppmeshMeshDataSource_basic
=== RUN   TestAccAWSAppmeshMeshDataSource_meshOwner
=== PAUSE TestAccAWSAppmeshMeshDataSource_meshOwner
=== RUN   TestAccAWSAppmeshMeshDataSource_specAndTagsSet
=== PAUSE TestAccAWSAppmeshMeshDataSource_specAndTagsSet
=== RUN   TestAccAWSAppmeshMeshDataSource_nonExistent
=== PAUSE TestAccAWSAppmeshMeshDataSource_nonExistent
=== CONT  TestAccAWSAppmeshMeshDataSource_basic
=== CONT  TestAccAWSAppmeshMeshDataSource_nonExistent
=== CONT  TestAccAWSAppmeshMeshDataSource_meshOwner
=== CONT  TestAccAWSAppmeshMeshDataSource_specAndTagsSet
--- PASS: TestAccAWSAppmeshMeshDataSource_nonExistent (3.52s)
--- PASS: TestAccAWSAppmeshMeshDataSource_basic (12.84s)
--- PASS: TestAccAWSAppmeshMeshDataSource_specAndTagsSet (14.62s)
--- PASS: TestAccAWSAppmeshMeshDataSource_meshOwner (14.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.147s
$ make lint
$ make fmt
==> Fixing source code with gofmt...
gofmt -s -w ./aws ./awsproviderlint/helper ./awsproviderlint/main.go ./awsproviderlint/passes
```
Thanks in advance for your review!
Wasn't sure if I was meant to include the change to provider.go, so let me know if you want this removed.