### PR TITLE
Add codebuild_source_credential note

### DIFF
--- a/website/docs/r/codebuild_source_credential.html.markdown
+++ b/website/docs/r/codebuild_source_credential.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Provides a CodeBuild Source Credentials Resource.
 
+~> **NOTE:**
+[Codebuild only allows a single credential per given server type in a given region](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_codebuild.GitHubSourceCredentials.html). Therefore, when you define `aws_codebuild_source_credential`, [`aws_codebuild_project` resource](/docs/providers/aws/r/codebuild_project.html) defined in the same module will use it.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9613

## Reason for Change
Some people (includes me) confused with how to use aws_codebuild_source_credential because there is no reference from aws_codebuild_project resource. So I add explanation of this reason.