### PR TITLE
r/aws_cloudwatch_event_api_destination: Maximum value for `invocation_rate_limit_per_second` is `300`

### DIFF
--- a/.changelog/19594.txt
+++ b/.changelog/19594.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_api_destination: Reduce the maximum allowed value for the `invocation_rate_limit_per_second` argument to `300`
+```

--- a/aws/resource_aws_cloudwatch_event_api_destination.go
+++ b/aws/resource_aws_cloudwatch_event_api_destination.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,7 +43,7 @@ func resourceAwsCloudWatchEventApiDestination() *schema.Resource {
 			"invocation_rate_limit_per_second": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, math.MaxInt64),
+				ValidateFunc: validation.IntBetween(1, 300),
 				Default:      300,
 			},
 			"http_method": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18905.

When building the Terraform AWS Provider for 32-bit platforms we get this error:

```
aws/resource_aws_cloudwatch_event_api_destination.go:47:41: constant 9223372036854775807 overflows int
```

This is caused by an incorrect maximum value for the `invocation_rate_limit_per_second` argument, which should be `300`:

<img width="805" alt="Screenshot 2021-05-31 080407" src="https://user-images.githubusercontent.com/2404182/120191880-80a80300-c1e8-11eb-87bf-37ddf74d9911.png">

This PR corrects the maximum value allowed for this argument.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventApiDestination_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventApiDestination_ -timeout 180m
=== RUN   TestAccAWSCloudWatchEventApiDestination_basic
=== PAUSE TestAccAWSCloudWatchEventApiDestination_basic
=== RUN   TestAccAWSCloudWatchEventApiDestination_optional
=== PAUSE TestAccAWSCloudWatchEventApiDestination_optional
=== RUN   TestAccAWSCloudWatchEventApiDestination_disappears
=== PAUSE TestAccAWSCloudWatchEventApiDestination_disappears
=== CONT  TestAccAWSCloudWatchEventApiDestination_basic
=== CONT  TestAccAWSCloudWatchEventApiDestination_disappears
=== CONT  TestAccAWSCloudWatchEventApiDestination_optional
--- PASS: TestAccAWSCloudWatchEventApiDestination_disappears (18.57s)
--- PASS: TestAccAWSCloudWatchEventApiDestination_optional (45.04s)
--- PASS: TestAccAWSCloudWatchEventApiDestination_basic (46.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.511s
```
