### PR TITLE
Update ssoadmin_managed_policy_attachment.html.markdown

### DIFF
--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ssoadmin_permission_set" "example" {
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "example" {
-  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
   managed_policy_arn = "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup"
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 }


### PR DESCRIPTION
Update example from aws_ssoadmin_managed_policy_attachment resource docs.
The `instance_arn` incorrectly references the permission_set arn instead of the aws_ssoadmin_instances arn


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

