### PR TITLE
fix default status for aws_iam_access_key

### DIFF
--- a/.changelog/19606.txt
+++ b/.changelog/19606.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_access_key: Fix status not defaulting to Active
+```

--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -58,7 +58,7 @@ func resourceAwsIamAccessKey() *schema.Resource {
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "Active",
 				ValidateFunc: validation.StringInSlice([]string{
 					iam.StatusTypeActive,
 					iam.StatusTypeInactive,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19605

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAWSAccessKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAccessKey -timeout 180m
=== RUN   TestAccAWSAccessKey_basic
=== PAUSE TestAccAWSAccessKey_basic
=== RUN   TestAccAWSAccessKey_encrypted
=== PAUSE TestAccAWSAccessKey_encrypted
=== RUN   TestAccAWSAccessKey_Status
=== PAUSE TestAccAWSAccessKey_Status
=== CONT  TestAccAWSAccessKey_basic
=== CONT  TestAccAWSAccessKey_Status
=== CONT  TestAccAWSAccessKey_encrypted
--- PASS: TestAccAWSAccessKey_encrypted (41.92s)
--- PASS: TestAccAWSAccessKey_basic (42.17s)
--- PASS: TestAccAWSAccessKey_Status (98.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	98.869s
...
```
