### PR TITLE
r/elasticache_cluster: add `SetTagsDiff` function to CustomizeDiff sequence

### DIFF
--- a/.changelog/19615.txt
+++ b/.changelog/19615.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_cluster: Fix provider-level `default_tags` support for resource
+```

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -268,6 +268,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 			CustomizeDiffValidateClusterNumCacheNodes,
 			CustomizeDiffClusterMemcachedNodeType,
 			CustomizeDiffValidateClusterMemcachedSnapshotIdentifier,
+			SetTagsDiff,
 		),
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19614 

Output from acceptance testing (Commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- SKIP: TestAccAWSElasticacheCluster_SecurityGroup_Ec2Classic (2.08s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (13.19s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (498.22s)
--- PASS: TestAccAWSElasticacheCluster_Memcached_FinalSnapshot (2.71s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (624.22s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (632.30s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (652.45s)
--- PASS: TestAccAWSElasticacheCluster_Port (652.73s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (654.06s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (654.42s)
--- PASS: TestAccAWSElasticacheCluster_vpc (655.63s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (673.70s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (689.04s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (865.83s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1095.04s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1132.08s)
--- PASS: TestAccAWSElasticacheCluster_Redis_FinalSnapshot (778.00s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1283.16s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1384.90s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1403.37s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1406.74s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (1405.37s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1423.06s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (2106.66s)
```
