### PR TITLE
Adding GP3 support for launch configurations

### DIFF
--- a/.changelog/19632.txt
+++ b/.changelog/19632.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_launch_configuration: Add `throughput` argument to `ebs_block_device` and `root_block_device` configuration blocks to support GP3 volumes
+```

--- a/.changelog/19632.txt
+++ b/.changelog/19632.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_launch_configuration: Add `throughput` argument to `ebs_block_device` and `root_block_device` configuration blocks to support GP3 volumes
 ```
+
+```release-note:enhancement
+data-source/aws_launch_configuration: Add `throughput` attribute to `ebs_block_device` and `root_block_device` configuration blocks to support GP3 volumes
+```

--- a/aws/data_source_aws_launch_configuration.go
+++ b/aws/data_source_aws_launch_configuration.go
@@ -105,7 +105,7 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 							Computed: true,
 						},
 
-						"no_device": {
+						"encrypted": {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
@@ -115,8 +115,18 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 							Computed: true,
 						},
 
+						"no_device": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
 						"snapshot_id": {
 							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"throughput": {
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 
@@ -127,11 +137,6 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 
 						"volume_type": {
 							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"encrypted": {
-							Type:     schema.TypeBool,
 							Computed: true,
 						},
 					},
@@ -194,6 +199,11 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 
 						"iops": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"throughput": {
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -21,10 +21,18 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(autoscaling.EndpointsID, testAccErrorCheckSkipAutoScaling)
+
 	resource.AddTestSweepers("aws_autoscaling_group", &resource.Sweeper{
 		Name: "aws_autoscaling_group",
 		F:    testSweepAutoscalingGroups,
 	})
+}
+
+func testAccErrorCheckSkipAutoScaling(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"gp3 is invalid",
+	)
 }
 
 func testSweepAutoscalingGroups(region string) error {

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -178,9 +178,10 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							ForceNew: true,
 						},
 
-						"no_device": {
+						"encrypted": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 
@@ -191,8 +192,21 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"no_device": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+
 						"snapshot_id": {
 							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"throughput": {
+							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
@@ -207,20 +221,6 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 
 						"volume_type": {
 							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-
-						"encrypted": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-
-						"throughput": {
-							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
@@ -319,6 +319,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"throughput": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -328,13 +335,6 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 
 						"volume_type": {
 							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
-
-						"throughput": {
-							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -218,6 +218,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+
+						"throughput": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},
@@ -321,6 +328,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 
 						"volume_type": {
 							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"throughput": {
+							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
@@ -435,6 +449,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 				ebs.Iops = aws.Int64(int64(v))
 			}
 
+			if v, ok := bd["throughput"].(int); ok && v > 0 {
+				ebs.Throughput = aws.Int64(int64(v))
+			}
+
 			if bd["device_name"].(string) == aws.StringValue(rootDeviceName) {
 				return fmt.Errorf("Root device (%s) declared as an 'ebs_block_device'.  Use 'root_block_device' keyword.", *rootDeviceName)
 			}
@@ -480,6 +498,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 			if v, ok := bd["iops"].(int); ok && v > 0 {
 				ebs.Iops = aws.Int64(int64(v))
+			}
+
+			if v, ok := bd["throughput"].(int); ok && v > 0 {
+				ebs.Throughput = aws.Int64(int64(v))
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("image_id").(string), ec2conn); err == nil {
@@ -762,6 +784,9 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 		}
 		if bdm.Ebs != nil && bdm.Ebs.Iops != nil {
 			bd["iops"] = *bdm.Ebs.Iops
+		}
+		if bdm.Ebs != nil && bdm.Ebs.Throughput != nil {
+			bd["throughput"] = *bdm.Ebs.Throughput
 		}
 		if bdm.Ebs != nil && bdm.Ebs.Encrypted != nil {
 			bd["encrypted"] = *bdm.Ebs.Encrypted

--- a/website/docs/d/launch_configuration.html.markdown
+++ b/website/docs/d/launch_configuration.html.markdown
@@ -57,6 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `delete_on_termination` - Whether the EBS Volume will be deleted on instance termination.
 * `encrypted` - Whether the volume is Encrypted.
 * `iops` - The provisioned IOPs of the volume.
+* `throughput` - The Throughput of the volume.
 * `volume_size` - The Size of the volume.
 * `volume_type` - The Type of the volume.
 
@@ -64,12 +65,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `delete_on_termination` - Whether the EBS Volume will be deleted on instance termination.
 * `device_name` - The Name of the device.
-* `no_device` - Whether the device in the block device mapping of the AMI is suppressed.
+* `encrypted` - Whether the volume is Encrypted.
 * `iops` - The provisioned IOPs of the volume.
+* `no_device` - Whether the device in the block device mapping of the AMI is suppressed.
 * `snapshot_id` - The Snapshot ID of the mount.
+* `throughput` - The Throughput of the volume.
 * `volume_size` - The Size of the volume.
 * `volume_type` - The Type of the volume.
-* `encrypted` - Whether the volume is Encrypted.
 
 `ephemeral_block_device` is exported with the following attributes:
 

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -176,12 +176,13 @@ to understand the implications of using these attributes.
 
 The `root_block_device` mapping supports the following:
 
-* `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`,
+* `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`, `"gp3"`, `"st1"`, `"sc1"`
   or `"io1"`. (Default: `"standard"`).
 * `volume_size` - (Optional) The size of the volume in gigabytes.
 * `iops` - (Optional) The amount of provisioned
   [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
   This must be set with a `volume_type` of `"io1"`.
+* `throughput` - (Optional) The throughput (MiBps) to provision for a `gp3` volume.
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
 * `encrypted` - (Optional) Whether the volume should be encrypted or not. (Default: `false`).
@@ -193,12 +194,13 @@ Each `ebs_block_device` supports the following:
 
 * `device_name` - (Required) The name of the device to mount.
 * `snapshot_id` - (Optional) The Snapshot ID to mount.
-* `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`,
+* `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`, `"gp3"`, `"st1"`, `"sc1"`
   or `"io1"`. (Default: `"standard"`).
 * `volume_size` - (Optional) The size of the volume in gigabytes.
 * `iops` - (Optional) The amount of provisioned
   [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
   This must be set with a `volume_type` of `"io1"`.
+* `throughput` - (Optional) The throughput (MiBps) to provision for a `gp3` volume.
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
 * `encrypted` - (Optional) Whether the volume should be encrypted or not. Do not use this option if you are using `snapshot_id` as the encrypted flag will be determined by the snapshot. (Default: `false`).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchConfiguration_withGP3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfiguration_withGP3 -timeout 180m
=== RUN   TestAccAWSLaunchConfiguration_withGP3
=== PAUSE TestAccAWSLaunchConfiguration_withGP3
=== CONT  TestAccAWSLaunchConfiguration_withGP3
--- PASS: TestAccAWSLaunchConfiguration_withGP3 (21.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.350s
```
