### PR TITLE
r/aws_sqs_queue: support high-throughput FIFO queues

### DIFF
--- a/.changelog/19639.txt
+++ b/.changelog/19639.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sqs_queue: Add `deduplication_scope` and `fifo_throughput_limit` arguments
+```

--- a/.changelog/19639.txt
+++ b/.changelog/19639.txt
@@ -1,3 +1,15 @@
 ```release-note:enhancement
 resource/aws_sqs_queue: Add `deduplication_scope` and `fifo_throughput_limit` arguments
 ```
+
+```release-note:enhancement
+resource/aws_sqs_queue: Add `url` attribute
+```
+
+```release-note:bug
+resource/aws_sqs_queue: Allow `visibility_timeout_seconds` to be `0` when creating queue
+```
+
+```release-note:bug
+resource/aws_sqs_queue: Ensure that queue attributes propagate completely during Create and Update
+```

--- a/aws/internal/attrmap/attrmap.go
+++ b/aws/internal/attrmap/attrmap.go
@@ -1,0 +1,38 @@
+package attrmap
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// AttributeMap represents a map of Terraform resource attribute name to AWS API attribute name.
+// Useful for SQS Queue or SNS Topic attribute handling.
+type AttributeMap map[string]string
+
+// ResourceDataToApiAttributes returns a map of AWS API attributes from Terraform ResourceData.
+func (m AttributeMap) ResourceDataToApiAttributes(d *schema.ResourceData) (map[string]string, error) {
+	apiAttributes := map[string]string{}
+
+	for tfAttributeName, apiAttributeName := range m {
+		if v, ok := d.GetOk(tfAttributeName); ok {
+			var apiAttributeValue string
+
+			switch v := v.(type) {
+			case int:
+				apiAttributeValue = strconv.Itoa(v)
+			case bool:
+				apiAttributeValue = strconv.FormatBool(v)
+			case string:
+				apiAttributeValue = v
+			default:
+				return nil, fmt.Errorf("attribute %s is of unsupported type: %T", tfAttributeName, v)
+			}
+
+			apiAttributes[apiAttributeName] = apiAttributeValue
+		}
+	}
+
+	return apiAttributes, nil
+}

--- a/aws/internal/attrmap/attrmap.go
+++ b/aws/internal/attrmap/attrmap.go
@@ -11,8 +11,9 @@ import (
 // Useful for SQS Queue or SNS Topic attribute handling.
 type AttributeMap map[string]string
 
-// ResourceDataToApiAttributes returns a map of AWS API attributes from Terraform ResourceData.
-func (m AttributeMap) ResourceDataToApiAttributes(d *schema.ResourceData) (map[string]string, error) {
+// ResourceDataToApiAttributesCreate returns a map of AWS API attributes from Terraform ResourceData.
+// The API attributes map is suitable for resource create.
+func (m AttributeMap) ResourceDataToApiAttributesCreate(d *schema.ResourceData) (map[string]string, error) {
 	apiAttributes := map[string]string{}
 
 	for tfAttributeName, apiAttributeName := range m {
@@ -20,6 +21,33 @@ func (m AttributeMap) ResourceDataToApiAttributes(d *schema.ResourceData) (map[s
 			var apiAttributeValue string
 
 			switch v := v.(type) {
+			case int:
+				apiAttributeValue = strconv.Itoa(v)
+			case bool:
+				apiAttributeValue = strconv.FormatBool(v)
+			case string:
+				apiAttributeValue = v
+			default:
+				return nil, fmt.Errorf("attribute %s is of unsupported type: %T", tfAttributeName, v)
+			}
+
+			apiAttributes[apiAttributeName] = apiAttributeValue
+		}
+	}
+
+	return apiAttributes, nil
+}
+
+// ResourceDataToApiAttributesUpdate returns a map of AWS API attributes from Terraform ResourceData.
+// The API attributes map is suitable for resource update.
+func (m AttributeMap) ResourceDataToApiAttributesUpdate(d *schema.ResourceData) (map[string]string, error) {
+	apiAttributes := map[string]string{}
+
+	for tfAttributeName, apiAttributeName := range m {
+		if d.HasChange(tfAttributeName) {
+			var apiAttributeValue string
+
+			switch v := d.Get(tfAttributeName).(type) {
 			case int:
 				apiAttributeValue = strconv.Itoa(v)
 			case bool:

--- a/aws/internal/attrmap/attrmap.go
+++ b/aws/internal/attrmap/attrmap.go
@@ -11,6 +11,19 @@ import (
 // Useful for SQS Queue or SNS Topic attribute handling.
 type AttributeMap map[string]string
 
+// ApiAttributesToResourceData sets Terraform ResourceData from a map of AWS API attributes.
+func (m AttributeMap) ApiAttributesToResourceData(apiAttributes map[string]string, d *schema.ResourceData) error {
+	for tfAttributeName, apiAttributeName := range m {
+		if v, ok := apiAttributes[apiAttributeName]; ok {
+			if err := d.Set(tfAttributeName, v); err != nil {
+				return fmt.Errorf("error setting %s: %w", tfAttributeName, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // ResourceDataToApiAttributesCreate returns a map of AWS API attributes from Terraform ResourceData.
 // The API attributes map is suitable for resource create.
 func (m AttributeMap) ResourceDataToApiAttributesCreate(d *schema.ResourceData) (map[string]string, error) {

--- a/aws/internal/json/equivalence.go
+++ b/aws/internal/json/equivalence.go
@@ -1,0 +1,37 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+)
+
+// BytesEqual compares two arrays of JSON bytes and returns true if the unmarshaled objects represented by the bytes
+// are equal according to `reflect.DeepEqual`.
+func BytesEqual(b1, b2 []byte) bool {
+	var o1 interface{}
+	if err := json.Unmarshal(b1, &o1); err != nil {
+		return false
+	}
+
+	var o2 interface{}
+	if err := json.Unmarshal(b2, &o2); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(o1, o2)
+}
+
+func StringsEquivalent(s1, s2 string) bool {
+	b1 := bytes.NewBufferString("")
+	if err := json.Compact(b1, []byte(s1)); err != nil {
+		return false
+	}
+
+	b2 := bytes.NewBufferString("")
+	if err := json.Compact(b2, []byte(s2)); err != nil {
+		return false
+	}
+
+	return BytesEqual(b1.Bytes(), b2.Bytes())
+}

--- a/aws/internal/json/equivalence_test.go
+++ b/aws/internal/json/equivalence_test.go
@@ -1,0 +1,65 @@
+package json
+
+import (
+	"testing"
+)
+
+func TestBytesEqualQuotedAndUnquoted(t *testing.T) {
+	unquoted := `{"test": "test"}`
+	quoted := "{\"test\": \"test\"}"
+
+	if !BytesEqual([]byte(unquoted), []byte(quoted)) {
+		t.Errorf("Expected BytesEqual to return true for %s == %s", unquoted, quoted)
+	}
+
+	unquotedDiff := `{"test": "test"}`
+	quotedDiff := "{\"test\": \"tested\"}"
+
+	if BytesEqual([]byte(unquotedDiff), []byte(quotedDiff)) {
+		t.Errorf("Expected BytesEqual to return false for %s == %s", unquotedDiff, quotedDiff)
+	}
+}
+
+func TestBytesEqualWhitespaceAndNoWhitespace(t *testing.T) {
+	noWhitespace := `{"test":"test"}`
+	whitespace := `
+{
+  "test": "test"
+}`
+
+	if !BytesEqual([]byte(noWhitespace), []byte(whitespace)) {
+		t.Errorf("Expected BytesEqual to return true for %s == %s", noWhitespace, whitespace)
+	}
+
+	noWhitespaceDiff := `{"test":"test"}`
+	whitespaceDiff := `
+{
+  "test": "tested"
+}`
+
+	if BytesEqual([]byte(noWhitespaceDiff), []byte(whitespaceDiff)) {
+		t.Errorf("Expected BytesEqual to return false for %s == %s", noWhitespaceDiff, whitespaceDiff)
+	}
+}
+
+func TestStringsEquivalentWhitespaceAndNoWhitespace(t *testing.T) {
+	noWhitespace := `{"test":"test"}`
+	whitespace := `
+{
+  "test": "test"
+}`
+
+	if !StringsEquivalent(noWhitespace, whitespace) {
+		t.Errorf("Expected StringsEquivalent to return true for %s == %s", noWhitespace, whitespace)
+	}
+
+	noWhitespaceDiff := `{"test":"test"}`
+	whitespaceDiff := `
+{
+  "test": "tested"
+}`
+
+	if StringsEquivalent(noWhitespaceDiff, whitespaceDiff) {
+		t.Errorf("Expected StringsEquivalent to return false for %s == %s", noWhitespaceDiff, whitespaceDiff)
+	}
+}

--- a/aws/internal/service/sqs/consts.go
+++ b/aws/internal/service/sqs/consts.go
@@ -3,3 +3,11 @@ package sqs
 const (
 	FifoQueueNameSuffix = ".fifo"
 )
+
+const (
+	DefaultQueueDelaySeconds                  = 0
+	DefaultQueueMaximumMessageSize            = 262144
+	DefaultQueueMessageRetentionPeriod        = 345600
+	DefaultQueueReceiveMessageWaitTimeSeconds = 0
+	DefaultQueueVisibilityTimeout             = 30
+)

--- a/aws/internal/service/sqs/consts.go
+++ b/aws/internal/service/sqs/consts.go
@@ -11,3 +11,27 @@ const (
 	DefaultQueueReceiveMessageWaitTimeSeconds = 0
 	DefaultQueueVisibilityTimeout             = 30
 )
+
+const (
+	DeduplicationScopeMessageGroup = "messageGroup"
+	DeduplicationScopeQueue        = "queue"
+)
+
+func DeduplicationScope_Values() []string {
+	return []string{
+		DeduplicationScopeMessageGroup,
+		DeduplicationScopeQueue,
+	}
+}
+
+const (
+	FifoThroughputLimitPerMessageGroupId = "perMessageGroupId"
+	FifoThroughputLimitPerQueue          = "perQueue"
+)
+
+func FifoThroughputLimit_Values() []string {
+	return []string{
+		FifoThroughputLimitPerMessageGroupId,
+		FifoThroughputLimitPerQueue,
+	}
+}

--- a/aws/internal/service/sqs/consts.go
+++ b/aws/internal/service/sqs/consts.go
@@ -1,11 +1,16 @@
 package sqs
 
 const (
+	ErrCodeInvalidAction = "InvalidAction"
+)
+
+const (
 	FifoQueueNameSuffix = ".fifo"
 )
 
 const (
 	DefaultQueueDelaySeconds                  = 0
+	DefaultQueueKmsDataKeyReusePeriodSeconds  = 300
 	DefaultQueueMaximumMessageSize            = 262144
 	DefaultQueueMessageRetentionPeriod        = 345600
 	DefaultQueueReceiveMessageWaitTimeSeconds = 0

--- a/aws/internal/service/sqs/consts.go
+++ b/aws/internal/service/sqs/consts.go
@@ -10,7 +10,6 @@ const (
 
 const (
 	DefaultQueueDelaySeconds                  = 0
-	DefaultQueueKmsDataKeyReusePeriodSeconds  = 300
 	DefaultQueueMaximumMessageSize            = 262_144 // 256 KiB.
 	DefaultQueueMessageRetentionPeriod        = 345_600 // 4 days.
 	DefaultQueueReceiveMessageWaitTimeSeconds = 0

--- a/aws/internal/service/sqs/consts.go
+++ b/aws/internal/service/sqs/consts.go
@@ -11,8 +11,8 @@ const (
 const (
 	DefaultQueueDelaySeconds                  = 0
 	DefaultQueueKmsDataKeyReusePeriodSeconds  = 300
-	DefaultQueueMaximumMessageSize            = 262144
-	DefaultQueueMessageRetentionPeriod        = 345600
+	DefaultQueueMaximumMessageSize            = 262_144 // 256 KiB.
+	DefaultQueueMessageRetentionPeriod        = 345_600 // 4 days.
 	DefaultQueueReceiveMessageWaitTimeSeconds = 0
 	DefaultQueueVisibilityTimeout             = 30
 )

--- a/aws/internal/service/sqs/finder/finder.go
+++ b/aws/internal/service/sqs/finder/finder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func QueueAttributesByURL(conn *sqs.SQS, url string) (map[string]*string, error) {
+func QueueAttributesByURL(conn *sqs.SQS, url string) (map[string]string, error) {
 	input := &sqs.GetQueueAttributesInput{
 		AttributeNames: aws.StringSlice([]string{sqs.QueueAttributeNameAll}),
 		QueueUrl:       aws.String(url),
@@ -33,5 +33,5 @@ func QueueAttributesByURL(conn *sqs.SQS, url string) (map[string]*string, error)
 		}
 	}
 
-	return output.Attributes, nil
+	return aws.StringValueMap(output.Attributes), nil
 }

--- a/aws/internal/service/sqs/finder/finder.go
+++ b/aws/internal/service/sqs/finder/finder.go
@@ -1,0 +1,37 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func QueueAttributesByURL(conn *sqs.SQS, url string) (map[string]*string, error) {
+	input := &sqs.GetQueueAttributesInput{
+		AttributeNames: aws.StringSlice([]string{sqs.QueueAttributeNameAll}),
+		QueueUrl:       aws.String(url),
+	}
+
+	output, err := conn.GetQueueAttributes(input)
+
+	if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDoesNotExist) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Attributes == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Attributes, nil
+}

--- a/aws/internal/service/sqs/finder/finder.go
+++ b/aws/internal/service/sqs/finder/finder.go
@@ -35,3 +35,41 @@ func QueueAttributesByURL(conn *sqs.SQS, url string) (map[string]string, error) 
 
 	return aws.StringValueMap(output.Attributes), nil
 }
+
+func QueuePolicyByURL(conn *sqs.SQS, url string) (string, error) {
+	input := &sqs.GetQueueAttributesInput{
+		AttributeNames: aws.StringSlice([]string{sqs.QueueAttributeNamePolicy}),
+		QueueUrl:       aws.String(url),
+	}
+
+	output, err := conn.GetQueueAttributes(input)
+
+	if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDoesNotExist) {
+		return "", &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	if output == nil || output.Attributes == nil {
+		return "", &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	v, ok := output.Attributes[sqs.QueueAttributeNamePolicy]
+
+	if !ok || aws.StringValue(v) == "" {
+		return "", &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return aws.StringValue(v), nil
+}

--- a/aws/internal/service/sqs/name.go
+++ b/aws/internal/service/sqs/name.go
@@ -1,0 +1,25 @@
+package sqs
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// QueueNameFromURL returns the SQS queue name from the specified URL.
+func QueueNameFromURL(u string) (string, error) {
+	v, err := url.Parse(u)
+
+	if err != nil {
+		return "", err
+	}
+
+	// http://sqs.us-west-2.amazonaws.com/123456789012/queueName
+	parts := strings.Split(v.Path, "/")
+
+	if len(parts) != 3 {
+		return "", fmt.Errorf("SQS Queue URL (%s) is in the incorrect format", u)
+	}
+
+	return parts[2], nil
+}

--- a/aws/internal/service/sqs/name_test.go
+++ b/aws/internal/service/sqs/name_test.go
@@ -1,0 +1,57 @@
+package sqs
+
+import (
+	"testing"
+)
+
+func TestQueueNameFromURL(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		URL               string
+		ExpectedQueueName string
+		ExpectError       bool
+	}{
+		{
+			Name:        "empty URL",
+			ExpectError: true,
+		},
+		{
+			Name:        "invalid URL",
+			URL:         "---",
+			ExpectError: true,
+		},
+		{
+			Name:        "too few path parts",
+			URL:         "http://sqs.us-west-2.amazonaws.com",
+			ExpectError: true,
+		},
+		{
+			Name:        "too many path parts",
+			URL:         "http://sqs.us-west-2.amazonaws.com/123456789012/queueName/extra",
+			ExpectError: true,
+		},
+		{
+			Name:              "valid URL",
+			URL:               "http://sqs.us-west-2.amazonaws.com/123456789012/queueName",
+			ExpectedQueueName: "queueName",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got, err := QueueNameFromURL(testCase.URL)
+
+			if err != nil && !testCase.ExpectError {
+				t.Errorf("got unexpected error: %s", err)
+			}
+
+			if err == nil && testCase.ExpectError {
+				t.Errorf("expected error, but received none")
+			}
+
+			if got != testCase.ExpectedQueueName {
+				t.Errorf("got %s, expected %s", got, testCase.ExpectedQueueName)
+			}
+		})
+	}
+}

--- a/aws/internal/service/sqs/waiter/status.go
+++ b/aws/internal/service/sqs/waiter/status.go
@@ -1,0 +1,24 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func QueueState(conn *sqs.SQS, url string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.QueueAttributesByURL(conn, url)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, queueStateExists, nil
+	}
+}

--- a/aws/internal/service/sqs/waiter/waiter.go
+++ b/aws/internal/service/sqs/waiter/waiter.go
@@ -1,0 +1,14 @@
+package waiter
+
+import (
+	"time"
+)
+
+const (
+	// Maximum amount of time to wait for SQS queue attribute changes to propagate
+	// This timeout should not be increased without strong consideration
+	// as this will negatively impact user experience when configurations
+	// have incorrect references or permissions.
+	// Reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
+	QueueAttributePropagationTimeout = 1 * time.Minute
+)

--- a/aws/internal/service/sqs/waiter/waiter.go
+++ b/aws/internal/service/sqs/waiter/waiter.go
@@ -1,7 +1,13 @@
 package waiter
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -11,4 +17,42 @@ const (
 	// have incorrect references or permissions.
 	// Reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
 	QueueAttributePropagationTimeout = 1 * time.Minute
+
+	// If you delete a queue, you must wait at least 60 seconds before creating a queue with the same name.
+	// ReferenceL https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html
+	QueueCreatedTimeout = 70 * time.Second
+
+	QueueDeletedTimeout = 15 * time.Second
 )
+
+func QueueDeleted(conn *sqs.SQS, url string) error {
+	err := resource.Retry(QueueDeletedTimeout, func() *resource.RetryError {
+		var err error
+
+		_, err = finder.QueueAttributesByURL(conn, url)
+
+		if tfresource.NotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(fmt.Errorf("SQS Queue (%s) still exists", url))
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = finder.QueueAttributesByURL(conn, url)
+
+		if tfresource.NotFound(err) {
+			return nil
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/internal/service/sqs/waiter/waiter.go
+++ b/aws/internal/service/sqs/waiter/waiter.go
@@ -43,7 +43,7 @@ func QueueAttributesPropagated(conn *sqs.SQS, url string, expected map[string]st
 				equivalent, err := awspolicy.PoliciesAreEquivalent(g, e)
 
 				if err != nil {
-					return nil
+					return err
 				}
 
 				if !equivalent {

--- a/aws/internal/service/sqs/waiter/waiter.go
+++ b/aws/internal/service/sqs/waiter/waiter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	awspolicy "github.com/jen20/awspolicyequivalence"
+	tfjson "github.com/terraform-providers/terraform-provider-aws/aws/internal/json"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
@@ -47,6 +48,10 @@ func QueueAttributesPropagated(conn *sqs.SQS, url string, expected map[string]st
 
 				if !equivalent {
 					return fmt.Errorf("SQS Queue policies are not equivalent")
+				}
+			case sqs.QueueAttributeNameRedrivePolicy:
+				if !tfjson.StringsEquivalent(g, e) {
+					return fmt.Errorf("SQS Queue redrive policies are not equivalent")
 				}
 			default:
 				if g != e {

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -74,27 +74,27 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"delay_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  0,
+				Default:  tfsqs.DefaultQueueDelaySeconds,
 			},
 			"max_message_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  262144,
+				Default:  tfsqs.DefaultQueueMaximumMessageSize,
 			},
 			"message_retention_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  345600,
+				Default:  tfsqs.DefaultQueueMessageRetentionPeriod,
 			},
 			"receive_wait_time_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  0,
+				Default:  tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds,
 			},
 			"visibility_timeout_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  30,
+				Default:  tfsqs.DefaultQueueVisibilityTimeout,
 			},
 			"policy": {
 				Type:             schema.TypeString,
@@ -297,15 +297,15 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	// Always set attribute defaults
 	d.Set("arn", "")
 	d.Set("content_based_deduplication", false)
-	d.Set("delay_seconds", 0)
+	d.Set("delay_seconds", tfsqs.DefaultQueueDelaySeconds)
 	d.Set("kms_data_key_reuse_period_seconds", 300)
 	d.Set("kms_master_key_id", "")
-	d.Set("max_message_size", 262144)
-	d.Set("message_retention_seconds", 345600)
+	d.Set("max_message_size", tfsqs.DefaultQueueMaximumMessageSize)
+	d.Set("message_retention_seconds", tfsqs.DefaultQueueMessageRetentionPeriod)
 	d.Set("policy", "")
-	d.Set("receive_wait_time_seconds", 0)
+	d.Set("receive_wait_time_seconds", tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)
 	d.Set("redrive_policy", "")
-	d.Set("visibility_timeout_seconds", 30)
+	d.Set("visibility_timeout_seconds", tfsqs.DefaultQueueVisibilityTimeout)
 
 	if attributeOutput != nil {
 		queueAttributes := aws.StringValueMap(attributeOutput.Attributes)

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -4,14 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
@@ -20,12 +16,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/attrmap"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 	tfsqs "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-var sqsQueueAttributeMap = map[string]string{
+var sqsQueueAttributeMap = attrmap.AttributeMap(map[string]string{
 	"delay_seconds":                     sqs.QueueAttributeNameDelaySeconds,
 	"max_message_size":                  sqs.QueueAttributeNameMaximumMessageSize,
 	"message_retention_seconds":         sqs.QueueAttributeNameMessageRetentionPeriod,
@@ -40,7 +40,7 @@ var sqsQueueAttributeMap = map[string]string{
 	"kms_data_key_reuse_period_seconds": sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds,
 	"deduplication_scope":               sqs.QueueAttributeNameDeduplicationScope,
 	"fifo_throughput_limit":             sqs.QueueAttributeNameFifoThroughputLimit,
-}
+})
 
 // A number of these are marked as computed because if you don't
 // provide a value, SQS will provide you with defaults (which are the
@@ -158,7 +158,7 @@ func resourceAwsSqsQueue() *schema.Resource {
 }
 
 func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
-	sqsconn := meta.(*AWSClient).sqsconn
+	conn := meta.(*AWSClient).sqsconn
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
@@ -171,109 +171,55 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		name = naming.Generate(d.Get("name").(string), d.Get("name_prefix").(string))
 	}
 
-	log.Printf("[DEBUG] SQS queue create: %s", name)
-
-	req := &sqs.CreateQueueInput{
+	input := &sqs.CreateQueueInput{
 		QueueName: aws.String(name),
 	}
 
+	attributes, err := sqsQueueAttributeMap.ResourceDataToApiAttributesCreate(d)
+
+	if err != nil {
+		return err
+	}
+
+	input.Attributes = aws.StringMap(attributes)
+
 	// Tag-on-create is currently only supported in AWS Commercial
 	if len(tags) > 0 && meta.(*AWSClient).partition == endpoints.AwsPartitionID {
-		req.Tags = tags.IgnoreAws().SqsTags()
+		input.Tags = tags.IgnoreAws().SqsTags()
 	}
 
-	attributes := make(map[string]*string)
-
-	queueResource := *resourceAwsSqsQueue()
-
-	for k, s := range queueResource.Schema {
-		if attrKey, ok := sqsQueueAttributeMap[k]; ok {
-			if value, ok := d.GetOk(k); ok {
-				switch s.Type {
-				case schema.TypeInt:
-					attributes[attrKey] = aws.String(strconv.Itoa(value.(int)))
-				case schema.TypeBool:
-					attributes[attrKey] = aws.String(strconv.FormatBool(value.(bool)))
-				default:
-					attributes[attrKey] = aws.String(value.(string))
-				}
-			}
-
-		}
-	}
-
-	if len(attributes) > 0 {
-		req.Attributes = attributes
-	}
-
+	log.Printf("[DEBUG] Creating SQS Queue: %s", input)
 	var output *sqs.CreateQueueOutput
-	err := resource.Retry(70*time.Second, func() *resource.RetryError {
+	err = resource.Retry(waiter.QueueCreatedTimeout, func() *resource.RetryError {
 		var err error
-		output, err = sqsconn.CreateQueue(req)
+
+		output, err = conn.CreateQueue(input)
+
+		if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDeletedRecently) {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
-			if isAWSErr(err, sqs.ErrCodeQueueDeletedRecently, "You must wait 60 seconds after deleting a queue before you can create another with the same name.") {
-				return resource.RetryableError(err)
-			}
 			return resource.NonRetryableError(err)
 		}
+
 		return nil
 	})
-	if isResourceTimeoutError(err) {
-		output, err = sqsconn.CreateQueue(req)
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateQueue(input)
 	}
+
 	if err != nil {
-		return fmt.Errorf("Error creating SQS queue: %s", err)
+		return fmt.Errorf("error creating SQS Queue (%s): %w", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.QueueUrl))
 
 	// Tag-on-create is currently only supported in AWS Commercial
-	if meta.(*AWSClient).partition == endpoints.AwsPartitionID {
-		return resourceAwsSqsQueueRead(d, meta)
-	} else {
-		return resourceAwsSqsQueueUpdate(d, meta)
-	}
-}
-
-func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
-	sqsconn := meta.(*AWSClient).sqsconn
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := keyvaluetags.SqsUpdateTags(sqsconn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating SQS Queue (%s) tags: %s", d.Id(), err)
-		}
-	}
-
-	attributes := make(map[string]*string)
-
-	resource := *resourceAwsSqsQueue()
-
-	for k, s := range resource.Schema {
-		if attrKey, ok := sqsQueueAttributeMap[k]; ok {
-			if d.HasChange(k) {
-				log.Printf("[DEBUG] Updating %s", attrKey)
-				_, n := d.GetChange(k)
-				switch s.Type {
-				case schema.TypeInt:
-					attributes[attrKey] = aws.String(strconv.Itoa(n.(int)))
-				case schema.TypeBool:
-					attributes[attrKey] = aws.String(strconv.FormatBool(n.(bool)))
-				default:
-					attributes[attrKey] = aws.String(n.(string))
-				}
-			}
-		}
-	}
-
-	if len(attributes) > 0 {
-		req := &sqs.SetQueueAttributesInput{
-			QueueUrl:   aws.String(d.Id()),
-			Attributes: attributes,
-		}
-		if _, err := sqsconn.SetQueueAttributes(req); err != nil {
-			return fmt.Errorf("Error updating SQS attributes: %s", err)
+	if len(tags) > 0 && meta.(*AWSClient).partition != endpoints.AwsPartitionID {
+		if err := keyvaluetags.SqsUpdateTags(conn, d.Id(), nil, tags); err != nil {
+			return fmt.Errorf("error updating SQS Queue (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -281,28 +227,24 @@ func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
-	sqsconn := meta.(*AWSClient).sqsconn
+	conn := meta.(*AWSClient).sqsconn
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	attributeOutput, err := sqsconn.GetQueueAttributes(&sqs.GetQueueAttributesInput{
-		QueueUrl:       aws.String(d.Id()),
-		AttributeNames: []*string{aws.String("All")},
-	})
+	output, err := finder.QueueAttributesByURL(conn, d.Id())
 
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			log.Printf("ERROR Found %s", awsErr.Code())
-			if awsErr.Code() == sqs.ErrCodeQueueDoesNotExist {
-				d.SetId("")
-				log.Printf("[DEBUG] SQS Queue (%s) not found", d.Get("name").(string))
-				return nil
-			}
-		}
-		return err
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SQS Queue (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	name, err := extractNameFromSqsQueueUrl(d.Id())
+	if err != nil {
+		return fmt.Errorf("error reading SQS Queue (%s): %w", d.Id(), err)
+	}
+
+	name, err := tfsqs.QueueNameFromURL(d.Id())
+
 	if err != nil {
 		return err
 	}
@@ -324,113 +266,113 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("deduplication_scope", "")
 	d.Set("fifo_throughput_limit", "")
 
-	if attributeOutput != nil {
-		queueAttributes := aws.StringValueMap(attributeOutput.Attributes)
+	// if attributeOutput != nil {
+	queueAttributes := output
 
-		if v, ok := queueAttributes[sqs.QueueAttributeNameQueueArn]; ok {
-			d.Set("arn", v)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameContentBasedDeduplication]; ok && v != "" {
-			vBool, err := strconv.ParseBool(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing content_based_deduplication value (%s) into boolean: %s", v, err)
-			}
-
-			d.Set("content_based_deduplication", vBool)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameDelaySeconds]; ok && v != "" {
-			vInt, err := strconv.Atoi(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing delay_seconds value (%s) into integer: %s", v, err)
-			}
-
-			d.Set("delay_seconds", vInt)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameFifoQueue]; ok && v != "" {
-			vBool, err := strconv.ParseBool(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing fifo_queue value (%s) into boolean: %s", v, err)
-			}
-
-			fifoQueue = vBool
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds]; ok && v != "" {
-			vInt, err := strconv.Atoi(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing kms_data_key_reuse_period_seconds value (%s) into integer: %s", v, err)
-			}
-
-			d.Set("kms_data_key_reuse_period_seconds", vInt)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameKmsMasterKeyId]; ok {
-			d.Set("kms_master_key_id", v)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameMaximumMessageSize]; ok && v != "" {
-			vInt, err := strconv.Atoi(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing max_message_size value (%s) into integer: %s", v, err)
-			}
-
-			d.Set("max_message_size", vInt)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameMessageRetentionPeriod]; ok && v != "" {
-			vInt, err := strconv.Atoi(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing message_retention_seconds value (%s) into integer: %s", v, err)
-			}
-
-			d.Set("message_retention_seconds", vInt)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNamePolicy]; ok {
-			d.Set("policy", v)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameReceiveMessageWaitTimeSeconds]; ok && v != "" {
-			vInt, err := strconv.Atoi(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing receive_wait_time_seconds value (%s) into integer: %s", v, err)
-			}
-
-			d.Set("receive_wait_time_seconds", vInt)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameRedrivePolicy]; ok {
-			d.Set("redrive_policy", v)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameVisibilityTimeout]; ok && v != "" {
-			vInt, err := strconv.Atoi(v)
-
-			if err != nil {
-				return fmt.Errorf("error parsing visibility_timeout_seconds value (%s) into integer: %s", v, err)
-			}
-
-			d.Set("visibility_timeout_seconds", vInt)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameDeduplicationScope]; ok && v != "" {
-			d.Set("deduplication_scope", v)
-		}
-
-		if v, ok := queueAttributes[sqs.QueueAttributeNameFifoThroughputLimit]; ok && v != "" {
-			d.Set("fifo_throughput_limit", v)
-		}
+	if v, ok := queueAttributes[sqs.QueueAttributeNameQueueArn]; ok {
+		d.Set("arn", v)
 	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameContentBasedDeduplication]; ok && v != "" {
+		vBool, err := strconv.ParseBool(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing content_based_deduplication value (%s) into boolean: %s", v, err)
+		}
+
+		d.Set("content_based_deduplication", vBool)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameDelaySeconds]; ok && v != "" {
+		vInt, err := strconv.Atoi(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing delay_seconds value (%s) into integer: %s", v, err)
+		}
+
+		d.Set("delay_seconds", vInt)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameFifoQueue]; ok && v != "" {
+		vBool, err := strconv.ParseBool(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing fifo_queue value (%s) into boolean: %s", v, err)
+		}
+
+		fifoQueue = vBool
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds]; ok && v != "" {
+		vInt, err := strconv.Atoi(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing kms_data_key_reuse_period_seconds value (%s) into integer: %s", v, err)
+		}
+
+		d.Set("kms_data_key_reuse_period_seconds", vInt)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameKmsMasterKeyId]; ok {
+		d.Set("kms_master_key_id", v)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameMaximumMessageSize]; ok && v != "" {
+		vInt, err := strconv.Atoi(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing max_message_size value (%s) into integer: %s", v, err)
+		}
+
+		d.Set("max_message_size", vInt)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameMessageRetentionPeriod]; ok && v != "" {
+		vInt, err := strconv.Atoi(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing message_retention_seconds value (%s) into integer: %s", v, err)
+		}
+
+		d.Set("message_retention_seconds", vInt)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNamePolicy]; ok {
+		d.Set("policy", v)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameReceiveMessageWaitTimeSeconds]; ok && v != "" {
+		vInt, err := strconv.Atoi(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing receive_wait_time_seconds value (%s) into integer: %s", v, err)
+		}
+
+		d.Set("receive_wait_time_seconds", vInt)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameRedrivePolicy]; ok {
+		d.Set("redrive_policy", v)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameVisibilityTimeout]; ok && v != "" {
+		vInt, err := strconv.Atoi(v)
+
+		if err != nil {
+			return fmt.Errorf("error parsing visibility_timeout_seconds value (%s) into integer: %s", v, err)
+		}
+
+		d.Set("visibility_timeout_seconds", vInt)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameDeduplicationScope]; ok && v != "" {
+		d.Set("deduplication_scope", v)
+	}
+
+	if v, ok := queueAttributes[sqs.QueueAttributeNameFifoThroughputLimit]; ok && v != "" {
+		d.Set("fifo_throughput_limit", v)
+	}
+	// }
 
 	d.Set("fifo_queue", fifoQueue)
 	d.Set("name", name)
@@ -440,14 +382,14 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("name_prefix", naming.NamePrefixFromName(name))
 	}
 
-	tags, err := keyvaluetags.SqsListTags(sqsconn, d.Id())
+	tags, err := keyvaluetags.SqsListTags(conn, d.Id())
 
 	if err != nil {
 		// Non-standard partitions (e.g. US Gov) and some local development
 		// solutions do not yet support this API call. Depending on the
 		// implementation it may return InvalidAction or AWS.SimpleQueueService.UnsupportedOperation
-		if !isAWSErr(err, "InvalidAction", "") && !isAWSErr(err, sqs.ErrCodeUnsupportedOperation, "") {
-			return fmt.Errorf("error listing tags for SQS Queue (%s): %s", d.Id(), err)
+		if !tfawserr.ErrCodeEquals(err, tfsqs.ErrCodeInvalidAction) && !tfawserr.ErrCodeEquals(err, sqs.ErrCodeUnsupportedOperation) {
+			return fmt.Errorf("error listing tags for SQS Queue (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -465,11 +407,44 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
+func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sqsconn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		attributes, err := sqsQueueAttributeMap.ResourceDataToApiAttributesUpdate(d)
+
+		if err != nil {
+			return err
+		}
+
+		input := &sqs.SetQueueAttributesInput{
+			Attributes: aws.StringMap(attributes),
+			QueueUrl:   aws.String(d.Id()),
+		}
+
+		log.Printf("[DEBUG] Updating SQS Queue: %s", input)
+		_, err = conn.SetQueueAttributes(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating SQS Queue (%s) attributes: %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		if err := keyvaluetags.SqsUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating SQS Queue (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSqsQueueRead(d, meta)
+}
+
 func resourceAwsSqsQueueDelete(d *schema.ResourceData, meta interface{}) error {
-	sqsconn := meta.(*AWSClient).sqsconn
+	conn := meta.(*AWSClient).sqsconn
 
 	log.Printf("[DEBUG] Deleting SQS Queue: %s", d.Id())
-	_, err := sqsconn.DeleteQueue(&sqs.DeleteQueueInput{
+	_, err := conn.DeleteQueue(&sqs.DeleteQueueInput{
 		QueueUrl: aws.String(d.Id()),
 	})
 
@@ -481,7 +456,13 @@ func resourceAwsSqsQueueDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error deleting SQS Queue (%s): %w", d.Id(), err)
 	}
 
-	return err
+	err = waiter.QueueDeleted(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error waiting for SQS Queue (%s) to delete: %w", d.Id(), err)
+	}
+
+	return nil
 }
 
 func resourceAwsSqsQueueCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
@@ -518,19 +499,4 @@ func resourceAwsSqsQueueCustomizeDiff(_ context.Context, diff *schema.ResourceDi
 	}
 
 	return nil
-}
-
-func extractNameFromSqsQueueUrl(queue string) (string, error) {
-	//http://sqs.us-west-2.amazonaws.com/123456789012/queueName
-	u, err := url.Parse(queue)
-	if err != nil {
-		return "", err
-	}
-	segments := strings.Split(u.Path, "/")
-	if len(segments) != 3 {
-		return "", fmt.Errorf("SQS Url not parsed correctly")
-	}
-
-	return segments[2], nil
-
 }

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -139,20 +139,16 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Optional: true,
 			},
 			"deduplication_scope": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice(
-					[]string{"messageGroup", "queue"},
-					false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(tfsqs.DeduplicationScope_Values(), false),
 			},
 			"fifo_throughput_limit": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice(
-					[]string{"perQueue", "perMessageGroupId"},
-					false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(tfsqs.FifoThroughputLimit_Values(), false),
 			},
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -240,6 +240,12 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(aws.StringValue(output.QueueUrl))
 
+	err = waiter.QueueAttributesPropagated(conn, d.Id(), attributes)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for SQS Queue (%s) attributes to create: %w", d.Id(), err)
+	}
+
 	// Tag-on-create is currently only supported in AWS Commercial
 	if len(tags) > 0 && meta.(*AWSClient).partition != endpoints.AwsPartitionID {
 		if err := keyvaluetags.SqsUpdateTags(conn, d.Id(), nil, tags); err != nil {
@@ -331,6 +337,12 @@ func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if err != nil {
 			return fmt.Errorf("error updating SQS Queue (%s) attributes: %w", d.Id(), err)
+		}
+
+		err = waiter.QueueAttributesPropagated(conn, d.Id(), attributes)
+
+		if err != nil {
+			return fmt.Errorf("error waiting for SQS Queue (%s) attributes to update: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -131,6 +131,11 @@ var (
 			},
 		},
 
+		"url": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
 		"visibility_timeout_seconds": {
 			Type:         schema.TypeInt,
 			Optional:     true,
@@ -291,6 +296,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		d.Set("name_prefix", naming.NamePrefixFromName(name))
 	}
+	d.Set("url", d.Id())
 
 	tags, err := keyvaluetags.SqsListTags(conn, d.Id())
 

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -67,8 +67,8 @@ var (
 
 		"kms_data_key_reuse_period_seconds": {
 			Type:         schema.TypeInt,
-			Computed:     true,
 			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validation.IntBetween(60, 86_400),
 		},
 

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -60,6 +60,71 @@ func resourceAwsSqsQueue() *schema.Resource {
 		),
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"content_based_deduplication": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+
+			"deduplication_scope": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(tfsqs.DeduplicationScope_Values(), false),
+			},
+
+			"delay_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      tfsqs.DefaultQueueDelaySeconds,
+				ValidateFunc: validation.IntBetween(0, 900),
+			},
+
+			"fifo_queue": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"fifo_throughput_limit": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(tfsqs.FifoThroughputLimit_Values(), false),
+			},
+
+			"kms_data_key_reuse_period_seconds": {
+				Type:         schema.TypeInt,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(60, 86_400),
+			},
+
+			"kms_master_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"max_message_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      tfsqs.DefaultQueueMaximumMessageSize,
+				ValidateFunc: validation.IntBetween(1024, 262_144),
+			},
+
+			"message_retention_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      tfsqs.DefaultQueueMessageRetentionPeriod,
+				ValidateFunc: validation.IntBetween(60, 1_209_600),
+			},
+
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -67,6 +132,7 @@ func resourceAwsSqsQueue() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 			},
+
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -74,31 +140,7 @@ func resourceAwsSqsQueue() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
 			},
-			"delay_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  tfsqs.DefaultQueueDelaySeconds,
-			},
-			"max_message_size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  tfsqs.DefaultQueueMaximumMessageSize,
-			},
-			"message_retention_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  tfsqs.DefaultQueueMessageRetentionPeriod,
-			},
-			"receive_wait_time_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds,
-			},
-			"visibility_timeout_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  tfsqs.DefaultQueueVisibilityTimeout,
-			},
+
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -106,6 +148,13 @@ func resourceAwsSqsQueue() *schema.Resource {
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
+
+			"receive_wait_time_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds,
+			},
+
 			"redrive_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -115,42 +164,14 @@ func resourceAwsSqsQueue() *schema.Resource {
 					return json
 				},
 			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"fifo_queue": {
-				Type:     schema.TypeBool,
-				Default:  false,
-				ForceNew: true,
-				Optional: true,
-			},
-			"content_based_deduplication": {
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			},
-			"kms_master_key_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"kms_data_key_reuse_period_seconds": {
-				Type:     schema.TypeInt,
-				Computed: true,
-				Optional: true,
-			},
-			"deduplication_scope": {
-				Type:         schema.TypeString,
+
+			"visibility_timeout_seconds": {
+				Type:         schema.TypeInt,
 				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(tfsqs.DeduplicationScope_Values(), false),
+				Default:      tfsqs.DefaultQueueVisibilityTimeout,
+				ValidateFunc: validation.IntBetween(0, 43_200),
 			},
-			"fifo_throughput_limit": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(tfsqs.FifoThroughputLimit_Values(), false),
-			},
+
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
 		},

--- a/aws/resource_aws_sqs_queue_policy.go
+++ b/aws/resource_aws_sqs_queue_policy.go
@@ -81,6 +81,7 @@ func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) e
 			log.Printf("[DEBUG] SQS attribute %s not found - retrying", sqs.QueueAttributeNamePolicy)
 			return resource.RetryableError(notUpdatedError)
 		}
+
 		equivalent, err := awspolicy.PoliciesAreEquivalent(aws.StringValue(queuePolicy), policy)
 		if err != nil {
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_sqs_queue_policy.go
+++ b/aws/resource_aws_sqs_queue_policy.go
@@ -3,14 +3,21 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	awspolicy "github.com/jen20/awspolicyequivalence"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sqs/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+var (
+	sqsQueueEmptyPolicyAttributes = map[string]string{
+		sqs.QueueAttributeNamePolicy: "",
+	}
 )
 
 func resourceAwsSqsQueuePolicy() *schema.Resource {
@@ -27,17 +34,17 @@ func resourceAwsSqsQueuePolicy() *schema.Resource {
 		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
-			"queue_url": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"policy": {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+
+			"queue_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 		},
 	}
@@ -45,73 +52,30 @@ func resourceAwsSqsQueuePolicy() *schema.Resource {
 
 func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sqsconn
-	policy := d.Get("policy").(string)
+
+	policyAttributes := map[string]string{
+		sqs.QueueAttributeNamePolicy: d.Get("policy").(string),
+	}
 	url := d.Get("queue_url").(string)
-
-	sqaInput := &sqs.SetQueueAttributesInput{
-		QueueUrl: aws.String(url),
-		Attributes: aws.StringMap(map[string]string{
-			sqs.QueueAttributeNamePolicy: policy,
-		}),
+	input := &sqs.SetQueueAttributesInput{
+		Attributes: aws.StringMap(policyAttributes),
+		QueueUrl:   aws.String(url),
 	}
-	log.Printf("[DEBUG] Updating SQS attributes: %s", sqaInput)
-	_, err := conn.SetQueueAttributes(sqaInput)
+
+	log.Printf("[DEBUG] Setting SQS Queue Policy: %s", input)
+	_, err := conn.SetQueueAttributes(input)
+
 	if err != nil {
-		return fmt.Errorf("Error updating SQS attributes: %s", err)
-	}
-
-	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
-	// When you change a queue's attributes, the change can take up to 60 seconds
-	// for most of the attributes to propagate throughout the Amazon SQS system.
-	gqaInput := &sqs.GetQueueAttributesInput{
-		QueueUrl:       aws.String(url),
-		AttributeNames: []*string{aws.String(sqs.QueueAttributeNamePolicy)},
-	}
-	notUpdatedError := fmt.Errorf("SQS attribute %s not updated", sqs.QueueAttributeNamePolicy)
-	var out *sqs.GetQueueAttributesOutput
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		log.Printf("[DEBUG] Reading SQS attributes: %s", gqaInput)
-		var err error
-		out, err = conn.GetQueueAttributes(gqaInput)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		queuePolicy, ok := out.Attributes[sqs.QueueAttributeNamePolicy]
-		if !ok {
-			log.Printf("[DEBUG] SQS attribute %s not found - retrying", sqs.QueueAttributeNamePolicy)
-			return resource.RetryableError(notUpdatedError)
-		}
-
-		equivalent, err := awspolicy.PoliciesAreEquivalent(aws.StringValue(queuePolicy), policy)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		if !equivalent {
-			log.Printf("[DEBUG] SQS attribute %s not updated - retrying", sqs.QueueAttributeNamePolicy)
-			return resource.RetryableError(notUpdatedError)
-		}
-		return nil
-	})
-	if isResourceTimeoutError(err) {
-		out, err = conn.GetQueueAttributes(gqaInput)
-		if err == nil {
-			queuePolicy, ok := out.Attributes[sqs.QueueAttributeNamePolicy]
-			if !ok {
-				return notUpdatedError
-			}
-
-			var equivalent bool
-			equivalent, err = awspolicy.PoliciesAreEquivalent(aws.StringValue(queuePolicy), policy)
-			if !equivalent {
-				return notUpdatedError
-			}
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("Error updating SQS queue attributes: %s", err)
+		return fmt.Errorf("error setting SQS Queue Policy (%s): %w", url, err)
 	}
 
 	d.SetId(url)
+
+	err = waiter.QueueAttributesPropagated(conn, d.Id(), policyAttributes)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for SQS Queue Policy (%s) to be set: %w", d.Id(), err)
+	}
 
 	return resourceAwsSqsQueuePolicyRead(d, meta)
 }
@@ -119,29 +83,19 @@ func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) e
 func resourceAwsSqsQueuePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sqsconn
 
-	out, err := conn.GetQueueAttributes(&sqs.GetQueueAttributesInput{
-		QueueUrl:       aws.String(d.Id()),
-		AttributeNames: []*string{aws.String(sqs.QueueAttributeNamePolicy)},
-	})
+	policy, err := finder.QueuePolicyByURL(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SQS Queue Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, sqs.ErrCodeQueueDoesNotExist, "") {
-			log.Printf("[WARN] SQS Queue (%s) not found", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
-	}
-	if out == nil {
-		return fmt.Errorf("Received empty response for SQS queue %s", d.Id())
+		return fmt.Errorf("error reading SQS Queue Policy (%s): %w", d.Id(), err)
 	}
 
-	policy, ok := out.Attributes[sqs.QueueAttributeNamePolicy]
-	if ok {
-		d.Set("policy", policy)
-	} else {
-		d.Set("policy", "")
-	}
-
+	d.Set("policy", policy)
 	d.Set("queue_url", d.Id())
 
 	return nil
@@ -150,15 +104,25 @@ func resourceAwsSqsQueuePolicyRead(d *schema.ResourceData, meta interface{}) err
 func resourceAwsSqsQueuePolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sqsconn
 
-	log.Printf("[DEBUG] Deleting SQS Queue Policy of %s", d.Id())
+	log.Printf("[DEBUG] Deleting SQS Queue Policy: %s", d.Id())
 	_, err := conn.SetQueueAttributes(&sqs.SetQueueAttributesInput{
-		QueueUrl: aws.String(d.Id()),
-		Attributes: aws.StringMap(map[string]string{
-			sqs.QueueAttributeNamePolicy: "",
-		}),
+		Attributes: aws.StringMap(sqsQueueEmptyPolicyAttributes),
+		QueueUrl:   aws.String(d.Id()),
 	})
-	if err != nil {
-		return fmt.Errorf("Error deleting SQS Queue policy: %s", err)
+
+	if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDoesNotExist) {
+		return nil
 	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting SQS Queue Policy (%s): %w", d.Id(), err)
+	}
+
+	err = waiter.QueueAttributesPropagated(conn, d.Id(), sqsQueueEmptyPolicyAttributes)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for SQS Queue Policy (%s) to delete: %w", d.Id(), err)
+	}
+
 	return nil
 }

--- a/aws/resource_aws_sqs_queue_policy_test.go
+++ b/aws/resource_aws_sqs_queue_policy_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 	var queueAttributes map[string]*string
 	resourceName := "aws_sqs_queue_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,9 +25,8 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 			{
 				Config: testAccAWSSQSPolicyConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test", &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
-					resource.TestMatchResourceAttr("aws_sqs_queue_policy.test", "policy",
+					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
+					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
 				),
 			},
@@ -39,7 +39,7 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 				Config:   testAccAWSSQSPolicyConfigBasic(rName),
 				PlanOnly: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "policy", "aws_sqs_queue.test", "policy"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy", queueResourceName, "policy"),
 				),
 			},
 		},
@@ -48,7 +48,7 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 
 func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
 	var queueAttributes map[string]*string
-	resourceName := "aws_sqs_queue_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -60,9 +60,8 @@ func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
 			{
 				Config: testAccAWSSQSPolicyConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test", &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), resourceName),
+					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), queueResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -73,6 +72,7 @@ func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
 func TestAccAWSSQSQueuePolicy_disappears(t *testing.T) {
 	var queueAttributes map[string]*string
 	resourceName := "aws_sqs_queue_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -84,8 +84,7 @@ func TestAccAWSSQSQueuePolicy_disappears(t *testing.T) {
 			{
 				Config: testAccAWSSQSPolicyConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test", &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueuePolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,

--- a/aws/resource_aws_sqs_queue_policy_test.go
+++ b/aws/resource_aws_sqs_queue_policy_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue_policy.test"
 	queueResourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -47,7 +47,7 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 }
 
 func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	queueResourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -70,7 +70,7 @@ func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
 }
 
 func TestAccAWSSQSQueuePolicy_disappears(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue_policy.test"
 	queueResourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_sqs_queue_policy_test.go
+++ b/aws/resource_aws_sqs_queue_policy_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -23,11 +22,10 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSPolicyConfigBasic(rName),
+				Config: testAccAWSSQSPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
-					resource.TestMatchResourceAttr(resourceName, "policy",
-						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
 			{
@@ -36,34 +34,11 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:   testAccAWSSQSPolicyConfigBasic(rName),
+				Config:   testAccAWSSQSPolicyConfig(rName),
 				PlanOnly: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "policy", queueResourceName, "policy"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
-	var queueAttributes map[string]string
-	queueResourceName := "aws_sqs_queue.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSPolicyConfigBasic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), queueResourceName),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -82,7 +57,7 @@ func TestAccAWSSQSQueuePolicy_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSPolicyConfigBasic(rName),
+				Config: testAccAWSSQSPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueuePolicy(), resourceName),
@@ -93,7 +68,64 @@ func TestAccAWSSQSQueuePolicy_disappears(t *testing.T) {
 	})
 }
 
-func testAccAWSSQSPolicyConfigBasic(rName string) string {
+func TestAccAWSSQSQueuePolicy_disappears_queue(t *testing.T) {
+	var queueAttributes map[string]string
+	queueResourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), queueResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueuePolicy_Update(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue_policy.test"
+	queueResourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(queueResourceName, &queueAttributes),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSQSPolicyConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSSQSPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "test" {
   name = %[1]q
@@ -105,21 +137,44 @@ resource "aws_sqs_queue_policy" "test" {
   policy = <<POLICY
 {
   "Version": "2012-10-17",
-  "Id": "sqspolicy",
-  "Statement": [
-    {
-      "Sid": "First",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "sqs:SendMessage",
-      "Resource": "${aws_sqs_queue.test.arn}",
-      "Condition": {
-        "ArnEquals": {
-          "aws:SourceArn": "${aws_sqs_queue.test.arn}"
-        }
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "sqs:*",
+    "Resource": "${aws_sqs_queue.test.arn}",
+    "Condition": {
+      "ArnEquals": {
+        "aws:SourceArn": "${aws_sqs_queue.test.arn}"
       }
     }
-  ]
+  }]
+}
+POLICY
+}
+`, rName)
+}
+
+func testAccAWSSQSPolicyConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
+}
+
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = aws_sqs_queue.test.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": [
+      "sqs:SendMessage",
+      "sqs:ReceiveMessage"
+    ],
+    "Resource": "${aws_sqs_queue.test.arn}"
+  }]
 }
 POLICY
 }

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -76,9 +77,9 @@ func testSweepSqsQueues(region string) error {
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
 	var queueAttributes map[string]*string
-
 	resourceName := "aws_sqs_queue.queue"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -89,7 +90,11 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -101,15 +106,46 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 				Config: testAccAWSSQSConfigWithOverrides(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueOverrideAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "60"),
 				),
 			},
 			{
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_disappears(t *testing.T) {
+	var queueAttributes map[string]*string
+	resourceName := "aws_sqs_queue.queue"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithDefaults(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -117,9 +153,9 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 
 func TestAccAWSSQSQueue_tags(t *testing.T) {
 	var queueAttributes map[string]*string
-
 	resourceName := "aws_sqs_queue.queue"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -130,7 +166,11 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 				Config: testAccAWSSQSConfigWithTags(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
 				),
@@ -144,7 +184,11 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 				Config: testAccAWSSQSConfigWithTagsChanged(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
 				),
@@ -153,7 +197,11 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 					resource.TestCheckNoResourceAttr(resourceName, "tags"),
 				),
 			},
@@ -178,6 +226,11 @@ func TestAccAWSSQSQueue_Name_Generated(t *testing.T) {
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -206,6 +259,11 @@ func TestAccAWSSQSQueue_Name_Generated_FIFOQueue(t *testing.T) {
 					naming.TestCheckResourceAttrNameWithSuffixGenerated(resourceName, "name", tfsqs.FifoQueueNameSuffix),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -232,10 +290,14 @@ func TestAccAWSSQSQueue_NamePrefix(t *testing.T) {
 				Config: testAccAWSSQSQueueConfigNamePrefix(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
 					naming.TestCheckResourceAttrNameFromPrefix(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -262,10 +324,14 @@ func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
 				Config: testAccAWSSQSQueueConfigNamePrefixFIFOQueue(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
 					naming.TestCheckResourceAttrNameWithSuffixFromPrefix(resourceName, "name", rName, tfsqs.FifoQueueNameSuffix),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -279,7 +345,7 @@ func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
 
 func TestAccAWSSQSQueue_policy(t *testing.T) {
 	var queueAttributes map[string]*string
-
+	resourceName := "aws_sqs_queue.test-email-events"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
 
@@ -292,12 +358,12 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 			{
 				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test-email-events", &queueAttributes),
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
 					testAccCheckAWSSQSQueuePolicyAttribute(&queueAttributes, topicName, queueName),
 				),
 			},
 			{
-				ResourceName:      "aws_sqs_queue.test-email-events",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -307,9 +373,9 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 
 func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
 	var queueAttributes map[string]*string
-
 	resourceName := "aws_sqs_queue.queue"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -320,14 +386,22 @@ func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 				Taint: []string{resourceName},
 			},
@@ -337,6 +411,7 @@ func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
 
 func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 	var queueAttributes map[string]*string
+	resourceName := "aws_sqs_queue.my_dead_letter_queue"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -347,12 +422,16 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 			{
 				Config: testAccAWSSQSConfigWithRedrive(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists("aws_sqs_queue.my_dead_letter_queue", &queueAttributes),
-					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
-				ResourceName:      "aws_sqs_queue.my_dead_letter_queue",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -363,9 +442,10 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 // Tests formatting and compacting of Policy, Redrive json
 func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 	var queueAttributes map[string]*string
-
+	resourceName := "aws_sqs_queue.test-email-events"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -375,12 +455,16 @@ func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 			{
 				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test-email-events", &queueAttributes),
-					testAccCheckAWSSQSQueueOverrideAttributes(&queueAttributes),
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "60"),
 				),
 			},
 			{
-				ResourceName:      "aws_sqs_queue.test-email-events",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -390,8 +474,8 @@ func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 
 func TestAccAWSSQSQueue_FIFO(t *testing.T) {
 	var queueAttributes map[string]*string
-
 	resourceName := "aws_sqs_queue.queue"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -431,8 +515,8 @@ func TestAccAWSSQSQueue_FIFOExpectNameError(t *testing.T) {
 
 func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
 	var queueAttributes map[string]*string
-
 	resourceName := "aws_sqs_queue.queue"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -473,8 +557,8 @@ func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
 
 func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 	var queueAttributes map[string]*string
-
 	resourceName := "aws_sqs_queue.queue"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -579,66 +663,6 @@ func testAccCheckAWSSQSQueueExists(resourceName string, queueAttributes *map[str
 		}
 
 		*queueAttributes = output.Attributes
-
-		return nil
-	}
-}
-
-func testAccCheckAWSSQSQueueDefaultAttributes(queueAttributes *map[string]*string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// checking if attributes are defaults
-		for key, valuePointer := range *queueAttributes {
-			value := aws.StringValue(valuePointer)
-			if key == "VisibilityTimeout" && value != "30" {
-				return fmt.Errorf("VisibilityTimeout (%s) was not set to 30", value)
-			}
-
-			if key == "MessageRetentionPeriod" && value != "345600" {
-				return fmt.Errorf("MessageRetentionPeriod (%s) was not set to 345600", value)
-			}
-
-			if key == "MaximumMessageSize" && value != "262144" {
-				return fmt.Errorf("MaximumMessageSize (%s) was not set to 262144", value)
-			}
-
-			if key == "DelaySeconds" && value != "0" {
-				return fmt.Errorf("DelaySeconds (%s) was not set to 0", value)
-			}
-
-			if key == "ReceiveMessageWaitTimeSeconds" && value != "0" {
-				return fmt.Errorf("ReceiveMessageWaitTimeSeconds (%s) was not set to 0", value)
-			}
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSSQSQueueOverrideAttributes(queueAttributes *map[string]*string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// checking if attributes match our overrides
-		for key, valuePointer := range *queueAttributes {
-			value := aws.StringValue(valuePointer)
-			if key == "VisibilityTimeout" && value != "60" {
-				return fmt.Errorf("VisibilityTimeout (%s) was not set to 60", value)
-			}
-
-			if key == "MessageRetentionPeriod" && value != "86400" {
-				return fmt.Errorf("MessageRetentionPeriod (%s) was not set to 86400", value)
-			}
-
-			if key == "MaximumMessageSize" && value != "2048" {
-				return fmt.Errorf("MaximumMessageSize (%s) was not set to 2048", value)
-			}
-
-			if key == "DelaySeconds" && value != "90" {
-				return fmt.Errorf("DelaySeconds (%s) was not set to 90", value)
-			}
-
-			if key == "ReceiveMessageWaitTimeSeconds" && value != "10" {
-				return fmt.Errorf("ReceiveMessageWaitTimeSeconds (%s) was not set to 10", value)
-			}
-		}
 
 		return nil
 	}

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -79,7 +79,7 @@ func testSweepSqsQueues(region string) error {
 }
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 
@@ -135,7 +135,7 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_disappears(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -158,7 +158,7 @@ func TestAccAWSSQSQueue_disappears(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_tags(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 
@@ -216,7 +216,7 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_Name_Generated(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -249,7 +249,7 @@ func TestAccAWSSQSQueue_Name_Generated(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_Name_Generated_FIFOQueue(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -282,7 +282,7 @@ func TestAccAWSSQSQueue_Name_Generated_FIFOQueue(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_NamePrefix(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"
 	rName := "tf-acc-test-prefix-"
 
@@ -316,7 +316,7 @@ func TestAccAWSSQSQueue_NamePrefix(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"
 	rName := "tf-acc-test-prefix-"
 
@@ -350,7 +350,7 @@ func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_policy(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test-email-events"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
@@ -378,7 +378,7 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 
@@ -416,7 +416,7 @@ func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.my_dead_letter_queue"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -447,7 +447,7 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 
 // Tests formatting and compacting of Policy, Redrive json
 func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test-email-events"
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
@@ -479,7 +479,7 @@ func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_FIFO(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -522,7 +522,7 @@ func TestAccAWSSQSQueue_FIFOExpectNameError(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -549,7 +549,7 @@ func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 
 	resourceName := "aws_sqs_queue.queue"
 	queueName := acctest.RandString(10)
@@ -567,7 +567,6 @@ func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", "queue"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", "perQueue"),
-					testAccCheckAWSSQSFIFOQueueHighThroughputAttributes(&queueAttributes, "queue", "perQueue"),
 				),
 			},
 			{
@@ -581,13 +580,7 @@ func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
 					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", "messageGroup"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", "perMessageGroupId"),
-					testAccCheckAWSSQSFIFOQueueHighThroughputAttributes(&queueAttributes, "messageGroup", "perMessageGroupId"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -609,7 +602,7 @@ func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_Encryption(t *testing.T) {
-	var queueAttributes map[string]*string
+	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.queue"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -634,7 +627,7 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]*string, topicName, queueName string) resource.TestCheckFunc {
+func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]string, topicName, queueName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		accountID := testAccProvider.Meta().(*AWSClient).accountid
 
@@ -642,9 +635,9 @@ func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]*string,
 		expectedPolicyText := fmt.Sprintf(expectedPolicyFormat, testAccGetPartition(), testAccGetRegion(), accountID, topicName, queueName)
 
 		var actualPolicyText string
-		for key, valuePointer := range *queueAttributes {
-			if key == "Policy" {
-				actualPolicyText = aws.StringValue(valuePointer)
+		for key, value := range *queueAttributes {
+			if key == sqs.QueueAttributeNamePolicy {
+				actualPolicyText = value
 				break
 			}
 		}
@@ -662,7 +655,7 @@ func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]*string,
 	}
 }
 
-func testAccCheckAWSSQSQueueExists(resourceName string, v *map[string]*string) resource.TestCheckFunc {
+func testAccCheckAWSSQSQueueExists(resourceName string, v *map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -109,6 +109,7 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
 					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "url", resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -622,6 +622,33 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 	})
 }
 
+func TestAccAWSSQSQueue_ZeroVisibilityTimeoutSeconds(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigZeroVisibilityTimeoutSeconds(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]string, rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		expectedPolicyText := fmt.Sprintf(
@@ -914,4 +941,13 @@ resource "aws_sqs_queue" "test" {
   kms_data_key_reuse_period_seconds = %[2]s
 }
 `, rName, kmsDataKeyReusePeriodSeconds)
+}
+
+func testAccAWSSQSConfigZeroVisibilityTimeoutSeconds(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name                       = %[1]q
+  visibility_timeout_seconds = 0
+}
+`, rName)
 }

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -99,7 +99,50 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", ""),
-					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", strconv.Itoa(tfsqs.DefaultQueueKmsDataKeyReusePeriodSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_update(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.queue"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sqs", rName),
+					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
+					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", ""),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
 					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
@@ -227,12 +270,7 @@ func TestAccAWSSQSQueue_Name_Generated(t *testing.T) {
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
 					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -261,11 +299,6 @@ func TestAccAWSSQSQueue_Name_Generated_FIFOQueue(t *testing.T) {
 					naming.TestCheckResourceAttrNameWithSuffixGenerated(resourceName, "name", tfsqs.FifoQueueNameSuffix),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -294,11 +327,6 @@ func TestAccAWSSQSQueue_NamePrefix(t *testing.T) {
 					naming.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -327,11 +355,6 @@ func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
 					naming.TestCheckResourceAttrNameWithSuffixFromPrefix(resourceName, "name", "tf-acc-test-prefix-", tfsqs.FifoQueueNameSuffix),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
 				),
 			},
 			{
@@ -343,11 +366,10 @@ func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
 	})
 }
 
-func TestAccAWSSQSQueue_policy(t *testing.T) {
+func TestAccAWSSQSQueue_Policy(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.test-email-events"
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
-	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
+	resourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -356,111 +378,73 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
+				Config: testAccAWSSQSConfigPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckAWSSQSQueuePolicyAttribute(&queueAttributes, topicName, queueName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
-	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigName(queueName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
-				),
-			},
-			{
-				Config: testAccAWSSQSConfigName(queueName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
-				),
-				Taint: []string{resourceName},
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
-	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.my_dead_letter_queue"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigWithRedrive(acctest.RandString(10)),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-// Tests formatting and compacting of Policy, Redrive json
-func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
-	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.test-email-events"
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
-	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckAWSSQSQueuePolicyAttribute(&queueAttributes, rName),
 					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
 					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
 					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
 					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", "10"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "60"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_RecentlyDeleted(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.queue"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAWSSQSConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_RedrivePolicy(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigRedrivePolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "redrive_policy"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "300"),
 				),
 			},
 			{
@@ -621,12 +605,24 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]string, topicName, queueName string) resource.TestCheckFunc {
+func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]string, rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		accountID := testAccProvider.Meta().(*AWSClient).accountid
-
-		expectedPolicyFormat := `{"Version": "2012-10-17","Id": "sqspolicy","Statement":[{"Sid": "Stmt1451501026839","Effect": "Allow","Principal":"*","Action":"sqs:SendMessage","Resource":"arn:%[1]s:sqs:%[2]s:%[3]s:%[4]s","Condition":{"ArnEquals":{"aws:SourceArn":"arn:%[1]s:sns:%[2]s:%[3]s:%[5]s"}}}]}`
-		expectedPolicyText := fmt.Sprintf(expectedPolicyFormat, testAccGetPartition(), testAccGetRegion(), accountID, topicName, queueName)
+		expectedPolicyText := fmt.Sprintf(
+			`{
+"Version": "2012-10-17",
+"Id": "sqspolicy",
+"Statement":[{
+  "Sid": "Stmt1451501026839",
+  "Effect": "Allow",
+  "Principal":"*",
+  "Action":"sqs:SendMessage",
+  "Resource":"arn:%[1]s:sqs:%[2]s:%[3]s:%[4]s",
+  "Condition":{
+    "ArnEquals":{"aws:SourceArn":"arn:%[1]s:sns:%[2]s:%[3]s:%[5]s"}
+  }
+}]
+             }`,
+			testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName, rName)
 
 		var actualPolicyText string
 		for key, value := range *queueAttributes {
@@ -641,8 +637,7 @@ func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]string, 
 			return fmt.Errorf("Error testing policy equivalence: %s", err)
 		}
 		if !equivalent {
-			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
-				expectedPolicyText, actualPolicyText)
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n", expectedPolicyText, actualPolicyText)
 		}
 
 		return nil
@@ -771,39 +766,35 @@ resource "aws_sqs_queue" "queue" {
 `, rName)
 }
 
-func testAccAWSSQSConfigWithRedrive(name string) string {
+func testAccAWSSQSConfigRedrivePolicy(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "my_queue" {
-  name                       = "tftestqueuq-%[1]s"
+resource "aws_sqs_queue" "test" {
+  name                       = "%[1]s-1"
   delay_seconds              = 0
   visibility_timeout_seconds = 300
 
   redrive_policy = <<EOF
 {
   "maxReceiveCount": 3,
-  "deadLetterTargetArn": "${aws_sqs_queue.my_dead_letter_queue.arn}"
+  "deadLetterTargetArn": "${aws_sqs_queue.dlq.arn}"
 }
 EOF
 }
 
-resource "aws_sqs_queue" "my_dead_letter_queue" {
-  name = "tfotherqueuq-%[1]s"
+resource "aws_sqs_queue" "dlq" {
+  name = "%[1]s-2"
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSSQSConfig_PolicyFormat(queue, topic string) string {
+func testAccAWSSQSConfigPolicy(rName string) string {
 	return fmt.Sprintf(`
-variable "sns_name" {
-  default = "%s"
+locals {
+  queue_name = %[1]q
 }
 
-variable "sqs_name" {
-  default = "%s"
-}
-
-resource "aws_sns_topic" "test_topic" {
-  name = var.sns_name
+resource "aws_sns_topic" "test" {
+  name = %[1]q
 }
 
 data "aws_partition" "current" {}
@@ -812,9 +803,8 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_sqs_queue" "test-email-events" {
-  name                       = var.sqs_name
-  depends_on                 = [aws_sns_topic.test_topic]
+resource "aws_sqs_queue" "test" {
+  name                       = local.queue_name
   delay_seconds              = 90
   max_message_size           = 2048
   message_retention_seconds  = 86400
@@ -831,10 +821,10 @@ resource "aws_sqs_queue" "test-email-events" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "sqs:SendMessage",
-      "Resource": "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sqs_name}",
+      "Resource": "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${local.queue_name}",
       "Condition": {
         "ArnEquals": {
-          "aws:SourceArn": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sns_name}"
+          "aws:SourceArn": "${aws_sns_topic.test.arn}"
         }
       }
     }
@@ -843,12 +833,12 @@ resource "aws_sqs_queue" "test-email-events" {
 EOF
 }
 
-resource "aws_sns_topic_subscription" "test_queue_target" {
-  topic_arn = aws_sns_topic.test_topic.arn
+resource "aws_sns_topic_subscription" "test" {
+  topic_arn = aws_sns_topic.test.arn
   protocol  = "sqs"
-  endpoint  = aws_sqs_queue.test-email-events.arn
+  endpoint  = aws_sqs_queue.test.arn
 }
-`, topic, queue)
+`, rName)
 }
 
 func testAccAWSSQSConfigWithFIFO(queue string) string {

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -80,7 +80,7 @@ func testSweepSqsQueues(region string) error {
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
+	resourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,71 +116,6 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_update(t *testing.T) {
-	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigName(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sqs", rName),
-					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
-					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", ""),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
-					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", ""),
-					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "0"),
-					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "name_prefix", ""),
-					resource.TestCheckResourceAttr(resourceName, "policy", ""),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAWSSQSConfigWithOverrides(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", "10"),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "60"),
-				),
-			},
-			{
-				Config: testAccAWSSQSConfigName(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
-					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
-					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
-					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
-					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
-				),
 			},
 		},
 	})
@@ -188,7 +123,7 @@ func TestAccAWSSQSQueue_update(t *testing.T) {
 
 func TestAccAWSSQSQueue_disappears(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
+	resourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -204,51 +139,6 @@ func TestAccAWSSQSQueue_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSqsQueue(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_Tags(t *testing.T) {
-	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigTags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAWSSQSConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-				),
-			},
-			{
-				Config: testAccAWSSQSConfigTags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-				),
 			},
 		},
 	})
@@ -366,6 +256,117 @@ func TestAccAWSSQSQueue_NamePrefix_FIFOQueue(t *testing.T) {
 	})
 }
 
+func TestAccAWSSQSQueue_Tags(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSQSConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSQSConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_Update(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sqs", rName),
+					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
+					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", ""),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", strconv.Itoa(tfsqs.DefaultQueueDelaySeconds)),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", strconv.Itoa(tfsqs.DefaultQueueMaximumMessageSize)),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", strconv.Itoa(tfsqs.DefaultQueueMessageRetentionPeriod)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
+				),
+			},
+			{
+				Config: testAccAWSSQSConfigUpdated(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sqs", rName),
+					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
+					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", ""),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "false"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "60"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSSQSQueue_Policy(t *testing.T) {
 	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"
@@ -400,7 +401,7 @@ func TestAccAWSSQSQueue_Policy(t *testing.T) {
 
 func TestAccAWSSQSQueue_RecentlyDeleted(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
+	resourceName := "aws_sqs_queue.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -456,9 +457,10 @@ func TestAccAWSSQSQueue_RedrivePolicy(t *testing.T) {
 	})
 }
 
-func TestAccAWSSQSQueue_FIFO(t *testing.T) {
+func TestAccAWSSQSQueue_FIFOQueue(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
+	resourceName := "aws_sqs_queue.test"
+	rName := fmt.Sprintf("%s.fifo", acctest.RandomWithPrefix("tf-acc-test"))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -467,11 +469,11 @@ func TestAccAWSSQSQueue_FIFO(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfigWithFIFO(acctest.RandString(10)),
+				Config: testAccAWSSQSConfigFIFOQueue(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", "queue"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", "perQueue"),
 				),
 			},
@@ -484,7 +486,9 @@ func TestAccAWSSQSQueue_FIFO(t *testing.T) {
 	})
 }
 
-func TestAccAWSSQSQueue_FIFOExpectNameError(t *testing.T) {
+func TestAccAWSSQSQueue_FIFOQueue_ExpectNameError(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -492,16 +496,17 @@ func TestAccAWSSQSQueue_FIFOExpectNameError(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSSQSConfigWithFIFOExpectError(acctest.RandString(10)),
+				Config:      testAccAWSSQSConfigFIFOQueue(rName),
 				ExpectError: regexp.MustCompile(`invalid queue name:`),
 			},
 		},
 	})
 }
 
-func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
+func TestAccAWSSQSQueue_FIFOQueue_ContentBasedDeduplication(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
+	resourceName := "aws_sqs_queue.test"
+	rName := fmt.Sprintf("%s.fifo", acctest.RandomWithPrefix("tf-acc-test"))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -510,11 +515,11 @@ func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfigWithFIFOContentBasedDeduplication(acctest.RandString(10)),
+				Config: testAccAWSSQSConfigFIFOQueueContentBasedDeduplication(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 				),
 			},
 			{
@@ -526,11 +531,10 @@ func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
 	})
 }
 
-func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
+func TestAccAWSSQSQueue_FIFOQueue_HighThroughputMode(t *testing.T) {
 	var queueAttributes map[string]string
-
-	resourceName := "aws_sqs_queue.queue"
-	queueName := acctest.RandString(10)
+	resourceName := "aws_sqs_queue.test"
+	rName := fmt.Sprintf("%s.fifo", acctest.RandomWithPrefix("tf-acc-test"))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -539,11 +543,11 @@ func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfigWithFIFOHighThroughputMode1(queueName),
+				Config: testAccAWSSQSConfigFIFOQueueHighThroughputMode(rName, "null", "null"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
-					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", "queue"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", "perQueue"),
 				),
 			},
@@ -553,10 +557,11 @@ func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSSQSConfigWithFIFOHighThroughputMode2(queueName),
+				Config: testAccAWSSQSConfigFIFOQueueHighThroughputMode(rName, "messageGroup", "perMessageGroupId"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
 					resource.TestCheckResourceAttr(resourceName, "deduplication_scope", "messageGroup"),
+					resource.TestCheckResourceAttr(resourceName, "fifo_queue", "true"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_throughput_limit", "perMessageGroupId"),
 				),
 			},
@@ -564,7 +569,9 @@ func TestAccAWSSQSQueue_FIFOWithHighThroughputMode(t *testing.T) {
 	})
 }
 
-func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
+func TestAccAWSSQSQueue_StandardQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sqs.EndpointsID),
@@ -572,7 +579,7 @@ func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccExpectContentBasedDeduplicationError(acctest.RandString(10)),
+				Config:      testAccAWSSQSConfigStandardQueueExpectContentBasedDeduplicationError(rName),
 				ExpectError: regexp.MustCompile(`content-based deduplication can only be set for FIFO queue`),
 			},
 		},
@@ -581,7 +588,8 @@ func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
 
 func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 	var queueAttributes map[string]string
-	resourceName := "aws_sqs_queue.queue"
+	resourceName := "aws_sqs_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -590,9 +598,10 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfigWithEncryption(acctest.RandString(10)),
+				Config: testAccAWSSQSConfigEncryption(rName, "null"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "300"),
 					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", "alias/aws/sqs"),
 				),
 			},
@@ -600,6 +609,14 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSQSConfigEncryption(rName, "3600"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", "alias/aws/sqs"),
+				),
 			},
 		},
 	})
@@ -705,7 +722,7 @@ resource "aws_sqs_queue" "test" {
 
 func testAccAWSSQSConfigName(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
+resource "aws_sqs_queue" "test" {
   name = %[1]q
 }
 `, rName)
@@ -730,7 +747,7 @@ resource "aws_sqs_queue" "test" {
 
 func testAccAWSSQSConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
+resource "aws_sqs_queue" "test" {
   name = %[1]q
 
   tags = {
@@ -742,7 +759,7 @@ resource "aws_sqs_queue" "queue" {
 
 func testAccAWSSQSConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
+resource "aws_sqs_queue" "test" {
   name = %[1]q
 
   tags = {
@@ -753,36 +770,15 @@ resource "aws_sqs_queue" "queue" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSSQSConfigWithOverrides(rName string) string {
+func testAccAWSSQSConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
+resource "aws_sqs_queue" "test" {
   name                       = %[1]q
   delay_seconds              = 90
   max_message_size           = 2048
   message_retention_seconds  = 86400
   receive_wait_time_seconds  = 10
   visibility_timeout_seconds = 60
-}
-`, rName)
-}
-
-func testAccAWSSQSConfigRedrivePolicy(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_sqs_queue" "test" {
-  name                       = "%[1]s-1"
-  delay_seconds              = 0
-  visibility_timeout_seconds = 300
-
-  redrive_policy = <<EOF
-{
-  "maxReceiveCount": 3,
-  "deadLetterTargetArn": "${aws_sqs_queue.dlq.arn}"
-}
-EOF
-}
-
-resource "aws_sqs_queue" "dlq" {
-  name = "%[1]s-2"
 }
 `, rName)
 }
@@ -841,69 +837,81 @@ resource "aws_sns_topic_subscription" "test" {
 `, rName)
 }
 
-func testAccAWSSQSConfigWithFIFO(queue string) string {
+func testAccAWSSQSConfigRedrivePolicy(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name       = "%s.fifo"
-  fifo_queue = true
+resource "aws_sqs_queue" "test" {
+  name                       = "%[1]s-1"
+  delay_seconds              = 0
+  visibility_timeout_seconds = 300
+
+  redrive_policy = <<EOF
+{
+  "maxReceiveCount": 3,
+  "deadLetterTargetArn": "${aws_sqs_queue.dlq.arn}"
 }
-`, queue)
+EOF
 }
 
-func testAccAWSSQSConfigWithFIFOContentBasedDeduplication(queue string) string {
+resource "aws_sqs_queue" "dlq" {
+  name = "%[1]s-2"
+}
+`, rName)
+}
+
+func testAccAWSSQSConfigFIFOQueue(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name                        = "%s.fifo"
+resource "aws_sqs_queue" "test" {
+  name       = %[1]q
+  fifo_queue = true
+}
+`, rName)
+}
+
+func testAccAWSSQSConfigFIFOQueueContentBasedDeduplication(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name                        = %[1]q
   fifo_queue                  = true
   content_based_deduplication = true
 }
-`, queue)
+`, rName)
 }
 
-func testAccAWSSQSConfigWithFIFOHighThroughputMode1(queue string) string {
+func testAccAWSSQSConfigFIFOQueueHighThroughputMode(rName, deduplicationScope, fifoThroughputLimit string) string {
+	if deduplicationScope != "null" {
+		deduplicationScope = strconv.Quote(deduplicationScope)
+	}
+
+	if fifoThroughputLimit != "null" {
+		fifoThroughputLimit = strconv.Quote(fifoThroughputLimit)
+	}
+
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name       = "%s.fifo"
+resource "aws_sqs_queue" "test" {
+  name       = %[1]q
   fifo_queue = true
+
+  deduplication_scope   = %[2]s
+  fifo_throughput_limit = %[3]s
 }
-`, queue)
+`, rName, deduplicationScope, fifoThroughputLimit)
 }
 
-func testAccAWSSQSConfigWithFIFOHighThroughputMode2(queue string) string {
+func testAccAWSSQSConfigStandardQueueExpectContentBasedDeduplicationError(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name                  = "%s.fifo"
-  fifo_queue            = true
-  deduplication_scope   = "messageGroup"
-  fifo_throughput_limit = "perMessageGroupId"
-}
-`, queue)
-}
-
-func testAccAWSSQSConfigWithFIFOExpectError(queue string) string {
-	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name       = "%s"
-  fifo_queue = true
-}
-`, queue)
-}
-
-func testAccExpectContentBasedDeduplicationError(queue string) string {
-	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name                        = "%s"
+resource "aws_sqs_queue" "test" {
+  name                        = %[1]q
   content_based_deduplication = true
 }
-`, queue)
+`, rName)
 }
 
-func testAccAWSSQSConfigWithEncryption(queue string) string {
+func testAccAWSSQSConfigEncryption(rName, kmsDataKeyReusePeriodSeconds string) string {
 	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name                              = "%s"
+resource "aws_sqs_queue" "test" {
+  name                              = %[1]q
   kms_master_key_id                 = "alias/aws/sqs"
-  kms_data_key_reuse_period_seconds = 300
+  kms_data_key_reuse_period_seconds = %[2]s
 }
-`, queue)
+`, rName, kmsDataKeyReusePeriodSeconds)
 }

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -38,6 +38,17 @@ resource "aws_sqs_queue" "terraform_queue" {
 }
 ```
 
+## High-throughput FIFO queue
+
+```terraform
+resource "aws_sqs_queue" "terraform_queue" {
+  name                  = "terraform-example-queue.fifo"
+  fifo_queue            = true
+  deduplication_scope   = "messageGroup"
+  fifo_throughput_limit = "perMessageGroupId"
+}
+```
+
 ## Server-side encryption (SSE)
 
 ```terraform
@@ -65,6 +76,8 @@ The following arguments are supported:
 * `content_based_deduplication` - (Optional) Enables content-based deduplication for FIFO queues. For more information, see the [related documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
 * `kms_master_key_id` - (Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see [Key Terms](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms).
 * `kms_data_key_reuse_period_seconds` - (Optional) The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes).
+* `deduplication_scope` - (Optional) Specifies whether message deduplication occurs at the message group or queue level. Valid values are `messageGroup` and `queue` (default).
+* `fifo_throughput_limit` - (Optional) Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are `perQueue` (default) and `perMessageGroupId`.
 * `tags` - (Optional) A map of tags to assign to the queue. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -87,6 +87,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The URL for the created Amazon SQS queue.
 * `arn` - The ARN of the SQS queue
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `url` - Same as `id`: The URL for the created Amazon SQS queue.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19630
Closes #19498
Closes #11848
Closes #14166
Closes #13759
Closes #13980

Adds the `deduplication_scope` and `fifo_throughput_limit`, which can be used to enable the high-throughput mode of FIFO queues.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSQSQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSQSQueue -timeout 180m
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (5.79s)
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (5.86s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears_queue (22.37s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears (27.34s)
--- PASS: TestAccAWSSQSQueue_FIFO (27.76s)
--- PASS: TestAccAWSSQSQueue_Name_Generated_FIFOQueue (30.16s)
--- PASS: TestAccAWSSQSQueue_NamePrefix_FIFOQueue (30.22s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (30.37s)
--- PASS: TestAccAWSSQSQueue_Encryption (30.51s)
--- PASS: TestAccAWSSQSQueue_Name_Generated (30.55s)
--- PASS: TestAccAWSSQSQueue_NamePrefix (30.62s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (30.78s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (37.34s)
--- PASS: TestAccAWSSQSQueuePolicy_basic (38.52s)
--- PASS: TestAccAWSSQSQueue_FIFOWithHighThroughputMode (42.96s)
--- PASS: TestAccAWSSQSQueue_basic (53.77s)
--- PASS: TestAccAWSSQSQueue_tags (54.01s)
--- PASS: TestAccAWSSQSQueue_policy (75.21s)
--- PASS: TestAccAWSSQSQueue_Policybasic (75.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       76.954s
```
