### PR TITLE
r/aws_cloudwatch_event_api_destination: Fix crash on update

### DIFF
--- a/.changelog/19654.txt
+++ b/.changelog/19654.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_api_destination: Fix crash on resource update
+```

--- a/aws/resource_aws_cloudwatch_event_api_destination.go
+++ b/aws/resource_aws_cloudwatch_event_api_destination.go
@@ -148,7 +148,7 @@ func resourceAwsCloudWatchEventApiDestinationUpdate(d *schema.ResourceData, meta
 		input.InvocationEndpoint = aws.String(invocationEndpoint.(string))
 	}
 	if invocationRateLimitPerSecond, ok := d.GetOk("invocation_rate_limit_per_second"); ok {
-		input.InvocationRateLimitPerSecond = aws.Int64(invocationRateLimitPerSecond.(int64))
+		input.InvocationRateLimitPerSecond = aws.Int64(int64(invocationRateLimitPerSecond.(int)))
 	}
 	if httpMethod, ok := d.GetOk("http_method"); ok {
 		input.HttpMethod = aws.String(httpMethod.(string))

--- a/aws/resource_aws_cloudwatch_event_api_destination_test.go
+++ b/aws/resource_aws_cloudwatch_event_api_destination_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -84,7 +83,7 @@ func TestAccAWSCloudWatchEventApiDestination_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, cloudwatchevents.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchEventApiDestinationDestroy,
 		Steps: []resource.TestStep{
@@ -157,7 +156,7 @@ func TestAccAWSCloudWatchEventApiDestination_optional(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, cloudwatchevents.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchEventApiDestinationDestroy,
 		Steps: []resource.TestStep{
@@ -207,7 +206,7 @@ func TestAccAWSCloudWatchEventApiDestination_optional(t *testing.T) {
 					invocationEndpointModified,
 					httpMethodModified,
 					descriptionModified,
-					int64(invocationRateLimitPerSecondModified),
+					int64(invocationRateLimitPerSecond),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventApiDestinationExists(resourceName, &v3),
@@ -216,7 +215,7 @@ func TestAccAWSCloudWatchEventApiDestination_optional(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "http_method", httpMethodModified),
 					resource.TestCheckResourceAttr(resourceName, "invocation_endpoint", invocationEndpointModified),
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionModified),
-					resource.TestCheckResourceAttr(resourceName, "invocation_rate_limit_per_second", fmt.Sprint(invocationRateLimitPerSecondModified)),
+					resource.TestCheckResourceAttr(resourceName, "invocation_rate_limit_per_second", fmt.Sprint(invocationRateLimitPerSecond)),
 				),
 			},
 		},
@@ -233,7 +232,7 @@ func TestAccAWSCloudWatchEventApiDestination_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, cloudwatchevents.EndpointsID),
+		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchEventApiDestinationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19628.

Without the fix the updated acceptance test crashes with the same panic:

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventApiDestination_optional'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventApiDestination_optional -timeout 180m
=== RUN   TestAccAWSCloudWatchEventApiDestination_optional
=== PAUSE TestAccAWSCloudWatchEventApiDestination_optional
=== CONT  TestAccAWSCloudWatchEventApiDestination_optional
panic: interface conversion: interface {} is int, not int64

goroutine 1874 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCloudWatchEventApiDestinationUpdate(0xc003a9d700, 0x8183da0, 0xc003a60c00, 0x0, 0xffffffffffffffff)
	/Users/ewbankkit/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_cloudwatch_event_api_destination.go:151 +0x7b9
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0xc0016dae00, 0xa0a2ee8, 0xc002c63800, 0xc003a9d700, 0x8183da0, 0xc003a60c00, 0x0, 0x0, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/resource.go:352 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0016dae00, 0xa0a2ee8, 0xc002c63800, 0xc002bf4cb0, 0xc00229e380, 0x8183da0, 0xc003a60c00, 0xc00095c790, 0x7f8fe60, 0xc002b2b410, ...)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/resource.go:464 +0x390
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0039910f8, 0xa0a2ee8, 0xc002c63800, 0xc002b340a0, 0xc002c63800, 0x8db1660, 0xc002b2af00)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.6.1/helper/schema/grpc_provider.go:955 +0x8ef
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ApplyResourceChange(0xc001fba7c0, 0xa0a2f90, 0xc002c63800, 0xc002bf4bd0, 0xc001fba7c0, 0xc002b2af90, 0xc000090ba0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:332 +0xb5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x8db1660, 0xc001fba7c0, 0xa0a2f90, 0xc002b2af90, 0xc002b22840, 0x0, 0xa0a2f90, 0xc002b2af90, 0xc002b36000, 0x589)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0044c28c0, 0xa0cd798, 0xc003a79c80, 0xc002bea700, 0xc002bb6420, 0xded7ea0, 0x0, 0x0, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc0044c28c0, 0xa0cd798, 0xc003a79c80, 0xc002bea700, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0022d6370, 0xc0044c28c0, 0xa0cd798, 0xc003a79c80, 0xc002bea700)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	32.671s
FAIL
make: *** [testacc] Error 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventApiDestination_'        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventApiDestination_ -timeout 180m
=== RUN   TestAccAWSCloudWatchEventApiDestination_basic
=== PAUSE TestAccAWSCloudWatchEventApiDestination_basic
=== RUN   TestAccAWSCloudWatchEventApiDestination_optional
=== PAUSE TestAccAWSCloudWatchEventApiDestination_optional
=== RUN   TestAccAWSCloudWatchEventApiDestination_disappears
=== PAUSE TestAccAWSCloudWatchEventApiDestination_disappears
=== CONT  TestAccAWSCloudWatchEventApiDestination_basic
=== CONT  TestAccAWSCloudWatchEventApiDestination_disappears
=== CONT  TestAccAWSCloudWatchEventApiDestination_optional
--- PASS: TestAccAWSCloudWatchEventApiDestination_disappears (14.90s)
--- PASS: TestAccAWSCloudWatchEventApiDestination_basic (40.15s)
--- PASS: TestAccAWSCloudWatchEventApiDestination_optional (42.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	45.348s
```

#### GovCloud

```console
%  make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventApiDestination_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventApiDestination_ -timeout 180m
=== RUN   TestAccAWSCloudWatchEventApiDestination_basic
=== PAUSE TestAccAWSCloudWatchEventApiDestination_basic
=== RUN   TestAccAWSCloudWatchEventApiDestination_optional
=== PAUSE TestAccAWSCloudWatchEventApiDestination_optional
=== RUN   TestAccAWSCloudWatchEventApiDestination_disappears
=== PAUSE TestAccAWSCloudWatchEventApiDestination_disappears
=== CONT  TestAccAWSCloudWatchEventApiDestination_basic
=== CONT  TestAccAWSCloudWatchEventApiDestination_disappears
=== CONT  TestAccAWSCloudWatchEventApiDestination_optional
    provider_test.go:1103: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/06/03 16:41:31 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: error creating CloudWatch Events connection (tf-acc-test-8676558331784668077): UnknownOperationException: Operation is disabled in this region.
        	status code: 400, request id: 4c06f910-8db1-481b-a21c-e1595254f2a2
        
          on terraform_plugin_test.tf line 12, in resource "aws_cloudwatch_event_connection" "test":
          12: resource "aws_cloudwatch_event_connection" "test" {
        
        
=== CONT  TestAccAWSCloudWatchEventApiDestination_disappears
    provider_test.go:1103: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/06/03 16:41:31 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: error creating CloudWatch Events connection (tf-acc-test-3528424025845291578): UnknownOperationException: Operation is disabled in this region.
        	status code: 400, request id: 4068ba8e-17d9-4bf4-98cf-fc452e1f8dcc
        
          on terraform_plugin_test.tf line 9, in resource "aws_cloudwatch_event_connection" "test":
           9: resource "aws_cloudwatch_event_connection" "test" {
        
        
=== CONT  TestAccAWSCloudWatchEventApiDestination_basic
    provider_test.go:1103: skipping test for aws-us-gov/us-gov-west-1: Error running apply: exit status 1
        2021/06/03 16:41:31 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.13.3
        
        Error: error creating CloudWatch Events connection (tf-acc-test-2193223589896250247): UnknownOperationException: Operation is disabled in this region.
        	status code: 400, request id: 40c10697-f011-4257-b961-789fad4e87de
        
          on terraform_plugin_test.tf line 9, in resource "aws_cloudwatch_event_connection" "test":
           9: resource "aws_cloudwatch_event_connection" "test" {
        
        
--- SKIP: TestAccAWSCloudWatchEventApiDestination_optional (5.99s)
--- SKIP: TestAccAWSCloudWatchEventApiDestination_disappears (5.99s)
--- SKIP: TestAccAWSCloudWatchEventApiDestination_basic (6.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.055s
```