### PR TITLE
r/default_vpc_dhcp_options - add `owner_id` arg

### DIFF
--- a/.changelog/19656.txt
+++ b/.changelog/19656.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_default_vpc_dhcp_options: Add `owner_id` argument.
+```

--- a/aws/resource_aws_default_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_default_vpc_dhcp_options_test.go
@@ -79,7 +79,7 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_default_vpc_dhcp_options" "test" {
   owner_id = data.aws_caller_identity.current.account_id
-  
+
   tags = {
     Name = "Default DHCP Option Set"
   }

--- a/aws/resource_aws_default_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_default_vpc_dhcp_options_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccAWSDefaultVpcDhcpOptions_basic(t *testing.T) {
 	var d ec2.DhcpOptions
-	resourceName := "aws_default_vpc_dhcp_options.foo"
+	resourceName := "aws_default_vpc_dhcp_options.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,13 +35,51 @@ func TestAccAWSDefaultVpcDhcpOptions_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDefaultVpcDhcpOptions_owner(t *testing.T) {
+	var d ec2.DhcpOptions
+	resourceName := "aws_default_vpc_dhcp_options.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDefaultVpcDhcpOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultVpcDhcpOptionsConfigOwner,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists(resourceName, &d),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`dhcp-options/dopt-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", resourceAwsEc2RegionalPrivateDnsSuffix(testAccGetRegion())),
+					resource.TestCheckResourceAttr(resourceName, "domain_name_servers", "AmazonProvidedDNS"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Default DHCP Option Set"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDefaultVpcDhcpOptionsDestroy(s *terraform.State) error {
 	// We expect DHCP Options Set to still exist
 	return nil
 }
 
 const testAccAWSDefaultVpcDhcpOptionsConfigBasic = `
-resource "aws_default_vpc_dhcp_options" "foo" {
+resource "aws_default_vpc_dhcp_options" "test" {
+  tags = {
+    Name = "Default DHCP Option Set"
+  }
+}
+`
+
+const testAccAWSDefaultVpcDhcpOptionsConfigOwner = `
+data "aws_caller_identity" "current" {}
+
+resource "aws_default_vpc_dhcp_options" "test" {
+  owner_id = data.aws_caller_identity.current.account_id
+  
   tags = {
     Name = "Default DHCP Option Set"
   }

--- a/website/docs/r/default_vpc_dhcp_options.html.markdown
+++ b/website/docs/r/default_vpc_dhcp_options.html.markdown
@@ -39,6 +39,7 @@ The following arguments are still supported:
 
 * `netbios_name_servers` - (Optional) List of NETBIOS name servers.
 * `netbios_node_type` - (Optional) The NetBIOS node type (1, 2, 4, or 8). AWS recommends to specify 2 since broadcast and multicast are not supported in their network. For more information about these node types, see [RFC 2132](http://www.ietf.org/rfc/rfc2132.txt).
+* `owner_id` - The ID of the AWS account that owns the DHCP options set.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ### Removing `aws_default_vpc_dhcp_options` from your configuration
@@ -54,7 +55,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the DHCP Options Set.
 * `arn` - The ARN of the DHCP Options Set.
-* `owner_id` - The ID of the AWS account that owns the DHCP options set.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19558

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=estAccAWSDefaultVpcDhcpOptions_''
--- PASS: TestAccAWSDefaultVpcDhcpOptions_basic (35.35s)
--- PASS: TestAccAWSDefaultVpcDhcpOptions_owner (43.05s)
```
