### PR TITLE
r/fsx _lustre_file_system - add `data_compression_type`

### DIFF
--- a/.changelog/19664.txt
+++ b/.changelog/19664.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_lustre_filesystem: Add `data_compression_type` argument.
+```

--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -182,6 +182,12 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 				ForceNew: true,
 				Default:  false,
 			},
+			"data_compression_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(fsx.DataCompressionType_Values(), false),
+				Default:      fsx.DataCompressionTypeNone,
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -274,6 +280,10 @@ func resourceAwsFsxLustreFileSystemCreate(d *schema.ResourceData, meta interface
 		input.LustreConfiguration.CopyTagsToBackups = aws.Bool(v.(bool))
 	}
 
+	if v, ok := d.GetOk("data_compression_type"); ok {
+		input.LustreConfiguration.DataCompressionType = aws.String(v.(string))
+	}
+
 	result, err := conn.CreateFileSystem(input)
 	if err != nil {
 		return fmt.Errorf("Error creating FSx Lustre filesystem: %w", err)
@@ -301,39 +311,37 @@ func resourceAwsFsxLustreFileSystemUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	requestUpdate := false
-	input := &fsx.UpdateFileSystemInput{
-		ClientRequestToken:  aws.String(resource.UniqueId()),
-		FileSystemId:        aws.String(d.Id()),
-		LustreConfiguration: &fsx.UpdateFileSystemLustreConfiguration{},
-	}
+	if d.HasChangesExcept("tags_all", "tags") {
+		input := &fsx.UpdateFileSystemInput{
+			ClientRequestToken:  aws.String(resource.UniqueId()),
+			FileSystemId:        aws.String(d.Id()),
+			LustreConfiguration: &fsx.UpdateFileSystemLustreConfiguration{},
+		}
 
-	if d.HasChange("weekly_maintenance_start_time") {
-		input.LustreConfiguration.WeeklyMaintenanceStartTime = aws.String(d.Get("weekly_maintenance_start_time").(string))
-		requestUpdate = true
-	}
+		if d.HasChange("weekly_maintenance_start_time") {
+			input.LustreConfiguration.WeeklyMaintenanceStartTime = aws.String(d.Get("weekly_maintenance_start_time").(string))
+		}
 
-	if d.HasChange("automatic_backup_retention_days") {
-		input.LustreConfiguration.AutomaticBackupRetentionDays = aws.Int64(int64(d.Get("automatic_backup_retention_days").(int)))
-		requestUpdate = true
-	}
+		if d.HasChange("automatic_backup_retention_days") {
+			input.LustreConfiguration.AutomaticBackupRetentionDays = aws.Int64(int64(d.Get("automatic_backup_retention_days").(int)))
+		}
 
-	if d.HasChange("daily_automatic_backup_start_time") {
-		input.LustreConfiguration.DailyAutomaticBackupStartTime = aws.String(d.Get("daily_automatic_backup_start_time").(string))
-		requestUpdate = true
-	}
+		if d.HasChange("daily_automatic_backup_start_time") {
+			input.LustreConfiguration.DailyAutomaticBackupStartTime = aws.String(d.Get("daily_automatic_backup_start_time").(string))
+		}
 
-	if d.HasChange("auto_import_policy") {
-		input.LustreConfiguration.AutoImportPolicy = aws.String(d.Get("auto_import_policy").(string))
-		requestUpdate = true
-	}
+		if d.HasChange("auto_import_policy") {
+			input.LustreConfiguration.AutoImportPolicy = aws.String(d.Get("auto_import_policy").(string))
+		}
 
-	if d.HasChange("storage_capacity") {
-		input.StorageCapacity = aws.Int64(int64(d.Get("storage_capacity").(int)))
-		requestUpdate = true
-	}
+		if d.HasChange("storage_capacity") {
+			input.StorageCapacity = aws.Int64(int64(d.Get("storage_capacity").(int)))
+		}
 
-	if requestUpdate {
+		if v, ok := d.GetOk("data_compression_type"); ok {
+			input.LustreConfiguration.DataCompressionType = aws.String(v.(string))
+		}
+
 		_, err := conn.UpdateFileSystem(input)
 		if err != nil {
 			return fmt.Errorf("error updating FSX Lustre File System (%s): %w", d.Id(), err)
@@ -397,10 +405,10 @@ func resourceAwsFsxLustreFileSystemRead(d *schema.ResourceData, meta interface{}
 	if lustreConfig.PerUnitStorageThroughput != nil {
 		d.Set("per_unit_storage_throughput", lustreConfig.PerUnitStorageThroughput)
 	}
-	d.Set("mount_name", filesystem.LustreConfiguration.MountName)
+	d.Set("mount_name", lustreConfig.MountName)
 	d.Set("storage_type", filesystem.StorageType)
-	if filesystem.LustreConfiguration.DriveCacheType != nil {
-		d.Set("drive_cache_type", filesystem.LustreConfiguration.DriveCacheType)
+	if lustreConfig.DriveCacheType != nil {
+		d.Set("drive_cache_type", lustreConfig.DriveCacheType)
 	}
 
 	if filesystem.KmsKeyId != nil {
@@ -433,7 +441,8 @@ func resourceAwsFsxLustreFileSystemRead(d *schema.ResourceData, meta interface{}
 	d.Set("weekly_maintenance_start_time", lustreConfig.WeeklyMaintenanceStartTime)
 	d.Set("automatic_backup_retention_days", lustreConfig.AutomaticBackupRetentionDays)
 	d.Set("daily_automatic_backup_start_time", lustreConfig.DailyAutomaticBackupStartTime)
-	d.Set("copy_tags_to_backups", filesystem.LustreConfiguration.CopyTagsToBackups)
+	d.Set("copy_tags_to_backups", lustreConfig.CopyTagsToBackups)
+	d.Set("data_compression_type", lustreConfig.DataCompressionType)
 
 	return nil
 }

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `daily_automatic_backup_start_time` - (Optional) A recurring daily time, in the format HH:MM. HH is the zero-padded hour of the day (0-23), and MM is the zero-padded minute of the hour. For example, 05:00 specifies 5 AM daily. only valid for `PERSISTENT_1` deployment_type. Requires `automatic_backup_retention_days` to be set.
 * `auto_import_policy` - (Optional) How Amazon FSx keeps your file and directory listings up to date as you add or modify objects in your linked S3 bucket. see [Auto Import Data Repo](https://docs.aws.amazon.com/fsx/latest/LustreGuide/autoimport-data-repo.html) for more details.
 * `copy_tags_to_backups` - (Optional) A boolean flag indicating whether tags for the file system should be copied to backups. Applicable for `PERSISTENT_1` deployment_type. The default value is false.
+* `data_compression_type` - (Optional) Sets the data compression configuration for the file system. Valid values are `LZ4` and `NONE`. Default value is `NONE`. Unsetting this value reverts the compression type back to `NONE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSFsxLustreFileSystem_dataCompression (826.21s)
```
