### PR TITLE
r/aws_batch_job_definition: Match equivalency of `null` and `[]` for `linuxParameters.devices` and `linuxParameters.tmpfs`

### DIFF
--- a/.changelog/19666.txt
+++ b/.changelog/19666.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Suppress differences for empty `linuxParameters.devices` and `linuxParameters.tmpfs` arrays in the `container_properties` argument
+```

--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -36,8 +36,34 @@ func (cp *containerProperties) Reduce() error {
 		}
 	}
 
+	if cp.LinuxParameters != nil {
+		if len(cp.LinuxParameters.Devices) == 0 {
+			cp.LinuxParameters.Devices = nil
+		}
+
+		for _, device := range cp.LinuxParameters.Devices {
+			if len(device.Permissions) == 0 {
+				device.Permissions = nil
+			}
+		}
+
+		if len(cp.LinuxParameters.Tmpfs) == 0 {
+			cp.LinuxParameters.Tmpfs = nil
+		}
+
+		for _, tmpfs := range cp.LinuxParameters.Tmpfs {
+			if len(tmpfs.MountOptions) == 0 {
+				tmpfs.MountOptions = nil
+			}
+		}
+	}
+
 	// Prevent difference of API response that adds an empty array when not configured during the request
 	if cp.LogConfiguration != nil {
+		if len(cp.LogConfiguration.Options) == 0 {
+			cp.LogConfiguration.Options = nil
+		}
+
 		if len(cp.LogConfiguration.SecretOptions) == 0 {
 			cp.LogConfiguration.SecretOptions = nil
 		}

--- a/aws/internal/service/batch/equivalency/container_properties_test.go
+++ b/aws/internal/service/batch/equivalency/container_properties_test.go
@@ -285,6 +285,89 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
+		{
+			Name: "empty linuxParameters.devices, linuxParameters.tmpfs, logConfiguration.options",
+			ApiJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"vcpus": 1,
+	"memory": 4096,
+	"jobRoleArn": "arn:aws:iam::123:role/role-test",
+	"environment": [{"name":"ENVIRONMENT","value":"test"}],
+    "linuxParameters": {
+		"devices": [],
+		"initProcessEnabled": true,
+		"tmpfs": []
+	},
+	"logConfiguration": {
+		"logDriver": "awslogs",
+		"options": {}
+	}
+}
+`,
+			ConfigurationJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"vcpus": 1,
+	"memory": 4096,
+	"jobRoleArn": "arn:aws:iam::123:role/role-test",
+	"environment": [{"name":"ENVIRONMENT","value":"test"}],
+    "linuxParameters": {
+		"initProcessEnabled": true
+	},
+	"logConfiguration": {
+		"logDriver": "awslogs"
+	}
+}
+`,
+			ExpectEquivalent: true,
+		},
+		{
+			Name: "empty linuxParameters.devices.permissions, linuxParameters.tmpfs.mountOptions",
+			ApiJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"vcpus": 1,
+	"memory": 4096,
+	"jobRoleArn": "arn:aws:iam::123:role/role-test",
+	"environment": [{"name":"ENVIRONMENT","value":"test"}],
+    "linuxParameters": {
+		"devices": [{
+			"containerPath": "/test",
+			"hostPath": "/tmp",
+			"permissions": []
+		}],
+		"initProcessEnabled": true,
+		"tmpfs": [{
+			"containerPath": "/tmp",
+			"mountOptions": [],
+			"size": 4096
+		}]
+	}
+}
+`,
+			ConfigurationJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"vcpus": 1,
+	"memory": 4096,
+	"jobRoleArn": "arn:aws:iam::123:role/role-test",
+	"environment": [{"name":"ENVIRONMENT","value":"test"}],
+    "linuxParameters": {
+		"devices": [{
+			"containerPath": "/test",
+			"hostPath": "/tmp"
+		}],
+		"initProcessEnabled": true,
+		"tmpfs": [{
+			"containerPath": "/tmp",
+			"size": 4096
+		}]
+	}
+}
+`,
+			ExpectEquivalent: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19624.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_ -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== CONT  TestAccAWSBatchJobDefinition_disappears
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (20.62s)
--- PASS: TestAccAWSBatchJobDefinition_disappears (21.13s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (22.43s)
--- PASS: TestAccAWSBatchJobDefinition_basic (22.54s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (22.84s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (23.58s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (23.64s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (34.60s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (38.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.262s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_ -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== CONT  TestAccAWSBatchJobDefinition_disappears
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (20.36s)
--- PASS: TestAccAWSBatchJobDefinition_basic (22.25s)
--- PASS: TestAccAWSBatchJobDefinition_disappears (22.47s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (26.80s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (27.56s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (27.81s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (31.80s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (35.52s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (50.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.190s
```