### PR TITLE
r/aws_cloudwatch_metric_alarm: Allow extended statistics in `metric.stat` argument

### DIFF
--- a/.changelog/19668.txt
+++ b/.changelog/19668.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_metric_alarm: Allow extended statistics in the `stat` argument of the `metric` configuration block
+```

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -99,9 +99,12 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 										Required: true,
 									},
 									"stat": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice(cloudwatch.Statistic_Values(), false),
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.Any(
+											validation.StringInSlice(cloudwatch.Statistic_Values(), false),
+											validation.StringMatch(regexp.MustCompile(`p(\d{1,2}(\.\d{0,2})?|100)`), "must specify a value between p0.0 and p100"),
+										),
 									},
 									"unit": {
 										Type:         schema.TypeString,

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -716,7 +716,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
       period      = "120"
-      stat        = "Average"
+      stat        = "p95.45"
       unit        = "Count"
 
       dimensions = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19665.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_'                  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchMetricAlarm_ -timeout 180m
=== RUN   TestAccAWSCloudWatchMetricAlarm_basic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_basic
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== RUN   TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== PAUSE TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== RUN   TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== PAUSE TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== RUN   TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== PAUSE TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== RUN   TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== RUN   TestAccAWSCloudWatchMetricAlarm_expression
=== PAUSE TestAccAWSCloudWatchMetricAlarm_expression
=== RUN   TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== RUN   TestAccAWSCloudWatchMetricAlarm_tags
=== PAUSE TestAccAWSCloudWatchMetricAlarm_tags
=== RUN   TestAccAWSCloudWatchMetricAlarm_disappears
=== PAUSE TestAccAWSCloudWatchMetricAlarm_disappears
=== CONT  TestAccAWSCloudWatchMetricAlarm_basic
=== CONT  TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_tags
=== CONT  TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== CONT  TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== CONT  TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== CONT  TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== CONT  TestAccAWSCloudWatchMetricAlarm_expression
=== CONT  TestAccAWSCloudWatchMetricAlarm_disappears
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (7.31s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_disappears (15.83s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (19.86s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (19.90s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (21.76s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (22.94s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (23.88s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (29.75s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (31.05s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_tags (45.69s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (70.02s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (171.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	174.685s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchMetricAlarm_ -timeout 180m
=== RUN   TestAccAWSCloudWatchMetricAlarm_basic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_basic
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== RUN   TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== PAUSE TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== RUN   TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== PAUSE TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== RUN   TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== PAUSE TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== RUN   TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== RUN   TestAccAWSCloudWatchMetricAlarm_expression
=== PAUSE TestAccAWSCloudWatchMetricAlarm_expression
=== RUN   TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== RUN   TestAccAWSCloudWatchMetricAlarm_tags
=== PAUSE TestAccAWSCloudWatchMetricAlarm_tags
=== RUN   TestAccAWSCloudWatchMetricAlarm_disappears
=== PAUSE TestAccAWSCloudWatchMetricAlarm_disappears
=== CONT  TestAccAWSCloudWatchMetricAlarm_basic
=== CONT  TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_tags
=== CONT  TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== CONT  TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== CONT  TestAccAWSCloudWatchMetricAlarm_expression
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== CONT  TestAccAWSCloudWatchMetricAlarm_disappears
=== CONT  TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (10.26s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_disappears (20.03s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (25.22s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (25.43s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (28.09s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (28.54s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (29.02s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (36.57s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (38.44s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_tags (55.17s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (83.10s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (168.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	171.318s
```
