### PR TITLE
sweeper/aws_elasticache_global_replication_group: Reduce run time during failures

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-SWEEP?=us-east-1,us-west-2
+SWEEP?=us-east-1,us-east-2,us-west-2
 TEST?=./...
 SWEEP_DIR?=./aws
 PKG_NAME=aws

--- a/aws/internal/service/elasticache/waiter/waiter.go
+++ b/aws/internal/service/elasticache/waiter/waiter.go
@@ -201,8 +201,11 @@ func GlobalReplicationGroupDeleted(conn *elasticache.ElastiCache, globalReplicat
 }
 
 const (
-	GlobalReplicationGroupDisassociationRetryTimeout = 45 * time.Minute
+	// GlobalReplicationGroupDisassociationReadyTimeout specifies how long to wait for a global replication group
+	// to be in a valid state before disassociating
+	GlobalReplicationGroupDisassociationReadyTimeout = 45 * time.Minute
 
+	// globalReplicationGroupDisassociationTimeout specifies how long to wait for the actual disassociation
 	globalReplicationGroupDisassociationTimeout = 20 * time.Minute
 
 	globalReplicationGroupDisassociationMinTimeout = 10 * time.Second

--- a/aws/resource_aws_elasticache_global_replication_group_test.go
+++ b/aws/resource_aws_elasticache_global_replication_group_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -26,6 +27,12 @@ func init() {
 	})
 }
 
+// These timeouts are lower to fail faster during sweepers
+const (
+	sweeperGlobalReplicationGroupDisassociationReadyTimeout = 10 * time.Minute
+	sweeperGlobalReplicationGroupDefaultUpdatedTimeout      = 10 * time.Minute
+)
+
 func testSweepElasticacheGlobalReplicationGroups(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
@@ -33,7 +40,7 @@ func testSweepElasticacheGlobalReplicationGroups(region string) error {
 	}
 	conn := client.(*AWSClient).elasticacheconn
 
-	var sweeperErrs *multierror.Error
+	var grgGroup multierror.Group
 
 	input := &elasticache.DescribeGlobalReplicationGroupsInput{
 		ShowMemberInfo: aws.Bool(true),
@@ -44,46 +51,72 @@ func testSweepElasticacheGlobalReplicationGroups(region string) error {
 		}
 
 		for _, globalReplicationGroup := range page.GlobalReplicationGroups {
-			id := aws.StringValue(globalReplicationGroup.GlobalReplicationGroupId)
+			globalReplicationGroup := globalReplicationGroup
 
-			for _, member := range globalReplicationGroup.Members {
-				if aws.StringValue(member.Role) == GlobalReplicationGroupMemberRolePrimary {
-					continue
-				}
+			grgGroup.Go(func() error {
+				id := aws.StringValue(globalReplicationGroup.GlobalReplicationGroupId)
 
-				if err := disassociateElasticacheReplicationGroup(conn, id, aws.StringValue(member.ReplicationGroupId), aws.StringValue(member.ReplicationGroupRegion)); err != nil {
-					sweeperErr := fmt.Errorf(
-						"error disassociating ElastiCache Replication Group (%s) in %s from Global Group (%s): %w",
-						aws.StringValue(member.ReplicationGroupId), aws.StringValue(member.ReplicationGroupRegion), id, err,
-					)
+				disassociationErrors := disassociateMembers(conn, globalReplicationGroup)
+				if disassociationErrors != nil {
+					sweeperErr := fmt.Errorf("failed to disassociate ElastiCache Global Replication Group (%s) members: %w", id, disassociationErrors)
 					log.Printf("[ERROR] %s", sweeperErr)
-					sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+					return sweeperErr
 				}
-			}
 
-			log.Printf("[INFO] Deleting ElastiCache Global Replication Group: %s", id)
-			err := deleteElasticacheGlobalReplicationGroup(conn, id)
-			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting ElastiCache Global Replication Group (%s): %w", id, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
-			}
+				log.Printf("[INFO] Deleting ElastiCache Global Replication Group: %s", id)
+				err := deleteElasticacheGlobalReplicationGroup(conn, id, sweeperGlobalReplicationGroupDefaultUpdatedTimeout)
+				if err != nil {
+					sweeperErr := fmt.Errorf("error deleting ElastiCache Global Replication Group (%s): %w", id, err)
+					log.Printf("[ERROR] %s", sweeperErr)
+					return sweeperErr
+				}
+				return nil
+			})
 		}
 
 		return !lastPage
 	})
 
+	grgErrs := grgGroup.Wait()
+
 	if testSweepSkipSweepError(err) {
 		log.Printf("[WARN] Skipping ElastiCache Global Replication Group sweep for %q: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		return grgErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 	}
 
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing ElastiCache Global Replication Groups: %w", err))
+		grgErrs = multierror.Append(grgErrs, fmt.Errorf("error listing ElastiCache Global Replication Groups: %w", err))
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return grgErrs.ErrorOrNil()
+}
+
+func disassociateMembers(conn *elasticache.ElastiCache, globalReplicationGroup *elasticache.GlobalReplicationGroup) error {
+	var membersGroup multierror.Group
+
+	for _, member := range globalReplicationGroup.Members {
+		member := member
+
+		if aws.StringValue(member.Role) == GlobalReplicationGroupMemberRolePrimary {
+			continue
+		}
+
+		id := aws.StringValue(globalReplicationGroup.GlobalReplicationGroupId)
+
+		membersGroup.Go(func() error {
+			if err := disassociateElasticacheReplicationGroup(conn, id, aws.StringValue(member.ReplicationGroupId), aws.StringValue(member.ReplicationGroupRegion), sweeperGlobalReplicationGroupDisassociationReadyTimeout); err != nil {
+				sweeperErr := fmt.Errorf(
+					"error disassociating ElastiCache Replication Group (%s) in %s from Global Group (%s): %w",
+					aws.StringValue(member.ReplicationGroupId), aws.StringValue(member.ReplicationGroupRegion), id, err,
+				)
+				log.Printf("[ERROR] %s", sweeperErr)
+				return sweeperErr
+			}
+			return nil
+		})
+	}
+
+	return membersGroup.Wait().ErrorOrNil()
 }
 
 func TestAccAWSElasticacheGlobalReplicationGroup_basic(t *testing.T) {


### PR DESCRIPTION
When problems occur during global replication group member disassociation, a single ElastiCache global replication group can cause the sweeper to run for hours.

This PR reduces the wait time for sweepers and adds concurrency to global replication group sweeper steps. It also addresses an issue with reading tags on the global replication group.

Adds `us-east-2` to default sweeper regions, since it's the default "third" acceptance testing region.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19438
Closes #18625

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSElasticacheGlobalReplicationGroup_'

--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_basic (954.30s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_disappears (1008.32s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_Description (1206.08s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_MultipleSecondaries (2957.05s)
--- PASS: TestAccAWSElasticacheGlobalReplicationGroup_ReplaceSecondary_DifferentRegion (3048.89s)
```

```console
$ make sweep SWEEPARGS="-sweep-run=aws_elasticache_replication_group"
2021/06/01 16:52:59 [DEBUG] Running Sweepers for region (us-east-1):
2021/06/01 16:52:59 [DEBUG] Sweeper (aws_elasticache_replication_group) has dependency (aws_elasticache_global_replication_group), running..
2021/06/01 16:52:59 [DEBUG] Running Sweeper (aws_elasticache_global_replication_group) in region (us-east-1)
2021/06/01 16:52:59 [INFO] Attempting to use session-derived credentials
2021/06/01 16:53:00 [INFO] Successfully derived credentials from session
2021/06/01 16:53:00 [INFO] AWS Auth provider used: "CredentialsEndpointProvider"
2021/06/01 16:53:00 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/01 16:53:00 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/01 16:53:02 [INFO] Deleting ElastiCache Global Replication Group: sgaui-gmdtest4
2021/06/01 16:53:02 [INFO] Deleting ElastiCache Global Replication Group: sgaui-gmdtest3
2021/06/01 16:53:02 [DEBUG] Waiting for state to become: [success]
2021/06/01 16:53:02 [DEBUG] Waiting for state to become: [success]
2021/06/01 16:53:03 [DEBUG] Waiting for state to become: []
2021/06/01 16:53:03 [DEBUG] Waiting for state to become: []
2021/06/01 16:53:33 [TRACE] Waiting 10s before next try
2021/06/01 16:53:33 [TRACE] Waiting 10s before next try
2021/06/01 16:53:44 [DEBUG] Running Sweeper (aws_elasticache_replication_group) in region (us-east-1)
2021/06/01 16:53:44 [DEBUG] Waiting for state to become: [success]
2021/06/01 16:53:44 [DEBUG] Waiting for state to become: [success]
2021/06/01 16:53:45 [DEBUG] Waiting for state to become: []
2021/06/01 16:53:45 [DEBUG] Waiting for state to become: []
2021/06/01 16:54:15 [TRACE] Waiting 10s before next try
2021/06/01 16:54:15 [TRACE] Waiting 10s before next try
...
2021/06/01 16:59:00 [TRACE] Waiting 10s before next try
2021/06/01 16:59:00 [TRACE] Waiting 10s before next try
2021/06/01 16:59:11 [DEBUG] Sweeper (aws_elasticache_global_replication_group) already ran in region (us-east-1)
2021/06/01 16:59:11 Sweeper Tests ran successfully:
	- aws_elasticache_global_replication_group
	- aws_elasticache_replication_group
2021/06/01 16:59:11 [DEBUG] Running Sweepers for region (us-east-2):
2021/06/01 16:59:11 [DEBUG] Sweeper (aws_elasticache_replication_group) has dependency (aws_elasticache_global_replication_group), running..
2021/06/01 16:59:11 [DEBUG] Running Sweeper (aws_elasticache_global_replication_group) in region (us-east-2)
2021/06/01 16:59:11 [INFO] Attempting to use session-derived credentials
2021/06/01 16:59:11 [INFO] Successfully derived credentials from session
2021/06/01 16:59:11 [INFO] AWS Auth provider used: "CredentialsEndpointProvider"
2021/06/01 16:59:11 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/01 16:59:11 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/01 16:59:13 [DEBUG] Running Sweeper (aws_elasticache_replication_group) in region (us-east-2)
2021/06/01 16:59:14 [DEBUG] Waiting for state to become: [success]
2021/06/01 16:59:14 [DEBUG] Waiting for state to become: []
2021/06/01 16:59:45 [TRACE] Waiting 10s before next try
...
2021/06/01 17:04:20 [TRACE] Waiting 10s before next try
2021/06/01 17:04:31 [DEBUG] Sweeper (aws_elasticache_global_replication_group) already ran in region (us-east-2)
2021/06/01 17:04:31 Sweeper Tests ran successfully:
	- aws_elasticache_global_replication_group
	- aws_elasticache_replication_group
2021/06/01 17:04:31 [DEBUG] Running Sweepers for region (us-west-2):
2021/06/01 17:04:31 [DEBUG] Sweeper (aws_elasticache_replication_group) has dependency (aws_elasticache_global_replication_group), running..
2021/06/01 17:04:31 [DEBUG] Running Sweeper (aws_elasticache_global_replication_group) in region (us-west-2)
2021/06/01 17:04:31 [INFO] Attempting to use session-derived credentials
2021/06/01 17:04:31 [INFO] Successfully derived credentials from session
2021/06/01 17:04:31 [INFO] AWS Auth provider used: "CredentialsEndpointProvider"
2021/06/01 17:04:31 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/01 17:04:31 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/01 17:04:33 [DEBUG] Running Sweeper (aws_elasticache_replication_group) in region (us-west-2)
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: [success]
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: [success]
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: [success]
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: [success]
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: []
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: []
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: []
2021/06/01 17:04:33 [DEBUG] Waiting for state to become: []
2021/06/01 17:05:04 [TRACE] Waiting 10s before next try
2021/06/01 17:05:04 [TRACE] Waiting 10s before next try
2021/06/01 17:05:04 [TRACE] Waiting 10s before next try
2021/06/01 17:05:04 [TRACE] Waiting 10s before next try
...
2021/06/01 17:10:45 [TRACE] Waiting 10s before next try
2021/06/01 17:10:46 [TRACE] Waiting 10s before next try
2021/06/01 17:10:56 [TRACE] Waiting 10s before next try
2021/06/01 17:10:57 [TRACE] Waiting 10s before next try
2021/06/01 17:11:07 [DEBUG] Sweeper (aws_elasticache_global_replication_group) already ran in region (us-west-2)
2021/06/01 17:11:07 Sweeper Tests ran successfully:
	- aws_elasticache_global_replication_group
	- aws_elasticache_replication_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1091.045s
```
