### PR TITLE
resource/aws_iot_topic_rule: Allow tags with '@' on creation

### DIFF
--- a/.changelog/19677.txt
+++ b/.changelog/19677.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_topic_rule: Allow tags containing `@` character
+```

--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -500,6 +500,30 @@ func (tags KeyValueTags) UrlEncode() string {
 	return values.Encode()
 }
 
+// UrlQueryString returns the KeyValueTags formatted as URL Query parameters without encoding.
+func (tags KeyValueTags) UrlQueryString() string {
+	keys := make([]string, 0, len(tags))
+	for k, v := range tags {
+		if v == nil || v.Value == nil {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, k := range keys {
+		if buf.Len() > 0 {
+			buf.WriteByte('&')
+		}
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		buf.WriteString(*tags[k].Value)
+	}
+
+	return buf.String()
+}
+
 // New creates KeyValueTags from common types or returns an empty KeyValueTags.
 //
 // Supports various Terraform Plugin SDK types including map[string]string,

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -2050,6 +2050,62 @@ func TestKeyValueTagsUrlEncode(t *testing.T) {
 	}
 }
 
+func TestKeyValueTagsUrlQueryString(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags KeyValueTags
+		want string
+	}{
+		{
+			name: "empty",
+			tags: New(map[string]string{}),
+			want: "",
+		},
+		{
+			name: "nil value",
+			tags: New(map[string]*string{
+				"key1": nil,
+			}),
+			want: "",
+		},
+		{
+			name: "single",
+			tags: New(map[string]string{
+				"key1": "value1",
+			}),
+			want: "key1=value1",
+		},
+		{
+			name: "multiple",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			want: "key1=value1&key2=value2&key3=value3",
+		},
+		{
+			name: "multiple_with_encoded",
+			tags: New(map[string]string{
+				"key1":  "value 1",
+				"key@2": "value+:2",
+				"key3":  "value3",
+			}),
+			want: "key1=value 1&key3=value3&key@2=value+:2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.tags.UrlQueryString()
+
+			if got != testCase.want {
+				t.Errorf("unexpected query string value: %q", got)
+			}
+		})
+	}
+}
+
 func TestNew(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -1090,7 +1090,7 @@ func resourceAwsIotTopicRuleCreate(d *schema.ResourceData, meta interface{}) err
 
 	input := &iot.CreateTopicRuleInput{
 		RuleName:         aws.String(ruleName),
-		Tags:             aws.String(tags.IgnoreAws().UrlEncode()),
+		Tags:             aws.String(tags.IgnoreAws().UrlQueryString()),
 		TopicRulePayload: expandIotTopicRulePayload(d),
 	}
 

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -528,11 +528,11 @@ func TestAccAWSIoTTopicRule_Tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSIoTTopicRuleTags1(rName, "key1", "value1"),
+				Config: testAccAWSIoTTopicRuleTags1(rName, "key1", "user@example"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIoTTopicRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "user@example"),
 				),
 			},
 			{
@@ -541,11 +541,11 @@ func TestAccAWSIoTTopicRule_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSIoTTopicRuleTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccAWSIoTTopicRuleTags2(rName, "key1", "user@example", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIoTTopicRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "user@example"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -677,7 +677,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -690,7 +690,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj2, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "B@BB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "X X"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key4", "DDD"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key5", "E:/"),
@@ -714,7 +714,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj4, &obj3),
 					testAccCheckAWSS3BucketObjectBody(&obj4, "changed stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -742,7 +742,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSingleSlash(t *testing.T) {
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -755,7 +755,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSingleSlash(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj2, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "B@BB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "X X"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key4", "DDD"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key5", "E:/"),
@@ -779,7 +779,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSingleSlash(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj4, &obj3),
 					testAccCheckAWSS3BucketObjectBody(&obj4, "changed stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -807,7 +807,7 @@ func TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes(t *testing.T) {
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -820,7 +820,7 @@ func TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj2, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "B@BB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "X X"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key4", "DDD"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key5", "E:/"),
@@ -844,7 +844,7 @@ func TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj4, &obj3),
 					testAccCheckAWSS3BucketObjectBody(&obj4, "changed stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -872,7 +872,7 @@ func TestAccAWSS3BucketObject_tagsMultipleSlashes(t *testing.T) {
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -885,7 +885,7 @@ func TestAccAWSS3BucketObject_tagsMultipleSlashes(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj2, "stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "B@BB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "X X"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key4", "DDD"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key5", "E:/"),
@@ -909,7 +909,7 @@ func TestAccAWSS3BucketObject_tagsMultipleSlashes(t *testing.T) {
 					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj4, &obj3),
 					testAccCheckAWSS3BucketObjectBody(&obj4, "changed stuff"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "A@AA"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
@@ -1707,7 +1707,7 @@ resource "aws_s3_bucket_object" "object" {
   content = %[3]q
 
   tags = {
-    Key1 = "AAA"
+    Key1 = "A@AA"
     Key2 = "BBB"
     Key3 = "CCC"
   }
@@ -1731,7 +1731,7 @@ resource "aws_s3_bucket_object" "object" {
   content = %[3]q
 
   tags = {
-    Key2 = "BBB"
+    Key2 = "B@BB"
     Key3 = "X X"
     Key4 = "DDD"
     Key5 = "E:/"


### PR DESCRIPTION
Tags with `@` are valid for IoT topic rules, but they were not accepted at creation time. The AWS API handles its own URL encoding for this call, while we were handling it.

Also validates S3 bucket object tags with `@` which were using the same URL encoding call.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19653

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSIoTTopicRule_Tags\|TestAccAWSS3BucketObject_tags'

--- PASS: TestAccAWSIoTTopicRule_Tags (257.21s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSingleSlash (320.11s)
--- PASS: TestAccAWSS3BucketObject_tagsMultipleSlashes (324.51s)
--- PASS: TestAccAWSS3BucketObject_tags (326.24s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingMultipleSlashes (326.33s)
```

```console
$ make test TEST=./aws/internal/keyvaluetags

ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.617s
```
