### PR TITLE
rd/transfer_server - add support for `domain`

### DIFF
--- a/.changelog/19691.txt
+++ b/.changelog/19691.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_transfer_server: Add `domain` argument.
+```
+
+```release-note:enhancement
+data-source/aws_transfer_server: Add `domain` attribute.
+```

--- a/aws/data_source_aws_transfer_server.go
+++ b/aws/data_source_aws_transfer_server.go
@@ -20,6 +20,10 @@ func dataSourceAwsTransferServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -88,6 +92,7 @@ func dataSourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(aws.StringValue(output.ServerId))
 	d.Set("arn", output.Arn)
 	d.Set("certificate", output.Certificate)
+	d.Set("domain", output.Domain)
 	d.Set("endpoint", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.server.transfer", serverID)))
 	d.Set("endpoint_type", output.EndpointType)
 	d.Set("identity_provider_type", output.IdentityProviderType)

--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -22,6 +22,7 @@ func TestAccDataSourceAwsTransferServer_basic(t *testing.T) {
 				Config: testAccDataSourceAwsTransferServerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain", resourceName, "domain"),
 					resource.TestCheckResourceAttrPair(datasourceName, "endpoint", resourceName, "endpoint"),
 					resource.TestCheckResourceAttrPair(datasourceName, "identity_provider_type", resourceName, "identity_provider_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "logging_role", resourceName, "logging_role"),

--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -40,6 +40,13 @@ func resourceAwsTransferServer() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validateArn,
 			},
+			"domain": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      transfer.DomainS3,
+				ValidateFunc: validation.StringInSlice(transfer.Domain_Values(), false),
+			},
 
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -175,6 +182,10 @@ func resourceAwsTransferServerCreate(d *schema.ResourceData, meta interface{}) e
 		input.Certificate = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("domain"); ok {
+		input.Domain = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("endpoint_details"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.EndpointDetails = expandTransferEndpointDetails(v.([]interface{})[0].(map[string]interface{}))
 
@@ -286,6 +297,7 @@ func resourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("arn", output.Arn)
 	d.Set("certificate", output.Certificate)
+	d.Set("domain", output.Domain)
 	d.Set("endpoint", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.server.transfer", d.Id())))
 	if output.EndpointDetails != nil {
 		if err := d.Set("endpoint_details", []interface{}{flattenTransferEndpointDetails(output.EndpointDetails)}); err != nil {

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -121,6 +121,7 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`server/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "certificate", ""),
+					resource.TestCheckResourceAttr(resourceName, "domain", "S3"),
 					testAccMatchResourceAttrRegionalHostname(resourceName, "endpoint", "server.transfer", regexp.MustCompile(`s-[a-z0-9]+`)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_details.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "PUBLIC"),
@@ -136,6 +137,33 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "url", ""),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSTransferServer_domain(t *testing.T) {
+	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferServerDomainConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "domain", "EFS"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -676,6 +704,14 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSTransferServerBasicConfig() string {
 	return `
 resource "aws_transfer_server" "test" {}
+`
+}
+
+func testAccAWSTransferServerDomainConfig() string {
+	return `
+resource "aws_transfer_server" "test" {
+  domain = "EFS"
+}
 `
 }
 

--- a/website/docs/d/transfer_server.html.markdown
+++ b/website/docs/d/transfer_server.html.markdown
@@ -27,6 +27,7 @@ data "aws_transfer_server" "example" {
 
 * `arn` - Amazon Resource Name (ARN) of Transfer Server.
 * `certificate` - The ARN of any certificate.
+* `domain` -  The domain of the storage system that is used for file transfers.
 * `endpoint` - The endpoint of the Transfer Server (e.g. `s-12345678.server.transfer.REGION.amazonaws.com`).
 * `endpoint_type` - The type of endpoint that the server is connected to.
 * `identity_provider_type` - The mode of authentication enabled for this service. The default value is `SERVICE_MANAGED`, which allows you to store and access SFTP user credentials within the service. `API_GATEWAY` indicates that user authentication requires a call to an API Gateway endpoint URL provided by you to integrate an identity provider of your choice.

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -86,6 +86,7 @@ resource "aws_transfer_server" "example" {
 The following arguments are supported:
 
 * `certificate` - (Optional) The Amazon Resource Name (ARN) of the AWS Certificate Manager (ACM) certificate. This is required when `protocols` is set to `FTPS`
+* `domain` - (Optional) The domain of the storage system that is used for file transfers. Valid values are: `S3` and `EFS`. The default value is `S3`.
 * `protocols` - (Optional) Specifies the file transfer protocol or protocols over which your file transfer protocol client can connect to your server's endpoint. This defaults to `SFTP` . The available protocols are:
     * `SFTP`: File transfer over SSH
     * `FTPS`: File transfer with TLS encryption


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17022

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSTransferServer_vpcEndpointId (148.42s)
--- PASS: TestAccAWSTransferServer_forceDestroy (188.83s)
--- PASS: TestAccAWSTransferServer_hostKey (216.91s)
--- PASS: TestAccAWSTransferServer_domain (219.98s)
--- PASS: TestAccAWSTransferServer_apiGateway (227.95s)
--- PASS: TestAccAWSTransferServer_securityPolicy (231.31s)
--- PASS: TestAccAWSTransferServer_disappears (233.67s)
--- PASS: TestAccAWSTransferServer_basic (238.02s)
--- PASS: TestAccAWSTransferServer_vpc (290.41s)
--- PASS: TestAccAWSTransferServer_protocols (384.76s)


--- PASS: TestAccDataSourceAwsTransferServer_service_managed (214.97s)
--- PASS: TestAccDataSourceAwsTransferServer_basic (219.49s)
--- PASS: TestAccDataSourceAwsTransferServer_apigateway (233.32s)
```
