### PR TITLE
Accept multiple IP addresses in the same subnet for aws_route53_resolver_endpoint

### DIFF
--- a/.changelog/19692.txt
+++ b/.changelog/19692.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_resolver_endpoint: Accept multiple ip_address blocks with the same `subnet_id` when `ip` is specified
+```

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -346,6 +346,6 @@ func route53ResolverEndpointWaitUntilTargetState(conn *route53resolver.Route53Re
 func route53ResolverEndpointHashIpAddress(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-%s-", m["subnet_id"].(string), m["ip"].(string)))
 	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -326,11 +326,13 @@ resource "aws_route53_resolver_endpoint" "foo" {
   ]
 
   ip_address {
-    subnet_id = aws_subnet.sn1.id
+    subnet_id = aws_subnet.sn3.id
+    ip        = cidrhost(aws_subnet.sn3.cidr_block, 53)
   }
 
   ip_address {
     subnet_id = aws_subnet.sn3.id
+    ip        = cidrhost(aws_subnet.sn3.cidr_block, 54)
   }
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9626

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53ResolverEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53ResolverEndpoint_ -timeout 180m
=== RUN   TestAccAWSRoute53ResolverEndpoint_basicInbound
=== PAUSE TestAccAWSRoute53ResolverEndpoint_basicInbound
=== RUN   TestAccAWSRoute53ResolverEndpoint_updateOutbound
=== PAUSE TestAccAWSRoute53ResolverEndpoint_updateOutbound
=== CONT  TestAccAWSRoute53ResolverEndpoint_basicInbound
=== CONT  TestAccAWSRoute53ResolverEndpoint_updateOutbound
--- PASS: TestAccAWSRoute53ResolverEndpoint_basicInbound (116.71s)
--- PASS: TestAccAWSRoute53ResolverEndpoint_updateOutbound (569.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	569.654s
```

I'm aware of the original discussion when this resource was introduced regarding the hash function. Please correct if I'm wrong or provide some guidance on how to address this issue, but it seems like this change at least _partially_ addresses the issue of assigning multiple IP addresses per subnet, without breaking existing functionality:
* If multiple `ip_address {}` blocks are defined with the same `subnet_id`, but no `ip` specified directly (e.g. IP address is computed), then there will still be a clash. This is the same as the existing behaviour.
* If multiple `ip_address {}` blocks are defined with the same `subnet_id`, but `ip` _is specified_ for each block, then the resource will be created/updated as specified, with multiple IP addresses in the same subnet.
