### PR TITLE
r/transfer_user - add support for `posix_profile`

### DIFF
--- a/.changelog/19693.txt
+++ b/.changelog/19693.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_transfer_user: Add `posix_profile` argument.
+```

--- a/aws/internal/service/transfer/finder/finder.go
+++ b/aws/internal/service/transfer/finder/finder.go
@@ -34,3 +34,32 @@ func ServerByID(conn *transfer.Transfer, id string) (*transfer.DescribedServer, 
 
 	return output.Server, nil
 }
+
+func UserByID(conn *transfer.Transfer, serverId, userName string) (*transfer.DescribeUserOutput, error) {
+	input := &transfer.DescribeUserInput{
+		ServerId: aws.String(serverId),
+		UserName: aws.String(userName),
+	}
+
+	output, err := conn.DescribeUser(input)
+
+	if tfawserr.ErrCodeEquals(err, transfer.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.User == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/transfer/waiter/status.go
+++ b/aws/internal/service/transfer/waiter/status.go
@@ -23,3 +23,19 @@ func ServerState(conn *transfer.Transfer, id string) resource.StateRefreshFunc {
 		return output, aws.StringValue(output.State), nil
 	}
 }
+
+func UserState(conn *transfer.Transfer, serverId, userName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.UserByID(conn, serverId, userName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, "Available", nil
+	}
+}

--- a/aws/internal/service/transfer/waiter/waiter.go
+++ b/aws/internal/service/transfer/waiter/waiter.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	ServerDeletedTimeout = 10 * time.Minute
+	UserDeletedTimeout   = 10 * time.Minute
 )
 
 func ServerCreated(conn *transfer.Transfer, id string, timeout time.Duration) (*transfer.DescribedServer, error) {
@@ -73,6 +74,23 @@ func ServerStopped(conn *transfer.Transfer, id string, timeout time.Duration) (*
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*transfer.DescribedServer); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func UserDeleted(conn *transfer.Transfer, serverId, userName string) (*transfer.DescribedUser, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Available"},
+		Target:  []string{},
+		Refresh: UserState(conn, serverId, userName),
+		Timeout: UserDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*transfer.DescribedUser); ok {
 		return output, err
 	}
 

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -5,16 +5,17 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/transfer/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func TestAccAWSTransferUser_basic(t *testing.T) {
 	var conf transfer.DescribedUser
-	resourceName := "aws_transfer_user.foo"
+	resourceName := "aws_transfer_user.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -28,10 +29,9 @@ func TestAccAWSTransferUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferUserExists(resourceName, &conf),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`user/.+`)),
-					resource.TestCheckResourceAttrPair(
-						resourceName, "server_id", "aws_transfer_server.foo", "id"),
-					resource.TestCheckResourceAttrPair(
-						resourceName, "role", "aws_iam_role.foo", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_id", "aws_transfer_server.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.#", "0"),
 				),
 			},
 			{
@@ -43,9 +43,48 @@ func TestAccAWSTransferUser_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSTransferUser_posix(t *testing.T) {
+	var conf transfer.DescribedUser
+	resourceName := "aws_transfer_user.test"
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		ErrorCheck:   testAccErrorCheck(t, transfer.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferUserConfigPosix(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.0.gid", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.0.uid", "1000"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSTransferUserConfigPosixUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.0.gid", "1001"),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.0.uid", "1001"),
+					resource.TestCheckResourceAttr(resourceName, "posix_profile.0.secondary_gids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSTransferUser_modifyWithOptions(t *testing.T) {
 	var conf transfer.DescribedUser
-	resourceName := "aws_transfer_user.foo"
+	resourceName := "aws_transfer_user.test"
 	rName := acctest.RandString(10)
 	rName2 := acctest.RandString(10)
 
@@ -59,44 +98,31 @@ func TestAccAWSTransferUser_modifyWithOptions(t *testing.T) {
 				Config: testAccAWSTransferUserConfig_options(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferUserExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "home_directory", "/home/tftestuser"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.NAME", "tftestuser"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.ENV", "test"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.ADMIN", "test"),
+					resource.TestCheckResourceAttr(resourceName, "home_directory", "/home/tftestuser"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.NAME", "tftestuser"),
+					resource.TestCheckResourceAttr(resourceName, "tags.ENV", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.ADMIN", "test"),
 				),
 			},
 			{
 				Config: testAccAWSTransferUserConfig_modify(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferUserExists(resourceName, &conf),
-					resource.TestCheckResourceAttrPair(
-						resourceName, "role", "aws_iam_role.foo", "arn"),
-					resource.TestCheckResourceAttr(
-						resourceName, "home_directory", "/test"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.NAME", "tf-test-user"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.TEST", "test2"),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "home_directory", "/test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.NAME", "tf-test-user"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TEST", "test2"),
 				),
 			},
 			{
 				Config: testAccAWSTransferUserConfig_forceNew(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferUserExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(
-						resourceName, "user_name", "tftestuser2"),
-					resource.TestCheckResourceAttrPair(
-						resourceName, "role", "aws_iam_role.foo", "arn"),
-					resource.TestCheckResourceAttr(
-						resourceName, "home_directory", "/home/tftestuser2"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "tftestuser2"),
+					resource.TestCheckResourceAttrPair(resourceName, "role", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "home_directory", "/home/tftestuser2"),
 				),
 			},
 		},
@@ -107,6 +133,7 @@ func TestAccAWSTransferUser_disappears(t *testing.T) {
 	var serverConf transfer.DescribedServer
 	var userConf transfer.DescribedUser
 	rName := acctest.RandString(10)
+	resourceName := "aws_transfer_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -117,9 +144,9 @@ func TestAccAWSTransferUser_disappears(t *testing.T) {
 			{
 				Config: testAccAWSTransferUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &serverConf),
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &userConf),
-					testAccCheckAWSTransferUserDisappears(&serverConf, &userConf),
+					testAccCheckAWSTransferServerExists("aws_transfer_server.test", &serverConf),
+					testAccCheckAWSTransferUserExists("aws_transfer_user.test", &userConf),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsTransferUser(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -167,7 +194,7 @@ func TestAccAWSTransferUser_UserName_Validation(t *testing.T) {
 func TestAccAWSTransferUser_homeDirectoryMappings(t *testing.T) {
 	var conf transfer.DescribedUser
 	rName := acctest.RandString(10)
-	resourceName := "aws_transfer_user.foo"
+	resourceName := "aws_transfer_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -213,11 +240,7 @@ func testAccCheckAWSTransferUserExists(n string, res *transfer.DescribedUser) re
 		userName := rs.Primary.Attributes["user_name"]
 		serverID := rs.Primary.Attributes["server_id"]
 
-		describe, err := conn.DescribeUser(&transfer.DescribeUserInput{
-			ServerId: aws.String(serverID),
-			UserName: aws.String(userName),
-		})
-
+		describe, err := finder.UserByID(conn, serverID, userName)
 		if err != nil {
 			return err
 		}
@@ -225,24 +248,6 @@ func testAccCheckAWSTransferUserExists(n string, res *transfer.DescribedUser) re
 		*res = *describe.User
 
 		return nil
-	}
-}
-
-func testAccCheckAWSTransferUserDisappears(serverConf *transfer.DescribedServer, userConf *transfer.DescribedUser) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).transferconn
-
-		params := &transfer.DeleteUserInput{
-			ServerId: serverConf.ServerId,
-			UserName: userConf.UserName,
-		}
-
-		_, err := conn.DeleteUser(params)
-		if err != nil {
-			return err
-		}
-
-		return waitForTransferUserDeletion(conn, *serverConf.ServerId, *userConf.UserName)
 	}
 }
 
@@ -257,12 +262,8 @@ func testAccCheckAWSTransferUserDestroy(s *terraform.State) error {
 		userName := rs.Primary.Attributes["user_name"]
 		serverID := rs.Primary.Attributes["server_id"]
 
-		_, err := conn.DescribeUser(&transfer.DescribeUserInput{
-			UserName: aws.String(userName),
-			ServerId: aws.String(serverID),
-		})
-
-		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+		_, err := finder.UserByID(conn, serverID, userName)
+		if tfresource.NotFound(err) {
 			continue
 		}
 
@@ -275,7 +276,7 @@ func testAccCheckAWSTransferUserDestroy(s *terraform.State) error {
 }
 
 const testAccAWSTransferUserConfig_base = `
-resource "aws_transfer_server" "foo" {
+resource "aws_transfer_server" "test" {
   identity_provider_type = "SERVICE_MANAGED"
 
   tags = {
@@ -288,7 +289,7 @@ data "aws_partition" "current" {}
 
 func testAccAWSTransferUserConfig_basic(rName string) string {
 	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
@@ -307,9 +308,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -328,23 +329,23 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-resource "aws_transfer_user" "foo" {
-  server_id = aws_transfer_server.foo.id
+resource "aws_transfer_user" "test" {
+  server_id = aws_transfer_server.test.id
   user_name = "tftestuser"
-  role      = aws_iam_role.foo.arn
+  role      = aws_iam_role.test.arn
 }
 `, rName))
 }
 
 func testAccAWSTransferUserName_validation(rName string) string {
 	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
-resource "aws_transfer_user" "foo" {
-  server_id = aws_transfer_server.foo.id
+resource "aws_transfer_user" "test" {
+  server_id = aws_transfer_server.test.id
   user_name = "%s"
-  role      = aws_iam_role.foo.arn
+  role      = aws_iam_role.test.arn
 }
 
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role"
 
   assume_role_policy = <<EOF
@@ -367,7 +368,7 @@ EOF
 
 func testAccAWSTransferUserConfig_options(rName string) string {
 	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
@@ -386,9 +387,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -407,7 +408,7 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-data "aws_iam_policy_document" "foo" {
+data "aws_iam_policy_document" "test" {
   statement {
     sid = "ListHomeDir"
 
@@ -450,11 +451,11 @@ data "aws_iam_policy_document" "foo" {
   }
 }
 
-resource "aws_transfer_user" "foo" {
-  server_id      = aws_transfer_server.foo.id
+resource "aws_transfer_user" "test" {
+  server_id      = aws_transfer_server.test.id
   user_name      = "tftestuser"
-  role           = aws_iam_role.foo.arn
-  policy         = data.aws_iam_policy_document.foo.json
+  role           = aws_iam_role.test.arn
+  policy         = data.aws_iam_policy_document.test.json
   home_directory = "/home/tftestuser"
 
   tags = {
@@ -468,7 +469,7 @@ resource "aws_transfer_user" "foo" {
 
 func testAccAWSTransferUserConfig_modify(rName string) string {
 	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
@@ -487,9 +488,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -508,7 +509,7 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-data "aws_iam_policy_document" "foo" {
+data "aws_iam_policy_document" "test" {
   statement {
     sid = "ListHomeDir"
 
@@ -549,11 +550,11 @@ data "aws_iam_policy_document" "foo" {
   }
 }
 
-resource "aws_transfer_user" "foo" {
-  server_id      = aws_transfer_server.foo.id
+resource "aws_transfer_user" "test" {
+  server_id      = aws_transfer_server.test.id
   user_name      = "tftestuser"
-  role           = aws_iam_role.foo.arn
-  policy         = data.aws_iam_policy_document.foo.json
+  role           = aws_iam_role.test.arn
+  policy         = data.aws_iam_policy_document.test.json
   home_directory = "/test"
 
   tags = {
@@ -566,7 +567,7 @@ resource "aws_transfer_user" "foo" {
 
 func testAccAWSTransferUserConfig_forceNew(rName string) string {
 	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
@@ -585,9 +586,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -606,7 +607,7 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-data "aws_iam_policy_document" "foo" {
+data "aws_iam_policy_document" "test" {
   statement {
     sid = "ListHomeDir"
 
@@ -649,11 +650,11 @@ data "aws_iam_policy_document" "foo" {
   }
 }
 
-resource "aws_transfer_user" "foo" {
-  server_id      = aws_transfer_server.foo.id
+resource "aws_transfer_user" "test" {
+  server_id      = aws_transfer_server.test.id
   user_name      = "tftestuser2"
-  role           = aws_iam_role.foo.arn
-  policy         = data.aws_iam_policy_document.foo.json
+  role           = aws_iam_role.test.arn
+  policy         = data.aws_iam_policy_document.test.json
   home_directory = "/home/tftestuser2"
 
   tags = {
@@ -668,7 +669,7 @@ func testAccAWSTransferUserConfig_homeDirectoryMappings(rName string) string {
 	return composeConfig(
 		testAccAWSTransferUserConfig_base,
 		fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
@@ -687,9 +688,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -708,10 +709,10 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-resource "aws_transfer_user" "foo" {
+resource "aws_transfer_user" "test" {
   home_directory_type = "LOGICAL"
-  role                = aws_iam_role.foo.arn
-  server_id           = aws_transfer_server.foo.id
+  role                = aws_iam_role.test.arn
+  server_id           = aws_transfer_server.test.id
   user_name           = "tftestuser"
 
   home_directory_mappings {
@@ -726,7 +727,7 @@ func testAccAWSTransferUserConfig_homeDirectoryMappingsUpdate(rName string) stri
 	return composeConfig(
 		testAccAWSTransferUserConfig_base,
 		fmt.Sprintf(`
-resource "aws_iam_role" "foo" {
+resource "aws_iam_role" "test" {
   name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
@@ -745,9 +746,9 @@ resource "aws_iam_role" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-user-iam-policy-%[1]s"
-  role = aws_iam_role.foo.id
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
@@ -766,10 +767,10 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-resource "aws_transfer_user" "foo" {
+resource "aws_transfer_user" "test" {
   home_directory_type = "LOGICAL"
-  role                = aws_iam_role.foo.arn
-  server_id           = aws_transfer_server.foo.id
+  role                = aws_iam_role.test.arn
+  server_id           = aws_transfer_server.test.id
   user_name           = "tftestuser"
 
   home_directory_mappings {
@@ -783,4 +784,127 @@ resource "aws_transfer_user" "foo" {
   }
 }
 `, rName))
+}
+
+func testAccAWSTransferUserConfigPosix(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_transfer_server" "test" {
+  domain = "EFS"
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = "tf-test-transfer-user-iam-role-%[1]s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
+  role = aws_iam_role.test.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowFullAccesstoS3",
+      "Effect": "Allow",
+      "Action": [
+        "efs:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_transfer_user" "test" {
+  server_id = aws_transfer_server.test.id
+  user_name = "tftestuser"
+  role      = aws_iam_role.test.arn
+
+  posix_profile {
+    gid = 1000
+    uid = 1000
+  }
+}
+`, rName)
+}
+
+func testAccAWSTransferUserConfigPosixUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_transfer_server" "test" {
+  domain = "EFS"
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = "tf-test-transfer-user-iam-role-%[1]s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
+  role = aws_iam_role.test.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowFullAccesstoS3",
+      "Effect": "Allow",
+      "Action": [
+        "efs:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_transfer_user" "test" {
+  server_id = aws_transfer_server.test.id
+  user_name = "tftestuser"
+  role      = aws_iam_role.test.arn
+
+  posix_profile {
+    gid            = 1001
+    uid            = 1001
+    secondary_gids = [1000, 1002]
+  }
+}
+`, rName)
 }

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -78,19 +78,27 @@ resource "aws_transfer_user" "foo" {
 
 The following arguments are supported:
 
-* `server_id` - (Requirement) The Server ID of the Transfer Server (e.g. `s-12345678`)
-* `user_name` - (Requirement) The name used for log in to your SFTP server.
+* `server_id` - (Required) The Server ID of the Transfer Server (e.g. `s-12345678`)
+* `user_name` - (Required) The name used for log in to your SFTP server.
 * `home_directory` - (Optional) The landing directory (folder) for a user when they log in to the server using their SFTP client.  It should begin with a `/`.  The first item in the path is the name of the home bucket (accessible as `${Transfer:HomeBucket}` in the policy) and the rest is the home directory (accessible as `${Transfer:HomeDirectory}` in the policy). For example, `/example-bucket-1234/username` would set the home bucket to `example-bucket-1234` and the home directory to `username`.
-* `home_directory_mappings` - (Optional) Logical directory mappings that specify what S3 paths and keys should be visible to your user and how you want to make them visible. documented below.
+* `home_directory_mappings` - (Optional) Logical directory mappings that specify what S3 paths and keys should be visible to your user and how you want to make them visible. See [Home Directory Mappings](#home-directory-mappings) below.
 * `home_directory_type` - (Optional) The type of landing directory (folder) you mapped for your users' home directory. Valid values are `PATH` and `LOGICAL`.
 * `policy` - (Optional) An IAM JSON policy document that scopes down user access to portions of their Amazon S3 bucket. IAM variables you can use inside this policy include `${Transfer:UserName}`, `${Transfer:HomeDirectory}`, and `${Transfer:HomeBucket}`. Since the IAM variable syntax matches Terraform's interpolation syntax, they must be escaped inside Terraform configuration strings (`$${Transfer:UserName}`).  These are evaluated on-the-fly when navigating the bucket.
-* `role` - (Requirement) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
+* `posix_profile` - (Optional) Specifies the full POSIX identity, including user ID (Uid), group ID (Gid), and any secondary groups IDs (SecondaryGids), that controls your users' access to your Amazon EFS file systems. See [Posix Profile](#posix-profile) below.
+* `role` - (Required) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-Home Directory Mappings (`home_directory_mappings`) support the following:
 
-* `entry` - (Requirement) Represents an entry and a target.
-* `target` - (Requirement) Represents the map target.
+### Home Directory Mappings
+
+* `entry` - (Required) Represents an entry and a target.
+* `target` - (Required) Represents the map target.
+
+### Posix Profile
+
+* `gid` - (Required) The POSIX group ID used for all EFS operations by this user.
+* `uid` - (Required) The POSIX user ID used for all EFS operations by this user.
+* `secondary_gids` - (Optional) The secondary POSIX group IDs used for all EFS operations by this user.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17022
Depends On #19691

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSTransferUser_'
--- PASS: TestAccAWSTransferUser_UserName_Validation (31.73s)
--- PASS: TestAccAWSTransferUser_homeDirectoryMappings (214.30s)
--- PASS: TestAccAWSTransferUser_basic (218.56s)
--- PASS: TestAccAWSTransferUser_disappears (224.98s)
--- PASS: TestAccAWSTransferUser_posix (247.17s)
--- PASS: TestAccAWSTransferUser_modifyWithOptions (536.80s)
```
