### PR TITLE
r/ecs_task_definition - add support for `ephemeral_storage`

### DIFF
--- a/.changelog/19694.txt
+++ b/.changelog/19694.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_task_definition: Add support for `ephemeral_storage`.
+```

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -217,6 +217,7 @@ The following arguments are optional:
 * `pid_mode` - (Optional) Process namespace to use for the containers in the task. The valid values are `host` and `task`.
 * `placement_constraints` - (Optional) Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. [Detailed below](#placement_constraints).
 * `proxy_configuration` - (Optional) Configuration block for the App Mesh proxy. [Detailed below.](#proxy_configuration)
+* `ephemeral_storage` - (Optional)  The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See [Ephemeral Storage](#ephemeral_storage).
 * `requires_compatibilities` - (Optional) Set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `task_role_arn` - (Optional) ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
@@ -279,6 +280,10 @@ For more information, see [Specifying an FSX Windows File Server volume in your 
 * `container_name` - (Required) Name of the container that will serve as the App Mesh proxy.
 * `properties` - (Required) Set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified a key-value mapping.
 * `type` - (Optional) Proxy type. The default value is `APPMESH`. The only supported value is `APPMESH`.
+
+### ephemeral_storage
+
+* `size_in_gib` - (Required) The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is `21` GiB and the maximum supported value is `200` GiB.
 
 ### inference_accelerator
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19263

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsTaskDefinition_'
--- PASS: TestAccAWSEcsTaskDefinition_inferenceAccelerator (46.57s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (47.72s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (48.44s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (49.30s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (49.50s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (51.57s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (51.63s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (54.37s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (55.97s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (57.77s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (58.96s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (59.01s)
--- PASS: TestAccAWSEcsTaskDefinition_withTransitEncryptionEFSVolume (63.87s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (65.66s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (66.31s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSAccessPoint (67.72s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (76.83s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (78.45s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate_ephemeralStorage (32.64s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (43.40s)
--- PASS: TestAccAWSEcsTaskDefinition_disappears (47.69s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (46.31s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (104.37s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (148.39s)
```
