### PR TITLE
Migrate from GitHub HashiBot release_commenter behavior to GitHub Actions

### DIFF
--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -1,0 +1,20 @@
+name: Closed Milestones
+
+on:
+  milestone:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  Comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bflad/action-milestone-comment@v1
+        with:
+          body: |
+            This functionality has been released in [${{ github.event.milestone.title }} of the Terraform AWS Provider](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).  Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
+
+            For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,13 +1,3 @@
-queued_behavior "release_commenter" "releases" {
-  repo_prefix = "terraform-provider-"
-
-  message = <<-EOF
-    This has been released in [version ${var.release_version} of the Terraform AWS provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
-
-    For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/hashicorp/terraform-provider-aws/issues/new/choose) following the template for triage. Thanks!
-  EOF
-}
-
 behavior "pull_request_size_labeler" "size" {
     label_prefix = "size/"
     label_map = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
This action handles transient error, rate limit, and abuse limit retries automatically.

Output from acceptance testing: N/A (repository automation configuration)
