### PR TITLE
r/aws_autoscaling_policy predictive_scaling_configuration requires resource_label to be defined

### DIFF
--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -183,21 +183,21 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `predefined_metric_type` - (Required) The metric type. Valid values are `ASGTotalCPUUtilization`, `ASGTotalNetworkIn`, `ASGTotalNetworkOut`, or `ALBTargetGroupRequestCount`.
-* `resource_label` - (Optional) A label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group.
+* `resource_label` - (Required) A label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group.
 
 ##### predefined_metric_pair_specification
 
 The following arguments are supported:
 
 * `predefined_metric_type` - (Required) Indicates which metrics to use. There are two different types of metrics for each metric type: one is a load metric and one is a scaling metric. For example, if the metric type is `ASGCPUUtilization`, the Auto Scaling group's total CPU metric is used as the load metric, and the average CPU metric is used for the scaling metric. Valid values are `ASGCPUUtilization`, `ASGNetworkIn`, `ASGNetworkOut`, or `ALBRequestCount`.
-* `resource_label` - (Optional) A label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group.
+* `resource_label` - (Required) A label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group.
 
 ##### predefined_scaling_metric_specification
 
 The following arguments are supported:
 
 * `predefined_metric_type` - (Required) Describes a scaling metric for a predictive scaling policy. Valid values are `ASGAverageCPUUtilization`, `ASGAverageNetworkIn`, `ASGAverageNetworkOut`, or `ALBRequestCountPerTarget`.
-* `resource_label` - (Optional) A label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group.
+* `resource_label` - (Required) A label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: #19700
Closes #19706

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoscalingPolicy_ -timeout 180m
=== RUN   TestAccAWSAutoscalingPolicy_basic
=== PAUSE TestAccAWSAutoscalingPolicy_basic
=== RUN   TestAccAWSAutoscalingPolicy_predictiveScaling
=== PAUSE TestAccAWSAutoscalingPolicy_predictiveScaling
=== RUN   TestAccAWSAutoscalingPolicy_predictiveScalingRemoved
=== PAUSE TestAccAWSAutoscalingPolicy_predictiveScalingRemoved
=== RUN   TestAccAWSAutoscalingPolicy_predictiveScalingUpdated
=== PAUSE TestAccAWSAutoscalingPolicy_predictiveScalingUpdated
=== RUN   TestAccAWSAutoscalingPolicy_disappears
=== PAUSE TestAccAWSAutoscalingPolicy_disappears
=== RUN   TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment
=== PAUSE TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment
=== RUN   TestAccAWSAutoscalingPolicy_TargetTrack_Predefined
=== PAUSE TestAccAWSAutoscalingPolicy_TargetTrack_Predefined
=== RUN   TestAccAWSAutoscalingPolicy_TargetTrack_Custom
=== PAUSE TestAccAWSAutoscalingPolicy_TargetTrack_Custom
=== RUN   TestAccAWSAutoscalingPolicy_zerovalue
=== PAUSE TestAccAWSAutoscalingPolicy_zerovalue
=== CONT  TestAccAWSAutoscalingPolicy_basic
=== CONT  TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment
=== CONT  TestAccAWSAutoscalingPolicy_TargetTrack_Custom
=== CONT  TestAccAWSAutoscalingPolicy_predictiveScaling
=== CONT  TestAccAWSAutoscalingPolicy_predictiveScalingUpdated
=== CONT  TestAccAWSAutoscalingPolicy_predictiveScalingRemoved
=== CONT  TestAccAWSAutoscalingPolicy_zerovalue
=== CONT  TestAccAWSAutoscalingPolicy_disappears
=== CONT  TestAccAWSAutoscalingPolicy_TargetTrack_Predefined
--- PASS: TestAccAWSAutoscalingPolicy_disappears (57.14s)
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (58.61s)
--- PASS: TestAccAWSAutoscalingPolicy_predictiveScaling (61.01s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (62.98s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (63.81s)
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (67.18s)
--- PASS: TestAccAWSAutoscalingPolicy_predictiveScalingUpdated (75.46s)
--- PASS: TestAccAWSAutoscalingPolicy_predictiveScalingRemoved (91.24s)
--- PASS: TestAccAWSAutoscalingPolicy_basic (103.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	103.495s
...
```
