### PR TITLE
r/user_pool_client - adjust token validity validation

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -26,8 +26,9 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 		// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html
 		Schema: map[string]*schema.Schema{
 			"access_token_validity": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 86400),
 			},
 			"allowed_oauth_flows": {
 				Type:     schema.TypeSet,
@@ -133,8 +134,9 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				ForceNew: true,
 			},
 			"id_token_validity": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 86400),
 			},
 			"logout_urls": {
 				Type:     schema.TypeSet,
@@ -175,7 +177,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      30,
-				ValidateFunc: validation.IntBetween(0, 3650),
+				ValidateFunc: validation.IntBetween(0, 315360000),
 			},
 			"supported_identity_providers": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -761,15 +761,15 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_cognito_user_pool" "test" {
-  name = "%[1]s"
+  name = %[1]q
 }
 
 resource "aws_pinpoint_app" "test" {
-  name = "%[2]s"
+  name = %[2]q
 }
 
 resource "aws_iam_role" "test" {
-  name = "%[2]s"
+  name = %[2]q
 
   assume_role_policy = <<EOF
 {
@@ -789,7 +789,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "%[2]s"
+  name = %[2]q
   role = aws_iam_role.test.id
 
   policy = <<-EOF
@@ -814,12 +814,12 @@ EOF
 func testAccAWSCognitoUserPoolClientConfigAnalyticsConfig(userPoolName, clientName string) string {
 	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name         = "%[1]s"
+  name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
 
   analytics_configuration {
     application_id = aws_pinpoint_app.test.application_id
-    external_id    = "%[1]s"
+    external_id    = %[1]q
     role_arn       = aws_iam_role.test.arn
   }
 }
@@ -829,12 +829,12 @@ resource "aws_cognito_user_pool_client" "test" {
 func testAccAWSCognitoUserPoolClientConfigAnalyticsConfigShareUserData(userPoolName, clientName string) string {
 	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name         = "%[1]s"
+  name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
 
   analytics_configuration {
     application_id   = aws_pinpoint_app.test.application_id
-    external_id      = "%[1]s"
+    external_id      = %[1]q
     role_arn         = aws_iam_role.test.arn
     user_data_shared = true
   }
@@ -845,7 +845,7 @@ resource "aws_cognito_user_pool_client" "test" {
 func testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(userPoolName, clientName string) string {
 	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name         = "%[1]s"
+  name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
 
   analytics_configuration {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18090

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolClient_'
--- PASS: TestAccAWSCognitoUserPoolClient_disappears_userPool (42.75s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (52.69s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (56.13s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (57.51s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn (68.38s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnits (90.85s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (92.22s)
--- PASS: TestAccAWSCognitoUserPoolClient_refreshTokenValidity (93.02s)
--- PASS: TestAccAWSCognitoUserPoolClient_idTokenValidity (93.08s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (95.26s)
--- PASS: TestAccAWSCognitoUserPoolClient_accessTokenValidity (95.86s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity (97.71s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (138.17s)
```
