### PR TITLE
r/aws_cloudwatch_event_target - fix input transformer input paths validation

### DIFF
--- a/.changelog/19703.txt
+++ b/.changelog/19703.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Increase the maximum allowed value for the `input_transformer` `input_paths` argument to 100
+```

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -261,7 +261,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							ValidateFunc: validation.All(
-								MapMaxItems(10),
+								MapMaxItems(100),
 								MapKeysDoNotMatch(regexp.MustCompile(`^AWS.*$`), "input_path must not start with \"AWS\""),
 							),
 						},

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -573,31 +573,16 @@ func TestAccAWSCloudWatchEventTarget_input_transformer(t *testing.T) {
 	var v events.Target
 	rName := acctest.RandomWithPrefix("tf_input_transformer")
 
-	tooManyInputPaths := []string{
-		"account",
-		"count",
-		"eventFirstSeen",
-		"eventLastSeen",
-		"Finding_ID",
-		"Finding_Type",
-		"instanceId",
-		"port",
-		"region",
-		"severity",
-		"time",
+	tooManyInputPaths := make([]string, 101)
+	for i := range tooManyInputPaths {
+		tooManyInputPaths[i] = fmt.Sprintf("InvalidField_%d", i)
 	}
-	validInputPaths := []string{
-		"account",
-		"count",
-		"eventFirstSeen",
-		"eventLastSeen",
-		"Finding_ID",
-		"Finding_Type",
-		"instanceId",
-		"region",
-		"severity",
-		"time",
+
+	validInputPaths := make([]string, 100)
+	for i := range validInputPaths {
+		validInputPaths[i] = fmt.Sprintf("ValidField_%d", i)
 	}
+
 	var expectedInputTemplate strings.Builder
 	fmt.Fprintf(&expectedInputTemplate, `{
   "detail-type": "Scheduled Event",
@@ -626,7 +611,7 @@ func TestAccAWSCloudWatchEventTarget_input_transformer(t *testing.T) {
 					testAccCheckCloudWatchEventTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "input_transformer.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "input_transformer.0.input_paths.%", strconv.Itoa(len(validInputPaths))),
-					resource.TestCheckResourceAttr(resourceName, "input_transformer.0.input_paths.time", "$.time"),
+					resource.TestCheckResourceAttr(resourceName, "input_transformer.0.input_paths.ValidField_99", "$.ValidField_99"),
 					resource.TestCheckResourceAttr(resourceName, "input_transformer.0.input_template", expectedInputTemplate.String()),
 				),
 			},

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -390,7 +390,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 `input_transformer` support the following:
 
 * `input_paths` - (Optional) Key value pairs specified in the form of JSONPath (for example, time = $.time)
-    * You can have as many as 10 key-value pairs.
+    * You can have as many as 100 key-value pairs.
     * You must use JSON dot notation, not bracket notation.
     * The keys can't start with "AWS".
 


### PR DESCRIPTION
Set max items to be 100 to match current [AWS Documentation][1]

[1]: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_InputTransformer.html#API_InputTransformer_Contents

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19698

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchEventTarget_input_transformer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventTarget_input_transformer -timeout 180m
=== RUN   TestAccAWSCloudWatchEventTarget_input_transformer
=== PAUSE TestAccAWSCloudWatchEventTarget_input_transformer
=== CONT  TestAccAWSCloudWatchEventTarget_input_transformer
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (76.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       78.102s

...
```
