### PR TITLE
r/cognito_user_pool: Suppress diff for empty `account_recovery_setting`

### DIFF
--- a/.changelog/19704.txt
+++ b/.changelog/19704.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Suppress diff for empty `account_recovery_setting`.
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17228

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_'
--- PASS: TestAccAWSCognitoUserPool_disappears (36.21s)
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (48.64s)
--- PASS: TestAccAWSCognitoUserPool_basic (49.39s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesModified (55.65s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesRemoved (69.13s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (84.86s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (85.12s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (89.72s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributes (90.26s)
--- PASS: TestAccAWSCognitoUserPool_SmsVerificationMessage (90.54s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameConfiguration (92.42s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameAttributes (93.19s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration (117.97s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (80.43s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn (132.00s)
--- PASS: TestAccAWSCognitoUserPool_withTags (132.07s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (44.21s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (70.04s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig (142.36s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration (148.96s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId (114.95s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig (156.79s)
--- PASS: TestAccAWSCognitoUserPool_update (162.28s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (77.89s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (167.04s)
--- PASS: TestAccAWSCognitoUserPool_SmsAuthenticationMessage (77.55s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration (97.68s)
--- PASS: TestAccAWSCognitoUserPool_recovery (106.39s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration (148.63s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration (107.22s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (110.59s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration (157.08s)
```
