### PR TITLE
Destroy aws_ram_resource_share_accepter from member account when share contains some resource types

### DIFF
--- a/.changelog/19718.txt
+++ b/.changelog/19718.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ram_resource_share_acceptor: Destroy aws_ram_resource_share_accepter from member account when share contains some resource types
+resource/aws_ram_resource_share_acceptor: Allow destroy even where AWS API provides no way to disassociate
 ```

--- a/.changelog/19718.txt
+++ b/.changelog/19718.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ram_resource_share_acceptor: Destroy aws_ram_resource_share_accepter from member account when share contains some resource types
+```

--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -207,8 +207,9 @@ func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta inte
 
 	_, err := conn.DisassociateResourceShare(input)
 
-	if err != nil {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ram.ErrCodeOperationNotPermittedException) {
 		return fmt.Errorf("Error leaving RAM resource share: %s", err)
+
 	}
 
 	_, err = waiter.ResourceShareOwnedBySelfDisassociated(conn, d.Id(), d.Timeout(schema.TimeoutDelete))

--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -207,12 +207,16 @@ func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta inte
 
 	_, err := conn.DisassociateResourceShare(input)
 
+	if tfawserr.ErrCodeEquals(err, ram.ErrCodeOperationNotPermittedException) {
+		log.Printf("[WARN] Resource share could not be disassociated, but continuing: %s", err)
+	}
+
 	if err != nil && !tfawserr.ErrCodeEquals(err, ram.ErrCodeOperationNotPermittedException) {
 		return fmt.Errorf("Error leaving RAM resource share: %s", err)
-
 	}
 
 	_, err = waiter.ResourceShareOwnedBySelfDisassociated(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+
 	if err != nil {
 		return fmt.Errorf("Error waiting for RAM resource share (%s) state: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -201,7 +201,8 @@ data "aws_caller_identity" "receiver" {}
 func testAccAwsRamResourceShareAccepterResourceAssociation(rName string) string {
 	return composeConfig(testAccAwsRamResourceShareAccepterBasic(rName), fmt.Sprintf(`
 resource "aws_ram_resource_association" "test" {
-  provider           = "awsalternate"
+  provider = "awsalternate"
+
   resource_arn       = aws_codebuild_project.test.arn
   resource_share_arn = aws_ram_resource_share.test.arn
 }

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -78,7 +78,7 @@ func TestAccAwsRamResourceShareAccepter_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsRamResourceShareAccepter_resource_association(t *testing.T) {
+func TestAccAwsRamResourceShareAccepter_resourceAssociation(t *testing.T) {
 	var providers []*schema.Provider
 	resourceName := "aws_ram_resource_share_accepter.test"
 	principalAssociationResourceName := "aws_ram_principal_association.test"
@@ -207,7 +207,7 @@ resource "aws_ram_resource_association" "test" {
 }
 
 resource "aws_codebuild_project" "test" {
-  provider     = "awsalternate"
+  provider = "awsalternate"
 
   name         = %[1]q
   service_role = aws_iam_role.test.arn
@@ -228,51 +228,43 @@ resource "aws_codebuild_project" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   provider = "awsalternate"
 
-  name     = %[1]q
+  name = %[1]q
 
-  assume_role_policy = <<-EOF
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": {
-            "Service": "codebuild.amazonaws.com"
-          },
-          "Action": "sts:AssumeRole"
-        }
-      ]
-    }
-    EOF
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "codebuild.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
 }
 
 resource "aws_iam_role_policy" "test" {
   provider = "awsalternate"
 
-  name     = %[1]q
-  role     = aws_iam_role.test.name
+  name = %[1]q
+  role = aws_iam_role.test.name
 
-  policy = <<-POLICY
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Resource": [
-            "*"
-          ],
-          "Action": [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-          ]
-        }
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Resource = ["*"]
+      Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
       ]
-    }
-    POLICY
+    }]
+  })
 }
 `, rName))
 }

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -78,6 +78,45 @@ func TestAccAwsRamResourceShareAccepter_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAwsRamResourceShareAccepter_resource_association(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_ram_resource_share_accepter.test"
+	principalAssociationResourceName := "aws_ram_principal_association.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ErrorCheck:        testAccErrorCheck(t, ram.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
+		CheckDestroy:      testAccCheckAwsRamResourceShareAccepterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRamResourceShareAccepterResourceAssociation(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRamResourceShareAccepterExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "share_arn", principalAssociationResourceName, "resource_share_arn"),
+					testAccMatchResourceAttrRegionalARNAccountID(resourceName, "invitation_arn", "ram", `\d{12}`, regexp.MustCompile(fmt.Sprintf("resource-share-invitation/%s$", uuidRegexPattern))),
+					resource.TestMatchResourceAttr(resourceName, "share_id", regexp.MustCompile(fmt.Sprintf(`^rs-%s$`, uuidRegexPattern))),
+					resource.TestCheckResourceAttr(resourceName, "status", ram.ResourceShareStatusActive),
+					testAccCheckResourceAttrAccountID(resourceName, "receiver_account_id"),
+					resource.TestMatchResourceAttr(resourceName, "sender_account_id", regexp.MustCompile(`\d{12}`)),
+					resource.TestCheckResourceAttr(resourceName, "share_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "resources.%", "0"),
+				),
+			},
+			{
+				Config:            testAccAwsRamResourceShareAccepterResourceAssociation(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsRamResourceShareAccepterDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ramconn
 
@@ -157,4 +196,28 @@ resource "aws_ram_principal_association" "test" {
 
 data "aws_caller_identity" "receiver" {}
 `, rName)
+}
+
+func testAccAwsRamResourceShareAccepterResourceAssociation(rName string) string {
+	return composeConfig(testAccAwsRamResourceShareAccepterBasic(rName), fmt.Sprintf(`
+resource "aws_ram_resource_association" "test" {
+  provider           = "awsalternate"
+  resource_arn       = aws_route53_resolver_query_log_config.test.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
+}
+
+resource "aws_route53_resolver_query_log_config" "test" {
+  provider        = "awsalternate"
+
+  name            = %[1]q
+  destination_arn = aws_s3_bucket.test.arn
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  provider      = "awsalternate"
+
+  force_destroy = true
+}
+`, rName))
 }

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -255,14 +255,14 @@ resource "aws_iam_role_policy" "test" {
   role = aws_iam_role.test.name
 
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [{
       Effect   = "Allow"
       Resource = ["*"]
       Action = [
-          "logs:CreateLogGroup",
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
       ]
     }]
   })


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19319

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAwsRamResourceShareAccept
=== RUN   TestAccAwsRamResourceShareAccepter_basic
=== PAUSE TestAccAwsRamResourceShareAccepter_basic
=== RUN   TestAccAwsRamResourceShareAccepter_disappears
=== PAUSE TestAccAwsRamResourceShareAccepter_disappears
=== RUN   TestAccAwsRamResourceShareAccepter_resource_association
=== PAUSE TestAccAwsRamResourceShareAccepter_resource_association
=== CONT  TestAccAwsRamResourceShareAccepter_basic
--- PASS: TestAccAwsRamResourceShareAccepter_basic (80.79s)
=== CONT  TestAccAwsRamResourceShareAccepter_resource_association
--- PASS: TestAccAwsRamResourceShareAccepter_resource_association (90.39s)
=== CONT  TestAccAwsRamResourceShareAccepter_disappears
--- PASS: TestAccAwsRamResourceShareAccepter_disappears (257.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	428.329s
```

I just realized that the comments associated with this PR are probably confusing:  The original unit test submitted with this code change brought out a timing issue.  As this timing issue was not the result of the code change, a different unit test was created to demonstrate that the code change worked.  The timing issue still needs to be addressed and Terraform will need to decide how they want to handle it.  The original unit test can be retrieved from the commits and the comments provide more information on the timing problem.