### PR TITLE
resource,data_source/aws_servicequotas_service_quota: Handle embedded error in ServiceQuota struct

### DIFF
--- a/.changelog/19722.txt
+++ b/.changelog/19722.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_servicequotas_service_quota: Correctly handle errors embedded in API struct
+```
+
+```release-note:bug
+resource/aws_servicequotas_service_quota: Correctly handle errors embedded in API struct
+```

--- a/aws/data_source_aws_servicequotas_service_quota.go
+++ b/aws/data_source_aws_servicequotas_service_quota.go
@@ -105,11 +105,19 @@ func dataSourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta int
 			return fmt.Errorf("error getting Service (%s) Quota (%s): %w", serviceCode, quotaCode, err)
 		}
 
-		if output == nil {
+		if output == nil || output.Quota == nil {
 			return fmt.Errorf("error getting Service (%s) Quota (%s): empty result", serviceCode, quotaCode)
 		}
 
 		serviceQuota = output.Quota
+	}
+
+	if serviceQuota.ErrorReason != nil {
+		return fmt.Errorf("error getting Service (%s) Quota (%s): %s: %s", serviceCode, quotaCode, aws.StringValue(serviceQuota.ErrorReason.ErrorCode), aws.StringValue(serviceQuota.ErrorReason.ErrorMessage))
+	}
+
+	if serviceQuota.Value == nil {
+		return fmt.Errorf("error getting Service (%s) Quota (%s): empty value", serviceCode, quotaCode)
 	}
 
 	input := &servicequotas.GetAWSDefaultServiceQuotaInput{

--- a/aws/resource_aws_servicequotas_service_quota.go
+++ b/aws/resource_aws_servicequotas_service_quota.go
@@ -99,8 +99,16 @@ func resourceAwsServiceQuotasServiceQuotaCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)
 	}
 
-	if output == nil {
+	if output == nil || output.Quota == nil {
 		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty result", d.Id())
+	}
+
+	if output.Quota.ErrorReason != nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s: %s", d.Id(), aws.StringValue(output.Quota.ErrorReason.ErrorCode), aws.StringValue(output.Quota.ErrorReason.ErrorMessage))
+	}
+
+	if output.Quota.Value == nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty value", d.Id())
 	}
 
 	if value > aws.Float64Value(output.Quota.Value) {
@@ -152,8 +160,16 @@ func resourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)
 	}
 
-	if output == nil {
+	if output == nil || output.Quota == nil {
 		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty result", d.Id())
+	}
+
+	if output.Quota.ErrorReason != nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s: %s", d.Id(), aws.StringValue(output.Quota.ErrorReason.ErrorCode), aws.StringValue(output.Quota.ErrorReason.ErrorMessage))
+	}
+
+	if output.Quota.Value == nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty value", d.Id())
 	}
 
 	defaultInput := &servicequotas.GetAWSDefaultServiceQuotaInput{


### PR DESCRIPTION
Handles errors embedded errors in `ServiceQuota` struct instead of being returned as an API error code.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19719

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsServiceQuotasServiceQuotaDataSource\|TestAccAwsServiceQuotasServiceQuota'

--- SKIP: TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnCreate (0.00s)
--- SKIP: TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnUpdate (0.00s)
--- PASS: TestAccAwsServiceQuotasServiceQuotaDataSource_PermissionError_QuotaCode (5.28s)
--- PASS: TestAccAwsServiceQuotasServiceQuotaDataSource_PermissionError_QuotaName (5.52s)
--- PASS: TestAccAwsServiceQuotasServiceQuota_PermissionError (9.46s)
--- PASS: TestAccAwsServiceQuotasServiceQuotaDataSource_QuotaCode (16.47s)
--- PASS: TestAccAwsServiceQuotasServiceQuotaDataSource_QuotaName (16.54s)
--- PASS: TestAccAwsServiceQuotasServiceQuota_basic (18.61s)
```
