### PR TITLE
documentation/servicequotas resources

### DIFF
--- a/website/docs/d/servicequotas_service.html.markdown
+++ b/website/docs/d/servicequotas_service.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Retrieve information about a Service Quotas Service.
 
+~> **NOTE:** Global quotas apply to all AWS regions, but can only be accessed in `us-east-1` in the Commercial partition or `us-gov-west-1` in the GovCloud partition. In other regions, the AWS API will return the error `The request failed because the specified service does not exist.`
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/d/servicequotas_service_quota.html.markdown
+++ b/website/docs/d/servicequotas_service_quota.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Retrieve information about a Service Quota.
 
+~> **NOTE:** Global quotas apply to all AWS regions, but can only be accessed in `us-east-1` in the Commercial partition or `us-gov-west-1` in the GovCloud partition. In other regions, the AWS API will return the error `The request failed because the specified service does not exist.`
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/servicequotas_service_quota.html.markdown
+++ b/website/docs/r/servicequotas_service_quota.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an individual Service Quota.
 
+~> **NOTE:** Global quotas apply to all AWS regions, but can only be accessed in `us-east-1` in the Commercial partition or `us-gov-west-1` in the GovCloud partition. In other regions, the AWS API will return the error `The request failed because the specified service does not exist.`
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
Adds note to documentation indicating that global quotas can only be accessed from `us-east-1` or `us-gov-west-1`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19735

Output from acceptance testing:

N/A