### PR TITLE
r/glue_catalog_table - fix update for `schema_reference`

### DIFF
--- a/.changelog/19742.txt
+++ b/.changelog/19742.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Fix updating `schema_reference` when columns are present.
+```

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -622,7 +622,7 @@ func expandGlueStorageDescriptor(l []interface{}) *glue.StorageDescriptor {
 		storageDescriptor.StoredAsSubDirectories = aws.Bool(v.(bool))
 	}
 
-	if v, ok := s["schema_reference"]; ok {
+	if v, ok := s["schema_reference"]; ok && len(v.([]interface{})) > 0 {
 		storageDescriptor.Columns = nil
 		storageDescriptor.SchemaReference = expandGlueTableSchemaReference(v.([]interface{}))
 	}

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -623,6 +623,7 @@ func expandGlueStorageDescriptor(l []interface{}) *glue.StorageDescriptor {
 	}
 
 	if v, ok := s["schema_reference"]; ok {
+		storageDescriptor.Columns = nil
 		storageDescriptor.SchemaReference = expandGlueTableSchemaReference(v.([]interface{}))
 	}
 

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -471,6 +471,17 @@ func TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReference(t *testing.T) 
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccGlueCatalogTableConfigStorageDescriptorSchemaReferenceArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.schema_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.schema_reference.0.schema_version_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.schema_reference.0.schema_id.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_descriptor.0.schema_reference.0.schema_id.0.schema_arn", "aws_glue_schema.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.#", "2"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19739

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogTable_'
--- PASS: TestAccAWSGlueCatalogTable_disappears_database (37.61s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock (42.69s)
--- PASS: TestAccAWSGlueCatalogTable_disappears (42.83s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock (44.73s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock (45.53s)
--- PASS: TestAccAWSGlueCatalogTable_columnParameters (48.85s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesSingle (49.78s)
--- PASS: TestAccAWSGlueCatalogTable_basic (50.49s)
--- PASS: TestAccAWSGlueCatalogTable_partitionIndexesMultiple (51.91s)
--- PASS: TestAccAWSGlueCatalogTable_full (54.68s)
--- PASS: TestAccAWSGlueCatalogTable_targetTable (55.98s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReferenceArn (63.22s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (78.49s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_UpdateValues (80.36s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (80.36s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_schemaReference (105.18s)
```
