### PR TITLE
r/glue_catalog_database - set `location_uri` to computed

### DIFF
--- a/.changelog/19743.txt
+++ b/.changelog/19743.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: Set `location_uri` as compute to prevent drift when `target_table` has `location_uri` set.
+```

--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -51,6 +51,7 @@ func resourceAwsGlueCatalogDatabase() *schema.Resource {
 			"location_uri": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"parameters": {
 				Type:     schema.TypeMap,

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -141,6 +141,17 @@ func TestAccAWSGlueCatalogDatabase_targetDatabase(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config:  testAccGlueCatalogDatabaseConfigTargetDatabaseWithLocation(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test2", "catalog_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "location_uri", "aws_glue_catalog_database.test2", "location_uri"),
+				),
+			},
 		},
 	})
 }
@@ -234,6 +245,24 @@ resource "aws_glue_catalog_database" "test" {
 
 resource "aws_glue_catalog_database" "test2" {
   name = "%[1]s-2"
+}
+`, rName)
+}
+
+func testAccGlueCatalogDatabaseConfigTargetDatabaseWithLocation(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  target_database {
+    catalog_id    = aws_glue_catalog_database.test2.catalog_id
+    database_name = aws_glue_catalog_database.test2.name
+  }
+}
+
+resource "aws_glue_catalog_database" "test2" {
+  name         = "%[1]s-2"
+  location_uri = "my-location"
 }
 `, rName)
 }

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -149,7 +149,6 @@ func TestAccAWSGlueCatalogDatabase_targetDatabase(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test2", "catalog_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "location_uri", "aws_glue_catalog_database.test2", "location_uri"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19585

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSGlueCatalogDatabase_disappears (23.16s)
--- PASS: TestAccAWSGlueCatalogDatabase_targetDatabase (62.40s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (77.78s)
```
