### PR TITLE
Update DNSSEC docs to a working example

### DIFF
--- a/website/docs/r/route53_hosted_zone_dnssec.html.markdown
+++ b/website/docs/r/route53_hosted_zone_dnssec.html.markdown
@@ -31,9 +31,24 @@ resource "aws_kms_key" "example" {
         ],
         Effect = "Allow"
         Principal = {
-          Service = "api-service.dnssec.route53.aws.internal"
+          Service = "dnssec-route53.amazonaws.com"
         }
-        Sid = "Route 53 DNSSEC Permissions"
+        Sid      = "Allow Route 53 DNSSEC Service",
+        Resource = "*"
+      },
+      {
+        Action = "kms:CreateGrant",
+        Effect = "Allow"
+        Principal = {
+          Service = "dnssec-route53.amazonaws.com"
+        }
+        Sid      = "Allow Route 53 DNSSEC Service to CreateGrant",
+        Resource = "*"
+        Condition = {
+          Bool = {
+            "kms:GrantIsForAWSResource" = "true"
+          }
+        }
       },
       {
         Action = "kms:*"
@@ -60,6 +75,9 @@ resource "aws_route53_key_signing_key" "example" {
 }
 
 resource "aws_route53_hosted_zone_dnssec" "example" {
+  depends_on = [
+    aws_route53_key_signing_key.example
+  ]
   hosted_zone_id = aws_route53_key_signing_key.example.hosted_zone_id
 }
 ```

--- a/website/docs/r/route53_hosted_zone_dnssec.html.markdown
+++ b/website/docs/r/route53_hosted_zone_dnssec.html.markdown
@@ -69,8 +69,8 @@ resource "aws_route53_zone" "example" {
 }
 
 resource "aws_route53_key_signing_key" "example" {
-  hosted_zone_id             = aws_route53_zone.test.id
-  key_management_service_arn = aws_kms_key.test.arn
+  hosted_zone_id             = aws_route53_zone.example.id
+  key_management_service_arn = aws_kms_key.example.arn
   name                       = "example"
 }
 

--- a/website/docs/r/route53_key_signing_key.html.markdown
+++ b/website/docs/r/route53_key_signing_key.html.markdown
@@ -31,9 +31,24 @@ resource "aws_kms_key" "example" {
         ],
         Effect = "Allow"
         Principal = {
-          Service = "api-service.dnssec.route53.aws.internal"
+          Service = "dnssec-route53.amazonaws.com"
         }
-        Sid = "Route 53 DNSSEC Permissions"
+        Sid      = "Allow Route 53 DNSSEC Service",
+        Resource = "*"
+      },
+      {
+        Action = "kms:CreateGrant",
+        Effect = "Allow"
+        Principal = {
+          Service = "dnssec-route53.amazonaws.com"
+        }
+        Sid      = "Allow Route 53 DNSSEC Service to CreateGrant",
+        Resource = "*"
+        Condition = {
+          Bool = {
+            "kms:GrantIsForAWSResource" = "true"
+          }
+        }
       },
       {
         Action = "kms:*"
@@ -60,6 +75,9 @@ resource "aws_route53_key_signing_key" "example" {
 }
 
 resource "aws_route53_hosted_zone_dnssec" "example" {
+  depends_on = [
+    aws_route53_key_signing_key.example
+  ]
   hosted_zone_id = aws_route53_key_signing_key.example.hosted_zone_id
 }
 ```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### What
I'm a copy/paste andy, and found that the docs for `aws_route53_hosted_zone_dnssec` and `aws_route53_key_signing_key` resulted in the following error when trying to apply.

```
Error: error enabling Route 53 Hosted Zone DNSSEC (xxxxxxxxxxxx): error enabling: KeySigningKeyWithActiveStatusNotFound: Hosted zone with ID 'xxxxxxxxxxxx' does not have a Key Signing Key in ACTIVE status.
status code: 400, request id: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


Error: error creating Route 53 Key Signing Key: InvalidKMSArn: The CMK with ARN 'arn:aws:kms:us-east-1:xxxxxxxx:key/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' did not grant all required permissions for DNSSEC usage. Please review your key-policy, and verify that you and Route 53 have permissions to perform the following actions: DescribeKey, GetPublicKey, and Sign.
status code: 400, request id: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```
Instead I ended up following https://jonathanj.nl/2021/02/03/aws-route53-dnssec-cloudformation.html as a guide and was able to translate his change to Terraform.
