### PR TITLE
handling access denied when reading vault policy when vault has been deleted

### DIFF
--- a/aws/resource_aws_backup_vault_policy.go
+++ b/aws/resource_aws_backup_vault_policy.go
@@ -81,7 +81,7 @@ func resourceAwsBackupVaultPolicyRead(d *schema.ResourceData, meta interface{}) 
 		}
 
 		for _, el := range resp.BackupVaultList {
-			if *el.BackupVaultName == d.Id() {
+			if aws.StringValue(el.BackupVaultName) == d.Id() {
 				return fmt.Errorf("error reading Backup Vault Policy (%s): %w", d.Id(), err)
 			}
 		}


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

It's a new issue we stumbled on but not reported.
In essence, if the backup vault is deleted outside of terraform, the update operation fails with `AccessDenied` error instead of `ResourceNotFoundException.` The cause for that is that authors of `GetBackupVaultAccessPolicy` API decided (allegedly) to follow some no-exposure security rule that advocates not exposing resource absence to avoid discovery of valid resource names using some kind of brute force iteration.

Output from acceptance testing:

TODO
@DrFaust92 any ideas how we can test this? The reproduction steps are:

- create vault and a policy so that terraform has a state with resource ids 
- remove the vault without modifying the terraform state 
- perform `resourceAwsBackupVaultPolicyRead` 

```
$ make testacc TESTARGS='-run=TestAccAwsBackupVaultPolicy_'

...
```
At this stage, the PR is not ready for merging, it's a discussion on how the issue can be tested.