### PR TITLE
Add KeyId and EncryptionAlgorithm parameters to aws_kms_secrets data source

### DIFF
--- a/.changelog/19752.txt
+++ b/.changelog/19752.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/data_source_aws_kms_secrets: Add optional KeyId and EncryptionAlgorithm parameters
+```

--- a/aws/data_source_aws_kms_secrets.go
+++ b/aws/data_source_aws_kms_secrets.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceAwsKmsSecrets() *schema.Resource {
@@ -23,6 +24,15 @@ func dataSourceAwsKmsSecrets() *schema.Resource {
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+						"key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"encryption_algorithm": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"SYMMETRIC_DEFAULT", "RSAES_OAEP_SHA_1", "RSAES_OAEP_SHA_256"}, false),
 						},
 						"payload": {
 							Type:     schema.TypeString,
@@ -81,6 +91,16 @@ func dataSourceAwsKmsSecretsRead(d *schema.ResourceData, meta interface{}) error
 			for _, v := range grant_tokens.([]interface{}) {
 				params.GrantTokens = append(params.GrantTokens, aws.String(v.(string)))
 			}
+		}
+
+		key_id := secret["key_id"]
+		if key_id != "" {
+			params.KeyId = aws.String(key_id.(string))
+		}
+
+		encryption_algorithm := secret["encryption_algorithm"]
+		if encryption_algorithm != "" {
+			params.EncryptionAlgorithm = aws.String(encryption_algorithm.(string))
 		}
 
 		// decrypt

--- a/website/docs/d/kms_secrets.html.markdown
+++ b/website/docs/d/kms_secrets.html.markdown
@@ -40,8 +40,10 @@ data "aws_kms_secrets" "example" {
 
   secret {
     # ... potentially other configuration ...
-    name    = "master_username"
-    payload = "AQECAHgaPa0J8WadplGCqqVAr4HNvDaFSQ+NaiwIBhmm6qDSFwAAAGIwYAYJKoZIhvcNAQcGoFMwUQIBADBMBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDI+LoLdvYv8l41OhAAIBEIAfx49FFJCLeYrkfMfAw6XlnxP23MmDBdqP8dPp28OoAQ=="
+    key_id               = "12345678-1234-1234-1234-123456789012"
+    encryption_algorithm =  "RSAES_OAEP_SHA_256"
+    name                 = "master_username"
+    payload              = "AQECAHgaPa0J8WadplGCqqVAr4HNvDaFSQ+NaiwIBhmm6qDSFwAAAGIwYAYJKoZIhvcNAQcGoFMwUQIBADBMBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDI+LoLdvYv8l41OhAAIBEIAfx49FFJCLeYrkfMfAw6XlnxP23MmDBdqP8dPp28OoAQ=="
   }
 }
 
@@ -64,6 +66,8 @@ Each `secret` supports the following arguments:
 
 * `name` - (Required) The name to export this secret under in the attributes.
 * `payload` - (Required) Base64 encoded payload, as returned from a KMS encrypt operation.
+* `key_id` - (Optional) Key ID of the asymmetric key used to encrypt the secret. Key ARN, Alias name or Alias ARN can also be used. Required if encryption_algorithm is set.
+* `encryption_algorithm` - (Optional) Encryption algorithm used to encrypt the secret. Valid values are `SYMMETRIC_DEFAULT`, `RSAES_OAEP_SHA_1` or `RSAES_OAEP_SHA_256`. Required if key_id is set.
 * `context` - (Optional) An optional mapping that makes up the Encryption Context for the secret.
 * `grant_tokens` (Optional) An optional list of Grant Tokens for the secret.
 


### PR DESCRIPTION
If a secert is encrypted using an asymmetric key, the current aws_kms_secrets data source
cannot decrypt in its current state. This commit adds two optional parameters to this data
source so that secerts encrypted using an asymmetric key can still be decrypted and used
with this data source.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSKmsSecretsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKmsSecretsDataSource_ -timeout 180m
=== RUN   TestAccAWSKmsSecretsDataSource_basic
--- PASS: TestAccAWSKmsSecretsDataSource_basic (41.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.985s
```
