### PR TITLE
Fix athena db reader

### DIFF
--- a/.changelog/19765.txt
+++ b/.changelog/19765.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_athena_database: Read the database name from the `AwsDataCatalog`
+```

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -112,17 +112,12 @@ func resourceAwsAthenaDatabaseCreate(d *schema.ResourceData, meta interface{}) e
 func resourceAwsAthenaDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).athenaconn
 
-	input := &athena.StartQueryExecutionInput{
-		QueryString:         aws.String("show databases;"),
-		ResultConfiguration: expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{})),
+	input := &athena.GetDatabaseInput{
+		DatabaseName: aws.String(d.Get("name").(string)),
+		CatalogName:  aws.String("AwsDataCatalog"),
 	}
-
-	resp, err := conn.StartQueryExecution(input)
+	_, err := conn.GetDatabase(input)
 	if err != nil {
-		return err
-	}
-
-	if err := executeAndExpectMatchingRow(*resp.QueryExecutionId, d.Get("name").(string), conn); err != nil {
 		return err
 	}
 	return nil
@@ -168,25 +163,6 @@ func executeAndExpectNoRowsWhenCreate(qeid string, conn *athena.Athena) error {
 		return fmt.Errorf("Athena create database, unexpected query result: %s", flattenAthenaResultSet(rs))
 	}
 	return nil
-}
-
-func executeAndExpectMatchingRow(qeid string, dbName string, conn *athena.Athena) error {
-	rs, err := queryExecutionResult(qeid, conn)
-	if err != nil {
-		return err
-	}
-	for _, row := range rs.Rows {
-		for _, datum := range row.Data {
-			if datum == nil {
-				continue
-			}
-
-			if aws.StringValue(datum.VarCharValue) == dbName {
-				return nil
-			}
-		}
-	}
-	return fmt.Errorf("Athena not found database: %s, query result: %s", dbName, flattenAthenaResultSet(rs))
 }
 
 func executeAndExpectNoRowsWhenDrop(qeid string, conn *athena.Athena) error {


### PR DESCRIPTION
Closes #19085

The current athena database implements a query on read. This means that the terraform plan needs
the permission to execute queries against athena as well as permission to write to the
s3 bucket where the execution results are stored. This makes it hard to run plan in an
environment where we don't want it to modify any aws resources. The StartQueryExecution
also does not have a way to restrict the queries. This means that it is possible to use
the permissions set up for a terraform plan to run any queries against athena.

The fix here is to read the database name from the AwsDataCatalog. In the future, this can
be extended to include other catalogs as the support for creating athena catalogs is added to
the provider

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
