### PR TITLE
r/datasync_location_nfs - support update + add `mount_options`

### DIFF
--- a/.changelog/19767.txt
+++ b/.changelog/19767.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_datasync_location_nfs: Add support for updating.
+```
+
+```release-note:enhancement
+resource/aws_datasync_location_nfs: Add `mount_options` argument.
+```
+
+```release-note:enhancement
+resource/aws_datasync_location_nfs: Add plan time validation for `on_prem_config.agent_arns`, `server_hostname`, and `subdirectory`.
+```

--- a/website/docs/r/datasync_location_nfs.html.markdown
+++ b/website/docs/r/datasync_location_nfs.html.markdown
@@ -29,10 +29,17 @@ resource "aws_datasync_location_nfs" "example" {
 
 The following arguments are supported:
 
+* `mount_options` - (Optional) Configuration block containing mount options used by DataSync to access the NFS Server.
 * `on_prem_config` - (Required) Configuration block containing information for connecting to the NFS File System.
 * `server_hostname` - (Required) Specifies the IP address or DNS name of the NFS server. The DataSync Agent(s) use this to mount the NFS server.
 * `subdirectory` - (Required) Subdirectory to perform actions as source or destination. Should be exported by the NFS server.
 * `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Location. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### mount_options Argument Reference
+
+The following arguments are supported inside the `mount_options` configuration block:
+
+* `version` - (Optional) The specific NFS version that you want DataSync to use for mounting your NFS share. Valid values: `AUTOMATIC`, `NFS3`, `NFS4_0` and `NFS4_1`. Default: `AUTOMATIC`
 
 ### on_prem_config Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14054

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDataSyncLocationNfs_'
--- PASS: TestAccAWSDataSyncLocationNfs_basic (254.52s)
--- PASS: TestAccAWSDataSyncLocationNfs_Subdirectory (351.00s)
--- PASS: TestAccAWSDataSyncLocationNfs_disappears (251.73s)
--- PASS: TestAccAWSDataSyncLocationNfs_AgentARNs_Multple (264.48s)
--- PASS: TestAccAWSDataSyncLocationNfs_mountOptions (324.74s)
```
