### PR TITLE
[WIP] Add aws_ad_user resource

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -166,6 +166,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/aws/aws-sdk-go/service/workdocs"
 	"github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/aws/aws-sdk-go/service/workmail"
 	"github.com/aws/aws-sdk-go/service/workspaces"
@@ -383,6 +384,7 @@ type AWSClient struct {
 	wafconn                             *waf.WAF
 	wafregionalconn                     *wafregional.WAFRegional
 	wafv2conn                           *wafv2.WAFV2
+	workdocsconn                        *workdocs.WorkDocs
 	worklinkconn                        *worklink.WorkLink
 	workmailconn                        *workmail.WorkMail
 	workspacesconn                      *workspaces.WorkSpaces
@@ -627,6 +629,7 @@ func (c *Config) Client() (interface{}, error) {
 		wafconn:                             waf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["waf"])})),
 		wafregionalconn:                     wafregional.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["wafregional"])})),
 		wafv2conn:                           wafv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["wafv2"])})),
+		workdocsconn:                        workdocs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["workdocs"])})),
 		worklinkconn:                        worklink.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["worklink"])})),
 		workmailconn:                        workmail.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["workmail"])})),
 		workspacesconn:                      workspaces.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["workspaces"])})),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -449,6 +449,7 @@ func Provider() *schema.Provider {
 			"aws_acmpca_certificate_authority":                        resourceAwsAcmpcaCertificateAuthority(),
 			"aws_acmpca_certificate_authority_certificate":            resourceAwsAcmpcaCertificateAuthorityCertificate(),
 			"aws_acmpca_certificate":                                  resourceAwsAcmpcaCertificate(),
+			"aws_ad_user":                                             resourceAwsAdUser(),
 			"aws_ami":                                                 resourceAwsAmi(),
 			"aws_ami_copy":                                            resourceAwsAmiCopy(),
 			"aws_ami_from_instance":                                   resourceAwsAmiFromInstance(),

--- a/aws/resource_aws_ad_user.go
+++ b/aws/resource_aws_ad_user.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workdocs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsAdUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAdUserCreate,
+		Read:   resourceAwsAdUserRead,
+		Update: resourceAwsAdUserUpdate,
+		Delete: resourceAwsAdUserDelete,
+
+		Schema: map[string]*schema.Schema{
+			"email_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"given_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"organization_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringLenBetween(4, 2048),
+			},
+			"surname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsAdUserCreate(d *schema.ResourceData, meta interface{}) error {
+	workdocsconn := meta.(*AWSClient).workdocsconn
+
+	emailAddress := d.Get("email_address").(string)
+	givenName := d.Get("given_name").(string)
+	organizationId := d.Get("organization_id").(string)
+	password := d.Get("password").(string)
+	surname := d.Get("surname").(string)
+	username := d.Get("username").(string)
+
+	request := &workdocs.CreateUserInput{
+		EmailAddress:   aws.String(emailAddress),
+		GivenName:      aws.String(givenName),
+		OrganizationId: aws.String(organizationId),
+		Password:       aws.String(password),
+		Surname:        aws.String(surname),
+		Username:       aws.String(username),
+	}
+
+	log.Println("[DEBUG] Create AD User request:", request)
+	createResp, err := workdocsconn.CreateUser(request)
+	if err != nil {
+		return fmt.Errorf("Error creating AD User %s: %s", username, err)
+	}
+
+	d.SetId(aws.StringValue(createResp.User.Id))
+
+	return resourceAwsAdUserRead(d, meta)
+}
+
+func resourceAwsAdUserRead(d *schema.ResourceData, meta interface{}) error {
+	workdocsconn := meta.(*AWSClient).workdocsconn
+
+	request := &workdocs.DescribeUsersInput{
+		UserIds: aws.String(d.Id()),
+	}
+
+	var output *workdocs.DescribeUsersOutput
+
+	var err error
+
+	output, err = workdocsconn.DescribeUsers(request)
+
+	if !d.IsNewResource() && len(output.Users) == 0 {
+		log.Printf("[WARN] AD User (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading AD User (%s): %w", d.Id(), err)
+	}
+
+	if output == nil || len(output.Users) == 0 {
+		return fmt.Errorf("error reading AD User (%s): empty response", d.Id())
+	}
+
+	user := output.Users[0]
+
+	d.Set("email_address", user.EmailAddress)
+	d.Set("given_name", user.GivenName)
+	d.Set("organization_id", user.OrganizationId)
+	d.Set("surname", user.Surname)
+	d.Set("username", user.Username)
+	d.Set("unique_id", user.Id)
+
+	return nil
+}
+
+func resourceAwsAdUserUpdate(d *schema.ResourceData, meta interface{}) error {
+	workdocsconn := meta.(*AWSClient).workdocsconn
+
+	if d.HasChanges("given_name", "surname") {
+		_, ng := d.GetChange("given_name")
+		_, ns := d.GetChange("surname")
+
+		request := &workdocs.UpdateUserInput{
+			GivenName: aws.String(ng.(string)),
+			Surname:   aws.String(ns.(string)),
+			UserId:    aws.String(d.Id()),
+		}
+
+		log.Println("[DEBUG] Update AD User request:", request)
+		_, err := workdocsconn.UpdateUser(request)
+		if err != nil {
+			return fmt.Errorf("Error updating AD User %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsAdUserRead(d, meta)
+}
+
+func resourceAwsAdUserDelete(d *schema.ResourceData, meta interface{}) error {
+	workdocsconn := meta.(*AWSClient).workdocsconn
+
+	deleteUserInput := &workdocs.DeleteUserInput{
+		UserId: aws.String(d.Id()),
+	}
+
+	log.Println("[DEBUG] Delete AD User request:", deleteUserInput)
+	_, err := workdocsconn.DeleteUser(deleteUserInput)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting AD User %s: %s", d.Id(), err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

We needed a way to add users to our AD instance, but there didn't seem to be a way to do this programmatically (except for using the terraform-provider-ad) . After looking around a bit we found that it could be done using the workdocs api. In this pull request we have a working implementation using this api, but this still needs work (tests, support all fields, etc..). If somebody could look at this and tell us if this could be useful to be in the aws terraform provider then I would be happy to further work on this!


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #19853

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
