### PR TITLE
fix docs: SSO credentials is now supported

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -126,7 +126,7 @@ provider "aws" {
 }
 ```
 
-Please note that the [AWS Go SDK](https://aws.amazon.com/sdk-for-go/), the underlying authentication handler used by the Terraform AWS Provider, does not support all AWS CLI features, such as Single Sign On (SSO) configuration or credentials.
+Please note that the [AWS Go SDK](https://aws.amazon.com/sdk-for-go/), the underlying authentication handler used by the Terraform AWS Provider, does not support all AWS CLI features.
 
 ### CodeBuild, ECS, and EKS Roles
 


### PR DESCRIPTION
The document says that Single Sign On (SSO) configuration or credentials is not supported.
However, support for cached SSO credentials was added in [v3.26.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3260-january-28-2021) of the Terraform AWS Provider.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
