### PR TITLE
.github/workflows: Fix waiting-response label removal

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           labels: |
             stale
-            waiting-reply
+            waiting-response


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform-provider-aws/labels/waiting-response

Output from acceptance testing: N/A
