### PR TITLE
Make Redshift parameters case sensitive

### DIFF
--- a/.changelog/19772.txt
+++ b/.changelog/19772.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshift_parameter_group: Make Redshift parameters case sensitive.
+```

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -720,8 +720,8 @@ func flattenRedshiftParameters(list []*redshift.Parameter) []map[string]interfac
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
 		result = append(result, map[string]interface{}{
-			"name":  *i.ParameterName,
-			"value": *i.ParameterValue,
+			"name":  aws.StringValue(i.ParameterName),
+			"value": aws.StringValue(i.ParameterValue),
 		})
 	}
 	return result

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -720,8 +720,8 @@ func flattenRedshiftParameters(list []*redshift.Parameter) []map[string]interfac
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
 		result = append(result, map[string]interface{}{
-			"name":  strings.ToLower(*i.ParameterName),
-			"value": strings.ToLower(*i.ParameterValue),
+			"name":  *i.ParameterName,
+			"value": *i.ParameterValue,
 		})
 	}
 	return result


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
vinaysaraogi@flashtime:~/vena/github/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSRedshiftParameterGroup_withParameters'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRedshiftParameterGroup_withParameters -timeout 180m
=== RUN   TestAccAWSRedshiftParameterGroup_withParameters
=== PAUSE TestAccAWSRedshiftParameterGroup_withParameters
=== CONT  TestAccAWSRedshiftParameterGroup_withParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (12.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.477s
```

Context:

Some of the Redshift parameters are case sensitive. AWS API returns Uppercase values for some of its parameters such as `datestyle` which takes values such as `ISO, MDY`. Because the aws terraform provide lowercases all parameters, terraform always shows a change for the parameters with case difference. 
