### PR TITLE
Add missing 'status' attribute to organizations datasource docs

### DIFF
--- a/website/docs/d/organizations_organization.html.markdown
+++ b/website/docs/d/organizations_organization.html.markdown
@@ -91,6 +91,7 @@ If the account is the master account for the organization, the following attribu
     * `email` - Email of the account
     * `id` - Identifier of the account
     * `name` - Name of the account
+    * `status` - Status of the account
 * `aws_service_access_principals` - A list of AWS service principal names that have integration enabled with your organization. Organization must have `feature_set` set to `ALL`. For additional information, see the [AWS Organizations User Guide](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html).
 * `enabled_policy_types` - A list of Organizations policy types that are enabled in the Organization Root. Organization must have `feature_set` set to `ALL`. For additional information about valid policy types (e.g. `SERVICE_CONTROL_POLICY`), see the [AWS Organizations API Reference](https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnablePolicyType.html).
 * `non_master_accounts` - List of organization accounts excluding the master account. For a list including the master account, see the `accounts` attribute. All elements have these attributes:
@@ -98,6 +99,7 @@ If the account is the master account for the organization, the following attribu
     * `email` - Email of the account
     * `id` - Identifier of the account
     * `name` - Name of the account
+    * `status` - Status of the account
 * `roots` - List of organization roots. All elements have these attributes:
     * `arn` - ARN of the root
     * `id` - Identifier of the root


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

The registry documentation page for the organizations data source is missing mention of the `status` attribute for `accounts` and `non_master_accounts` items.

- https://github.com/hashicorp/terraform-provider-aws/blob/c1630b35e0d18f674c60a6c72fb11bf451df64f2/aws/data_source_aws_organizations_organization.go#L29
- https://github.com/hashicorp/terraform-provider-aws/blob/c1630b35e0d18f674c60a6c72fb11bf451df64f2/aws/data_source_aws_organizations_organization.go#L89

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates to https://github.com/hashicorp/terraform-provider-aws/issues/17656