### PR TITLE
Docs use incorrect argument for on_premises_instance_tag_filter

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -331,9 +331,9 @@ The `test_traffic_route` configuration block supports the following:
 
 * `listener_arns` - (Required) List of Amazon Resource Names (ARNs) of the load balancer listeners.
 
-### on_premises_tag_filter Argument Reference
+### on_premises_instance_tag_filter Argument Reference
 
-The `on_premises_tag_filter` configuration block supports the following:
+The `on_premises_instance_tag_filter` configuration block supports the following:
 
 * `key` - (Optional) The key of the tag filter.
 * `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.


### PR DESCRIPTION
The documentation for `aws_codedeploy_deployment_group` incorrectly refers to the argument block type of `on_premises_tag_filter` instead of `on_premises_instance_tag_filter`.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request