### PR TITLE
d/aws_ssm_parameter: add `optional` parameter to not fail if parameter not found

### DIFF
--- a/.changelog/19781.txt
+++ b/.changelog/19781.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ssm_parameter: Add `optional` to allow parameters that do not exist
+```

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the parameter.
 * `with_decryption` - (Optional) Whether to return decrypted `SecureString` value. Defaults to `true`.
-
+* `optional` - (Optional) Whether to allow parameters that do not exist， defaults to `false`. If the value is true, the parameter allowed to not exist and `null` string will be returned.
 
 In addition to all arguments above, the following attributes are exported:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18282

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSsmParameterDataSource_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSsmParameterDataSource_* -timeout 180m
=== RUN   TestAccAWSSsmParameterDataSource_basic
=== PAUSE TestAccAWSSsmParameterDataSource_basic
=== RUN   TestAccAWSSsmParameterDataSource_fullPath
=== PAUSE TestAccAWSSsmParameterDataSource_fullPath
=== CONT  TestAccAWSSsmParameterDataSource_basic
=== CONT  TestAccAWSSsmParameterDataSource_fullPath
--- PASS: TestAccAWSSsmParameterDataSource_basic (186.67s)
--- PASS: TestAccAWSSsmParameterDataSource_fullPath (233.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       234.871s
```
