### PR TITLE
r/ecs _cluster - add `configuration` block + refactor to user finder and waiters package

### DIFF
--- a/.changelog/19785.txt
+++ b/.changelog/19785.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ecs_cluster: Add support for `configuration`.
+```
+
+```release-note:enhancement
+resource/aws_ecs_cluster: Add plan time validation for `name`.
+```

--- a/aws/internal/service/ecs/finder/finder.go
+++ b/aws/internal/service/ecs/finder/finder.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func CluserByARN(conn *ecs.ECS, arn string) (*ecs.DescribeClustersOutput, error) {
+func ClusterByARN(conn *ecs.ECS, arn string) (*ecs.DescribeClustersOutput, error) {
 	input := &ecs.DescribeClustersInput{
 		Clusters: []*string{aws.String(arn)},
 		Include:  []*string{aws.String(ecs.ClusterFieldTags), aws.String(ecs.ClusterFieldConfigurations)},

--- a/aws/internal/service/ecs/finder/finder.go
+++ b/aws/internal/service/ecs/finder/finder.go
@@ -1,0 +1,32 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func CluserByARN(conn *ecs.ECS, arn string) (*ecs.DescribeClustersOutput, error) {
+	input := &ecs.DescribeClustersInput{
+		Clusters: []*string{aws.String(arn)},
+		Include:  []*string{aws.String(ecs.ClusterFieldTags), aws.String(ecs.ClusterFieldConfigurations)},
+	}
+
+	output, err := conn.DescribeClusters(input)
+
+	if err != nil {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if output == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/ecs/waiter/status.go
+++ b/aws/internal/service/ecs/waiter/status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ecs/finder"
 )
 
 const (
@@ -23,6 +24,9 @@ const (
 
 	ServiceStatusError = "ERROR"
 	ServiceStatusNone  = "NONE"
+
+	ClusterStatusError = "ERROR"
+	ClusterStatusNone  = "NONE"
 )
 
 // CapacityProviderStatus fetches the Capacity Provider and its Status
@@ -69,5 +73,25 @@ func ServiceStatus(conn *ecs.ECS, id, cluster string) resource.StateRefreshFunc 
 
 		log.Printf("[DEBUG] ECS service (%s) is currently %q", id, *output.Services[0].Status)
 		return output, aws.StringValue(output.Services[0].Status), err
+	}
+}
+
+func ClusterStatus(conn *ecs.ECS, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.CluserByARN(conn, arn)
+
+		if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException) {
+			return nil, ClusterStatusNone, nil
+		}
+
+		if err != nil {
+			return nil, ClusterStatusError, err
+		}
+
+		if len(output.Clusters) == 0 {
+			return nil, ClusterStatusNone, nil
+		}
+
+		return output, aws.StringValue(output.Clusters[0].Status), err
 	}
 }

--- a/aws/internal/service/ecs/waiter/status.go
+++ b/aws/internal/service/ecs/waiter/status.go
@@ -78,7 +78,7 @@ func ServiceStatus(conn *ecs.ECS, id, cluster string) resource.StateRefreshFunc 
 
 func ClusterStatus(conn *ecs.ECS, arn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := finder.CluserByARN(conn, arn)
+		output, err := finder.ClusterByARN(conn, arn)
 
 		if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException) {
 			return nil, ClusterStatusNone, nil

--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -240,7 +240,7 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 	var out *ecs.DescribeClustersOutput
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
-		out, err = finder.CluserByARN(conn, d.Id())
+		out, err = finder.ClusterByARN(conn, d.Id())
 
 		if err != nil {
 			return resource.NonRetryableError(err)
@@ -256,7 +256,7 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 	if isResourceTimeoutError(err) {
-		out, err = finder.CluserByARN(conn, d.Id())
+		out, err = finder.ClusterByARN(conn, d.Id())
 	}
 
 	if isResourceNotFoundError(err) {

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -632,14 +632,14 @@ resource "aws_ecs_cluster" "test" {
 
   configuration {
     execute_command_configuration {
-	  kms_key_id = aws_kms_key.test.arn
-	  logging    = "OVERRIDE"
+      kms_key_id = aws_kms_key.test.arn
+      logging    = "OVERRIDE"
 
-	  log_configuration {
+      log_configuration {
         cloud_watch_encryption_enabled = %[2]t
-		cloud_watch_log_group_name     = aws_cloudwatch_log_group.test.name
-	  }
-	}
+        cloud_watch_log_group_name     = aws_cloudwatch_log_group.test.name
+      }
+    }
   }
 }
 `, rName, enable)

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -367,7 +367,6 @@ func TestAccAWSEcsCluster_configuration(t *testing.T) {
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.#", "1"),
-
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.execute_command_configuration.0.kms_key_id", "aws_kms_key.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.logging", "OVERRIDE"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.#", "1"),

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -392,7 +392,7 @@ func testAccCheckAWSEcsClusterDestroy(s *terraform.State) error {
 			continue
 		}
 
-		out, err := finder.CluserByARN(conn, rs.Primary.ID)
+		out, err := finder.ClusterByARN(conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -416,7 +416,7 @@ func testAccCheckAWSEcsClusterExists(resourceName string, cluster *ecs.Cluster) 
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ecsconn
-		output, err := finder.CluserByARN(conn, rs.Primary.ID)
+		output, err := finder.ClusterByARN(conn, rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("error reading ECS Cluster (%s): %w", rs.Primary.ID, err)

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -106,7 +106,7 @@ func TestAccAWSEcsCluster_disappears(t *testing.T) {
 				Config: testAccAWSEcsClusterConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
-					testAccCheckAWSEcsClusterDisappears(&cluster1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEcsCluster(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -432,22 +432,6 @@ func testAccCheckAWSEcsClusterExists(resourceName string, cluster *ecs.Cluster) 
 		}
 
 		return fmt.Errorf("ECS Cluster (%s) not found", rs.Primary.ID)
-	}
-}
-
-func testAccCheckAWSEcsClusterDisappears(cluster *ecs.Cluster) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ecsconn
-
-		input := &ecs.DeleteClusterInput{
-			Cluster: cluster.ClusterArn,
-		}
-
-		if _, err := conn.DeleteCluster(input); err != nil {
-			return fmt.Errorf("error deleting ECS Cluster (%s): %s", aws.StringValue(cluster.ClusterArn), err)
-		}
-
-		return nil
 	}
 }
 

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -40,14 +40,14 @@ resource "aws_ecs_cluster" "test" {
 
   configuration {
     execute_command_configuration {
-	    kms_key_id = aws_kms_key.example.arn
-	    logging    = "OVERRIDE"
+      kms_key_id = aws_kms_key.example.arn
+      logging    = "OVERRIDE"
 
-	    log_configuration {
+      log_configuration {
         cloud_watch_encryption_enabled = true
-		    cloud_watch_log_group_name     = aws_cloudwatch_log_group.example.name
-	    }
-	  }
+        cloud_watch_log_group_name     = aws_cloudwatch_log_group.example.name
+      }
+    }
   }
 }
 ```

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -28,10 +28,29 @@ resource "aws_ecs_cluster" "foo" {
 The following arguments are supported:
 
 * `capacity_providers` - (Optional) List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
+* `configuration` - (Optional) The execute command configuration for the cluster. Detailed below.
 * `default_capacity_provider_strategy` - (Optional) Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 * `name` - (Required) Name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
 * `setting` - (Optional) Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### `configuration`
+
+* `execute_command_configuration` - (Optional) The details of the execute command configuration. Detailed below.
+
+#### `execute_command_configuration`
+
+* `kms_key_id` - (Optional) The AWS Key Management Service key ID to encrypt the data between the local client and the container.
+* `log_configuration` - (Optional) The log configuration for the results of the execute command actions Required when `logging` is `OVERRIDE`. Detailed below.
+* `logging` - (Optional) The log setting to use for redirecting logs for your execute command results. Valid values are `NONE`, `DEFAULT`, and `OVERRIDE`.
+
+##### `log_configuration`
+
+* `cloud_watch_encryption_enabled` - (Optional) Whether or not to enable encryption on the CloudWatch logs. If not specified, encryption will be disabled.
+* `cloud_watch_log_group_name` - (Optional) The name of the CloudWatch log group to send logs to.
+* `s3_bucket_name` - (Optional) The name of the S3 bucket to send logs to.
+* `s3_bucket_encryption_enabled` - (Optional) Whether or not to enable encryption on the logs sent to S3. If not specified, encryption will be disabled.
+* `s3_key_prefix` - (Optional) An optional folder in the S3 bucket to place logs in.
 
 ### `default_capacity_provider_strategy`
 

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -23,6 +23,35 @@ resource "aws_ecs_cluster" "foo" {
 }
 ```
 
+## Example W/Log Configuration
+
+```terraform
+resource "aws_kms_key" "example" {
+  description             = "example"
+  deletion_window_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example"
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = "example"
+
+  configuration {
+    execute_command_configuration {
+	    kms_key_id = aws_kms_key.example.arn
+	    logging    = "OVERRIDE"
+
+	    log_configuration {
+        cloud_watch_encryption_enabled = true
+		    cloud_watch_log_group_name     = aws_cloudwatch_log_group.example.name
+	    }
+	  }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #18334.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsCluster_'
--- PASS: TestAccAWSEcsCluster_disappears (40.63s)
--- PASS: TestAccAWSEcsCluster_basic (50.59s)
--- PASS: TestAccAWSEcsCluster_CapacityProviders (76.15s)
--- PASS: TestAccAWSEcsCluster_Tags (95.17s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersNoStrategy (95.57s)
--- PASS: TestAccAWSEcsCluster_configuration (103.91s)
--- PASS: TestAccAWSEcsCluster_containerInsights (112.43s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (129.26s)
--- PASS: TestAccAWSEcsCluster_SingleCapacityProvider (143.15s)
```
