### PR TITLE
Remove default group from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,51 +1,50 @@
-# Default owner for all pull requests
-*    @hashicorp/terraform-aws
+# There is no default owner for pull requests as reviews are scheduled based on community popularity.
 
 # Service specific owners
-/aws/*apigatewayv2*    @ewbankkit @hashicorp/terraform-aws
-/website/**/apigatewayv2*    @ewbankkit @hashicorp/terraform-aws
+/aws/*apigatewayv2*          @ewbankkit
+/website/**/apigatewayv2*    @ewbankkit
 
-/aws/*appmesh*    @ewbankkit @hashicorp/terraform-aws
-/website/**/appmesh*    @ewbankkit @hashicorp/terraform-aws
+/aws/*appmesh*          @ewbankkit
+/website/**/appmesh*    @ewbankkit
 
-/aws/*backup*    @ewbankkit @hashicorp/terraform-aws
-/website/**/backup*    @ewbankkit @hashicorp/terraform-aws
+/aws/*backup*          @ewbankkit
+/website/**/backup*    @ewbankkit
 
-/aws/*_aws_codeartifact_*.go     @DrFaust92 @hashicorp/terraform-aws
-/website/**/codeartifact*        @DrFaust92 @hashicorp/terraform-aws
+/aws/*_aws_codeartifact_*.go    @DrFaust92
+/website/**/codeartifact*       @DrFaust92
 
-/aws/*_aws_fsx_*.go     @DrFaust92 @hashicorp/terraform-aws
-/website/**/fsx*        @DrFaust92 @hashicorp/terraform-aws
+/aws/*_aws_fsx_*.go    @DrFaust92
+/website/**/fsx*       @DrFaust92
 
-/aws/*globalaccelerator*    @ewbankkit @hashicorp/terraform-aws
-/website/**/globalaccelerator*    @ewbankkit @hashicorp/terraform-aws
+/aws/*globalaccelerator*          @ewbankkit
+/website/**/globalaccelerator*    @ewbankkit
 
-/aws/*_aws_glue_*.go     @DrFaust92 @hashicorp/terraform-aws
-/website/**/glue*        @DrFaust92 @hashicorp/terraform-aws
+/aws/*_aws_glue_*.go    @DrFaust92
+/website/**/glue*       @DrFaust92
 
-/aws/*kinesis_analytics*    @ewbankkit @hashicorp/terraform-aws
-/website/**/kinesis_analytics*    @ewbankkit @hashicorp/terraform-aws
+/aws/*kinesis_analytics*          @ewbankkit
+/website/**/kinesis_analytics*    @ewbankkit
 
-/aws/*kinesisanalyticsv2*    @ewbankkit @hashicorp/terraform-aws
-/website/**/kinesisanalyticsv2*    @ewbankkit @hashicorp/terraform-aws
+/aws/*kinesisanalyticsv2*          @ewbankkit
+/website/**/kinesisanalyticsv2*    @ewbankkit
 
-/aws/*route53_resolver*    @ewbankkit @hashicorp/terraform-aws
-/website/**/route53_resolver*    @ewbankkit @hashicorp/terraform-aws
+/aws/*route53_resolver*          @ewbankkit
+/website/**/route53_resolver*    @ewbankkit
 
-/aws/*_aws_storagegateway_*.go     @DrFaust92 @hashicorp/terraform-aws
-/website/**/storagegateway*        @DrFaust92 @hashicorp/terraform-aws
+/aws/*_aws_storagegateway_*.go    @DrFaust92
+/website/**/storagegateway*       @DrFaust92
 
-/aws/*_aws_sagemaker_*.go     @DrFaust92 @hashicorp/terraform-aws
-/website/**/sagemaker*        @DrFaust92 @hashicorp/terraform-aws
+/aws/*_aws_sagemaker_*.go    @DrFaust92
+/website/**/sagemaker*       @DrFaust92
 
-/aws/*_aws_workspaces_*.go     @Tensho @hashicorp/terraform-aws
-/website/**/workspaces*        @Tensho @hashicorp/terraform-aws
+/aws/*_aws_workspaces_*.go    @Tensho
+/website/**/workspaces*       @Tensho
 
-/aws/*_aws_mwaa_*.go     @shuheiktgw @hashicorp/terraform-aws
-/website/**/mwaa*        @shuheiktgw @hashicorp/terraform-aws
+/aws/*_aws_mwaa_*.go    @shuheiktgw
+/website/**/mwaa*       @shuheiktgw
 
-/aws/*_aws_emr_*.go     @shuheiktgw @hashicorp/terraform-aws
-/website/**/emr*        @shuheiktgw @hashicorp/terraform-aws
+/aws/*_aws_emr_*.go    @shuheiktgw
+/website/**/emr*       @shuheiktgw
 
-/aws/*aws_cloudwatch_event_*.go		@heitorlessa @sthulb @hashicorp/terraform-aws
-/website/**/cloudwatch_event*		@heitorlessa @sthulb @hashicorp/terraform-aws
+/aws/*aws_cloudwatch_event_*.go    @heitorlessa @sthulb
+/website/**/cloudwatch_event*      @heitorlessa @sthulb


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This removes the default CODEOWNERS, currently all incoming PR's are assigned to the entire team. The reality of our workflow is that not every incoming PR is lined up for review and that we use the communities input to rank and schedule pull requests for review. Removing this will vastly reduce the notification load for maintainers, and allow them to more easily respond to individual level @ messages within PRs.