### PR TITLE
r/cloudwatch_log_metric_filter - add `unit`

### DIFF
--- a/.changelog/19804.txt
+++ b/.changelog/19804.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_log_metric_filter: Add support for `unit` in the `metric_transformation` block.
+```

--- a/aws/resource_aws_cloudwatch_log_metric_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter_test.go
@@ -127,6 +127,29 @@ func TestAccAWSCloudWatchLogMetricFilter_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchLogMetricFilter_disappears_logGroup(t *testing.T) {
+	var mf cloudwatchlogs.MetricFilter
+	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_metric_filter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, cloudwatchlogs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogMetricFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchLogMetricFilterConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogMetricFilterExists(resourceName, &mf),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchLogGroup(), "aws_cloudwatch_log_group.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckCloudWatchLogMetricFilterName(mf *cloudwatchlogs.MetricFilter, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if name != *mf.FilterName {

--- a/aws/resource_aws_cloudwatch_log_metric_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 	var mf cloudwatchlogs.MetricFilter
 	rInt := acctest.RandInt()
-	resourceName := "aws_cloudwatch_log_metric_filter.foobar"
+	resourceName := "aws_cloudwatch_log_metric_filter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,7 +98,30 @@ func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 			},
 			{
 				Config: testAccAWSCloudwatchLogMetricFilterConfigMany(rInt),
-				Check:  testAccCheckCloudwatchLogMetricFilterManyExist("aws_cloudwatch_log_metric_filter.count_dracula", &mf),
+				Check:  testAccCheckCloudwatchLogMetricFilterManyExist("aws_cloudwatch_log_metric_filter.test", &mf),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchLogMetricFilter_disappears(t *testing.T) {
+	var mf cloudwatchlogs.MetricFilter
+	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_metric_filter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, cloudwatchlogs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogMetricFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchLogMetricFilterConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogMetricFilterExists(resourceName, &mf),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchLogMetricFilter(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -233,10 +256,10 @@ func testAccCheckCloudwatchLogMetricFilterManyExist(basename string, mf *cloudwa
 
 func testAccAWSCloudWatchLogMetricFilterConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "foobar" {
+resource "aws_cloudwatch_log_metric_filter" "test" {
   name           = "MyAppAccessCount-%d"
   pattern        = ""
-  log_group_name = aws_cloudwatch_log_group.dada.name
+  log_group_name = aws_cloudwatch_log_group.test.name
 
   metric_transformation {
     name      = "EventCount"
@@ -245,7 +268,7 @@ resource "aws_cloudwatch_log_metric_filter" "foobar" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "dada" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "MyApp/access-%d.log"
 }
 `, rInt, rInt)
@@ -253,7 +276,7 @@ resource "aws_cloudwatch_log_group" "dada" {
 
 func testAccAWSCloudWatchLogMetricFilterConfigModified(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "foobar" {
+resource "aws_cloudwatch_log_metric_filter" "test" {
   name = "MyAppAccessCount-%d"
 
   pattern = <<PATTERN
@@ -261,7 +284,7 @@ resource "aws_cloudwatch_log_metric_filter" "foobar" {
 PATTERN
 
 
-  log_group_name = aws_cloudwatch_log_group.dada.name
+  log_group_name = aws_cloudwatch_log_group.test.name
 
   metric_transformation {
     name          = "AccessDeniedCount"
@@ -271,7 +294,7 @@ PATTERN
   }
 }
 
-resource "aws_cloudwatch_log_group" "dada" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "MyApp/access-%d.log"
 }
 `, rInt, rInt)
@@ -279,7 +302,7 @@ resource "aws_cloudwatch_log_group" "dada" {
 
 func testAccAWSCloudWatchLogMetricFilterConfigModifiedWithDimensions(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "foobar" {
+resource "aws_cloudwatch_log_metric_filter" "test" {
   name = "MyAppAccessCount-%d"
 
   pattern = <<PATTERN
@@ -287,7 +310,7 @@ resource "aws_cloudwatch_log_metric_filter" "foobar" {
 PATTERN
 
 
-  log_group_name = aws_cloudwatch_log_group.dada.name
+  log_group_name = aws_cloudwatch_log_group.test.name
 
   metric_transformation {
     name      = "AccessDeniedCount"
@@ -300,7 +323,7 @@ PATTERN
   }
 }
 
-resource "aws_cloudwatch_log_group" "dada" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "MyApp/access-%d.log"
 }
 `, rInt, rInt)
@@ -308,11 +331,11 @@ resource "aws_cloudwatch_log_group" "dada" {
 
 func testAccAWSCloudwatchLogMetricFilterConfigMany(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "count_dracula" {
+resource "aws_cloudwatch_log_metric_filter" "test" {
   count          = 15
   name           = "MyAppCountLog-${count.index}-%d"
   pattern        = "count ${count.index}"
-  log_group_name = aws_cloudwatch_log_group.mama.name
+  log_group_name = aws_cloudwatch_log_group.test.name
 
   metric_transformation {
     name      = "CountDracula-${count.index}"
@@ -321,7 +344,7 @@ resource "aws_cloudwatch_log_metric_filter" "count_dracula" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "mama" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "MyApp/count-log-%d.log"
 }
 `, rInt, rInt)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go/service/configservice"
@@ -1654,50 +1653,6 @@ func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key stri
 	}
 
 	return operations
-}
-
-func expandCloudWatchLogMetricTransformations(m map[string]interface{}) []*cloudwatchlogs.MetricTransformation {
-	transformation := cloudwatchlogs.MetricTransformation{
-		MetricName:      aws.String(m["name"].(string)),
-		MetricNamespace: aws.String(m["namespace"].(string)),
-		MetricValue:     aws.String(m["value"].(string)),
-	}
-
-	if m["default_value"].(string) != "" {
-		value, _ := strconv.ParseFloat(m["default_value"].(string), 64)
-		transformation.DefaultValue = aws.Float64(value)
-	}
-
-	if dims := m["dimensions"].(map[string]interface{}); len(dims) > 0 {
-		transformation.Dimensions = expandStringMap(dims)
-	}
-
-	return []*cloudwatchlogs.MetricTransformation{&transformation}
-}
-
-func flattenCloudWatchLogMetricTransformations(ts []*cloudwatchlogs.MetricTransformation) []interface{} {
-	mts := make([]interface{}, 0)
-	m := make(map[string]interface{})
-
-	m["name"] = aws.StringValue(ts[0].MetricName)
-	m["namespace"] = aws.StringValue(ts[0].MetricNamespace)
-	m["value"] = aws.StringValue(ts[0].MetricValue)
-
-	if ts[0].DefaultValue == nil {
-		m["default_value"] = ""
-	} else {
-		m["default_value"] = strconv.FormatFloat(aws.Float64Value(ts[0].DefaultValue), 'f', -1, 64)
-	}
-
-	if dims := ts[0].Dimensions; len(dims) > 0 {
-		m["dimensions"] = pointersMapToStringList(dims)
-	} else {
-		m["dimensions"] = nil
-	}
-
-	mts = append(mts, m)
-
-	return mts
 }
 
 func flattenBeanstalkAsg(list []*elasticbeanstalk.AutoScalingGroup) []string {

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -47,6 +47,7 @@ The `metric_transformation` block supports the following arguments:
 * `value` - (Required) What to publish to the metric. For example, if you're counting the occurrences of a particular term like "Error", the value will be "1" for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event.
 * `default_value` - (Optional) The value to emit when a filter pattern does not match a log event. Conflicts with `dimensions`.
 * `dimensions` - (Optional) Map of fields to use as dimensions for the metric. Up to 3 dimensions are allowed. Conflicts with `default_value`.
+* `unit` - (Optional) The unit to assign to the metric. If you omit this, the unit is set as `None`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19800

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_'
--- PASS: TestAccAWSCloudWatchLogMetricFilter_disappears (38.42s)
--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (226.30s)
--- PASS: TestAccAWSCloudWatchLogMetricFilter_disappears_logGroup (28.00s)
```
