### PR TITLE
EKS node group scaling_config.min_size can be 0 as well as desired

### DIFF
--- a/.changelog/19810.txt
+++ b/.changelog/19810.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_node_group: Allow minimum value of `0` for `desired_size` and `min_size` in the `scaling_config` configuration block
+```

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -606,7 +606,7 @@ func expandEksNodegroupScalingConfig(l []interface{}) *eks.NodegroupScalingConfi
 
 	config := &eks.NodegroupScalingConfig{}
 
-	if v, ok := m["desired_size"].(int); ok && v != 0 {
+	if v, ok := m["desired_size"].(int); ok {
 		config.DesiredSize = aws.Int64(int64(v))
 	}
 
@@ -614,7 +614,7 @@ func expandEksNodegroupScalingConfig(l []interface{}) *eks.NodegroupScalingConfi
 		config.MaxSize = aws.Int64(int64(v))
 	}
 
-	if v, ok := m["min_size"].(int); ok && v != 0 {
+	if v, ok := m["min_size"].(int); ok {
 		config.MinSize = aws.Int64(int64(v))
 	}
 

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -192,7 +192,7 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 						"desired_size": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntAtLeast(1),
+							ValidateFunc: validation.IntAtLeast(0),
 						},
 						"max_size": {
 							Type:         schema.TypeInt,
@@ -202,7 +202,7 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 						"min_size": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntAtLeast(1),
+							ValidateFunc: validation.IntAtLeast(0),
 						},
 					},
 				},

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -318,10 +318,10 @@ func TestAccAWSEksNodeGroup_ForceUpdateVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEksNodeGroupConfigForceUpdateVersion(rName, "1.15"),
+				Config: testAccAWSEksNodeGroupConfigForceUpdateVersion(rName, "1.19"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.15"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.19"),
 				),
 			},
 			{
@@ -331,10 +331,10 @@ func TestAccAWSEksNodeGroup_ForceUpdateVersion(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_update_version"},
 			},
 			{
-				Config: testAccAWSEksNodeGroupConfigForceUpdateVersion(rName, "1.16"),
+				Config: testAccAWSEksNodeGroupConfigForceUpdateVersion(rName, "1.20"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.16"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.20"),
 				),
 			},
 		},
@@ -945,10 +945,10 @@ func TestAccAWSEksNodeGroup_Version(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEksNodeGroupConfigVersion(rName, "1.15"),
+				Config: testAccAWSEksNodeGroupConfigVersion(rName, "1.19"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.15"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.19"),
 				),
 			},
 			{
@@ -957,11 +957,11 @@ func TestAccAWSEksNodeGroup_Version(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEksNodeGroupConfigVersion(rName, "1.16"),
+				Config: testAccAWSEksNodeGroupConfigVersion(rName, "1.20"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
 					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.16"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.20"),
 				),
 			},
 		},


### PR DESCRIPTION
As [https://github.com/aws/containers-roadmap/issues/724#issuecomment-859948729](https://github.com/aws/containers-roadmap/issues/724#issuecomment-859948729)


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Relates #13984

```release-note:enhancement
resource/aws_eks_node_group: Allow for 0 min_size and desired_size for scaling config of a node group.
```