### PR TITLE
d/servicecatalog_portfolio_constraints: New data source

### DIFF
--- a/.changelog/19813.txt
+++ b/.changelog/19813.txt
@@ -1,0 +1,3 @@
+```release-notes:new-data-source
+aws_servicecatalog_portfolio_constraints
+```

--- a/aws/data_source_aws_servicecatalog_constraint.go
+++ b/aws/data_source_aws_servicecatalog_constraint.go
@@ -71,7 +71,13 @@ func dataSourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("error getting Service Catalog Constraint: empty response")
 	}
 
-	d.Set("accept_language", d.Get("accept_language").(string))
+	acceptLanguage := d.Get("accept_language").(string)
+
+	if acceptLanguage == "" {
+		acceptLanguage = tfservicecatalog.AcceptLanguageEnglish
+	}
+
+	d.Set("accept_language", acceptLanguage)
 
 	d.Set("parameters", output.ConstraintParameters)
 	d.Set("status", output.Status)

--- a/aws/data_source_aws_servicecatalog_portfolio_constraints.go
+++ b/aws/data_source_aws_servicecatalog_portfolio_constraints.go
@@ -19,7 +19,7 @@ func dataSourceAwsServiceCatalogPortfolioConstraints() *schema.Resource {
 			"accept_language": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "en",
+				Default:      tfservicecatalog.AcceptLanguageEnglish,
 				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
 			},
 			"details": {
@@ -36,6 +36,10 @@ func dataSourceAwsServiceCatalogPortfolioConstraints() *schema.Resource {
 							Computed: true,
 						},
 						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"portfolio_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -75,7 +79,13 @@ func dataSourceAwsServiceCatalogPortfolioConstraintsRead(d *schema.ResourceData,
 		return fmt.Errorf("error getting Service Catalog Portfolio Constraints: no results, change your input")
 	}
 
-	d.Set("accept_language", d.Get("accept_language").(string))
+	acceptLanguage := d.Get("accept_language").(string)
+
+	if acceptLanguage == "" {
+		acceptLanguage = tfservicecatalog.AcceptLanguageEnglish
+	}
+
+	d.Set("accept_language", acceptLanguage)
 	d.Set("portfolio_id", d.Get("portfolio_id").(string))
 	d.Set("product_id", d.Get("product_id").(string))
 
@@ -105,6 +115,10 @@ func flattenServiceCatalogConstraintDetail(apiObject *servicecatalog.ConstraintD
 
 	if v := apiObject.Owner; v != nil {
 		tfMap["owner"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.PortfolioId; v != nil {
+		tfMap["portfolio_id"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.ProductId; v != nil {

--- a/aws/data_source_aws_servicecatalog_portfolio_constraints.go
+++ b/aws/data_source_aws_servicecatalog_portfolio_constraints.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tfservicecatalog "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicecatalog/waiter"
+)
+
+func dataSourceAwsServiceCatalogPortfolioConstraints() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsServiceCatalogPortfolioConstraintsRead,
+
+		Schema: map[string]*schema.Schema{
+			"accept_language": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "en",
+				ValidateFunc: validation.StringInSlice(tfservicecatalog.AcceptLanguage_Values(), false),
+			},
+			"details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"constraint_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"portfolio_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsServiceCatalogPortfolioConstraintsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).scconn
+
+	output, err := waiter.PortfolioConstraintsReady(conn, d.Get("accept_language").(string), d.Get("portfolio_id").(string), d.Get("product_id").(string))
+
+	if err != nil {
+		return fmt.Errorf("error describing Service Catalog Portfolio Constraints: %w", err)
+	}
+
+	if len(output) == 0 {
+		return fmt.Errorf("error getting Service Catalog Portfolio Constraints: no results, change your input")
+	}
+
+	d.Set("accept_language", d.Get("accept_language").(string))
+	d.Set("portfolio_id", d.Get("portfolio_id").(string))
+	d.Set("product_id", d.Get("product_id").(string))
+
+	if err := d.Set("details", flattenServiceCatalogConstraintDetails(output)); err != nil {
+		return fmt.Errorf("error setting details: %w", err)
+	}
+
+	d.SetId(tfservicecatalog.PortfolioConstraintsID(d.Get("accept_language").(string), d.Get("portfolio_id").(string), d.Get("product_id").(string)))
+
+	return nil
+}
+
+func flattenServiceCatalogConstraintDetail(apiObject *servicecatalog.ConstraintDetail) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ConstraintId; v != nil {
+		tfMap["constraint_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Description; v != nil {
+		tfMap["description"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Owner; v != nil {
+		tfMap["owner"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.ProductId; v != nil {
+		tfMap["product_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Type; v != nil {
+		tfMap["type"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenServiceCatalogConstraintDetails(apiObjects []*servicecatalog.ConstraintDetail) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenServiceCatalogConstraintDetail(apiObject))
+	}
+
+	return tfList
+}

--- a/aws/data_source_aws_servicecatalog_portfolio_constraints_test.go
+++ b/aws/data_source_aws_servicecatalog_portfolio_constraints_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestAccAWSServiceCatalogPortfolioConstraintDataSource_basic(t *testing.T) {
-	resourceName := "aws_servicecatalog_portfolio_constraint.test"
-	dataSourceName := "data.aws_servicecatalog_portfolio_constraint.test"
+	resourceName := "aws_servicecatalog_constraint.test"
+	dataSourceName := "data.aws_servicecatalog_portfolio_constraints.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,14 +21,15 @@ func TestAccAWSServiceCatalogPortfolioConstraintDataSource_basic(t *testing.T) {
 			{
 				Config: testAccAWSServiceCatalogPortfolioConstraintDataSourceConfig_basic(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "accept_language", dataSourceName, "accept_language"),
-					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
-					resource.TestCheckResourceAttrPair(resourceName, "owner", dataSourceName, "owner"),
-					resource.TestCheckResourceAttrPair(resourceName, "parameters", dataSourceName, "parameters"),
-					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", dataSourceName, "portfolio_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "product_id", dataSourceName, "product_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
-					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "accept_language", resourceName, "accept_language"),
+					resource.TestCheckResourceAttr(dataSourceName, "details.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "details.0.constraint_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "details.0.description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "details.0.owner", resourceName, "owner"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "details.0.portfolio_id", resourceName, "portfolio_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "details.0.product_id", resourceName, "product_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "details.0.type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "portfolio_id", resourceName, "portfolio_id"),
 				),
 			},
 		},
@@ -36,9 +37,9 @@ func TestAccAWSServiceCatalogPortfolioConstraintDataSource_basic(t *testing.T) {
 }
 
 func testAccAWSServiceCatalogPortfolioConstraintDataSourceConfig_basic(rName, description string) string {
-	return composeConfig(testAccAWSServiceCatalogPortfolioConstraintConfig_basic(rName, description), `
+	return composeConfig(testAccAWSServiceCatalogConstraintConfig_basic(rName, description), `
 data "aws_servicecatalog_portfolio_constraints" "test" {
-  id = aws_servicecatalog_portfolio_constraint.test.id
+  portfolio_id = aws_servicecatalog_constraint.test.portfolio_id
 }
 `)
 }

--- a/aws/data_source_aws_servicecatalog_portfolio_constraints_test.go
+++ b/aws/data_source_aws_servicecatalog_portfolio_constraints_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSServiceCatalogPortfolioConstraintDataSource_basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_portfolio_constraint.test"
+	dataSourceName := "data.aws_servicecatalog_portfolio_constraint.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, servicecatalog.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSServiceCatalogPortfolioConstraintDataSourceConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "accept_language", dataSourceName, "accept_language"),
+					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "owner", dataSourceName, "owner"),
+					resource.TestCheckResourceAttrPair(resourceName, "parameters", dataSourceName, "parameters"),
+					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", dataSourceName, "portfolio_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", dataSourceName, "product_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
+					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSServiceCatalogPortfolioConstraintDataSourceConfig_basic(rName, description string) string {
+	return composeConfig(testAccAWSServiceCatalogPortfolioConstraintConfig_basic(rName, description), `
+data "aws_servicecatalog_portfolio_constraints" "test" {
+  id = aws_servicecatalog_portfolio_constraint.test.id
+}
+`)
+}

--- a/aws/internal/service/servicecatalog/id.go
+++ b/aws/internal/service/servicecatalog/id.go
@@ -87,3 +87,7 @@ func PrincipalPortfolioAssociationParseID(id string) (string, string, string, er
 func PrincipalPortfolioAssociationID(acceptLanguage, principalARN, portfolioID string) string {
 	return strings.Join([]string{acceptLanguage, principalARN, portfolioID}, ",")
 }
+
+func PortfolioConstraintsID(acceptLanguage, portfolioID, productID string) string {
+	return strings.Join([]string{acceptLanguage, portfolioID, productID}, ":")
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -393,6 +393,7 @@ func Provider() *schema.Provider {
 			"aws_secretsmanager_secret_version":              dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_servicecatalog_constraint":                  dataSourceAwsServiceCatalogConstraint(),
 			"aws_servicecatalog_launch_paths":                dataSourceAwsServiceCatalogLaunchPaths(),
+			"aws_servicecatalog_portfolio_constraints":       dataSourceAwsServiceCatalogPortfolioConstraints(),
 			"aws_servicecatalog_portfolio":                   dataSourceAwsServiceCatalogPortfolio(),
 			"aws_servicecatalog_product":                     dataSourceAwsServiceCatalogProduct(),
 			"aws_servicequotas_service":                      dataSourceAwsServiceQuotasService(),

--- a/aws/resource_aws_servicecatalog_constraint.go
+++ b/aws/resource_aws_servicecatalog_constraint.go
@@ -144,7 +144,7 @@ func resourceAwsServiceCatalogConstraintRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("error describing Service Catalog Constraint (%s): %w", d.Id(), err)
 	}
 
-	if output == nil {
+	if output == nil || output.ConstraintDetail == nil {
 		return fmt.Errorf("error getting Service Catalog Constraint (%s): empty response", d.Id())
 	}
 

--- a/website/docs/d/servicecatalog_portfolio_constraints.html.markdown
+++ b/website/docs/d/servicecatalog_portfolio_constraints.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Service Catalog"
+layout: "aws"
+page_title: "AWS: aws_servicecatalog_portfolio_constraints"
+description: |-
+  Provides information on Service Catalog Portfolio Constraints
+---
+
+# Data source: aws_servicecatalog_portfolio_constraints
+
+Provides information on Service Catalog Portfolio Constraints.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_servicecatalog_portfolio_constraints" "example" {
+  portfolio_id = "port-3lli3b3an"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `portfolio_id` - Portfolio identifier.
+
+The following arguments are optional:
+
+* `accept_language` - (Optional) Language code. Valid values: `en` (English), `jp` (Japanese), `zh` (Chinese). Default value is `en`.
+* `product_id` - (Optional) Product identifier.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `details` - List of information about the constraints. See details below.
+
+### details
+
+* `constraint_id` - Identifier of the constraint.
+* `description` - Description of the constraint.
+* `product_id` - Identifier of the product the constraint applies to. A constraint applies to a specific instance of a product within a certain portfolio.
+* `type` - Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `STACKSET`, and `TEMPLATE`.

--- a/website/docs/d/servicecatalog_portfolio_constraints.html.markdown
+++ b/website/docs/d/servicecatalog_portfolio_constraints.html.markdown
@@ -24,7 +24,7 @@ data "aws_servicecatalog_portfolio_constraints" "example" {
 
 The following arguments are required:
 
-* `portfolio_id` - Portfolio identifier.
+* `portfolio_id` - (Required) Portfolio identifier.
 
 The following arguments are optional:
 
@@ -41,5 +41,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `constraint_id` - Identifier of the constraint.
 * `description` - Description of the constraint.
+* `portfolio_id` - Identifier of the portfolio the product resides in. The constraint applies only to the instance of the product that lives within this portfolio.
 * `product_id` - Identifier of the product the constraint applies to. A constraint applies to a specific instance of a product within a certain portfolio.
 * `type` - Type of constraint. Valid values are `LAUNCH`, `NOTIFICATION`, `STACKSET`, and `TEMPLATE`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15369
Relates #18074
Relates #19122

Output from acceptance testing (`us-west-2`):

```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run='TestAccAWSServiceCatalogConstraint_|TestAccAWSServiceCatalogConstraintDataSource_|TestAccAWSServiceCatalogPortfolioConstraintDataSource_' -timeout 180m
--- PASS: TestAccAWSServiceCatalogConstraint_disappears (35.16s)
--- PASS: TestAccAWSServiceCatalogPortfolioConstraintDataSource_basic (36.07s)
--- PASS: TestAccAWSServiceCatalogConstraintDataSource_basic (36.55s)
--- PASS: TestAccAWSServiceCatalogConstraint_basic (36.88s)
--- PASS: TestAccAWSServiceCatalogConstraint_update (55.08s)

```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogConstraint_disappears (38.68s)
--- PASS: TestAccAWSServiceCatalogPortfolioConstraintDataSource_basic (39.36s)
--- PASS: TestAccAWSServiceCatalogConstraintDataSource_basic (40.16s)
--- PASS: TestAccAWSServiceCatalogConstraint_basic (41.91s)
--- PASS: TestAccAWSServiceCatalogConstraint_update (63.57s)
```
