### PR TITLE
r/cognito_identity_provider - fix updating `idp_identifiers` crash

### DIFF
--- a/.changelog/19819.txt
+++ b/.changelog/19819.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_identity_provider: Fix updating `idp_identifiers` crash.
+```

--- a/.changelog/19819.txt
+++ b/.changelog/19819.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 resource/aws_cognito_identity_provider: Fix updating `idp_identifiers` crash.
 ```

--- a/aws/resource_aws_cognito_identity_provider.go
+++ b/aws/resource_aws_cognito_identity_provider.go
@@ -63,17 +63,10 @@ func resourceAwsCognitoIdentityProvider() *schema.Resource {
 			},
 
 			"provider_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					cognitoidentityprovider.IdentityProviderTypeTypeSaml,
-					cognitoidentityprovider.IdentityProviderTypeTypeFacebook,
-					cognitoidentityprovider.IdentityProviderTypeTypeGoogle,
-					cognitoidentityprovider.IdentityProviderTypeTypeLoginWithAmazon,
-					cognitoidentityprovider.IdentityProviderTypeTypeOidc,
-					cognitoidentityprovider.IdentityProviderTypeTypeSignInWithApple,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(cognitoidentityprovider.IdentityProviderTypeType_Values(), false),
 			},
 
 			"user_pool_id": {
@@ -111,7 +104,7 @@ func resourceAwsCognitoIdentityProviderCreate(d *schema.ResourceData, meta inter
 
 	_, err := conn.CreateIdentityProvider(params)
 	if err != nil {
-		return fmt.Errorf("Error creating Cognito Identity Provider: %s", err)
+		return fmt.Errorf("Error creating Cognito Identity Provider: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", userPoolID, providerName))
@@ -154,15 +147,15 @@ func resourceAwsCognitoIdentityProviderRead(d *schema.ResourceData, meta interfa
 	d.Set("user_pool_id", ip.UserPoolId)
 
 	if err := d.Set("attribute_mapping", aws.StringValueMap(ip.AttributeMapping)); err != nil {
-		return fmt.Errorf("error setting attribute_mapping error: %s", err)
+		return fmt.Errorf("error setting attribute_mapping error: %w", err)
 	}
 
 	if err := d.Set("provider_details", aws.StringValueMap(ip.ProviderDetails)); err != nil {
-		return fmt.Errorf("error setting provider_details error: %s", err)
+		return fmt.Errorf("error setting provider_details error: %w", err)
 	}
 
 	if err := d.Set("idp_identifiers", flattenStringList(ip.IdpIdentifiers)); err != nil {
-		return fmt.Errorf("error setting idp_identifiers error: %s", err)
+		return fmt.Errorf("error setting idp_identifiers error: %w", err)
 	}
 
 	return nil
@@ -191,12 +184,12 @@ func resourceAwsCognitoIdentityProviderUpdate(d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("idp_identifiers") {
-		params.IdpIdentifiers = expandStringList(d.Get("supported_login_providers").([]interface{}))
+		params.IdpIdentifiers = expandStringList(d.Get("idp_identifiers").([]interface{}))
 	}
 
 	_, err = conn.UpdateIdentityProvider(params)
 	if err != nil {
-		return fmt.Errorf("Error updating Cognito Identity Provider: %s", err)
+		return fmt.Errorf("Error updating Cognito Identity Provider: %w", err)
 	}
 
 	return resourceAwsCognitoIdentityProviderRead(d, meta)

--- a/aws/resource_aws_cognito_identity_provider_test.go
+++ b/aws/resource_aws_cognito_identity_provider_test.go
@@ -72,6 +72,88 @@ func TestAccAWSCognitoIdentityProvider_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoIdentityProvider_idpIdentifiers(t *testing.T) {
+	var identityProvider cognitoidentityprovider.IdentityProviderType
+	resourceName := "aws_cognito_identity_provider.test"
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		ErrorCheck:   testAccErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityProviderIDPIdentifierConfig(userPoolName, "test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityProviderExists(resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.0", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoIdentityProviderIDPIdentifierConfig(userPoolName, "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityProviderExists(resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "idp_identifiers.0", "test2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityProvider_disappears(t *testing.T) {
+	var identityProvider cognitoidentityprovider.IdentityProviderType
+	resourceName := "aws_cognito_identity_provider.test"
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		ErrorCheck:   testAccErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityProviderConfig_basic(userPoolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityProviderExists(resourceName, &identityProvider),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCognitoIdentityProvider(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityProvider_disappears_userPool(t *testing.T) {
+	var identityProvider cognitoidentityprovider.IdentityProviderType
+	resourceName := "aws_cognito_identity_provider.test"
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		ErrorCheck:   testAccErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityProviderConfig_basic(userPoolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityProviderExists(resourceName, &identityProvider),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCognitoUserPool(), "aws_cognito_user_pool.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSCognitoIdentityProviderDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
 
@@ -193,4 +275,33 @@ resource "aws_cognito_identity_provider" "test" {
   }
 }
 `, userPoolName)
+}
+
+func testAccAWSCognitoIdentityProviderIDPIdentifierConfig(userPoolName, attribute string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name                     = %[1]q
+  auto_verified_attributes = ["email"]
+}
+
+resource "aws_cognito_identity_provider" "test" {
+  user_pool_id  = aws_cognito_user_pool.test.id
+  provider_name = "Google"
+  provider_type = "Google"
+
+  idp_identifiers = [%[2]q]
+
+  provider_details = {
+    attributes_url                = "https://people.googleapis.com/v1/people/me?personFields="
+    attributes_url_add_attributes = "true"
+    authorize_scopes              = "email"
+    authorize_url                 = "https://accounts.google.com/o/oauth2/v2/auth"
+    client_id                     = "test-url.apps.googleusercontent.com"
+    client_secret                 = "client_secret"
+    oidc_issuer                   = "https://accounts.google.com"
+    token_request_method          = "POST"
+    token_url                     = "https://www.googleapis.com/oauth2/v4/token"
+  }
+}
+`, userPoolName, attribute)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19792

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoIdentityProvider_'
--- PASS: TestAccAWSCognitoIdentityProvider_disappears_userPool (32.44s)
--- PASS: TestAccAWSCognitoIdentityProvider_disappears (37.57s)
--- PASS: TestAccAWSCognitoIdentityProvider_basic (71.52s)
--- PASS: TestAccAWSCognitoIdentityProvider_idpIdentifiers (71.68s)
```
