### PR TITLE
Check VpcSettings and ConnectSettings for nil values

### DIFF
--- a/.changelog/19820.txt
+++ b/.changelog/19820.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_directory_service_directory: Check VpcSettings and ConnectSettings for nil values
+```

--- a/aws/data_source_aws_directory_service_directory.go
+++ b/aws/data_source_aws_directory_service_directory.go
@@ -182,9 +182,9 @@ func dataSourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta int
 	d.Set("enable_sso", dir.SsoEnabled)
 
 	var securityGroupId *string
-	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {
+	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector && dir.ConnectSettings != nil {
 		securityGroupId = dir.ConnectSettings.SecurityGroupId
-	} else {
+	} else if dir.VpcSettings != nil {
 		securityGroupId = dir.VpcSettings.SecurityGroupId
 	}
 	d.Set("security_group_id", securityGroupId)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #17168

Output from acceptance testing:

```
 TESTARGS="-run=TestAccDataSourceAwsDirectoryServiceDirectory_" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsDirectoryServiceDirectory_ -timeout 180m
=== RUN   TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent
=== PAUSE TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent
=== RUN   TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD
=== PAUSE TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD
=== RUN   TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD
=== PAUSE TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD
=== RUN   TestAccDataSourceAwsDirectoryServiceDirectory_connector
=== PAUSE TestAccDataSourceAwsDirectoryServiceDirectory_connector
=== CONT  TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent
=== CONT  TestAccDataSourceAwsDirectoryServiceDirectory_connector
=== CONT  TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD
=== CONT  TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent (3.56s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD (773.20s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_connector (1290.75s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD (1892.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1892.367s
```
