### PR TITLE
Adjust AWS Glue triggers default timeouts to be aligned with documentation

### DIFF
--- a/.changelog/19827.txt
+++ b/.changelog/19827.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_trigger: Fix default timeouts for Create and Delete operations
+```

--- a/aws/internal/service/glue/waiter/waiter.go
+++ b/aws/internal/service/glue/waiter/waiter.go
@@ -14,8 +14,8 @@ const (
 	SchemaAvailableTimeout        = 2 * time.Minute
 	SchemaDeleteTimeout           = 2 * time.Minute
 	SchemaVersionAvailableTimeout = 2 * time.Minute
-	TriggerCreateTimeout          = 2 * time.Minute
-	TriggerDeleteTimeout          = 2 * time.Minute
+	TriggerCreateTimeout          = 5 * time.Minute
+	TriggerDeleteTimeout          = 5 * time.Minute
 )
 
 // MLTransformDeleted waits for an MLTransform to return Deleted


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
### Description
Simple adjustment to change default timeouts for Create and Delete operations for AWS Glue triggers

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19826

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make testacc TESTARGS='-run=TestAccAWSGlueTrigger'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGlueTrigger -timeout 180m
=== RUN   TestAccAWSGlueTrigger_basic
=== PAUSE TestAccAWSGlueTrigger_basic
=== RUN   TestAccAWSGlueTrigger_Crawler
=== PAUSE TestAccAWSGlueTrigger_Crawler
=== RUN   TestAccAWSGlueTrigger_Description
=== PAUSE TestAccAWSGlueTrigger_Description
=== RUN   TestAccAWSGlueTrigger_Enabled
=== PAUSE TestAccAWSGlueTrigger_Enabled
=== RUN   TestAccAWSGlueTrigger_Predicate
=== PAUSE TestAccAWSGlueTrigger_Predicate
=== RUN   TestAccAWSGlueTrigger_Schedule
=== PAUSE TestAccAWSGlueTrigger_Schedule
=== RUN   TestAccAWSGlueTrigger_Tags
=== PAUSE TestAccAWSGlueTrigger_Tags
=== RUN   TestAccAWSGlueTrigger_WorkflowName
=== PAUSE TestAccAWSGlueTrigger_WorkflowName
=== RUN   TestAccAWSGlueTrigger_actions_notify
=== PAUSE TestAccAWSGlueTrigger_actions_notify
=== RUN   TestAccAWSGlueTrigger_actions_securityConfig
=== PAUSE TestAccAWSGlueTrigger_actions_securityConfig
=== RUN   TestAccAWSGlueTrigger_onDemandDisable
=== PAUSE TestAccAWSGlueTrigger_onDemandDisable
=== RUN   TestAccAWSGlueTrigger_disappears
=== PAUSE TestAccAWSGlueTrigger_disappears
=== CONT  TestAccAWSGlueTrigger_basic
=== CONT  TestAccAWSGlueTrigger_onDemandDisable
=== CONT  TestAccAWSGlueTrigger_Schedule
=== CONT  TestAccAWSGlueTrigger_actions_securityConfig
=== CONT  TestAccAWSGlueTrigger_Enabled
=== CONT  TestAccAWSGlueTrigger_disappears
=== CONT  TestAccAWSGlueTrigger_WorkflowName
=== CONT  TestAccAWSGlueTrigger_Predicate
=== CONT  TestAccAWSGlueTrigger_Tags
=== CONT  TestAccAWSGlueTrigger_actions_notify
=== CONT  TestAccAWSGlueTrigger_Crawler
=== CONT  TestAccAWSGlueTrigger_Description
--- PASS: TestAccAWSGlueTrigger_WorkflowName (99.40s)
--- PASS: TestAccAWSGlueTrigger_disappears (100.59s)
--- PASS: TestAccAWSGlueTrigger_basic (104.67s)
--- PASS: TestAccAWSGlueTrigger_actions_securityConfig (109.35s)
--- PASS: TestAccAWSGlueTrigger_Description (168.75s)
--- PASS: TestAccAWSGlueTrigger_Schedule (193.65s)
--- PASS: TestAccAWSGlueTrigger_Predicate (196.07s)
--- PASS: TestAccAWSGlueTrigger_Crawler (227.06s)
--- PASS: TestAccAWSGlueTrigger_onDemandDisable (240.18s)
--- PASS: TestAccAWSGlueTrigger_actions_notify (248.73s)
--- PASS: TestAccAWSGlueTrigger_Tags (263.17s)
--- PASS: TestAccAWSGlueTrigger_Enabled (264.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       264.314s


...
```
