### PR TITLE
Add time_zone parameter to aws_autoscaling_schedule

### DIFF
--- a/.changelog/19829.txt
+++ b/.changelog/19829.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+resource/aws_autoscaling_schedule: Add time_zone argument
+```

--- a/aws/resource_aws_autoscaling_schedule.go
+++ b/aws/resource_aws_autoscaling_schedule.go
@@ -51,6 +51,11 @@ func resourceAwsAutoscalingSchedule() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validateASGScheduleTimestamp,
 			},
+			"time_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"recurrence": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -117,6 +122,10 @@ func resourceAwsAutoscalingScheduleCreate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("Error Parsing AWS Autoscaling Group Schedule End Time: %s", err.Error())
 		}
 		params.EndTime = aws.Time(t)
+	}
+
+	if attr, ok := d.GetOk("time_zone"); ok {
+		params.TimeZone = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("recurrence"); ok {
@@ -192,6 +201,10 @@ func resourceAwsAutoscalingScheduleRead(d *schema.ResourceData, meta interface{}
 
 	if sa.EndTime != nil {
 		d.Set("end_time", sa.EndTime.Format(awsAutoscalingScheduleTimeLayout))
+	}
+
+	if sa.TimeZone != nil {
+		d.Set("time_zone", sa.TimeZone)
 	}
 
 	return nil

--- a/aws/resource_aws_autoscaling_schedule_test.go
+++ b/aws/resource_aws_autoscaling_schedule_test.go
@@ -359,6 +359,7 @@ resource "aws_autoscaling_schedule" "foobar" {
   max_size               = 1
   desired_capacity       = 0
   recurrence             = "0 8 * * *"
+  time_zone              = "Pacific/Tahiti"
   autoscaling_group_name = aws_autoscaling_group.foobar.name
 }
 `, r, r)

--- a/website/docs/r/autoscaling_schedule.html.markdown
+++ b/website/docs/r/autoscaling_schedule.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `end_time` - (Optional) The time for this action to end, in "YYYY-MM-DDThh:mm:ssZ" format in UTC/GMT only (for example, 2014-06-01T00:00:00Z ).
                           If you try to schedule your action in the past, Auto Scaling returns an error message.
 * `recurrence` - (Optional) The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format.
+* `time_zone` - (Optional)  The timezone for the cron expression. Valid values are the canonical names of the IANA time zones (such as Etc/GMT+9 or Pacific/Tahiti).
 * `min_size` - (Optional) The minimum size for the Auto Scaling group. Default 0.
 Set to -1 if you don't want to change the minimum size at the scheduled time.
 * `max_size` - (Optional) The maximum size for the Auto Scaling group. Default 0.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAutoscalingSchedule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoscalingSchedule -timeout 180m
go: downloading github.com/pquerna/otp v1.3.0
go: downloading github.com/apparentlymart/go-cidr v1.0.1
go: downloading github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc
=== RUN   TestAccAWSAutoscalingSchedule_basic
=== PAUSE TestAccAWSAutoscalingSchedule_basic
=== RUN   TestAccAWSAutoscalingSchedule_disappears
=== PAUSE TestAccAWSAutoscalingSchedule_disappears
=== RUN   TestAccAWSAutoscalingSchedule_recurrence
=== PAUSE TestAccAWSAutoscalingSchedule_recurrence
=== RUN   TestAccAWSAutoscalingSchedule_zeroValues
=== PAUSE TestAccAWSAutoscalingSchedule_zeroValues
=== RUN   TestAccAWSAutoscalingSchedule_negativeOne
=== PAUSE TestAccAWSAutoscalingSchedule_negativeOne
=== CONT  TestAccAWSAutoscalingSchedule_basic
=== CONT  TestAccAWSAutoscalingSchedule_zeroValues
=== CONT  TestAccAWSAutoscalingSchedule_negativeOne
=== CONT  TestAccAWSAutoscalingSchedule_recurrence
=== CONT  TestAccAWSAutoscalingSchedule_disappears
--- PASS: TestAccAWSAutoscalingSchedule_disappears (153.76s)
--- PASS: TestAccAWSAutoscalingSchedule_negativeOne (160.48s)
--- PASS: TestAccAWSAutoscalingSchedule_recurrence (167.91s)
--- PASS: TestAccAWSAutoscalingSchedule_basic (173.35s)
--- PASS: TestAccAWSAutoscalingSchedule_zeroValues (178.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	178.894s
...
```
