### PR TITLE
r/aws_lambda_event_source_mapping: Additional IAM eventual consistency error message

### DIFF
--- a/.changelog/19831.txt
+++ b/.changelog/19831.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_event_source_mapping: Enhance handling of IAM eventual consistency errors during create
+```

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -384,6 +384,10 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 			return resource.RetryableError(err)
 		}
 
+		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "execution role does not have permissions") {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19828.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_SQS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaEventSourceMapping_SQS -timeout 180m
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow (48.59s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (87.21s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_basic (113.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	118.730s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_SQS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaEventSourceMapping_SQS -timeout 180m
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow (56.95s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (106.36s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_basic (141.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	145.465s
```
