### PR TITLE
r/aws_backup_vault_policy: sweeper should not fail on AccessDeniedException 

### DIFF
--- a/.changelog/19749.txt
+++ b/.changelog/19749.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_backup_vault_policy: Correctly handle reading policy of deleted vault
+```

--- a/.changelog/19854.txt
+++ b/.changelog/19854.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_backup_vault_policy: Correctly handle deleting policy of deleted vault
+```

--- a/aws/internal/service/backup/errors.go
+++ b/aws/internal/service/backup/errors.go
@@ -1,0 +1,5 @@
+package backup
+
+const (
+	ErrCodeAccessDeniedException = "AccessDeniedException"
+)

--- a/aws/internal/service/backup/finder/finder.go
+++ b/aws/internal/service/backup/finder/finder.go
@@ -1,0 +1,37 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfbackup "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/backup"
+)
+
+func BackupVaultAccessPolicyByName(conn *backup.Backup, name string) (*backup.GetBackupVaultAccessPolicyOutput, error) {
+	input := &backup.GetBackupVaultAccessPolicyInput{
+		BackupVaultName: aws.String(name),
+	}
+
+	output, err := conn.GetBackupVaultAccessPolicy(input)
+
+	if tfawserr.ErrCodeEquals(err, backup.ErrCodeResourceNotFoundException) || tfawserr.ErrCodeEquals(err, tfbackup.ErrCodeAccessDeniedException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/resource_aws_backup_vault_policy.go
+++ b/aws/resource_aws_backup_vault_policy.go
@@ -91,7 +91,10 @@ func resourceAwsBackupVaultPolicyDelete(d *schema.ResourceData, meta interface{}
 
 	_, err := conn.DeleteBackupVaultAccessPolicy(input)
 	if err != nil {
-		if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+		if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") ||
+			isAWSErr(err, "AccessDeniedException", "") {
+			log.Printf("[WARN] Backup Vault Policy (%s) not found, removing from state", d.Id())
+			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("error deleting Backup Vault Policy (%s): %w", d.Id(), err)

--- a/aws/resource_aws_backup_vault_policy.go
+++ b/aws/resource_aws_backup_vault_policy.go
@@ -81,7 +81,7 @@ func resourceAwsBackupVaultPolicyRead(d *schema.ResourceData, meta interface{}) 
 		}
 
 		for _, el := range resp.BackupVaultList {
-			if *el.BackupVaultName == d.Id() {
+			if aws.StringValue(el.BackupVaultName) == d.Id() {
 				return fmt.Errorf("error reading Backup Vault Policy (%s): %w", d.Id(), err)
 			}
 		}

--- a/aws/resource_aws_backup_vault_policy.go
+++ b/aws/resource_aws_backup_vault_policy.go
@@ -6,8 +6,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tfbackup "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/backup"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/backup/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsBackupVaultPolicy() *schema.Resource {
@@ -21,6 +25,10 @@ func resourceAwsBackupVaultPolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"backup_vault_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"backup_vault_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -32,10 +40,6 @@ func resourceAwsBackupVaultPolicy() *schema.Resource {
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
-			"backup_vault_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -43,17 +47,19 @@ func resourceAwsBackupVaultPolicy() *schema.Resource {
 func resourceAwsBackupVaultPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
 
+	name := d.Get("backup_vault_name").(string)
 	input := &backup.PutBackupVaultAccessPolicyInput{
-		BackupVaultName: aws.String(d.Get("backup_vault_name").(string)),
+		BackupVaultName: aws.String(name),
 		Policy:          aws.String(d.Get("policy").(string)),
 	}
 
 	_, err := conn.PutBackupVaultAccessPolicy(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating Backup Vault Policy (%s): %w", d.Id(), err)
+		return fmt.Errorf("error creating Backup Vault Policy (%s): %w", name, err)
 	}
 
-	d.SetId(d.Get("backup_vault_name").(string))
+	d.SetId(name)
 
 	return resourceAwsBackupVaultPolicyRead(d, meta)
 }
@@ -61,39 +67,21 @@ func resourceAwsBackupVaultPolicyPut(d *schema.ResourceData, meta interface{}) e
 func resourceAwsBackupVaultPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
 
-	input := &backup.GetBackupVaultAccessPolicyInput{
-		BackupVaultName: aws.String(d.Id()),
-	}
+	output, err := finder.BackupVaultAccessPolicyByName(conn, d.Id())
 
-	resp, err := conn.GetBackupVaultAccessPolicy(input)
-	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
-		log.Printf("[WARN] Backup Vault Policy %s not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Backup Vault Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		listInput := &backup.ListBackupVaultsInput{}
-		resp, errList := conn.ListBackupVaults(listInput)
-
-		if errList != nil {
-			return fmt.Errorf("error reading Backup Vault Policy (%s): %w and could not list Backup Vaults (%s)", d.Id(), err, errList)
-		}
-
-		for _, el := range resp.BackupVaultList {
-			if aws.StringValue(el.BackupVaultName) == d.Id() {
-				return fmt.Errorf("error reading Backup Vault Policy (%s): %w", d.Id(), err)
-			}
-		}
-
-		log.Printf("[WARN] Backup Vault Policy %s not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
+		return fmt.Errorf("error reading Backup Vault Policy (%s): %w", d.Id(), err)
 	}
 
-	d.Set("backup_vault_name", resp.BackupVaultName)
-	d.Set("policy", resp.Policy)
-	d.Set("backup_vault_arn", resp.BackupVaultArn)
+	d.Set("backup_vault_arn", output.BackupVaultArn)
+	d.Set("backup_vault_name", output.BackupVaultName)
+	d.Set("policy", output.Policy)
 
 	return nil
 }
@@ -101,18 +89,16 @@ func resourceAwsBackupVaultPolicyRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsBackupVaultPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
 
-	input := &backup.DeleteBackupVaultAccessPolicyInput{
+	log.Printf("[DEBUG] Deleting Backup Vault Policy (%s)", d.Id())
+	_, err := conn.DeleteBackupVaultAccessPolicy(&backup.DeleteBackupVaultAccessPolicyInput{
 		BackupVaultName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, backup.ErrCodeResourceNotFoundException) || tfawserr.ErrCodeEquals(err, tfbackup.ErrCodeAccessDeniedException) {
+		return nil
 	}
 
-	_, err := conn.DeleteBackupVaultAccessPolicy(input)
 	if err != nil {
-		if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") ||
-			isAWSErr(err, "AccessDeniedException", "") {
-			log.Printf("[WARN] Backup Vault Policy (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
 		return fmt.Errorf("error deleting Backup Vault Policy (%s): %w", d.Id(), err)
 	}
 

--- a/aws/resource_aws_backup_vault_policy_test.go
+++ b/aws/resource_aws_backup_vault_policy_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -29,45 +29,37 @@ func testSweepBackupVaultPolicies(region string) error {
 		return fmt.Errorf("Error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).backupconn
-	var sweeperErrs *multierror.Error
-
 	input := &backup.ListBackupVaultsInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]*testSweepResource, 0)
 
-	for {
-		output, err := conn.ListBackupVaults(input)
-		if err != nil {
-			if testSweepSkipSweepError(err) {
-				log.Printf("[WARN] Skipping Backup Vault Policies sweep for %s: %s", region, err)
-				return nil
-			}
-			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Backup Vault Policies: %w", err))
-			return sweeperErrs.ErrorOrNil()
+	err = conn.ListBackupVaultsPages(input, func(page *backup.ListBackupVaultsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
 
-		if len(output.BackupVaultList) == 0 {
-			log.Print("[DEBUG] No Backup Vault Policies to sweep")
-			return nil
+		for _, vault := range page.BackupVaultList {
+			r := resourceAwsBackupVaultPolicy()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(vault.BackupVaultName))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
 
-		for _, rule := range output.BackupVaultList {
-			name := aws.StringValue(rule.BackupVaultName)
+		return !lastPage
+	})
 
-			log.Printf("[INFO] Deleting Backup Vault Policies %s", name)
-			_, err := conn.DeleteBackupVaultAccessPolicy(&backup.DeleteBackupVaultAccessPolicyInput{
-				BackupVaultName: aws.String(name),
-			})
-			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting Backup Vault Policies %s: %w", name, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
-			}
-		}
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Backup Vault Policies sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
+	}
 
-		if output.NextToken == nil {
-			break
-		}
-		input.NextToken = output.NextToken
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Backup Vaults for %s: %w", region, err))
+	}
+
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Backup Vault Policies for %s: %w", region, err))
 	}
 
 	return sweeperErrs.ErrorOrNil()
@@ -123,6 +115,30 @@ func TestAccAwsBackupVaultPolicy_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupVaultPolicyExists(resourceName, &vault),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupVaultPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsBackupVaultPolicy_disappears_vault(t *testing.T) {
+	var vault backup.GetBackupVaultAccessPolicyOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_backup_vault_policy.test"
+	vaultResourceName := "aws_backup_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		ErrorCheck:   testAccErrorCheck(t, backup.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupVaultPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupVaultPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultPolicyExists(resourceName, &vault),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupVault(), vaultResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19848

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupVaultPolicy_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupVaultPolicy_* -timeout 180m
=== RUN   TestAccAwsBackupVaultPolicy_basic
=== PAUSE TestAccAwsBackupVaultPolicy_basic
=== RUN   TestAccAwsBackupVaultPolicy_disappears
=== PAUSE TestAccAwsBackupVaultPolicy_disappears
=== CONT  TestAccAwsBackupVaultPolicy_basic
=== CONT  TestAccAwsBackupVaultPolicy_disappears
--- PASS: TestAccAwsBackupVaultPolicy_basic (173.38s)
--- PASS: TestAccAwsBackupVaultPolicy_disappears (177.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       179.798s
```
