### PR TITLE
r/aws_batch_job_definition: add `arn_prefix` attribute to aws_batch_job_definition

### DIFF
--- a/.changelog/19858.txt
+++ b/.changelog/19858.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_job_definition: add arn_prefix attribute to aws_batch_job_definition
+```

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -167,6 +167,10 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		CustomizeDiff: SetTagsDiff,
@@ -243,6 +247,7 @@ func resourceAwsBatchJobDefinitionRead(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Set("arn", jobDefinition.JobDefinitionArn)
+	d.Set("arn_prefix", strings.TrimSuffix(*jobDefinition.JobDefinitionArn, fmt.Sprintf(":%d", *jobDefinition.Revision)))
 
 	containerProperties, err := flattenBatchContainerProperties(jobDefinition.ContainerProperties)
 

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -88,6 +88,7 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
@@ -148,6 +149,7 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
@@ -186,6 +188,7 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerProperti
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
@@ -224,6 +227,7 @@ func TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
@@ -407,6 +411,7 @@ func TestAccAWSBatchJobDefinition_PropagateTags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn_prefix", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s`, rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -142,6 +142,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name of the job definition.
+* `arn_prefix` - The job definition ARN prefix without revision number.
 * `revision` - The revision of the job definition.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18111

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSBatchJobDefinition_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSBatchJobDefinition_* -timeout 180m
=== RUN   TestAccAWSBatchJobDefinition_basic
=== PAUSE TestAccAWSBatchJobDefinition_basic
=== RUN   TestAccAWSBatchJobDefinition_disappears
=== PAUSE TestAccAWSBatchJobDefinition_disappears
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== RUN   TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== PAUSE TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
=== RUN   TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== PAUSE TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== RUN   TestAccAWSBatchJobDefinition_updateForcesNewResource
=== PAUSE TestAccAWSBatchJobDefinition_updateForcesNewResource
=== RUN   TestAccAWSBatchJobDefinition_Tags
=== PAUSE TestAccAWSBatchJobDefinition_Tags
=== RUN   TestAccAWSBatchJobDefinition_PropagateTags
=== PAUSE TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_basic
=== CONT  TestAccAWSBatchJobDefinition_ContainerProperties_Advanced
=== CONT  TestAccAWSBatchJobDefinition_PropagateTags
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2
=== CONT  TestAccAWSBatchJobDefinition_disappears
=== CONT  TestAccAWSBatchJobDefinition_Tags
=== CONT  TestAccAWSBatchJobDefinition_updateForcesNewResource
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults
=== CONT  TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate
--- PASS: TestAccAWSBatchJobDefinition_PropagateTags (258.28s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate_ContainerPropertiesDefaults (258.82s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (264.21s)
--- PASS: TestAccAWSBatchJobDefinition_disappears (265.06s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_EC2 (267.19s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (268.69s)
--- PASS: TestAccAWSBatchJobDefinition_PlatformCapabilities_Fargate (279.68s)
--- PASS: TestAccAWSBatchJobDefinition_basic (281.46s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (345.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       347.515s
```
