### PR TITLE
r/codedeploy_app: Fix, parallelize sweeper

### DIFF
--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/envvar"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+const (
+	SweepThrottlingRetryTimeout = 5 * time.Minute
 )
 
 // sweeperAwsClients is a shared cache of regional AWSClient
@@ -77,7 +83,26 @@ func testSweepResourceOrchestrator(sweepResources []*testSweepResource) error {
 		sweepResource := sweepResource
 
 		g.Go(func() error {
-			return testAccDeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
+			err := resource.Retry(SweepThrottlingRetryTimeout, func() *resource.RetryError {
+				var err error
+
+				err = testAccDeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
+
+				if err != nil {
+					if tfawserr.ErrCodeContains(err, "ThrottlingException: Rate exceeded") {
+						return resource.RetryableError(err)
+					}
+
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+
+			if tfresource.TimedOut(err) {
+				err = testAccDeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
+			}
+
+			return err
 		})
 	}
 

--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -84,9 +84,7 @@ func testSweepResourceOrchestrator(sweepResources []*testSweepResource) error {
 
 		g.Go(func() error {
 			err := resource.Retry(SweepThrottlingRetryTimeout, func() *resource.RetryError {
-				var err error
-
-				err = testAccDeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
+				err := testAccDeleteResource(sweepResource.resource, sweepResource.d, sweepResource.meta)
 
 				if err != nil {
 					if tfawserr.ErrCodeContains(err, "ThrottlingException: Rate exceeded") {
@@ -95,6 +93,7 @@ func testSweepResourceOrchestrator(sweepResources []*testSweepResource) error {
 
 					return resource.NonRetryableError(err)
 				}
+
 				return nil
 			})
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19070

Output from testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
SWEEP=$AWS_DEFAULT_REGION SWEEPARGS=-sweep-run=aws_codedeploy_app make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_codedeploy_app -timeout 60m
2021/06/17 15:08:52 [DEBUG] Running Sweepers for region (us-west-2):
2021/06/17 15:08:52 [DEBUG] Running Sweeper (aws_codedeploy_app) in region (us-west-2)
2021/06/17 15:08:52 [INFO] AWS Auth provider used: "EnvProvider"
2021/06/17 15:08:53 Sweeper Tests ran successfully:
	- aws_codedeploy_app
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.430s
```
