### PR TITLE
closes #12923 - provisioned concurrency config for lambda alias

### DIFF
--- a/.changelog/19868.txt
+++ b/.changelog/19868.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_provisioned_concurrency_config: Fix split of ARN:Qualifier
+```

--- a/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
+++ b/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
@@ -151,6 +151,39 @@ func TestAccAWSLambdaProvisionedConcurrencyConfig_Qualifier_AliasName(t *testing
 	})
 }
 
+func Test_resourceAwsLambdaProvisionedConcurrencyConfigParseId(t *testing.T) {
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{		
+		{ "function with qualifier", args{ "my-function:alias" }, "my-function", "alias", false },
+		{ "function w/o qualifier", args{ "my-function" }, "", "", true },
+		{ "ARN with qualifier", args{ "arn:aws:lambda:nice-region:1234567890:function:my-function:alias" }, "arn:aws:lambda:nice-region:1234567890:function:my-function", "alias", false },
+		{ "ARN w/o qualifier", args{ "arn:aws:lambda:nice-region:1234567890:function:my-function" }, "", "", true },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := resourceAwsLambdaProvisionedConcurrencyConfigParseId(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resourceAwsLambdaProvisionedConcurrencyConfigParseId() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resourceAwsLambdaProvisionedConcurrencyConfigParseId() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("resourceAwsLambdaProvisionedConcurrencyConfigParseId() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
 func testAccCheckLambdaProvisionedConcurrencyConfigDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).lambdaconn
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12923

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
