### PR TITLE
tests/apprunner_service: update tests to use existing image in ECR (previous one dne)

### DIFF
--- a/aws/resource_aws_apprunner_service_test.go
+++ b/aws/resource_aws_apprunner_service_test.go
@@ -112,8 +112,8 @@ func TestAccAwsAppRunnerService_ImageRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.auto_deployments_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.0.port", "8000"),
-					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_identifier", "public.ecr.aws/jg/hello:latest"),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_configuration.0.port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_identifier", "public.ecr.aws/nginx/nginx:latest"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.0.image_repository.0.image_repository_type", apprunner.ImageRepositoryTypeEcrPublic),
 					resource.TestCheckResourceAttr(resourceName, "status", apprunner.ServiceStatusRunning),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -483,9 +483,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -501,12 +501,12 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
         runtime_environment_variables = {
           APP_NAME = %[1]q
         }
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -529,9 +529,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -557,9 +557,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -581,9 +581,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -606,9 +606,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -659,9 +659,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -686,9 +686,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -704,9 +704,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }
@@ -726,9 +726,9 @@ resource "aws_apprunner_service" "test" {
     auto_deployments_enabled = false
     image_repository {
       image_configuration {
-        port = "8000"
+        port = "80"
       }
-      image_identifier      = "public.ecr.aws/jg/hello:latest"
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
       image_repository_type = "ECR_PUBLIC"
     }
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/19840

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsAppRunnerService_disappears (227.18s)
--- PASS: TestAccAwsAppRunnerService_tags (269.18s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_basic (269.66s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_RuntimeEnvironmentVars (301.03s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_AutoScalingConfiguration (334.03s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_InstanceConfiguration (421.49s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_EncryptionConfiguration (482.59s)
--- PASS: TestAccAwsAppRunnerService_ImageRepository_HealthCheckConfiguration (523.96s)
```
