### PR TITLE
sweepers/apprunner_autoscaling_configuration_version: skip default configs

### DIFF
--- a/aws/resource_aws_apprunner_auto_scaling_configuration_version_test.go
+++ b/aws/resource_aws_apprunner_auto_scaling_configuration_version_test.go
@@ -49,6 +49,13 @@ func testSweepAppRunnerAutoScalingConfigurationVersions(region string) error {
 				continue
 			}
 
+			// Skip DefaultConfigurations as deletion not supported by the AppRunner service
+			// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19840
+			if aws.StringValue(summaryConfig.AutoScalingConfigurationName) == "DefaultConfiguration" {
+				log.Printf("[INFO] Skipping App Runner AutoScaling Configuration: DefaultConfiguration")
+				continue
+			}
+
 			arn := aws.StringValue(summaryConfig.AutoScalingConfigurationArn)
 
 			log.Printf("[INFO] Deleting App Runner AutoScaling Configuration Version (%s)", arn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19840

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEP='us-west-2' SWEEPARGS='-sweep-run=aws_apprunner_service'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_apprunner_service -timeout 60m
2021/06/17 17:07:38 [DEBUG] Running Sweepers for region (us-west-2):
2021/06/17 17:07:38 [DEBUG] Running Sweeper (aws_apprunner_service) in region (us-west-2)
2021/06/17 17:07:38 [INFO] AWS Auth provider used: "EnvProvider"
2021/06/17 17:07:38 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/17 17:07:38 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/06/17 17:07:45 Sweeper Tests ran successfully:
        - aws_apprunner_service
ok      github.com/terraform-providers/terraform-provider-aws/aws       10.476s
```
