### PR TITLE
sweepers/imagebuilder_image: find image builder version arns + concurrency

### DIFF
--- a/aws/resource_aws_imagebuilder_image_test.go
+++ b/aws/resource_aws_imagebuilder_image_test.go
@@ -24,12 +24,14 @@ func init() {
 
 func testSweepImageBuilderImages(region string) error {
 	client, err := sharedClientForRegion(region)
+
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-	conn := client.(*AWSClient).imagebuilderconn
 
-	var sweeperErrs *multierror.Error
+	conn := client.(*AWSClient).imagebuilderconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
 
 	input := &imagebuilder.ListImagesInput{
 		Owner: aws.String(imagebuilder.OwnershipSelf),
@@ -45,13 +47,14 @@ func testSweepImageBuilderImages(region string) error {
 				continue
 			}
 
+			// Retrieve the Image's Build Version ARNs required as input
+			// to the resourceAwsImageBuilderImage()'s Delete operation
+			// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19851
 			imageVersionArn := aws.StringValue(imageVersion.Arn)
 
 			input := &imagebuilder.ListImageBuildVersionsInput{
 				ImageVersionArn: imageVersion.Arn,
 			}
-
-			var imageBuildVersionArns []string
 
 			err := conn.ListImageBuildVersionsPages(input, func(page *imagebuilder.ListImageBuildVersionsOutput, lastPage bool) bool {
 				if page == nil {
@@ -63,48 +66,40 @@ func testSweepImageBuilderImages(region string) error {
 						continue
 					}
 
-					imageBuildVersionArns = append(imageBuildVersionArns, aws.StringValue(imageSummary.Arn))
+					imageBuildVersionArn := aws.StringValue(imageSummary.Arn)
+
+					r := resourceAwsImageBuilderImage()
+					d := r.Data(nil)
+					d.SetId(imageBuildVersionArn)
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 				}
 
 				return !lastPage
 			})
 
 			if err != nil {
-				sweeperErr := fmt.Errorf("error listing Image Builder Image Build Versions for image (%s): %w", imageVersionArn, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
-			}
-
-			for _, imageBuildVersionArn := range imageBuildVersionArns {
-				r := resourceAwsImageBuilderImage()
-				d := r.Data(nil)
-				d.SetId(imageBuildVersionArn)
-
-				err := r.Delete(d, client)
-
-				if err != nil {
-					sweeperErr := fmt.Errorf("error deleting Image Builder Image (%s): %w", imageBuildVersionArn, err)
-					log.Printf("[ERROR] %s", sweeperErr)
-					sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-					continue
-				}
+				errs = multierror.Append(errs, fmt.Errorf("error listing Image Builder Image Build Versions for image (%s): %w", imageVersionArn, err))
 			}
 		}
 
 		return !lastPage
 	})
 
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Image Builder Images for %s: %w", region, err))
+	}
+
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Image Builder Images for %s: %w", region, err))
+	}
+
 	if testSweepSkipSweepError(err) {
 		log.Printf("[WARN] Skipping Image Builder Image sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		return nil
 	}
 
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Image Builder Images: %w", err))
-	}
-
-	return sweeperErrs.ErrorOrNil()
+	return errs.ErrorOrNil()
 }
 
 func TestAccAwsImageBuilderImage_basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19851 
Relates #15334

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
will be verified by nightly TC runs
```
