### PR TITLE
Improve Route 53 resource code comments

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -509,8 +509,8 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	// If we don't have a zone ID, we're doing an import. Parse it from the ID.
 	if _, ok := d.GetOk("zone_id"); !ok {
 		parts := parseRecordId(d.Id())
-		//we check that we have parsed the id into the correct number of segments
-		//we need at least 3 segments!
+		// We check that we have parsed the id into the correct number of segments.
+		// We need at least 3 segments!
 		if parts[0] == "" || parts[1] == "" || parts[2] == "" {
 			return fmt.Errorf("Error Importing aws_route_53 record. Please make sure the record ID is in the form ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER (e.g. Z4KAPRWWNC7JR_dev.example.com_NS_dev), where SET-IDENTIFIER is optional")
 		}

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -674,9 +674,9 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 	// We need to loop over all records starting from the record we are looking for because
 	// Weighted, Latency, Geo, and Failover resource record sets have a special option
 	// called SetIdentifier which allows multiple entries with the same name and type but
-	// a different SetIdentifier
+	// a different SetIdentifier.
 	// For all other records we are setting the maxItems to 1 so that we don't return extra
-	// unneeded records
+	// unneeded records.
 	err = conn.ListResourceRecordSetsPages(lopts, func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
 		for _, recordSet := range resp.ResourceRecordSets {
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -616,7 +616,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 // If no matching recordset is found, it returns nil and a r53NoRecordsFound
 // error.
 //
-// If there are other errors, it returns nil a nil recordset and passes on the
+// If there are other errors, it returns a nil recordset and passes on the
 // error.
 func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceRecordSet, error) {
 	conn := meta.(*AWSClient).r53conn

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -42,7 +42,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					// AWS Provider aws_acm_certification.domain_validation_options.resource_record_name
 					// references (and perhaps others) contain a trailing period, requiring a custom StateFunc
-					// to trim the string to prevent Route53 API error
+					// to trim the string to prevent Route53 API error.
 					value := strings.TrimSuffix(v.(string), ".")
 					return strings.ToLower(value)
 				},

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -906,7 +906,7 @@ func FQDN(name string) string {
 }
 
 // Route 53 stores certain characters with the octal equivalent in ASCII format.
-// This function converts all of these characters back into the original character
+// This function converts all of these characters back into the original character.
 // E.g. "*" is stored as "\\052" and "@" as "\\100"
 func cleanRecordName(name string) string {
 	str := name

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -604,7 +604,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 // findRecord takes a ResourceData struct for aws_resource_route53_record. It
-// uses the referenced zone_id to query Route53 and find information on it's
+// uses the referenced zone_id to query Route53 and find information on its
 // records.
 //
 // If records are found, it returns the matching

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -908,7 +908,6 @@ func FQDN(name string) string {
 // Route 53 stores certain characters with the octal equivalent in ASCII format.
 // This function converts all of these characters back into the original character
 // E.g. "*" is stored as "\\052" and "@" as "\\100"
-
 func cleanRecordName(name string) string {
 	str := name
 	s, err := strconv.Unquote(`"` + str + `"`)
@@ -946,7 +945,7 @@ func resourceAwsRoute53AliasRecordHash(v interface{}) int {
 
 // nilString takes a string as an argument and returns a string
 // pointer. The returned pointer is nil if the string argument is
-// empty, otherwise it is a pointer to a copy of the string.
+// empty. Otherwise, it is a pointer to a copy of the string.
 func nilString(s string) *string {
 	if s == "" {
 		return nil

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -407,7 +407,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	// Protect existing DNS records which might be managed in another way
+	// Protect existing DNS records which might be managed in another way.
 	// Use UPSERT only if the overwrite flag is true or if the current action is an update
 	// Else CREATE is used and fail if the same record exists
 	var action string

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -614,7 +614,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 // error.
 //
 // If no matching recordset is found, it returns nil and a r53NoRecordsFound
-// error
+// error.
 //
 // If there are other errors, it returns nil a nil recordset and passes on the
 // error.

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -260,8 +260,8 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		return resourceAwsRoute53RecordCreate(d, meta)
 	}
 
-	// Otherwise we delete the existing record and create a new record within
-	// a transactional change
+	// Otherwise, we delete the existing record and create a new record within
+	// a transactional change.
 	conn := meta.(*AWSClient).r53conn
 	zone := cleanZoneID(d.Get("zone_id").(string))
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -506,7 +506,7 @@ func waitForRoute53RecordSetToSync(conn *route53.Route53, requestId string) erro
 }
 
 func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) error {
-	// If we don't have a zone ID we're doing an import. Parse it from the ID.
+	// If we don't have a zone ID, we're doing an import. Parse it from the ID.
 	if _, ok := d.GetOk("zone_id"); !ok {
 		parts := parseRecordId(d.Id())
 		//we check that we have parsed the id into the correct number of segments


### PR DESCRIPTION
Thanks for your hard work on `terraform-provider-aws`! This pull request contains no changes to functionality and only seeks to address a few typos and grammar issues I discovered while reading through `aws/resource_aws_route53_record.go`'s code comments.

Thanks again and I apologize if such a small, immaterial change is unwelcome -- I know the provider maintainers are very busy :) 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->