### PR TITLE
sweeper/backup_vault: add sweeper with concurrency

### DIFF
--- a/aws/resource_aws_backup_vault.go
+++ b/aws/resource_aws_backup_vault.go
@@ -140,7 +140,7 @@ func resourceAwsBackupVaultDelete(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).backupconn
 
 	input := &backup.DeleteBackupVaultInput{
-		BackupVaultName: aws.String(d.Get("name").(string)),
+		BackupVaultName: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteBackupVault(input)

--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -2,14 +2,89 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_backup_vault", &resource.Sweeper{
+		Name: "aws_backup_vault",
+		F:    testSweepBackupVaults,
+		Dependencies: []string{
+			"aws_backup_vault_notifications",
+			"aws_backup_vault_policy",
+		},
+	})
+}
+
+func testSweepBackupVaults(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("Error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).backupconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &backup.ListBackupVaultsInput{}
+
+	err = conn.ListBackupVaultsPages(input, func(page *backup.ListBackupVaultsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, vault := range page.BackupVaultList {
+			if vault == nil {
+				continue
+			}
+
+			// Ignore Default Backup Vault in region (cannot be deleted)
+			if aws.StringValue(vault.BackupVaultName) == "Default" {
+				log.Printf("[INFO] Skipping Backup Vault: Default")
+				continue
+			}
+
+			// Backup Vault deletion only supported when empty
+			// Reference: https://docs.aws.amazon.com/aws-backup/latest/devguide/API_DeleteBackupVault.html
+			if aws.Int64Value(vault.NumberOfRecoveryPoints) != 0 {
+				log.Printf("[INFO] Skipping Backup Vault (%s): not empty", aws.StringValue(vault.BackupVaultName))
+				continue
+			}
+
+			r := resourceAwsBackupVault()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(vault.BackupVaultName))
+
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing Backup Vaults for %s: %w", region, err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping Backup Vaults for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping Backup Vaults sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAwsBackupVault_basic(t *testing.T) {
 	var vault backup.DescribeBackupVaultOutput


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19847 
Relates #15334

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
will be covered by nightly runs
```
