### PR TITLE
sweeper/aws_api_gateway_vpc_link: Fails silently

### DIFF
--- a/aws/internal/service/apigateway/waiter/status.go
+++ b/aws/internal/service/apigateway/waiter/status.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func apiGatewayVpcLinkStatus(conn *apigateway.APIGateway, vpcLinkId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := conn.GetVpcLink(&apigateway.GetVpcLinkInput{
+			VpcLinkId: aws.String(vpcLinkId),
+		})
+		if tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		// Error messages can also be contained in the response with FAILED status
+		if aws.StringValue(output.Status) == apigateway.VpcLinkStatusFailed {
+			return output, apigateway.VpcLinkStatusFailed, fmt.Errorf("%s: %s", apigateway.VpcLinkStatusFailed, aws.StringValue(output.StatusMessage))
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/aws/internal/service/apigateway/waiter/waiter.go
+++ b/aws/internal/service/apigateway/waiter/waiter.go
@@ -1,0 +1,29 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	// Maximum amount of time for VpcLink to delete
+	ApiGatewayVpcLinkDeleteTimeout = 20 * time.Minute
+)
+
+func ApiGatewayVpcLinkDeleted(conn *apigateway.APIGateway, vpcLinkId string) error {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{apigateway.VpcLinkStatusPending,
+			apigateway.VpcLinkStatusAvailable,
+			apigateway.VpcLinkStatusDeleting},
+		Target:     []string{""},
+		Timeout:    ApiGatewayVpcLinkDeleteTimeout,
+		MinTimeout: 1 * time.Second,
+		Refresh:    apiGatewayVpcLinkStatus(conn, vpcLinkId),
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}

--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -11,13 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/apigateway/waiter"
 )
 
 const (
 	// Maximum amount of time for VpcLink to become available
 	apigatewayVpcLinkAvailableTimeout = 20 * time.Minute
-	// Maximum amount of time for VpcLink to delete
-	apigatewayVpcLinkDeleteTimeout = 20 * time.Minute
 )
 
 func resourceAwsApiGatewayVpcLink() *schema.Resource {
@@ -213,11 +212,11 @@ func resourceAwsApiGatewayVpcLinkDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting API Gateway VPC Link (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting API Gateway VPC Link (%s): %w", d.Id(), err)
 	}
 
-	if err := waitForApiGatewayVpcLinkDeletion(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for API Gateway VPC Link (%s) deletion: %s", d.Id(), err)
+	if err := waiter.ApiGatewayVpcLinkDeleted(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for API Gateway VPC Link (%s) deletion: %w", d.Id(), err)
 	}
 
 	return nil
@@ -234,34 +233,4 @@ func apigatewayVpcLinkRefreshStatusFunc(conn *apigateway.APIGateway, vl string) 
 		}
 		return resp, *resp.Status, nil
 	}
-}
-
-func waitForApiGatewayVpcLinkDeletion(conn *apigateway.APIGateway, vpcLinkID string) error {
-	stateConf := resource.StateChangeConf{
-		Pending: []string{apigateway.VpcLinkStatusPending,
-			apigateway.VpcLinkStatusAvailable,
-			apigateway.VpcLinkStatusDeleting},
-		Target:     []string{""},
-		Timeout:    apigatewayVpcLinkDeleteTimeout,
-		MinTimeout: 1 * time.Second,
-		Refresh: func() (interface{}, string, error) {
-			resp, err := conn.GetVpcLink(&apigateway.GetVpcLinkInput{
-				VpcLinkId: aws.String(vpcLinkID),
-			})
-
-			if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
-				return 1, "", nil
-			}
-
-			if err != nil {
-				return nil, apigateway.VpcLinkStatusFailed, err
-			}
-
-			return resp, aws.StringValue(resp.Status), nil
-		},
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
 }

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -53,7 +53,7 @@ func testSweepAPIGatewayVpcLinks(region string) error {
 	}
 
 	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping API Gateway VPC Links"))
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping API Gateway VPC Links: %w", err))
 	}
 
 	return sweeperErrs.ErrorOrNil()

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -23,40 +24,39 @@ func init() {
 func testSweepAPIGatewayVpcLinks(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).apigatewayconn
 
+	sweepResources := make([]*testSweepResource, 0)
+	var sweeperErrs *multierror.Error
+
 	err = conn.GetVpcLinksPages(&apigateway.GetVpcLinksInput{}, func(page *apigateway.GetVpcLinksOutput, lastPage bool) bool {
 		for _, item := range page.Items {
-			input := &apigateway.DeleteVpcLinkInput{
-				VpcLinkId: item.Id,
-			}
 			id := aws.StringValue(item.Id)
 
-			log.Printf("[INFO] Deleting API Gateway VPC Link: %s", id)
-			_, err := conn.DeleteVpcLink(input)
+			log.Printf("[INFO] Deleting API Gateway VPC Link (%s)", id)
+			r := resourceAwsApiGatewayVpcLink()
+			d := r.Data(nil)
+			d.SetId(id)
 
-			if err != nil {
-				log.Printf("[ERROR] Failed to delete API Gateway VPC Link %s: %s", id, err)
-				continue
-			}
-
-			if err := waitForApiGatewayVpcLinkDeletion(conn, id); err != nil {
-				log.Printf("[ERROR] Error waiting for API Gateway VPC Link (%s) deletion: %s", id, err)
-			}
+			sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 		}
 		return !lastPage
 	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping API Gateway VPC Link sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping API Gateway VPC Link sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("Error retrieving API Gateway VPC Links: %s", err)
+		return fmt.Errorf("error retrieving API Gateway VPC Links: %w", err)
 	}
 
-	return nil
+	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping App Runner AutoScaling Configuration Version for %s: %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
 }
 
 func TestAccAWSAPIGatewayVpcLink_basic(t *testing.T) {

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -53,7 +53,7 @@ func testSweepAPIGatewayVpcLinks(region string) error {
 	}
 
 	if err := testSweepResourceOrchestrator(sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping App Runner AutoScaling Configuration Version for %s: %w", region, err))
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping API Gateway VPC Links"))
 	}
 
 	return sweeperErrs.ErrorOrNil()


### PR DESCRIPTION
Now returns errors from the `aws_api_gateway_vpc_link` sweeper instead of failing silently.

Adds concurrency to sweeper

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #19842

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPARGS='-sweep-run=aws_api_gateway_vpc_link'

2021/06/18 11:19:44 [INFO] Deleting API Gateway VPC Link (abcxyz)
2021/06/18 11:19:45 [DEBUG] Waiting for state to become: []
2021/06/18 11:19:45 [TRACE] Waiting 1s before next try
2021/06/18 11:19:46 [TRACE] Waiting 2s before next try
2021/06/18 11:19:48 [TRACE] Waiting 4s before next try
2021/06/18 11:19:53 [TRACE] Waiting 8s before next try
2021/06/18 11:20:01 [TRACE] Waiting 10s before next try
2021/06/18 11:20:11 [TRACE] Waiting 10s before next try
2021/06/18 11:20:21 [TRACE] Waiting 10s before next try
2021/06/18 11:20:31 [TRACE] Waiting 10s before next try
2021/06/18 11:20:42 [TRACE] Waiting 10s before next try
2021/06/18 11:20:52 [TRACE] Waiting 10s before next try
2021/06/18 11:21:02 [TRACE] Waiting 10s before next try
2021/06/18 11:21:12 [TRACE] Waiting 10s before next try
2021/06/18 11:21:23 [TRACE] Waiting 10s before next try
2021/06/18 11:21:33 [TRACE] Waiting 10s before next try
2021/06/18 11:21:43 [TRACE] Waiting 10s before next try
2021/06/18 11:21:53 [TRACE] Waiting 10s before next try
2021/06/18 11:22:03 [TRACE] Waiting 10s before next try
2021/06/18 11:22:14 [TRACE] Waiting 10s before next try
2021/06/18 11:22:24 [TRACE] Waiting 10s before next try
2021/06/18 11:22:34 [ERROR] Error running Sweeper (aws_api_gateway_vpc_link) in region (us-west-2): 1 error occurred:
	* error sweeping API Gateway VPC Links: 1 error occurred:
	* error waiting for API Gateway VPC Link (abcxyz) deletion: FAILED: An internal error occurred while processing your request

```
