### PR TITLE
r/neptune_cluster - add `copy_snapshot_to_tags` and refactor to use waiters

### DIFF
--- a/.changelog/19899.txt
+++ b/.changelog/19899.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_neptune_cluster: Add `copy_snapshot_to_tags` argument
+```

--- a/aws/internal/service/neptune/waiter/status.go
+++ b/aws/internal/service/neptune/waiter/status.go
@@ -12,6 +12,12 @@ const (
 
 	// EventSubscription Unknown
 	EventSubscriptionStatusUnknown = "Unknown"
+
+	// Cluster NotFound
+	ClusterStatusNotFound = "NotFound"
+
+	// Cluster Unknown
+	ClusterStatusUnknown = "Unknown"
 )
 
 // EventSubscriptionStatus fetches the EventSubscription and its Status
@@ -32,5 +38,27 @@ func EventSubscriptionStatus(conn *neptune.Neptune, subscriptionName string) res
 		}
 
 		return output.EventSubscriptionsList[0], aws.StringValue(output.EventSubscriptionsList[0].Status), nil
+	}
+}
+
+// ClusterStatus fetches the Cluster and its Status
+func ClusterStatus(conn *neptune.Neptune, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &neptune.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(id),
+		}
+
+		output, err := conn.DescribeDBClusters(input)
+
+		if err != nil {
+			return nil, ClusterStatusUnknown, err
+		}
+
+		if len(output.DBClusters) == 0 {
+			return nil, ClusterStatusNotFound, nil
+		}
+
+		cluster := output.DBClusters[0]
+		return cluster, aws.StringValue(cluster.Status), nil
 	}
 }

--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -337,11 +337,6 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 		restoreDBClusterFromSnapshotInput.EngineVersion = aws.String(attr.(string))
 	}
 
-	if attr, ok := d.GetOk("copy_tags_to_snapshot"); ok {
-		createDbClusterInput.EngineVersion = aws.String(attr.(string))
-		restoreDBClusterFromSnapshotInput.EngineVersion = aws.String(attr.(string))
-	}
-
 	if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
 		createDbClusterInput.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
 		restoreDBClusterFromSnapshotInput.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))

--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/neptune/waiter"
 )
 
 const (
@@ -407,7 +408,7 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Neptune Cluster: %s", err)
+		return fmt.Errorf("error creating Neptune Cluster: %w", err)
 	}
 
 	d.SetId(d.Get("cluster_identifier").(string))
@@ -415,19 +416,9 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[INFO] Neptune Cluster ID: %s", d.Id())
 	log.Println("[INFO] Waiting for Neptune Cluster to be available")
 
-	stateConf := &resource.StateChangeConf{
-		Pending:    resourceAwsNeptuneClusterCreatePendingStates,
-		Target:     []string{"available"},
-		Refresh:    resourceAwsNeptuneClusterStateRefreshFunc(d, meta),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	// Wait, catching any errors
-	_, err = stateConf.WaitForState()
+	_, err = waiter.DBClusterAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("error waiting for Neptune Cluster state to be \"available\": %s", err)
+		return fmt.Errorf("error waiting for Neptune Cluster (%q) to be Available: %w", d.Id(), err)
 	}
 
 	if v, ok := d.GetOk("iam_roles"); ok {
@@ -486,7 +477,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
-		return fmt.Errorf("Error saving AvailabilityZones to state for Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving AvailabilityZones to state for Neptune Cluster (%s): %w", d.Id(), err)
 	}
 
 	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
@@ -495,7 +486,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 	d.Set("copy_tags_to_snapshot", dbc.CopyTagsToSnapshot)
 
 	if err := d.Set("enable_cloudwatch_logs_exports", aws.StringValueSlice(dbc.EnabledCloudwatchLogsExports)); err != nil {
-		return fmt.Errorf("Error saving EnableCloudwatchLogsExports to state for Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving EnableCloudwatchLogsExports to state for Neptune Cluster (%s): %w", d.Id(), err)
 	}
 
 	d.Set("endpoint", dbc.Endpoint)
@@ -519,7 +510,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 		sg = append(sg, aws.StringValue(g.VpcSecurityGroupId))
 	}
 	if err := d.Set("vpc_security_group_ids", sg); err != nil {
-		return fmt.Errorf("Error saving VPC Security Group IDs to state for Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving VPC Security Group IDs to state for Neptune Cluster (%s): %w", d.Id(), err)
 	}
 
 	var cm []string
@@ -527,7 +518,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 		cm = append(cm, aws.StringValue(m.DBInstanceIdentifier))
 	}
 	if err := d.Set("cluster_members", cm); err != nil {
-		return fmt.Errorf("Error saving Neptune Cluster Members to state for Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving Neptune Cluster Members to state for Neptune Cluster (%s): %w", d.Id(), err)
 	}
 
 	var roles []string
@@ -536,7 +527,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 	}
 
 	if err := d.Set("iam_roles", roles); err != nil {
-		return fmt.Errorf("Error saving IAM Roles to state for Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving IAM Roles to state for Neptune Cluster (%s): %w", d.Id(), err)
 	}
 
 	arn := aws.StringValue(dbc.DBClusterArn)
@@ -545,7 +536,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 	tags, err := keyvaluetags.NeptuneListTags(conn, d.Get("arn").(string))
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Neptune Cluster (%s): %s", d.Get("arn").(string), err)
+		return fmt.Errorf("error listing tags for Neptune Cluster (%s): %w", d.Get("arn").(string), err)
 	}
 
 	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -653,22 +644,12 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 			_, err = conn.ModifyDBCluster(req)
 		}
 		if err != nil {
-			return fmt.Errorf("Failed to modify Neptune Cluster (%s): %s", d.Id(), err)
+			return fmt.Errorf("Failed to modify Neptune Cluster (%s): %w", d.Id(), err)
 		}
 
-		stateConf := &resource.StateChangeConf{
-			Pending:    resourceAwsNeptuneClusterUpdatePendingStates,
-			Target:     []string{"available"},
-			Refresh:    resourceAwsNeptuneClusterStateRefreshFunc(d, meta),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			MinTimeout: 10 * time.Second,
-			Delay:      10 * time.Second,
-		}
-
-		log.Printf("[INFO] Waiting for Neptune Cluster (%s) to modify", d.Id())
-		_, err = stateConf.WaitForState()
+		_, err = waiter.DBClusterAvailable(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("error waiting for Neptune Cluster (%s) to modify: %s", d.Id(), err)
+			return fmt.Errorf("error waiting for Neptune Cluster (%q) to be Available: %w", d.Id(), err)
 		}
 	}
 
@@ -705,7 +686,7 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 		o, n := d.GetChange("tags_all")
 
 		if err := keyvaluetags.NeptuneUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Neptune Cluster (%s) tags: %s", d.Get("arn").(string), err)
+			return fmt.Errorf("error updating Neptune Cluster (%s) tags: %w", d.Get("arn").(string), err)
 		}
 
 	}
@@ -751,63 +732,18 @@ func resourceAwsNeptuneClusterDelete(d *schema.ResourceData, meta interface{}) e
 		_, err = conn.DeleteDBCluster(&deleteOpts)
 	}
 	if err != nil {
-		return fmt.Errorf("Neptune Cluster cannot be deleted: %s", err)
+		return fmt.Errorf("Neptune Cluster cannot be deleted: %w", err)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending:    resourceAwsNeptuneClusterDeletePendingStates,
-		Target:     []string{"destroyed"},
-		Refresh:    resourceAwsNeptuneClusterStateRefreshFunc(d, meta),
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	// Wait, catching any errors
-	_, err = stateConf.WaitForState()
+	_, err = waiter.DBClusterDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("Error deleting Neptune Cluster (%s): %s", d.Id(), err)
+		if isAWSErr(err, neptune.ErrCodeDBClusterNotFoundFault, "") {
+			return nil
+		}
+		return fmt.Errorf("error waiting for Neptune Cluster (%q) to be Deleted: %w", d.Id(), err)
 	}
 
 	return nil
-}
-
-func resourceAwsNeptuneClusterStateRefreshFunc(
-	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		conn := meta.(*AWSClient).neptuneconn
-
-		resp, err := conn.DescribeDBClusters(&neptune.DescribeDBClustersInput{
-			DBClusterIdentifier: aws.String(d.Id()),
-		})
-
-		if err != nil {
-			if isAWSErr(err, neptune.ErrCodeDBClusterNotFoundFault, "") {
-				log.Printf("[DEBUG] Neptune Cluster (%s) not found", d.Id())
-				return 42, "destroyed", nil
-			}
-			log.Printf("[DEBUG] Error on retrieving Neptune Cluster (%s) when waiting: %s", d.Id(), err)
-			return nil, "", err
-		}
-
-		var dbc *neptune.DBCluster
-
-		for _, v := range resp.DBClusters {
-			if aws.StringValue(v.DBClusterIdentifier) == d.Id() {
-				dbc = v
-			}
-		}
-
-		if dbc == nil {
-			return 42, "destroyed", nil
-		}
-
-		if dbc.Status != nil {
-			log.Printf("[DEBUG] Neptune Cluster status (%s): %s", d.Id(), aws.StringValue(dbc.Status))
-		}
-
-		return dbc, aws.StringValue(dbc.Status), nil
-	}
 }
 
 func setIamRoleToNeptuneCluster(clusterIdentifier string, roleArn string, conn *neptune.Neptune) error {
@@ -826,25 +762,4 @@ func removeIamRoleFromNeptuneCluster(clusterIdentifier string, roleArn string, c
 	}
 	_, err := conn.RemoveRoleFromDBCluster(params)
 	return err
-}
-
-var resourceAwsNeptuneClusterCreatePendingStates = []string{
-	"creating",
-	"backing-up",
-	"modifying",
-	"preparing-data-migration",
-	"migrating",
-}
-
-var resourceAwsNeptuneClusterUpdatePendingStates = []string{
-	"backing-up",
-	"modifying",
-	"configuring-iam-database-auth",
-}
-
-var resourceAwsNeptuneClusterDeletePendingStates = []string{
-	"available",
-	"deleting",
-	"backing-up",
-	"modifying",
 }

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -505,6 +505,29 @@ func TestAccAWSNeptuneCluster_deleteProtection(t *testing.T) {
 	})
 }
 
+func TestAccAWSNeptuneCluster_disappears(t *testing.T) {
+	var dbCluster neptune.DBCluster
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_neptune_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, neptune.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneClusterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterExists(resourceName, &dbCluster),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsNeptuneCluster(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSNeptuneClusterDestroy(s *terraform.State) error {
 	return testAccCheckAWSNeptuneClusterDestroyWithProvider(s, testAccProvider)
 }

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -57,6 +57,53 @@ func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSNeptuneCluster_copyTagsToSnapshot(t *testing.T) {
+	var dbCluster neptune.DBCluster
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_neptune_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, neptune.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneClusterCopyTagsConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterExists(resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
+			},
+			{
+				Config: testAccAWSNeptuneClusterCopyTagsConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterExists(resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "false"),
+				),
+			},
+			{
+				Config: testAccAWSNeptuneClusterCopyTagsConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterExists(resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSNeptuneCluster_namePrefix(t *testing.T) {
 	var v neptune.DBCluster
 	rName := "tf-test-"
@@ -598,6 +645,19 @@ resource "aws_neptune_cluster" "test" {
   skip_final_snapshot                  = true
 }
 `, rName))
+}
+
+func testAccAWSNeptuneClusterCopyTagsConfig(rName string, copy bool) string {
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                   = %[1]q
+  availability_zones                   = local.availability_zone_names
+  engine                               = "neptune"
+  neptune_cluster_parameter_group_name = "default.neptune1"
+  skip_final_snapshot                  = true
+  copy_tags_to_snapshot                = %[2]t
+}
+`, rName, copy))
 }
 
 func testAccAWSNeptuneClusterConfigDeleteProtection(rName string, isProtected bool) string {

--- a/website/docs/r/neptune_cluster.html.markdown
+++ b/website/docs/r/neptune_cluster.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
 * `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifier`.
+* `copy_tags_to_snapshot` - (Optional) If set to true, tags are copied to any snapshot of the DB cluster that is created.
 * `enable_cloudwatch_logs_exports` - (Optional) A list of the log types this DB cluster is configured to export to Cloudwatch Logs. Currently only supports `audit`.
 * `engine` - (Optional) The name of the database engine to be used for this Neptune cluster. Defaults to `neptune`.
 * `engine_version` - (Optional) The database engine version.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19835

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSNeptuneCluster_'
--- PASS: TestAccAWSNeptuneCluster_disappears (199.05s)
--- PASS: TestAccAWSNeptuneCluster_basic (207.84s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (208.65s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (209.52s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (212.36s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (229.47s)
--- PASS: TestAccAWSNeptuneCluster_tags (232.61s)
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (247.25s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (272.47s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (277.15s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (316.66s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (350.35s)
--- PASS: TestAccAWSNeptuneCluster_copyTagsToSnapshot (350.36s)
```
