### PR TITLE
Deprecate aws_iam_group_membership's name attribute and support importing aws_iam_group_membership

### DIFF
--- a/internal/service/iam/group_membership.go
+++ b/internal/service/iam/group_membership.go
@@ -35,11 +35,10 @@ func ResourceGroupMembership() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
-				// https://github.com/hashicorp/terraform-provider-aws/issues/2882
-				Deprecated: "don't set this attribute",
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   false,
+				Deprecated: "don't set this attribute. Please see https://github.com/hashicorp/terraform-provider-aws/issues/19900",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return true
 				},

--- a/internal/service/iam/group_membership.go
+++ b/internal/service/iam/group_membership.go
@@ -17,10 +17,13 @@ import (
 
 func ResourceGroupMembership() *schema.Resource {
 	return &schema.Resource{
-		Create:        resourceGroupMembershipCreate,
-		Read:          resourceGroupMembershipRead,
-		Update:        resourceGroupMembershipUpdate,
-		Delete:        resourceGroupMembershipDelete,
+		Create: resourceGroupMembershipCreate,
+		Read:   resourceGroupMembershipRead,
+		Update: resourceGroupMembershipUpdate,
+		Delete: resourceGroupMembershipDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{

--- a/internal/service/iam/group_membership_migrate.go
+++ b/internal/service/iam/group_membership_migrate.go
@@ -1,0 +1,44 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGroupMembershipV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"users": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"group": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGroupMembershipStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		rawState = map[string]interface{}{}
+	}
+
+	if group, ok := rawState["group"]; ok {
+		rawState["id"] = group
+	}
+	delete(rawState, "name")
+	return rawState, nil
+}

--- a/internal/service/iam/group_membership_test.go
+++ b/internal/service/iam/group_membership_test.go
@@ -23,7 +23,6 @@ func TestAccIAMGroupMembership_basic(t *testing.T) {
 	userName := fmt.Sprintf("tf-acc-user-gm-basic-%s", rString)
 	userName2 := fmt.Sprintf("tf-acc-user-gm-basic-two-%s", rString)
 	userName3 := fmt.Sprintf("tf-acc-user-gm-basic-three-%s", rString)
-	membershipName := fmt.Sprintf("tf-acc-membership-gm-basic-%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -32,7 +31,7 @@ func TestAccIAMGroupMembership_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGroupMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupMemberConfig(groupName, userName, membershipName),
+				Config: testAccGroupMemberConfig(groupName, userName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupMembershipExists("aws_iam_group_membership.team", &group),
 					testAccCheckGroupMembershipAttributes(&group, groupName, []string{userName}),
@@ -40,7 +39,7 @@ func TestAccIAMGroupMembership_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccGroupMemberUpdateConfig(groupName, userName, userName2, userName3, membershipName),
+				Config: testAccGroupMemberUpdateConfig(groupName, userName, userName2, userName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupMembershipExists("aws_iam_group_membership.team", &group),
 					testAccCheckGroupMembershipAttributes(&group, groupName, []string{userName2, userName3}),
@@ -48,7 +47,7 @@ func TestAccIAMGroupMembership_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccGroupMemberUpdateDownConfig(groupName, userName3, membershipName),
+				Config: testAccGroupMemberUpdateDownConfig(groupName, userName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupMembershipExists("aws_iam_group_membership.team", &group),
 					testAccCheckGroupMembershipAttributes(&group, groupName, []string{userName3}),
@@ -63,7 +62,6 @@ func TestAccIAMGroupMembership_paginatedUserList(t *testing.T) {
 
 	rString := sdkacctest.RandString(8)
 	groupName := fmt.Sprintf("tf-acc-group-gm-pul-%s", rString)
-	membershipName := fmt.Sprintf("tf-acc-membership-gm-pul-%s", rString)
 	userNamePrefix := fmt.Sprintf("tf-acc-user-gm-pul-%s-", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -73,7 +71,7 @@ func TestAccIAMGroupMembership_paginatedUserList(t *testing.T) {
 		CheckDestroy: testAccCheckGroupMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupMemberPaginatedUserListConfig(groupName, membershipName, userNamePrefix),
+				Config: testAccGroupMemberPaginatedUserListConfig(groupName, userNamePrefix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupMembershipExists("aws_iam_group_membership.team", &group),
 					resource.TestCheckResourceAttr(
@@ -161,7 +159,7 @@ func testAccCheckGroupMembershipAttributes(group *iam.GetGroupOutput, groupName 
 	}
 }
 
-func testAccGroupMemberConfig(groupName, userName, membershipName string) string {
+func testAccGroupMemberConfig(groupName, userName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
   name = "%s"
@@ -172,14 +170,13 @@ resource "aws_iam_user" "user" {
 }
 
 resource "aws_iam_group_membership" "team" {
-  name  = "%s"
   users = [aws_iam_user.user.name]
   group = aws_iam_group.group.name
 }
-`, groupName, userName, membershipName)
+`, groupName, userName)
 }
 
-func testAccGroupMemberUpdateConfig(groupName, userName, userName2, userName3, membershipName string) string {
+func testAccGroupMemberUpdateConfig(groupName, userName, userName2, userName3 string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
   name = "%s"
@@ -198,8 +195,6 @@ resource "aws_iam_user" "user_three" {
 }
 
 resource "aws_iam_group_membership" "team" {
-  name = "%s"
-
   users = [
     aws_iam_user.user_two.name,
     aws_iam_user.user_three.name,
@@ -207,10 +202,10 @@ resource "aws_iam_group_membership" "team" {
 
   group = aws_iam_group.group.name
 }
-`, groupName, userName, userName2, userName3, membershipName)
+`, groupName, userName, userName2, userName3)
 }
 
-func testAccGroupMemberUpdateDownConfig(groupName, userName3, membershipName string) string {
+func testAccGroupMemberUpdateDownConfig(groupName, userName3 string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
   name = "%s"
@@ -221,25 +216,22 @@ resource "aws_iam_user" "user_three" {
 }
 
 resource "aws_iam_group_membership" "team" {
-  name = "%s"
-
   users = [
     aws_iam_user.user_three.name,
   ]
 
   group = aws_iam_group.group.name
 }
-`, groupName, userName3, membershipName)
+`, groupName, userName3)
 }
 
-func testAccGroupMemberPaginatedUserListConfig(groupName, membershipName, userNamePrefix string) string {
+func testAccGroupMemberPaginatedUserListConfig(groupName, userNamePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
   name = "%s"
 }
 
 resource "aws_iam_group_membership" "team" {
-  name  = "%s"
   group = aws_iam_group.group.name
 
   # TODO: Switch back to simple list reference when test configurations are upgraded to 0.12 syntax
@@ -352,5 +344,5 @@ resource "aws_iam_user" "user" {
   count = 101
   name  = format("%s%%d", count.index + 1)
 }
-`, groupName, membershipName, userNamePrefix)
+`, groupName, userNamePrefix)
 }

--- a/website/docs/r/iam_group_membership.html.markdown
+++ b/website/docs/r/iam_group_membership.html.markdown
@@ -21,8 +21,6 @@ more information on managing IAM Groups or IAM Users, see [IAM Groups][1] or
 
 ```terraform
 resource "aws_iam_group_membership" "team" {
-  name = "tf-testing-group-membership"
-
   users = [
     aws_iam_user.user_one.name,
     aws_iam_user.user_two.name,
@@ -56,7 +54,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `name` - The name to identify the Group Membership
+* `name` - *Deprecated:* Don't set this attribute. The name to identify the Group Membership
 * `users` - list of IAM User names
 * `group` – IAM Group name
 
@@ -64,3 +62,11 @@ In addition to all arguments above, the following attributes are exported:
 [1]: /docs/providers/aws/r/iam_group.html
 [2]: /docs/providers/aws/r/iam_user.html
 [3]: /docs/providers/aws/r/iam_user_group_membership.html
+
+## Import
+
+IAM Group Membership can be imported using the `group`, e.g.
+
+```
+$ terraform import aws_iam_group_membership.team test-group
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Close #19900

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=AccIAMGroupMembership' PKG_NAME=internal/service/iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run=AccIAMGroupMembership -timeout 180m
=== RUN   TestAccIAMGroupMembership_basic
=== PAUSE TestAccIAMGroupMembership_basic
=== RUN   TestAccIAMGroupMembership_paginatedUserList
=== PAUSE TestAccIAMGroupMembership_paginatedUserList
=== CONT  TestAccIAMGroupMembership_basic
=== CONT  TestAccIAMGroupMembership_paginatedUserList
--- PASS: TestAccIAMGroupMembership_basic (137.21s)
--- PASS: TestAccIAMGroupMembership_paginatedUserList (371.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	372.967s
```
