### PR TITLE
Fixed description of role_arn attribute of aws_cloudwatch_event_target

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -333,7 +333,7 @@ The following arguments are supported:
 * `arn` - (Required) The Amazon Resource Name (ARN) of the target.
 * `input` - (Optional) Valid JSON text passed to the target. Conflicts with `input_path` and `input_transformer`.
 * `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/) that is used for extracting part of the matched event when passing it to the target. Conflicts with `input` and `input_transformer`.
-* `role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. Required if `ecs_target` is used.
+* `role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. Required if `ecs_target` is used or target in `arn` is EC2 instance, Kinesis data stream or Step Functions state machine.
 * `run_command_targets` - (Optional) Parameters used when you are using the rule to invoke Amazon EC2 Run Command. Documented below. A maximum of 5 are allowed.
 * `ecs_target` - (Optional) Parameters used when you are using the rule to invoke Amazon ECS Task. Documented below. A maximum of 1 are allowed.
 * `batch_target` - (Optional) Parameters used when you are using the rule to invoke an Amazon Batch Job. Documented below. A maximum of 1 are allowed.


### PR DESCRIPTION
# Documentation fix only

As stated in https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html#:~:text=For%20EC2%20instances%2C%20Kinesis%20data%20streams%2C%20and%20Step%20Functions%20state%20machines%2C%20EventBridge%20uses%20IAM%20roles%20that%20you%20specify%20in%20the%20RoleARN%20parameter%20in%20PutTargets.

Encountered the problem when using with State Machine:
```
Error: Creating CloudWatch Events Target failed: ValidationException: RoleArn is required for target arn:aws:states:eu-west-1:123456789012:stateMachine:Workflow.
	status code: 400, request id: 1bc81789-ea07-4a6f-9414-b56fa99972eb

  on eventbridge.tf line 54, in resource "aws_cloudwatch_event_target" "sns":
  54: resource "aws_cloudwatch_event_target" "target" {
```