### PR TITLE
Check target blocks are not nil

### DIFF
--- a/.changelog/19946.txt
+++ b/.changelog/19946.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Don't crash if `sqs_target` configuration block is empty.
+```

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -494,11 +494,11 @@ func buildPutTargetInputStruct(d *schema.ResourceData) *events.PutTargetsInput {
 		e.RoleArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("run_command_targets"); ok {
+	if v, ok := d.GetOk("run_command_targets"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.RunCommandParameters = expandAwsCloudWatchEventTargetRunParameters(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("ecs_target"); ok {
+	if v, ok := d.GetOk("ecs_target"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.EcsParameters = expandAwsCloudWatchEventTargetEcsParameters(v.([]interface{}))
 	}
 
@@ -506,27 +506,27 @@ func buildPutTargetInputStruct(d *schema.ResourceData) *events.PutTargetsInput {
 		e.HttpParameters = expandAwsCloudWatchEventTargetHttpParameters(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	if v, ok := d.GetOk("batch_target"); ok {
+	if v, ok := d.GetOk("batch_target"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.BatchParameters = expandAwsCloudWatchEventTargetBatchParameters(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("kinesis_target"); ok {
+	if v, ok := d.GetOk("kinesis_target"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.KinesisParameters = expandAwsCloudWatchEventTargetKinesisParameters(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("sqs_target"); ok {
+	if v, ok := d.GetOk("sqs_target"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.SqsParameters = expandAwsCloudWatchEventTargetSqsParameters(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("input_transformer"); ok {
+	if v, ok := d.GetOk("input_transformer"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.InputTransformer = expandAwsCloudWatchEventTransformerParameters(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("retry_policy"); ok {
+	if v, ok := d.GetOk("retry_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.RetryPolicy = expandAwsCloudWatchEventRetryPolicyParameters(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("dead_letter_config"); ok {
+	if v, ok := d.GetOk("dead_letter_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		e.DeadLetterConfig = expandAwsCloudWatchEventDeadLetterConfigParameters(v.([]interface{}))
 	}
 


### PR DESCRIPTION
If nothing is specified for these blocks then they cannot be cast to `map[string]interface`.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #19945

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 [fg-386] terraform-provider-aws > AWS_PROFILE=sandbox TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchEventTarget
=== RUN   TestAccAWSCloudWatchEventTarget_basic
=== PAUSE TestAccAWSCloudWatchEventTarget_basic
=== RUN   TestAccAWSCloudWatchEventTarget_EventBusName
=== PAUSE TestAccAWSCloudWatchEventTarget_EventBusName
=== RUN   TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== PAUSE TestAccAWSCloudWatchEventTarget_GeneratedTargetId
=== RUN   TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== PAUSE TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
=== RUN   TestAccAWSCloudWatchEventTarget_full
=== PAUSE TestAccAWSCloudWatchEventTarget_full
=== RUN   TestAccAWSCloudWatchEventTarget_disappears
=== PAUSE TestAccAWSCloudWatchEventTarget_disappears
=== RUN   TestAccAWSCloudWatchEventTarget_ssmDocument
=== PAUSE TestAccAWSCloudWatchEventTarget_ssmDocument
=== RUN   TestAccAWSCloudWatchEventTarget_http
=== PAUSE TestAccAWSCloudWatchEventTarget_http
=== RUN   TestAccAWSCloudWatchEventTarget_ecs
=== PAUSE TestAccAWSCloudWatchEventTarget_ecs
=== RUN   TestAccAWSCloudWatchEventTarget_ecsWithBlankLaunchType
=== PAUSE TestAccAWSCloudWatchEventTarget_ecsWithBlankLaunchType
=== RUN   TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== PAUSE TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== RUN   TestAccAWSCloudWatchEventTarget_batch
=== PAUSE TestAccAWSCloudWatchEventTarget_batch
=== RUN   TestAccAWSCloudWatchEventTarget_kinesis
=== PAUSE TestAccAWSCloudWatchEventTarget_kinesis
=== RUN   TestAccAWSCloudWatchEventTarget_sqs
=== PAUSE TestAccAWSCloudWatchEventTarget_sqs
=== RUN   TestAccAWSCloudWatchEventTarget_input_transformer
=== PAUSE TestAccAWSCloudWatchEventTarget_input_transformer
=== RUN   TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== PAUSE TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
=== RUN   TestAccAWSCloudWatchEventTarget_PartnerEventBus
    resource_aws_cloudwatch_event_target_test.go:714: Environment variable EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME is not set
--- SKIP: TestAccAWSCloudWatchEventTarget_PartnerEventBus (0.00s)
=== CONT  TestAccAWSCloudWatchEventTarget_basic
=== CONT  TestAccAWSCloudWatchEventTarget_disappears
=== CONT  TestAccAWSCloudWatchEventTarget_ecsWithBlankLaunchType
=== CONT  TestAccAWSCloudWatchEventTarget_inputTransformerJsonString
--- PASS: TestAccAWSCloudWatchEventTarget_disappears (12.66s)
=== CONT  TestAccAWSCloudWatchEventTarget_input_transformer
--- PASS: TestAccAWSCloudWatchEventTarget_basic (30.38s)
=== CONT  TestAccAWSCloudWatchEventTarget_sqs
--- PASS: TestAccAWSCloudWatchEventTarget_inputTransformerJsonString (35.89s)
=== CONT  TestAccAWSCloudWatchEventTarget_kinesis
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (31.89s)
=== CONT  TestAccAWSCloudWatchEventTarget_batch
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (14.55s)
=== CONT  TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankLaunchType (54.97s)
=== CONT  TestAccAWSCloudWatchEventTarget_http
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (25.19s)
=== CONT  TestAccAWSCloudWatchEventTarget_ecs
--- PASS: TestAccAWSCloudWatchEventTarget_http (15.16s)
=== CONT  TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (54.69s)
=== CONT  TestAccAWSCloudWatchEventTarget_full
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (25.74s)
=== CONT  TestAccAWSCloudWatchEventTarget_GeneratedTargetId
--- PASS: TestAccAWSCloudWatchEventTarget_GeneratedTargetId (11.12s)
=== CONT  TestAccAWSCloudWatchEventTarget_ssmDocument
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (12.12s)
=== CONT  TestAccAWSCloudWatchEventTarget_EventBusName
--- PASS: TestAccAWSCloudWatchEventTarget_RetryPolicy_DeadLetterConfig (52.63s)
--- PASS: TestAccAWSCloudWatchEventTarget_EventBusName (22.02s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (53.23s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (133.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       178.126s
...
```
