### PR TITLE
resource/aws_guardduty_detector: add support for datasources and s3_logs

### DIFF
--- a/.changelog/19954.txt
+++ b/.changelog/19954.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_guardduty_detector: Add `datasources` argument
+```

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -279,11 +279,11 @@ resource "aws_guardduty_detector" "test" {
 func testAccGuardDutyDetectorConfigDatasourcesS3Logs(enable bool) string {
 	return fmt.Sprintf(`
 resource "aws_guardduty_detector" "test" {
- datasources {
-   s3_logs {
-     enable = %[1]t
-   }
- }
+  datasources {
+    s3_logs {
+      enable = %[1]t
+    }
+  }
 }
 `, enable)
 }

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -160,6 +160,42 @@ func testAccAwsGuardDutyDetector_tags(t *testing.T) {
 	})
 }
 
+func testAccAwsGuardDutyDetector_datasources_s3logs(t *testing.T) {
+	resourceName := "aws_guardduty_detector.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, guardduty.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardDutyDetectorConfigDatasourcesS3Logs(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyDetectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGuardDutyDetectorConfigDatasourcesS3Logs(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyDetectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsGuardDutyDetectorDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).guarddutyconn
 
@@ -238,4 +274,16 @@ resource "aws_guardduty_detector" "test" {
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccGuardDutyDetectorConfigDatasourcesS3Logs(enable bool) string {
+	return fmt.Sprintf(`
+resource "aws_guardduty_detector" "test" {
+ datasources {
+   s3_logs {
+     enable = %[1]t
+   }
+ }
+}
+`, enable)
 }

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -8,10 +8,11 @@ import (
 func TestAccAWSGuardDuty_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Detector": {
-			"basic":            testAccAwsGuardDutyDetector_basic,
-			"tags":             testAccAwsGuardDutyDetector_tags,
-			"datasource_basic": testAccAWSGuarddutyDetectorDataSource_basic,
-			"datasource_id":    testAccAWSGuarddutyDetectorDataSource_Id,
+			"basic":              testAccAwsGuardDutyDetector_basic,
+			"datasources_s3logs": testAccAwsGuardDutyDetector_datasources_s3logs,
+			"tags":               testAccAwsGuardDutyDetector_tags,
+			"datasource_basic":   testAccAWSGuarddutyDetectorDataSource_basic,
+			"datasource_id":      testAccAWSGuarddutyDetectorDataSource_Id,
 		},
 		"Filter": {
 			"basic":      testAccAwsGuardDutyFilter_basic,

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -17,6 +17,12 @@ Provides a resource to manage a GuardDuty detector.
 ```terraform
 resource "aws_guardduty_detector" "MyDetector" {
   enable = true
+
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
 }
 ```
 
@@ -26,7 +32,20 @@ The following arguments are supported:
 
 * `enable` - (Optional) Enable monitoring and feedback reporting. Setting to `false` is equivalent to "suspending" GuardDuty. Defaults to `true`.
 * `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty primary account and cannot be modified, otherwise defaults to `SIX_HOURS`. For standalone and GuardDuty primary accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and primary accounts: `FIFTEEN_MINUTES`, `ONE_HOUR`, `SIX_HOURS`. See [AWS Documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency) for more information.
+* `datasources` - (Optional) Describes which data sources will be enabled for the detector. See [Data Sources](#data-sources) below for more details.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Data Sources
+
+The `datasources` block supports the following:
+
+* `s3_logs` - (Optional) Describes whether S3 data event logs are enabled as a data source. See [S3 Logs](#s3-logs) below for more details.
+
+### S3 Logs
+
+This `s3_logs` block supports the following:
+
+* `enable` - (Required) If true, enables [S3 Protection](https://docs.aws.amazon.com/guardduty/latest/ug/s3_detection.html). Defaults to `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14607

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
enhancement:

resource/aws_guardduty_detector: Add support for `datasources`, `s3_logs` and `enable` arguments

```

### Affected Resource(s)
- resource: aws_guardduty_detector

### Terraform Configuration
```HCL
resource "aws_guardduty_detector" "foo" {
  enable = true

  datasources {
    s3_logs {
      enable = true
    }
  }
}
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGuardDuty_serial/Detector'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGuardDuty_serial/Detector -timeout 180m
=== RUN   TestAccAWSGuardDuty_serial
=== RUN   TestAccAWSGuardDuty_serial/Detector
=== RUN   TestAccAWSGuardDuty_serial/Detector/datasources_s3logs
=== RUN   TestAccAWSGuardDuty_serial/Detector/tags
=== RUN   TestAccAWSGuardDuty_serial/Detector/datasource_basic
=== RUN   TestAccAWSGuardDuty_serial/Detector/datasource_id
=== RUN   TestAccAWSGuardDuty_serial/Detector/basic
--- PASS: TestAccAWSGuardDuty_serial (598.48s)
    --- PASS: TestAccAWSGuardDuty_serial/Detector (598.48s)
        --- PASS: TestAccAWSGuardDuty_serial/Detector/datasources_s3logs (110.09s)
        --- PASS: TestAccAWSGuardDuty_serial/Detector/tags (146.95s)
        --- PASS: TestAccAWSGuardDuty_serial/Detector/datasource_basic (103.87s)
        --- PASS: TestAccAWSGuardDuty_serial/Detector/datasource_id (56.30s)
        --- PASS: TestAccAWSGuardDuty_serial/Detector/basic (181.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       599.752s

...
```
