### PR TITLE
Fix crash in lb_target_group data source.

### DIFF
--- a/.changelog/18102.txt
+++ b/.changelog/18102.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lb_target_group: Add support for application cookie stickiness
+resource/aws_lb_target_group: Add support for `app_cookie` stickiness type and `cookie_name` argument
 ```

--- a/.changelog/19955.txt
+++ b/.changelog/19955.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_lb_target_group: Add cookie_name attribute for app_cookie support
+```

--- a/.changelog/19955.txt
+++ b/.changelog/19955.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-data-source/aws_lb_target_group: Add cookie_name attribute for app_cookie support
-```

--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -117,6 +117,10 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"cookie_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"enabled": {
 							Type:     schema.TypeBool,
 							Computed: true,

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -331,11 +331,11 @@ resource "aws_lb_target_group" "test" {
     matcher             = "200-299"
   }
 
-	stickiness {
-	  type            = "app_cookie"
-	  cookie_name     = "cookieName"
-		cookie_duration = 600
-	}
+  stickiness {
+    type            = "app_cookie"
+    cookie_name     = "cookieName"
+    cookie_duration = 600
+  }
 
   tags = {
     TestName = %[1]q

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -70,6 +70,47 @@ func TestAccDataSourceAWSLBTargetGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSLBTargetGroup_appCookie(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceNameArn := "data.aws_lb_target_group.alb_tg_test_with_arn"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, elbv2.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLBTargetGroupConfigAppCookie(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameArn, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceNameArn, "arn"),
+					resource.TestCheckResourceAttrSet(resourceNameArn, "arn_suffix"),
+					resource.TestCheckResourceAttr(resourceNameArn, "port", "8080"),
+					resource.TestCheckResourceAttr(resourceNameArn, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceNameArn, "protocol_version", "HTTP1"),
+					resource.TestCheckResourceAttrSet(resourceNameArn, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceNameArn, "load_balancing_algorithm_type"),
+					resource.TestCheckResourceAttr(resourceNameArn, "deregistration_delay", "300"),
+					resource.TestCheckResourceAttr(resourceNameArn, "slow_start", "0"),
+					resource.TestCheckResourceAttr(resourceNameArn, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceNameArn, "tags.TestName", rName),
+					resource.TestCheckResourceAttr(resourceNameArn, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameArn, "stickiness.0.cookie_duration", "600"),
+					resource.TestCheckResourceAttr(resourceNameArn, "stickiness.0.cookie_name", "cookieName"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.path", "/health"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.timeout", "3"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceNameArn, "health_check.0.matcher", "200-299"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceNameArn := "data.aws_alb_target_group.alb_tg_test_with_arn"
@@ -242,6 +283,125 @@ data "aws_lb_target_group" "alb_tg_test_with_arn" {
 
 data "aws_lb_target_group" "alb_tg_test_with_name" {
   name = aws_lb_target_group.test.name
+}
+`, rName)
+}
+
+func testAccDataSourceAWSLBTargetGroupConfigAppCookie(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_lb.alb_test.id
+  protocol          = "HTTP"
+  port              = "80"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.id
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.alb_test.id]
+  subnets         = aws_subnet.alb_test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    TestName = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.alb_test.id
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
+	stickiness {
+	  type            = "app_cookie"
+	  cookie_name     = "cookieName"
+		cookie_duration = 600
+	}
+
+  tags = {
+    TestName = %[1]q
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = list(string)
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = aws_vpc.alb_test.id
+  cidr_block              = element(var.subnets, count.index)
+  map_public_ip_on_launch = true
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = aws_vpc.alb_test.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    TestName = %[1]q
+  }
+}
+
+data "aws_lb_target_group" "alb_tg_test_with_arn" {
+  arn = aws_lb_target_group.test.arn
 }
 `, rName)
 }

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -216,33 +216,6 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"app_cookie": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								switch d.Get("protocol").(string) {
-								case elbv2.ProtocolEnumTcp, elbv2.ProtocolEnumUdp, elbv2.ProtocolEnumTcpUdp, elbv2.ProtocolEnumTls:
-									return true
-								}
-								return false
-							},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"cookie_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"duration_seconds": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      86400,
-										ValidateFunc: validation.IntBetween(0, 604800),
-									},
-								},
-							},
-						},
 						"cookie_duration": {
 							Type:         schema.TypeInt,
 							Optional:     true,
@@ -255,6 +228,10 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 								}
 								return false
 							},
+						},
+						"cookie_name": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"enabled": {
 							Type:     schema.TypeBool,
@@ -589,19 +566,15 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 									Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
 								})
 						case "app_cookie":
-							appCookieBlocks := stickiness["app_cookie"].([]interface{})
-							if len(appCookieBlocks) == 1 {
-								appStickiness := appCookieBlocks[0].(map[string]interface{})
-								attrs = append(attrs,
-									&elbv2.TargetGroupAttribute{
-										Key:   aws.String("stickiness.app_cookie.duration_seconds"),
-										Value: aws.String(fmt.Sprintf("%d", appStickiness["duration_seconds"].(int))),
-									},
-									&elbv2.TargetGroupAttribute{
-										Key:   aws.String("stickiness.app_cookie.cookie_name"),
-										Value: aws.String(appStickiness["cookie_name"].(string)),
-									})
-							}
+							attrs = append(attrs,
+								&elbv2.TargetGroupAttribute{
+									Key:   aws.String("stickiness.app_cookie.duration_seconds"),
+									Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+								},
+								&elbv2.TargetGroupAttribute{
+									Key:   aws.String("stickiness.app_cookie.cookie_name"),
+									Value: aws.String(stickiness["cookie_name"].(string)),
+								})
 						default:
 							log.Printf("[WARN] Unexpected stickiness type. Expected lb_cookie or app_cookie, got %s", stickiness["type"].(string))
 						}
@@ -838,7 +811,6 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 }
 
 func flattenAwsLbTargetGroupStickiness(attributes []*elbv2.TargetGroupAttribute) ([]interface{}, error) {
-	appStickinessMap := map[string]interface{}{}
 	if len(attributes) == 0 {
 		return []interface{}{}, nil
 	}
@@ -856,22 +828,25 @@ func flattenAwsLbTargetGroupStickiness(attributes []*elbv2.TargetGroupAttribute)
 		case "stickiness.type":
 			m["type"] = aws.StringValue(attr.Value)
 		case "stickiness.lb_cookie.duration_seconds":
-			duration, err := strconv.Atoi(aws.StringValue(attr.Value))
-			if err != nil {
-				return nil, fmt.Errorf("error converting stickiness.lb_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
+			if sType, ok := m["type"].(string); !ok || sType == "lb_cookie" {
+				duration, err := strconv.Atoi(aws.StringValue(attr.Value))
+				if err != nil {
+					return nil, fmt.Errorf("error converting stickiness.lb_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
+				}
+				m["cookie_duration"] = duration
 			}
-			m["cookie_duration"] = duration
 		case "stickiness.app_cookie.cookie_name":
-			appStickinessMap["cookie_name"] = aws.StringValue(attr.Value)
+			m["cookie_name"] = aws.StringValue(attr.Value)
 		case "stickiness.app_cookie.duration_seconds":
-			duration, err := strconv.Atoi(aws.StringValue(attr.Value))
-			if err != nil {
-				return nil, fmt.Errorf("Error converting stickiness.app_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
+			if sType, ok := m["type"].(string); !ok || sType == "app_cookie" {
+				duration, err := strconv.Atoi(aws.StringValue(attr.Value))
+				if err != nil {
+					return nil, fmt.Errorf("Error converting stickiness.app_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
+				}
+				m["cookie_duration"] = duration
 			}
-			appStickinessMap["duration_seconds"] = duration
 		}
 	}
-	m["app_cookie"] = []interface{}{appStickinessMap}
 
 	return []interface{}{m}, nil
 }

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1013,9 +1013,8 @@ func TestAccAWSLBTargetGroup_updateAppSticknessEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "app_cookie"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.app_cookie.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.app_cookie.0.cookie_name", "Cookie"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.app_cookie.0.duration_seconds", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_name", "Cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
@@ -1040,9 +1039,8 @@ func TestAccAWSLBTargetGroup_updateAppSticknessEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "app_cookie"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.app_cookie.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.app_cookie.0.cookie_name", "Cookie"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.app_cookie.0.duration_seconds", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_name", "Cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "10000"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.path", "/health2"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
@@ -2350,10 +2348,8 @@ func testAccAWSLBTargetGroupConfig_appStickiness(targetGroupName string, addAppS
 stickiness {
   enabled         = "%[1]t"
   type            = "app_cookie"
-  app_cookie  {
-		cookie_name = "Cookie"
-		duration_seconds = 10000
-	}
+  cookie_name     = "Cookie"
+  cookie_duration = 10000
 }
 `, enabled)
 	}

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -94,14 +94,9 @@ The following arguments are supported:
 ~> **NOTE:** Currently, an NLB (i.e., protocol of `HTTP` or `HTTPS`) can have an invalid `stickiness` block with `type` set to `lb_cookie` as long as `enabled` is set to `false`. However, please update your configurations to avoid errors in a future version of the provider: either remove the invalid `stickiness` block or set the `type` to `source_ip`.
 
 * `cookie_duration` - (Optional) Only used when the type is `lb_cookie`. The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
+* `cookie_name` - (Optional) Name of the application based cookie. AWSALB, AWSALBAPP, and AWSALBTG prefixes are reserved and cannot be used. Only needed when type is `app_cookie`.
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`.
 * `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie`, `app_cookie` for ALBs, and `source_ip` for NLBs.
-* `app_cookie` - (Option) An Application Cookie block. Application Cookie blocks are documented below.
-
-#### app_cookie
-
-* `cookie_name` - (Required) Name of the application based cookie. AWSALB, AWSALBAPP, and AWSALBTG prefixes are reserved and cannot be used.
-* `duration_seconds` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. The range is 1 to 604800 seconds. The default value is 86400.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes crash in lb_target_group data source and rearranges app_cookie related attributes.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBTargetGroup_ -timeout 180m
=== RUN   TestAccAWSLBTargetGroup_basic
=== PAUSE TestAccAWSLBTargetGroup_basic
=== RUN   TestAccAWSLBTargetGroup_basicUdp
=== PAUSE TestAccAWSLBTargetGroup_basicUdp
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion
=== RUN   TestAccAWSLBTargetGroup_withoutHealthcheck
=== PAUSE TestAccAWSLBTargetGroup_withoutHealthcheck
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== RUN   TestAccAWSLBTargetGroup_Protocol_Geneve
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Geneve
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
=== RUN   TestAccAWSLBTargetGroup_Protocol_Tls
=== PAUSE TestAccAWSLBTargetGroup_Protocol_Tls
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck
=== RUN   TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update
=== PAUSE TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
=== RUN   TestAccAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccAWSLBTargetGroup_BackwardsCompatibility
=== RUN   TestAccAWSLBTargetGroup_namePrefix
=== PAUSE TestAccAWSLBTargetGroup_namePrefix
=== RUN   TestAccAWSLBTargetGroup_generatedName
=== PAUSE TestAccAWSLBTargetGroup_generatedName
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeNameForceNew
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeProtocolForceNew
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
=== PAUSE TestAccAWSLBTargetGroup_changePortForceNew
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
=== PAUSE TestAccAWSLBTargetGroup_changeVpcForceNew
=== RUN   TestAccAWSLBTargetGroup_tags
=== PAUSE TestAccAWSLBTargetGroup_tags
=== RUN   TestAccAWSLBTargetGroup_enableHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_enableHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
=== PAUSE TestAccAWSLBTargetGroup_updateHealthCheck
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
=== PAUSE TestAccAWSLBTargetGroup_updateSticknessEnabled
=== RUN   TestAccAWSLBTargetGroup_updateAppSticknessEnabled
=== PAUSE TestAccAWSLBTargetGroup_updateAppSticknessEnabled
=== RUN   TestAccAWSLBTargetGroup_defaults_application
=== PAUSE TestAccAWSLBTargetGroup_defaults_application
=== RUN   TestAccAWSLBTargetGroup_defaults_network
=== PAUSE TestAccAWSLBTargetGroup_defaults_network
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessDefaultALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessDefaultALB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessValidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessValidALB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== RUN   TestAccAWSLBTargetGroup_stickinessInvalidALB
=== PAUSE TestAccAWSLBTargetGroup_stickinessInvalidALB
=== RUN   TestAccAWSLBTargetGroup_preserveClientIPValid
=== PAUSE TestAccAWSLBTargetGroup_preserveClientIPValid
=== CONT  TestAccAWSLBTargetGroup_basic
=== CONT  TestAccAWSLBTargetGroup_changePortForceNew
=== CONT  TestAccAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultNLB
=== CONT  TestAccAWSLBTargetGroup_preserveClientIPValid
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidALB
=== CONT  TestAccAWSLBTargetGroup_stickinessInvalidNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessValidALB
=== CONT  TestAccAWSLBTargetGroup_stickinessValidNLB
=== CONT  TestAccAWSLBTargetGroup_stickinessDefaultALB
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tls
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck
=== CONT  TestAccAWSLBTargetGroup_withoutHealthcheck
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== CONT  TestAccAWSLBTargetGroup_namePrefix
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update
=== CONT  TestAccAWSLBTargetGroup_changeProtocolForceNew
=== CONT  TestAccAWSLBTargetGroup_changeNameForceNew
=== CONT  TestAccAWSLBTargetGroup_generatedName
=== CONT  TestAccAWSLBTargetGroup_Protocol_Geneve
--- PASS: TestAccAWSLBTargetGroup_withoutHealthcheck (21.44s)
=== CONT  TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_basic (35.53s)
=== CONT  TestAccAWSLBTargetGroup_defaults_network
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (40.17s)
=== CONT  TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_GRPC_HealthCheck (43.34s)
=== CONT  TestAccAWSLBTargetGroup_updateAppSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultALB (45.27s)
=== CONT  TestAccAWSLBTargetGroup_enableHealthCheck
--- PASS: TestAccAWSLBTargetGroup_BackwardsCompatibility (45.91s)
=== CONT  TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol
--- PASS: TestAccAWSLBTargetGroup_generatedName (48.43s)
=== CONT  TestAccAWSLBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSLBTargetGroup_Protocol_Geneve (49.04s)
=== CONT  TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
--- PASS: TestAccAWSLBTargetGroup_namePrefix (57.39s)
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidNLB (58.49s)
=== CONT  TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_preserveClientIPValid (61.38s)
=== CONT  TestAccAWSLBTargetGroup_ProtocolVersion
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (62.74s)
=== CONT  TestAccAWSLBTargetGroup_basicUdp
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion_HTTP_GRPC_Update (66.56s)
=== CONT  TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (70.98s)
--- PASS: TestAccAWSLBTargetGroup_enableHealthCheck (27.88s)
--- PASS: TestAccAWSLBTargetGroup_stickinessInvalidALB (77.77s)
--- PASS: TestAccAWSLBTargetGroup_defaults_application (44.25s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidALB (85.50s)
--- PASS: TestAccAWSLBTargetGroup_ProtocolVersion (27.30s)
--- PASS: TestAccAWSLBTargetGroup_defaults_network (59.40s)
--- PASS: TestAccAWSLBTargetGroup_basicUdp (32.31s)
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (76.80s)
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (52.04s)
--- PASS: TestAccAWSLBTargetGroup_stickinessDefaultNLB (101.40s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (46.24s)
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (56.67s)
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (108.97s)
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (58.53s)
--- PASS: TestAccAWSLBTargetGroup_updateAppSticknessEnabled (81.75s)
--- PASS: TestAccAWSLBTargetGroup_tags (66.76s)
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tcp_HealthCheck_Protocol (85.83s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (145.62s)
--- PASS: TestAccAWSLBTargetGroup_stickinessValidNLB (149.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	149.234s

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLBTargetGroup_ -timeout 180m
=== RUN   TestAccDataSourceAWSLBTargetGroup_basic
=== PAUSE TestAccDataSourceAWSLBTargetGroup_basic
=== RUN   TestAccDataSourceAWSLBTargetGroup_appCookie
=== PAUSE TestAccDataSourceAWSLBTargetGroup_appCookie
=== RUN   TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLBTargetGroup_basic
=== CONT  TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLBTargetGroup_appCookie
--- PASS: TestAccDataSourceAWSLBTargetGroup_basic (194.71s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_appCookie (205.75s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (235.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	235.555s
```
