### PR TITLE
Fix typo in aws_autoscaling_attachment target group attachment example.

### DIFF
--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -33,7 +33,7 @@ resource "aws_autoscaling_attachment" "asg_attachment_bar" {
 # Create a new ALB Target Group attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
   autoscaling_group_name = aws_autoscaling_group.asg.id
-  alb_target_group_arn   = aws_alb_target_group.test.arn
+  alb_target_group_arn   = aws_lb_target_group.test.arn
 }
 ```
 


### PR DESCRIPTION
Docs fix: No resource aws_alb_target_group exists, it's simply "lb" not "alb".

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
