### PR TITLE
r/kms_key - correctly handle `PendingDeletion` state

### DIFF
--- a/.changelog/19967.txt
+++ b/.changelog/19967.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_kms_key: Add `multi_region` argument.
+```
+
+```release-note:enhancement
+resource/aws_kms_key: Add plan time validation to `description`.
+```

--- a/.changelog/19967.txt
+++ b/.changelog/19967.txt
@@ -1,7 +1,3 @@
 ```release-note:enhancement
-resource/aws_kms_key: Add `multi_region` argument.
-```
-
-```release-note:enhancement
 resource/aws_kms_key: Add plan time validation to `description`.
 ```

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -70,12 +70,6 @@ func resourceAwsKmsKey() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"multi_region": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
-			},
 			"enable_key_rotation": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -101,7 +95,6 @@ func resourceAwsKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	req := &kms.CreateKeyInput{
 		CustomerMasterKeySpec: aws.String(d.Get("customer_master_key_spec").(string)),
 		KeyUsage:              aws.String(d.Get("key_usage").(string)),
-		MultiRegion:           aws.Bool(d.Get("multi_region").(bool)),
 	}
 	if v, exists := d.GetOk("description"); exists {
 		req.Description = aws.String(v.(string))
@@ -191,7 +184,6 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_usage", metadata.KeyUsage)
 	d.Set("customer_master_key_spec", metadata.CustomerMasterKeySpec)
 	d.Set("is_enabled", metadata.Enabled)
-	d.Set("multi_region", metadata.MultiRegion)
 
 	pOut, err := retryOnAwsCode(kms.ErrCodeNotFoundException, func() (interface{}, error) {
 		return conn.GetKeyPolicy(&kms.GetKeyPolicyInput{

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,35 +39,24 @@ func resourceAwsKmsKey() *schema.Resource {
 				Computed: true,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringLenBetween(0, 8192),
 			},
 			"key_usage": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  kms.KeyUsageTypeEncryptDecrypt,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					kms.KeyUsageTypeEncryptDecrypt,
-					kms.KeyUsageTypeSignVerify,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      kms.KeyUsageTypeEncryptDecrypt,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(kms.KeyUsageType_Values(), false),
 			},
 			"customer_master_key_spec": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  kms.CustomerMasterKeySpecSymmetricDefault,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					kms.CustomerMasterKeySpecSymmetricDefault,
-					kms.CustomerMasterKeySpecRsa2048,
-					kms.CustomerMasterKeySpecRsa3072,
-					kms.CustomerMasterKeySpecRsa4096,
-					kms.CustomerMasterKeySpecEccNistP256,
-					kms.CustomerMasterKeySpecEccNistP384,
-					kms.CustomerMasterKeySpecEccNistP521,
-					kms.CustomerMasterKeySpecEccSecgP256k1,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      kms.CustomerMasterKeySpecSymmetricDefault,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(kms.CustomerMasterKeySpec_Values(), false),
 			},
 			"policy": {
 				Type:             schema.TypeString,
@@ -81,6 +69,12 @@ func resourceAwsKmsKey() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+			"multi_region": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 			"enable_key_rotation": {
 				Type:     schema.TypeBool,
@@ -107,6 +101,7 @@ func resourceAwsKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	req := &kms.CreateKeyInput{
 		CustomerMasterKeySpec: aws.String(d.Get("customer_master_key_spec").(string)),
 		KeyUsage:              aws.String(d.Get("key_usage").(string)),
+		MultiRegion:           aws.Bool(d.Get("multi_region").(bool)),
 	}
 	if v, exists := d.GetOk("description"); exists {
 		req.Description = aws.String(v.(string))
@@ -196,6 +191,7 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_usage", metadata.KeyUsage)
 	d.Set("customer_master_key_spec", metadata.CustomerMasterKeySpec)
 	d.Set("is_enabled", metadata.Enabled)
+	d.Set("multi_region", metadata.MultiRegion)
 
 	pOut, err := retryOnAwsCode(kms.ErrCodeNotFoundException, func() (interface{}, error) {
 		return conn.GetKeyPolicy(&kms.GetKeyPolicyInput{
@@ -210,7 +206,7 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	p := pOut.(*kms.GetKeyPolicyOutput)
 	policy, err := structure.NormalizeJsonString(*p.Policy)
 	if err != nil {
-		return fmt.Errorf("policy contains an invalid JSON: %s", err)
+		return fmt.Errorf("policy contains an invalid JSON: %w", err)
 	}
 	d.Set("policy", policy)
 
@@ -246,7 +242,7 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for KMS Key (%s): %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for KMS Key (%s): %w", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -302,7 +298,7 @@ func resourceAwsKmsKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 
 		if err := keyvaluetags.KmsUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating KMS Key (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating KMS Key (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -327,7 +323,7 @@ func resourceAwsKmsKeyDescriptionUpdate(conn *kms.KMS, d *schema.ResourceData) e
 func resourceAwsKmsKeyPolicyUpdate(conn *kms.KMS, d *schema.ResourceData) error {
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
 	if err != nil {
-		return fmt.Errorf("policy contains an invalid JSON: %s", err)
+		return fmt.Errorf("policy contains an invalid JSON: %w", err)
 	}
 	keyId := d.Get("key_id").(string)
 
@@ -377,8 +373,7 @@ func updateKmsKeyStatus(conn *kms.KMS, id string, shouldBeEnabled bool) error {
 				KeyId: aws.String(id),
 			})
 			if err != nil {
-				awsErr, ok := err.(awserr.Error)
-				if ok && awsErr.Code() == "NotFoundException" {
+				if isAWSErr(err, kms.ErrCodeNotFoundException, "") {
 					return nil, fmt.Sprintf("%t", !shouldBeEnabled), nil
 				}
 				return resp, "FAILED", err
@@ -392,7 +387,7 @@ func updateKmsKeyStatus(conn *kms.KMS, id string, shouldBeEnabled bool) error {
 
 	_, err = wait.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Failed setting KMS key status to %t: %s", shouldBeEnabled, err)
+		return fmt.Errorf("Failed setting KMS key status to %t: %w", shouldBeEnabled, err)
 	}
 
 	return nil
@@ -405,11 +400,10 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 		err := handleKeyRotation(conn, shouldEnableRotation, aws.String(d.Id()))
 
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "DisabledException" {
+			if isAWSErr(err, kms.ErrCodeDisabledException, "") {
 				return resource.RetryableError(err)
 			}
-			if ok && awsErr.Code() == "NotFoundException" {
+			if isAWSErr(err, kms.ErrCodeNotFoundException, "") {
 				return resource.RetryableError(err)
 			}
 
@@ -438,7 +432,7 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 			log.Printf("[DEBUG] Checking if KMS key %s rotation status is %t",
 				d.Id(), shouldEnableRotation)
 
-			out, err := retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+			out, err := retryOnAwsCode(kms.ErrCodeNotFoundException, func() (interface{}, error) {
 				return conn.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{
 					KeyId: aws.String(d.Id()),
 				})

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -87,7 +87,6 @@ func TestAccAWSKmsKey_basic(t *testing.T) {
 					testAccCheckAWSKmsKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "customer_master_key_spec", "SYMMETRIC_DEFAULT"),
 					resource.TestCheckResourceAttr(resourceName, "key_usage", "ENCRYPT_DECRYPT"),
-					resource.TestCheckResourceAttr(resourceName, "multi_region", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -315,34 +314,6 @@ func TestAccAWSKmsKey_tags(t *testing.T) {
 					testAccCheckAWSKmsKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSKmsKey_multiRegion(t *testing.T) {
-	var key kms.KeyMetadata
-	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandString(13))
-	resourceName := "aws_kms_key.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, kms.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSKmsKeyMultiRegionConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists(resourceName, &key),
-					resource.TestCheckResourceAttr(resourceName, "multi_region", "true"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
 			},
 		},
 	})
@@ -673,16 +644,6 @@ resource "aws_kms_key" "test" {
     Key1        = "Value One"
     Description = "Very interesting"
   }
-}
-`, rName)
-}
-
-func testAccAWSKmsKeyMultiRegionConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {
-  description             = %[1]q
-  deletion_window_in_days = 7
-  multi_region            = true
 }
 `, rName)
 }

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -23,34 +23,37 @@ func init() {
 func testSweepKmsKeys(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).kmsconn
 
 	err = conn.ListKeysPages(&kms.ListKeysInput{Limit: aws.Int64(int64(1000))}, func(out *kms.ListKeysOutput, lastPage bool) bool {
 		for _, k := range out.Keys {
+			kKeyId := aws.StringValue(k.KeyId)
 			kOut, err := conn.DescribeKey(&kms.DescribeKeyInput{
 				KeyId: k.KeyId,
 			})
 			if err != nil {
-				log.Printf("Error: Failed to describe key %q: %s", *k.KeyId, err)
+				log.Printf("Error: Failed to describe key %q: %s", kKeyId, err)
 				return false
 			}
-			if *kOut.KeyMetadata.KeyManager == kms.KeyManagerTypeAws {
+			if aws.StringValue(kOut.KeyMetadata.KeyManager) == kms.KeyManagerTypeAws {
 				// Skip (default) keys which are managed by AWS
 				continue
 			}
-			if *kOut.KeyMetadata.KeyState == kms.KeyStatePendingDeletion {
+			if aws.StringValue(kOut.KeyMetadata.KeyState) == kms.KeyStatePendingDeletion {
 				// Skip keys which are already scheduled for deletion
 				continue
 			}
 
-			_, err = conn.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
-				KeyId:               k.KeyId,
-				PendingWindowInDays: aws.Int64(int64(7)),
-			})
+			r := resourceAwsKmsKey()
+			d := r.Data(nil)
+			d.SetId(kKeyId)
+			d.Set("key_id", kKeyId)
+			d.Set("deletion_window_in_days", "7")
+			err = r.Delete(d, client)
 			if err != nil {
-				log.Printf("Error: Failed to schedule key %q for deletion: %s", *k.KeyId, err)
+				log.Printf("Error: Failed to schedule key %q for deletion: %s", kKeyId, err)
 				return false
 			}
 		}
@@ -61,7 +64,7 @@ func testSweepKmsKeys(region string) error {
 			log.Printf("[WARN] Skipping KMS Key sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error describing KMS keys: %s", err)
+		return fmt.Errorf("Error describing KMS keys: %w", err)
 	}
 
 	return nil

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_kms_key
 
-Provides a KMS customer master key.
+Provides a KMS single-Region customer master key (CMK).
 
 ## Example Usage
 
@@ -35,7 +35,6 @@ Valid values: `SYMMETRIC_DEFAULT`,  `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIS
 * `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
 * `is_enabled` - (Optional) Specifies whether the key is enabled. Defaults to true.
 * `enable_key_rotation` - (Optional) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) is enabled. Defaults to false.
-* `multi_region` - (Optional) Creates a multi-Region primary key that you can replicate into other AWS Regions. You cannot change this value after you create the CMK. Defaults to false.
 * `tags` - (Optional) A map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -35,6 +35,7 @@ Valid values: `SYMMETRIC_DEFAULT`,  `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIS
 * `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
 * `is_enabled` - (Optional) Specifies whether the key is enabled. Defaults to true.
 * `enable_key_rotation` - (Optional) Specifies whether [key rotation](http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) is enabled. Defaults to false.
+* `multi_region` - (Optional) Creates a multi-Region primary key that you can replicate into other AWS Regions. You cannot change this value after you create the CMK. Defaults to false.
 * `tags` - (Optional) A map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17889
~Relates #19896 (to close we need a solution for the replicas in other regions)~

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSKmsKey_'
--- PASS: TestAccAWSKmsKey_disappears (35.87s)
--- PASS: TestAccAWSKmsKey_asymmetricKey (45.35s)
--- PASS: TestAccAWSKmsKey_multiRegion (53.78s)
--- PASS: TestAccAWSKmsKey_basic (54.52s)
--- PASS: TestAccAWSKmsKey_Policy_IamRole (68.53s)
--- PASS: TestAccAWSKmsKey_Policy_IamServiceLinkedRole (77.73s)
--- PASS: TestAccAWSKmsKey_policy (90.72s)
--- PASS: TestAccAWSKmsKey_tags (95.71s)
--- PASS: TestAccAWSKmsKey_isEnabled (251.47s)
```
