### PR TITLE
WIP F/aws_redshift_cluster: Add MaintenanceTrackName Parameter

### DIFF
--- a/aws/data_source_aws_redshift_cluster.go
+++ b/aws/data_source_aws_redshift_cluster.go
@@ -118,6 +118,11 @@ func dataSourceAwsRedshiftCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"maintenance_track_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"master_username": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -244,6 +249,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("kms_key_id", rsc.KmsKeyId)
+	d.Set("maintenance_track_name", rsc.MaintenanceTrackName)
 	d.Set("master_username", rsc.MasterUsername)
 	d.Set("node_type", rsc.NodeType)
 	d.Set("number_of_nodes", rsc.NumberOfNodes)

--- a/aws/data_source_aws_redshift_cluster_test.go
+++ b/aws/data_source_aws_redshift_cluster_test.go
@@ -36,6 +36,7 @@ func TestAccAWSDataSourceRedshiftCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_redshift_cluster.test", "number_of_nodes"),
 					resource.TestCheckResourceAttrSet("data.aws_redshift_cluster.test", "port"),
 					resource.TestCheckResourceAttrSet("data.aws_redshift_cluster.test", "preferred_maintenance_window"),
+					resource.TestCheckResourceAttrSet("data.aws_redshift_cluster.test", "maintenance_track_name"),
 					resource.TestCheckResourceAttrSet("data.aws_redshift_cluster.test", "publicly_accessible"),
 				),
 			},
@@ -87,12 +88,13 @@ func testAccAWSDataSourceRedshiftClusterConfig(rInt int) string {
 resource "aws_redshift_cluster" "test" {
   cluster_identifier = "tf-redshift-cluster-%d"
 
-  database_name       = "testdb"
-  master_username     = "foo"
-  master_password     = "Password1"
-  node_type           = "dc1.large"
-  cluster_type        = "single-node"
-  skip_final_snapshot = true
+  database_name          = "testdb"
+  master_username        = "foo"
+  master_password        = "Password1"
+  node_type              = "dc1.large"
+  cluster_type           = "single-node"
+  skip_final_snapshot    = true
+	maintenance_track_name = "cluster-maintenance-track"
 }
 
 data "aws_redshift_cluster" "test" {

--- a/aws/data_source_aws_redshift_cluster_test.go
+++ b/aws/data_source_aws_redshift_cluster_test.go
@@ -94,7 +94,7 @@ resource "aws_redshift_cluster" "test" {
   node_type              = "dc1.large"
   cluster_type           = "single-node"
   skip_final_snapshot    = true
-	maintenance_track_name = "cluster-maintenance-track"
+  maintenance_track_name = "cluster-maintenance-track"
 }
 
 data "aws_redshift_cluster" "test" {

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -71,6 +71,11 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Required: true,
 			},
 
+			"maintenance_track_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"master_username": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -401,6 +406,10 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 			restoreOpts.IamRoles = expandStringSet(v.(*schema.Set))
 		}
 
+		if v, ok := d.GetOk("maintenance_track_name"); ok {
+			restoreOpts.MaintenanceTrackName = aws.String(v.(string))
+		}
+
 		log.Printf("[DEBUG] Redshift Cluster restore cluster options: %s", restoreOpts)
 
 		resp, err := conn.RestoreFromClusterSnapshot(restoreOpts)
@@ -483,6 +492,10 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 		if v, ok := d.GetOk("iam_roles"); ok {
 			createOpts.IamRoles = expandStringSet(v.(*schema.Set))
+		}
+
+		if v, ok := d.GetOk("maintenance_track_name"); ok {
+			createOpts.MaintenanceTrackName = aws.String(v.(string))
 		}
 
 		log.Printf("[DEBUG] Redshift Cluster create options: %s", createOpts)
@@ -581,6 +594,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("kms_key_id", rsc.KmsKeyId)
 	d.Set("automated_snapshot_retention_period", rsc.AutomatedSnapshotRetentionPeriod)
 	d.Set("preferred_maintenance_window", rsc.PreferredMaintenanceWindow)
+	d.Set("maintenance_track_name", rsc.MaintenanceTrackName)
 	if rsc.Endpoint != nil && rsc.Endpoint.Address != nil {
 		endpoint := *rsc.Endpoint.Address
 		if rsc.Endpoint.Port != nil {
@@ -713,6 +727,11 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("preferred_maintenance_window") {
 		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("maintenance_track_name") {
+		req.MaintenanceTrackName = aws.String(d.Get("maintenance_track_name").(string))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -822,7 +822,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
-	maintenance_track_name              = "cluster-maintenance-track"
+  maintenance_track_name              = "cluster-maintenance-track"
 }
 `, rInt))
 }
@@ -1486,7 +1486,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
-	maintenance_track_name              = "new-cluster-maintenance-track"
+  maintenance_track_name              = "new-cluster-maintenance-track"
 }
 `, rInt))
 }

--- a/website/docs/d/redshift_cluster.html.markdown
+++ b/website/docs/d/redshift_cluster.html.markdown
@@ -70,6 +70,7 @@ In addition to all arguments above, the following attributes are exported:
 * `enhanced_vpc_routing` - Whether enhanced VPC routing is enabled
 * `iam_roles` - The IAM roles associated to the cluster
 * `kms_key_id` - The KMS encryption key associated to the cluster
+* `maintenance_track_name` - The name of the maintenance track for the cluster
 * `master_username` - Username for the master DB user
 * `node_type` - The cluster node type
 * `number_of_nodes` - The number of nodes in the cluster

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -17,12 +17,13 @@ Provides a Redshift Cluster Resource.
 
 ```terraform
 resource "aws_redshift_cluster" "default" {
-  cluster_identifier = "tf-redshift-cluster"
-  database_name      = "mydb"
-  master_username    = "foo"
-  master_password    = "Mustbe8characters"
-  node_type          = "dc1.large"
-  cluster_type       = "single-node"
+  cluster_identifier     = "tf-redshift-cluster"
+  database_name          = "mydb"
+  master_username        = "foo"
+  master_password        = "Mustbe8characters"
+  node_type              = "dc1.large"
+  cluster_type           = "single-node"
+  maintenance_track_name = "cluster-maintenance-track"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18171

Output from acceptance testing:
**Although I have ran all other tests, I have not gotten the chance to run the acceptance tests. I plan on doing this going forward for other contributions to this project, but I was wondering if someone could run the tests on my behalf for this PR.**
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Other Comments

Hello! This is my first ever open source PR 🥳  I will follow this PR closely, so if there are any changes you would like me to make please let me know!