### PR TITLE
r/aws_eks_cluster: Don't associate an `encryption_config` if there's already one

### DIFF
--- a/.changelog/19986.txt
+++ b/.changelog/19986.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_cluster: Don't associate an `encryption_config` if there's already one
+```

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -91,14 +91,15 @@ func resourceAwsEksCluster() *schema.Resource {
 									"key_arn": {
 										Type:     schema.TypeString,
 										Required: true,
+										ForceNew: true,
 									},
 								},
 							},
 						},
 						"resources": {
 							Type:     schema.TypeSet,
-							MinItems: 1,
 							Required: true,
+							ForceNew: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringInSlice(tfeks.Resources_Values(), false),
@@ -409,24 +410,28 @@ func resourceAwsEksClusterUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("encryption_config") {
-		input := &eks.AssociateEncryptionConfigInput{
-			ClusterName:      aws.String(d.Id()),
-			EncryptionConfig: expandEksEncryptionConfig(d.Get("encryption_config").([]interface{})),
-		}
+		o, n := d.GetChange("encryption_config")
 
-		log.Printf("[DEBUG] Associating EKS Cluster (%s) encryption config: %s", d.Id(), input)
-		output, err := conn.AssociateEncryptionConfig(input)
+		if len(o.([]interface{})) == 0 && len(n.([]interface{})) == 1 {
+			input := &eks.AssociateEncryptionConfigInput{
+				ClusterName:      aws.String(d.Id()),
+				EncryptionConfig: expandEksEncryptionConfig(d.Get("encryption_config").([]interface{})),
+			}
 
-		if err != nil {
-			return fmt.Errorf("error associating EKS Cluster (%s) encryption config: %w", d.Id(), err)
-		}
+			log.Printf("[DEBUG] Associating EKS Cluster (%s) encryption config: %s", d.Id(), input)
+			output, err := conn.AssociateEncryptionConfig(input)
 
-		updateID := aws.StringValue(output.Update.Id)
+			if err != nil {
+				return fmt.Errorf("error associating EKS Cluster (%s) encryption config: %w", d.Id(), err)
+			}
 
-		_, err = waiter.ClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+			updateID := aws.StringValue(output.Update.Id)
 
-		if err != nil {
-			return fmt.Errorf("error waiting for EKS Cluster (%s) encryption config association (%s): %w", d.Id(), updateID, err)
+			_, err = waiter.ClusterUpdateSuccessful(conn, d.Id(), updateID, d.Timeout(schema.TimeoutUpdate))
+
+			if err != nil {
+				return fmt.Errorf("error waiting for EKS Cluster (%s) encryption config association (%s): %w", d.Id(), updateID, err)
+			}
 		}
 	}
 

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -91,7 +91,6 @@ func resourceAwsEksCluster() *schema.Resource {
 									"key_arn": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -99,7 +98,6 @@ func resourceAwsEksCluster() *schema.Resource {
 						"resources": {
 							Type:     schema.TypeSet,
 							Required: true,
-							ForceNew: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validation.StringInSlice(tfeks.Resources_Values(), false),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19968.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSEksCluster_EncryptionConfig_VersionUpdate\|TestAccAWSEksCluster_EncryptionConfig_Create\|TestAccAWSEksCluster_EncryptionConfig_Update'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksCluster_EncryptionConfig_VersionUpdate\|TestAccAWSEksCluster_EncryptionConfig_Create\|TestAccAWSEksCluster_EncryptionConfig_Update -timeout 180m
=== RUN   TestAccAWSEksCluster_EncryptionConfig_Create
=== PAUSE TestAccAWSEksCluster_EncryptionConfig_Create
=== RUN   TestAccAWSEksCluster_EncryptionConfig_Update
=== PAUSE TestAccAWSEksCluster_EncryptionConfig_Update
=== RUN   TestAccAWSEksCluster_EncryptionConfig_VersionUpdate
=== PAUSE TestAccAWSEksCluster_EncryptionConfig_VersionUpdate
=== CONT  TestAccAWSEksCluster_EncryptionConfig_Create
=== CONT  TestAccAWSEksCluster_EncryptionConfig_VersionUpdate
=== CONT  TestAccAWSEksCluster_EncryptionConfig_Update
--- PASS: TestAccAWSEksCluster_EncryptionConfig_Create (701.52s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig_VersionUpdate (2181.28s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig_Update (3741.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3744.552s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSEksCluster_EncryptionConfig_VersionUpdate\|TestAccAWSEksCluster_EncryptionConfig_Create\|TestAccAWSEksCluster_EncryptionConfig_Update'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksCluster_EncryptionConfig_VersionUpdate\|TestAccAWSEksCluster_EncryptionConfig_Create\|TestAccAWSEksCluster_EncryptionConfig_Update -timeout 180m
=== RUN   TestAccAWSEksCluster_EncryptionConfig_Create
=== PAUSE TestAccAWSEksCluster_EncryptionConfig_Create
=== RUN   TestAccAWSEksCluster_EncryptionConfig_Update
=== PAUSE TestAccAWSEksCluster_EncryptionConfig_Update
=== RUN   TestAccAWSEksCluster_EncryptionConfig_VersionUpdate
=== PAUSE TestAccAWSEksCluster_EncryptionConfig_VersionUpdate
=== CONT  TestAccAWSEksCluster_EncryptionConfig_Create
=== CONT  TestAccAWSEksCluster_EncryptionConfig_VersionUpdate
=== CONT  TestAccAWSEksCluster_EncryptionConfig_Update
--- PASS: TestAccAWSEksCluster_EncryptionConfig_Create (779.08s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig_VersionUpdate (2126.62s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig_Update (3491.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3495.209s
```