### PR TITLE
Added location to gamelift_fleet

### DIFF
--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -70,7 +70,7 @@ func resourceAwsGameliftFleet() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
-			"locations": {
+			"location_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 100,
@@ -231,7 +231,7 @@ func resourceAwsGameliftFleetCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("fleet_type"); ok {
 		input.FleetType = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("locations"); ok {
+	if v, ok := d.GetOk("location_configuration"); ok {
 		input.Locations = expandGameliftLocations(v.([]interface{}))
 	}
 	if v, ok := d.GetOk("ec2_inbound_permission"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGameliftFleet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGameliftFleet -timeout 180m
=== RUN   TestAccAWSGameliftFleet_basic
=== PAUSE TestAccAWSGameliftFleet_basic
=== RUN   TestAccAWSGameliftFleet_tags
=== PAUSE TestAccAWSGameliftFleet_tags
=== RUN   TestAccAWSGameliftFleet_allFields
=== PAUSE TestAccAWSGameliftFleet_allFields
=== RUN   TestAccAWSGameliftFleet_disappears
=== PAUSE TestAccAWSGameliftFleet_disappears
=== CONT  TestAccAWSGameliftFleet_basic
=== CONT  TestAccAWSGameliftFleet_disappears
=== CONT  TestAccAWSGameliftFleet_allFields
=== CONT  TestAccAWSGameliftFleet_tags
--- PASS: TestAccAWSGameliftFleet_basic (1804.84s)
--- PASS: TestAccAWSGameliftFleet_disappears (1889.02s)
--- PASS: TestAccAWSGameliftFleet_tags (1912.98s)
--- PASS: TestAccAWSGameliftFleet_allFields (2027.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2027.585s
```
