### PR TITLE
r/aws_mwaa_environment: Changing the KMS key used by MWAA should force recreation of the Airflow environment

### DIFF
--- a/.changelog/19994.txt
+++ b/.changelog/19994.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mwaa_environment: Changes to the `kms_key` argument force resource recreation
+```

--- a/aws/resource_aws_mwaa_environment.go
+++ b/aws/resource_aws_mwaa_environment.go
@@ -61,6 +61,7 @@ func resourceAwsMwaaEnvironment() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateArn,
+				ForceNew:     true,
 			},
 			"last_updated": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
This is currently an issue when updating the cluster from `aws/airflow` KMS key to a CMK for example. The current implementation will show a diff, apply an update to the cluster but will not be able to change to another KMS key leading to a perpetual diff.

```
Terraform will perform the following actions:

  # module.airflow[0].aws_mwaa_environment.airflow will be updated in-place
  ~ resource "aws_mwaa_environment" "airflow" {
        id                              = "myairflow"
      + kms_key                         = "arn:aws:kms:us-east-1:redacted:key/redacted"
        name                            = "myairflow"
        tags                            = {
            "Name"                 = "myairflow"
        }
        # (21 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
