### PR TITLE
tests/d/servicecat_launch_paths: Fix for assumed role

### DIFF
--- a/aws/data_source_aws_servicecatalog_launch_paths_test.go
+++ b/aws/data_source_aws_servicecatalog_launch_paths_test.go
@@ -90,7 +90,7 @@ resource "aws_servicecatalog_portfolio" "test" {
 }
 
 resource "aws_servicecatalog_product_portfolio_association" "test" {
-  portfolio_id = aws_servicecatalog_portfolio.test.id
+  portfolio_id = aws_servicecatalog_principal_portfolio_association.test.portfolio_id
   product_id   = aws_servicecatalog_product.test.id
 }
 
@@ -129,8 +129,6 @@ func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName string) str
 	return composeConfig(testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName), `
 data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
-
-  depends_on = [aws_servicecatalog_principal_portfolio_association.test]
 }
 `)
 }

--- a/aws/data_source_aws_servicecatalog_launch_paths_test.go
+++ b/aws/data_source_aws_servicecatalog_launch_paths_test.go
@@ -114,9 +114,13 @@ resource "aws_iam_role" "test" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
 resource "aws_servicecatalog_principal_portfolio_association" "test" {
   portfolio_id  = aws_servicecatalog_portfolio.test.id
-  principal_arn = data.aws_caller_identity.current.arn
+  principal_arn = data.aws_iam_session_context.current.issuer_arn
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19998

Output from acceptance testing (`us-west-2`):

Using an assumed role:

```
--- PASS: TestAccAWSServiceCatalogLaunchPathsDataSource_basic (74.30s)
```

Output from acceptance testing (GovCloud):

Not using an assumed role:

```
--- PASS: TestAccAWSServiceCatalogLaunchPathsDataSource_basic (75.94s)
```