### PR TITLE
Add documentation for aws_transfer_user and user directory restriction

### DIFF
--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -94,6 +94,15 @@ The following arguments are supported:
 * `entry` - (Required) Represents an entry and a target.
 * `target` - (Required) Represents the map target.
 
+The `Restricted` option is achieved using the following mapping:
+
+```
+home_directory_mappings {
+	entry  = "/"
+	target = "/${aws_s3_bucket.foo.id}/$${Transfer:UserName}"
+}
+```
+
 ### Posix Profile
 
 * `gid` - (Required) The POSIX group ID used for all EFS operations by this user.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #11632

# Summary

These changes add extra info to the `aws_transfer_user` documentation, related to the `Restricted` option.

This will help users better understand how to achieve the `Restricted` option as it's described in the AWS documentation: 

https://docs.aws.amazon.com/transfer/latest/userguide/getting-started.html (Step 3 - 7)

Currently, it's not clear how this can be achieved through Terraform. This was originally brought up in #11632

# Validation 

To validate the resulting user configurations match, I created 1 user via Terraform, and 1 in the console, applying the `Restricted` toggle. Using the AWS CLI we can see both match (unrelated values omitted): 

Terraform
```
{
    "User": {
        "Arn": "arn:aws:transfer:us-west-2:<omitted>:user/<omitted>/terraform-created-user",
        "HomeDirectoryMappings": [
            {
                "Entry": "/",
                "Target": "/uploads-20210701024506192800000001/terraform-created-user"
            }
        ],
        "HomeDirectoryType": "LOGICAL",
        "UserName": "terraform-created-user"
    }
}
```

AWS Console
```
}
    "User": {
        "Arn": "arn:aws:transfer:us-west-2:<omitted>:user/<omitted>/console-created-user",
        "HomeDirectoryMappings": [
            {
                "Entry": "/",
                "Target": "/uploads-20210701024506192800000001/console-created-user"
            }
        ],
        "HomeDirectoryType": "LOGICAL",
        "UserName": "console-created-user"
    }
}
```

This was the Terraform code used: 

```
resource "aws_transfer_user" "user" {

  server_id                      = aws_transfer_server.transfer_server.id
  user_name                   = "terraform-created-user"
  role                               = aws_iam_role.sftp_upload_user_s3_access_role.arn
  home_directory_type = "LOGICAL"
  
  home_directory_mappings {
    entry  = "/"
    target = "/${aws_s3_bucket.uploads_bucket.id}/$${Transfer:UserName}"
  }
}
```

I am a new contributor to this repository, so please do not hesitate with any feedback! 😄 