### PR TITLE
r/cognito_user_pool_client - add revocation support + retry on concurrent changes 

### DIFF
--- a/.changelog/20031.txt
+++ b/.changelog/20031.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_cognito_user_pool_client: Retry on `ConcurrentModificationException`
+```
+
+```release-note:bug
+resource/aws_cognito_user_pool_client: Allow the `default_redirect_uri` argument value to be an empty string
+```
+
+```release-note:enhancement
+resource/aws_cognito_user_pool_client: Add the `enable_token_revocation` argument to support targeted sign out
+```

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -45,7 +45,7 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCognitoUserPoolClient_enableRevokation(t *testing.T) {
+func TestAccAWSCognitoUserPoolClient_enableRevocation(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
 	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
 	clientName := acctest.RandString(10)
@@ -58,7 +58,7 @@ func TestAccAWSCognitoUserPoolClient_enableRevokation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientRevokationConfig(userPoolName, clientName, true),
+				Config: testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "name", clientName),
@@ -72,7 +72,7 @@ func TestAccAWSCognitoUserPoolClient_enableRevokation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientRevokationConfig(userPoolName, clientName, false),
+				Config: testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "name", clientName),
@@ -80,7 +80,7 @@ func TestAccAWSCognitoUserPoolClient_enableRevokation(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientRevokationConfig(userPoolName, clientName, true),
+				Config: testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "name", clientName),
@@ -669,7 +669,7 @@ resource "aws_cognito_user_pool_client" "test" {
 `, userPoolName, clientName)
 }
 
-func testAccAWSCognitoUserPoolClientRevokationConfig(userPoolName, clientName string, revoke bool) string {
+func testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName string, revoke bool) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -14,8 +14,7 @@ import (
 
 func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,10 +24,10 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "ADMIN_NO_SRP_AUTH"),
 					resource.TestCheckResourceAttr(resourceName, "token_validity_units.#", "0"),
@@ -47,8 +46,8 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_enableRevocation(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -58,10 +57,10 @@ func TestAccAWSCognitoUserPoolClient_enableRevocation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName, true),
+				Config: testAccAWSCognitoUserPoolClientRevocationConfig(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_token_revocation", "true"),
 				),
 			},
@@ -72,18 +71,18 @@ func TestAccAWSCognitoUserPoolClient_enableRevocation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName, false),
+				Config: testAccAWSCognitoUserPoolClientRevocationConfig(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_token_revocation", "false"),
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName, true),
+				Config: testAccAWSCognitoUserPoolClientRevocationConfig(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enable_token_revocation", "true"),
 				),
 			},
@@ -317,8 +316,7 @@ func TestAccAWSCognitoUserPoolClient_Name(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -328,10 +326,10 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(rName, 300),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "CUSTOM_AUTH_FLOW_ONLY"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "USER_PASSWORD_AUTH"),
@@ -374,8 +372,7 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -385,13 +382,13 @@ func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(rName, 300),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 299),
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(rName, 299),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "3"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "CUSTOM_AUTH_FLOW_ONLY"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "USER_PASSWORD_AUTH"),
@@ -434,8 +431,7 @@ func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 	pinpointResourceName := "aws_pinpoint_app.test"
 
@@ -450,12 +446,12 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsConfig(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "analytics_configuration.0.application_id", pinpointResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.external_id", clientName),
+					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.external_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.user_data_shared", "false"),
 				),
 			},
@@ -466,19 +462,19 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "0"),
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsConfigShareUserData(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsConfigShareUserData(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "analytics_configuration.0.application_id", pinpointResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.external_id", clientName),
+					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.external_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.0.user_data_shared", "true"),
 				),
 			},
@@ -488,8 +484,7 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := acctest.RandString(10)
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -503,7 +498,7 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "1"),
@@ -524,8 +519,7 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_disappears(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -535,7 +529,7 @@ func TestAccAWSCognitoUserPoolClient_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCognitoUserPoolClient(), resourceName),
@@ -548,8 +542,7 @@ func TestAccAWSCognitoUserPoolClient_disappears(t *testing.T) {
 
 func TestAccAWSCognitoUserPoolClient_disappears_userPool(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -559,7 +552,7 @@ func TestAccAWSCognitoUserPoolClient_disappears_userPool(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists(resourceName, &client),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCognitoUserPool(), "aws_cognito_user_pool.test"),
@@ -655,83 +648,67 @@ func testAccCheckAWSCognitoUserPoolClientExists(name string, client *cognitoiden
 	}
 }
 
-func testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName string) string {
+func testAccAWSCognitoUserPoolClientConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "%s"
+  name = %[1]q
+}
+`, rName)
 }
 
+func testAccAWSCognitoUserPoolClientConfig_basic(rName string) string {
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name                = "%s"
+  name                = %[1]q
   user_pool_id        = aws_cognito_user_pool.test.id
   explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
 }
-`, userPoolName, clientName)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolClientRevocationConfig(userPoolName, clientName string, revoke bool) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
-}
-
+func testAccAWSCognitoUserPoolClientRevocationConfig(rName string, revoke bool) string {
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name                    = %[2]q
+  name                    = %[1]q
   user_pool_id            = aws_cognito_user_pool.test.id
   explicit_auth_flows     = ["ADMIN_NO_SRP_AUTH"]
-  enable_token_revocation = %[3]t
+  enable_token_revocation = %[2]t
 }
-`, userPoolName, clientName, revoke)
+`, rName, revoke)
 }
 
 func testAccAWSCognitoUserPoolClientConfig_RefreshTokenValidity(rName string, refreshTokenValidity int) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = "%s"
-}
-
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name                   = "%s"
-  refresh_token_validity = %d
+  name                   = %[1]q
+  refresh_token_validity = %[2]d
   user_pool_id           = aws_cognito_user_pool.test.id
 }
-`, rName, rName, refreshTokenValidity)
+`, rName, refreshTokenValidity)
 }
 
 func testAccAWSCognitoUserPoolClientConfigAccessTokenValidity(rName string, validity int) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = "%s"
-}
-
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name                  = "%s"
-  access_token_validity = %d
+  name                  = %[1]q
+  access_token_validity = %[2]d
   user_pool_id          = aws_cognito_user_pool.test.id
 }
-`, rName, rName, validity)
+`, rName, validity)
 }
 
 func testAccAWSCognitoUserPoolClientConfigIDTokenValidity(rName string, validity int) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = "%s"
-}
-
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name              = "%s"
-  id_token_validity = %d
+  name              = %[1]q
+  id_token_validity = %[2]d
   user_pool_id      = aws_cognito_user_pool.test.id
 }
-`, rName, rName, validity)
+`, rName, validity)
 }
 
 func testAccAWSCognitoUserPoolClientConfigTokenValidityUnits(rName, units string) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
-}
-
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
   name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
@@ -746,11 +723,7 @@ resource "aws_cognito_user_pool_client" "test" {
 }
 
 func testAccAWSCognitoUserPoolClientConfigTokenValidityUnitsWithTokenValidity(rName, units string) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
-}
-
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
   name              = %[1]q
   user_pool_id      = aws_cognito_user_pool.test.id
@@ -766,26 +739,18 @@ resource "aws_cognito_user_pool_client" "test" {
 }
 
 func testAccAWSCognitoUserPoolClientConfig_Name(rName, name string) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
-}
-
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name         = %[2]q
+  name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
 }
-`, rName, name)
+`, name)
 }
 
-func testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName string, refreshTokenValidity int) string {
-	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "test" {
-  name = "%s"
-}
-
+func testAccAWSCognitoUserPoolClientConfig_allFields(rName string, refreshTokenValidity int) string {
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name = "%s"
+  name = %[1]q
 
   user_pool_id        = aws_cognito_user_pool.test.id
   explicit_auth_flows = ["ADMIN_NO_SRP_AUTH", "CUSTOM_AUTH_FLOW_ONLY", "USER_PASSWORD_AUTH"]
@@ -795,7 +760,7 @@ resource "aws_cognito_user_pool_client" "test" {
   read_attributes  = ["email"]
   write_attributes = ["email"]
 
-  refresh_token_validity        = %d
+  refresh_token_validity        = %[2]d
   prevent_user_existence_errors = "LEGACY"
 
   allowed_oauth_flows                  = ["code", "implicit"]
@@ -806,25 +771,21 @@ resource "aws_cognito_user_pool_client" "test" {
   default_redirect_uri = "https://www.example.com/redirect"
   logout_urls          = ["https://www.example.com/login"]
 }
-`, userPoolName, clientName, refreshTokenValidity)
+`, rName, refreshTokenValidity)
 }
 
-func testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName string) string {
-	return fmt.Sprintf(`
+func testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(rName string) string {
+	return testAccAWSCognitoUserPoolClientConfigBase(rName) + fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
 
-resource "aws_cognito_user_pool" "test" {
+resource "aws_pinpoint_app" "test" {
   name = %[1]q
 }
 
-resource "aws_pinpoint_app" "test" {
-  name = %[2]q
-}
-
 resource "aws_iam_role" "test" {
-  name = %[2]q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -844,7 +805,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = %[2]q
+  name = %[1]q
   role = aws_iam_role.test.id
 
   policy = <<-EOF
@@ -863,11 +824,11 @@ resource "aws_iam_role_policy" "test" {
 }
 EOF
 }
-`, userPoolName, clientName)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolClientConfigAnalyticsConfig(userPoolName, clientName string) string {
-	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
+func testAccAWSCognitoUserPoolClientConfigAnalyticsConfig(rName string) string {
+	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
   name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
@@ -878,11 +839,11 @@ resource "aws_cognito_user_pool_client" "test" {
     role_arn       = aws_iam_role.test.arn
   }
 }
-`, clientName)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolClientConfigAnalyticsConfigShareUserData(userPoolName, clientName string) string {
-	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
+func testAccAWSCognitoUserPoolClientConfigAnalyticsConfigShareUserData(rName string) string {
+	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
   name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
@@ -894,11 +855,11 @@ resource "aws_cognito_user_pool_client" "test" {
     user_data_shared = true
   }
 }
-`, clientName)
+`, rName)
 }
 
-func testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(userPoolName, clientName string) string {
-	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName) + fmt.Sprintf(`
+func testAccAWSCognitoUserPoolClientConfigAnalyticsWithArnConfig(rName string) string {
+	return testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
   name         = %[1]q
   user_pool_id = aws_cognito_user_pool.test.id
@@ -907,5 +868,5 @@ resource "aws_cognito_user_pool_client" "test" {
     application_arn = aws_pinpoint_app.test.arn
   }
 }
-`, clientName)
+`, rName)
 }

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -126,6 +126,7 @@ The following arguments are optional:
 * `analytics_configuration` - (Optional) Configuration block for Amazon Pinpoint analytics for collecting metrics for this user pool. [Detailed below](#analytics_configuration).
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
 * `default_redirect_uri` - (Optional) Default redirect URI. Must be in the list of callback URLs.
+* `enable_token_revocation` - (Optional) Enables or disables token revocation.
 * `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH, ALLOW_ADMIN_USER_PASSWORD_AUTH, ALLOW_CUSTOM_AUTH, ALLOW_USER_PASSWORD_AUTH, ALLOW_USER_SRP_AUTH, ALLOW_REFRESH_TOKEN_AUTH).
 * `generate_secret` - (Optional) Should an application secret be generated.
 * `id_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the ID token is no longer valid and cannot be used. This value will be overridden if you have entered a value in `token_validity_units`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19794
Closes #19924
Closes #20012

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolClient_'
--- PASS: TestAccAWSCognitoUserPoolClient_disappears_userPool (43.06s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (50.31s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (57.72s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (62.73s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn (67.18s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity (93.37s)
--- PASS: TestAccAWSCognitoUserPoolClient_refreshTokenValidity (93.82s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (94.42s)
--- PASS: TestAccAWSCognitoUserPoolClient_accessTokenValidity (94.44s)
--- PASS: TestAccAWSCognitoUserPoolClient_idTokenValidity (94.68s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (94.92s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnits (95.24s)
--- PASS: TestAccAWSCognitoUserPoolClient_enableRevocation (128.46s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (145.04s)
```
