### PR TITLE
r/fsx_windows_filesystem - support `aliases`

### DIFF
--- a/.changelog/20054.txt
+++ b/.changelog/20054.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/fsx_windows_file_system: Add `aliases` argument.
+```

--- a/aws/fsx.go
+++ b/aws/fsx.go
@@ -1,11 +1,13 @@
 package aws
 
 import (
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/fsx"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func describeFsxFileSystem(conn *fsx.FSx, id string) (*fsx.FileSystem, error) {
@@ -87,7 +89,13 @@ func waitForFsxFileSystemCreation(conn *fsx.FSx, id string, timeout time.Duratio
 		Delay:   30 * time.Second,
 	}
 
-	_, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*fsx.FileSystem); ok {
+		if output.FailureDetails != nil {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.FailureDetails.Message)))
+		}
+	}
 
 	return err
 }
@@ -101,7 +109,13 @@ func waitForFsxFileSystemDeletion(conn *fsx.FSx, id string, timeout time.Duratio
 		Delay:   30 * time.Second,
 	}
 
-	_, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*fsx.FileSystem); ok {
+		if output.FailureDetails != nil {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.FailureDetails.Message)))
+		}
+	}
 
 	return err
 }

--- a/aws/fsx.go
+++ b/aws/fsx.go
@@ -8,11 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-const (
-	fsxWindowsFileSystemAliasAvailable = 10 * time.Minute
-	fsxWindowsFileSystemAliasDeleted   = 10 * time.Minute
-)
-
 func describeFsxFileSystem(conn *fsx.FSx, id string) (*fsx.FileSystem, error) {
 	input := &fsx.DescribeFileSystemsInput{
 		FileSystemIds: []*string{aws.String(id)},
@@ -53,46 +48,7 @@ func refreshFsxFileSystemLifecycle(conn *fsx.FSx, id string) resource.StateRefre
 	}
 }
 
-func refreshFsxWindowsFileSystemAliasLifecycle(conn *fsx.FSx, id, aliasName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		filesystem, err := describeFsxFileSystem(conn, id)
-
-		if isAWSErr(err, fsx.ErrCodeFileSystemNotFound, "") {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		if filesystem == nil {
-			return nil, "", nil
-		}
-
-		if filesystem.WindowsConfiguration == nil {
-			return nil, "", nil
-		}
-
-		aliases := filesystem.WindowsConfiguration.Aliases
-		if aliases == nil {
-			return nil, "", nil
-		}
-
-		for _, alias := range aliases {
-			if alias == nil {
-				continue
-			}
-
-			if aws.StringValue(alias.Name) == aliasName {
-				return filesystem, aws.StringValue(alias.Lifecycle), nil
-			}
-		}
-
-		return filesystem, "", nil
-	}
-}
-
-func refreshFsxFileSystemAdministrativeActionsStatusFileSystemUpdate(conn *fsx.FSx, id string) resource.StateRefreshFunc {
+func refreshFsxFileSystemAdministrativeActionsStatusFileSystemUpdate(conn *fsx.FSx, id, action string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		filesystem, err := describeFsxFileSystem(conn, id)
 
@@ -113,41 +69,13 @@ func refreshFsxFileSystemAdministrativeActionsStatusFileSystemUpdate(conn *fsx.F
 				continue
 			}
 
-			if aws.StringValue(administrativeAction.AdministrativeActionType) == fsx.AdministrativeActionTypeFileSystemUpdate {
+			if aws.StringValue(administrativeAction.AdministrativeActionType) == action {
 				return filesystem, aws.StringValue(administrativeAction.Status), nil
 			}
 		}
 
 		return filesystem, fsx.StatusCompleted, nil
 	}
-}
-
-func waitForFsxWindowsFileSystemAliasAvailable(conn *fsx.FSx, id, alias string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{fsx.AliasLifecycleCreating},
-		Target:  []string{fsx.AliasLifecycleAvailable},
-		Refresh: refreshFsxWindowsFileSystemAliasLifecycle(conn, id, alias),
-		Timeout: fsxWindowsFileSystemAliasAvailable,
-		Delay:   30 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
-}
-
-func waitForFsxWindowsFileSystemAliasDeleted(conn *fsx.FSx, id, alias string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{fsx.AliasLifecycleAvailable, fsx.AliasLifecycleDeleting},
-		Target:  []string{""},
-		Refresh: refreshFsxWindowsFileSystemAliasLifecycle(conn, id, alias),
-		Timeout: fsxWindowsFileSystemAliasDeleted,
-		Delay:   30 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
 }
 
 func waitForFsxFileSystemCreation(conn *fsx.FSx, id string, timeout time.Duration) error {
@@ -192,7 +120,7 @@ func waitForFsxFileSystemUpdate(conn *fsx.FSx, id string, timeout time.Duration)
 	return err
 }
 
-func waitForFsxFileSystemUpdateAdministrativeActionsStatusFileSystemUpdate(conn *fsx.FSx, id string, timeout time.Duration) error {
+func waitForFsxFileSystemUpdateAdministrativeActionsStatusFileSystemUpdate(conn *fsx.FSx, id, action string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			fsx.StatusInProgress,
@@ -202,7 +130,7 @@ func waitForFsxFileSystemUpdateAdministrativeActionsStatusFileSystemUpdate(conn 
 			fsx.StatusCompleted,
 			fsx.StatusUpdatedOptimizing,
 		},
-		Refresh: refreshFsxFileSystemAdministrativeActionsStatusFileSystemUpdate(conn, id),
+		Refresh: refreshFsxFileSystemAdministrativeActionsStatusFileSystemUpdate(conn, id, action),
 		Timeout: timeout,
 		Delay:   30 * time.Second,
 	}

--- a/aws/internal/service/directoryservice/finder/finder.go
+++ b/aws/internal/service/directoryservice/finder/finder.go
@@ -1,0 +1,48 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func DirectoryByID(conn *directoryservice.DirectoryService, id string) (*directoryservice.DirectoryDescription, error) {
+	input := &directoryservice.DescribeDirectoriesInput{
+		DirectoryIds: aws.StringSlice([]string{id}),
+	}
+
+	output, err := conn.DescribeDirectories(input)
+
+	if tfawserr.ErrCodeEquals(err, directoryservice.ErrCodeEntityDoesNotExistException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.DirectoryDescriptions) == 0 || output.DirectoryDescriptions[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	// TODO Check for multiple results.
+	// TODO https://github.com/hashicorp/terraform-provider-aws/pull/17613.
+
+	directory := output.DirectoryDescriptions[0]
+
+	if stage := aws.StringValue(directory.Stage); stage == directoryservice.DirectoryStageDeleted {
+		return nil, &resource.NotFoundError{
+			Message:     stage,
+			LastRequest: input,
+		}
+	}
+
+	return directory, nil
+}

--- a/aws/internal/service/directoryservice/waiter/status.go
+++ b/aws/internal/service/directoryservice/waiter/status.go
@@ -1,0 +1,25 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/directoryservice/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func DirectoryStage(conn *directoryservice.DirectoryService, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.DirectoryByID(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Stage), nil
+	}
+}

--- a/aws/internal/service/directoryservice/waiter/waiter.go
+++ b/aws/internal/service/directoryservice/waiter/waiter.go
@@ -1,0 +1,54 @@
+package waiter
+
+import (
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+const (
+	DirectoryCreatedTimeout = 60 * time.Minute
+	DirectoryDeletedTimeout = 60 * time.Minute
+)
+
+func DirectoryCreated(conn *directoryservice.DirectoryService, id string) (*directoryservice.DirectoryDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{directoryservice.DirectoryStageRequested, directoryservice.DirectoryStageCreating, directoryservice.DirectoryStageCreated},
+		Target:  []string{directoryservice.DirectoryStageActive},
+		Refresh: DirectoryStage(conn, id),
+		Timeout: DirectoryCreatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*directoryservice.DirectoryDescription); ok {
+		tfresource.SetLastError(err, errors.New(aws.StringValue(output.StageReason)))
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func DirectoryDeleted(conn *directoryservice.DirectoryService, id string) (*directoryservice.DirectoryDescription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{directoryservice.DirectoryStageActive, directoryservice.DirectoryStageDeleting},
+		Target:  []string{},
+		Refresh: DirectoryStage(conn, id),
+		Timeout: DirectoryDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*directoryservice.DirectoryDescription); ok {
+		tfresource.SetLastError(err, errors.New(aws.StringValue(output.StageReason)))
+
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -43,6 +43,18 @@ func resourceAwsFsxWindowsFileSystem() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"self_managed_active_directory"},
 			},
+			"aliases": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 50,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(4, 253),
+						validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9]([.][A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])+$`), "must be in the fqdn format hostname.domain"),
+					),
+				},
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -265,6 +277,10 @@ func resourceAwsFsxWindowsFileSystemCreate(d *schema.ResourceData, meta interfac
 		input.WindowsConfiguration.ActiveDirectoryId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("aliases"); ok {
+		input.WindowsConfiguration.Aliases = expandStringSet(v.(*schema.Set))
+	}
+
 	if v, ok := d.GetOk("deployment_type"); ok {
 		input.WindowsConfiguration.DeploymentType = aws.String(v.(string))
 	}
@@ -337,6 +353,14 @@ func resourceAwsFsxWindowsFileSystemUpdate(d *schema.ResourceData, meta interfac
 			ClientRequestToken:   aws.String(resource.UniqueId()),
 			FileSystemId:         aws.String(d.Id()),
 			WindowsConfiguration: &fsx.UpdateFileSystemWindowsConfiguration{},
+		}
+
+		if d.HasChange("aliases") {
+			o, n := d.GetChange("aliases")
+
+			if err := updateFsxAliases(conn, d.Get("arn").(string), o.([]*fsx.Alias), n.([]*fsx.Alias)); err != nil {
+				return fmt.Errorf("error updating FSx Windows File System (%s) aliases: %s", d.Get("arn").(string), err)
+			}
 		}
 
 		if d.HasChange("automatic_backup_retention_days") {
@@ -425,6 +449,10 @@ func resourceAwsFsxWindowsFileSystemRead(d *schema.ResourceData, meta interface{
 	d.Set("kms_key_id", filesystem.KmsKeyId)
 	d.Set("storage_type", filesystem.StorageType)
 
+	if err := d.Set("aliases", aws.StringValueSlice(expandFsxAliasValues(filesystem.WindowsConfiguration.Aliases))); err != nil {
+		return fmt.Errorf("error setting aliases: %s", err)
+	}
+
 	if err := d.Set("network_interface_ids", aws.StringValueSlice(filesystem.NetworkInterfaceIds)); err != nil {
 		return fmt.Errorf("error setting network_interface_ids: %w", err)
 	}
@@ -488,6 +516,83 @@ func resourceAwsFsxWindowsFileSystemDelete(d *schema.ResourceData, meta interfac
 
 	if err := waitForFsxFileSystemDeletion(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("Error waiting for filesystem (%s) to delete: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandFsxAliasValues(aliases []*fsx.Alias) []*string {
+	var alternateDNSNames []*string
+
+	for i := 0; i < len(aliases); i++ {
+		alternateDNSNames[i] = aliases[i].Name
+	}
+
+	return alternateDNSNames
+}
+
+func updateFsxAliases(conn *fsx.FSx, identifier string, oldAliases []*fsx.Alias, newAliases []*fsx.Alias) error {
+	oldAliasValues := expandFsxAliasValues(oldAliases)
+	newAliasValues := expandFsxAliasValues(newAliases)
+
+	var removedAliases []*string
+
+	for _, oldAliasValue := range oldAliasValues {
+		exists := false
+
+		for _, newAliasValue := range newAliasValues {
+			if newAliasValue == oldAliasValue {
+				exists = true
+				break
+			}
+		}
+
+		if !exists {
+			removedAliases = append(removedAliases, oldAliasValue)
+		}
+	}
+
+	if len(removedAliases) > 0 {
+		input := &fsx.DisassociateFileSystemAliasesInput{
+			FileSystemId: aws.String(identifier),
+			Aliases:      removedAliases,
+		}
+
+		_, err := conn.DisassociateFileSystemAliases(input)
+
+		if err != nil {
+			return fmt.Errorf("error disassociating aliases from FSx file system (%s): %w", identifier, err)
+		}
+	}
+
+	var addedAliases []*string
+
+	for _, newAliasValue := range newAliasValues {
+		exists := false
+
+		for _, oldAliasValue := range oldAliasValues {
+			if oldAliasValue == newAliasValue {
+				exists = true
+				break
+			}
+		}
+
+		if !exists {
+			addedAliases = append(addedAliases, newAliasValue)
+		}
+	}
+
+	if len(addedAliases) > 0 {
+		input := &fsx.AssociateFileSystemAliasesInput{
+			FileSystemId: aws.String(identifier),
+			Aliases:      addedAliases,
+		}
+
+		_, err := conn.AssociateFileSystemAliases(input)
+
+		if err != nil {
+			return fmt.Errorf("error associating aliases to FSx file system (%s): %w", identifier, err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -532,27 +532,7 @@ func expandFsxAliasValues(aliases []*fsx.Alias) []*string {
 	return alternateDNSNames
 }
 
-func updateFsxAliases(conn *fsx.FSx, identifier string, newSet *schema.Set, oldSet *schema.Set) error {
-	// oldAliasValues := expandFsxAliasValues(oldAliases)
-	// newAliasValues := expandFsxAliasValues(newAliases)
-
-	// var removedAliases []*string
-
-	// for _, oldAliasValue := range oldAliasValues {
-	// 	exists := false
-
-	// 	for _, newAliasValue := range newAliasValues {
-	// 		if newAliasValue == oldAliasValue {
-	// 			exists = true
-	// 			break
-	// 		}
-	// 	}
-
-	// 	if !exists {
-	// 		removedAliases = append(removedAliases, oldAliasValue)
-	// 	}
-	// }
-
+func updateFsxAliases(conn *fsx.FSx, identifier string, oldSet *schema.Set, newSet *schema.Set) error {
 	if newSet.Len() > 0 {
 		if newAliases := newSet.Difference(oldSet); newAliases.Len() > 0 {
 
@@ -569,7 +549,7 @@ func updateFsxAliases(conn *fsx.FSx, identifier string, newSet *schema.Set, oldS
 
 			for _, alias := range newAliases.List() {
 				if err := waitForFsxWindowsFileSystemAliasAvailable(conn, identifier, alias.(string)); err != nil {
-					return fmt.Errorf("Error waiting for FSX Windows filesystem alias (%s) to be available: %w", identifier, err)
+					return fmt.Errorf("Error waiting for FSX Windows filesystem (%s) alias (%s) to be available: %w", identifier, alias.(string), err)
 				}
 			}
 		}
@@ -590,28 +570,11 @@ func updateFsxAliases(conn *fsx.FSx, identifier string, newSet *schema.Set, oldS
 
 			for _, alias := range oldAliases.List() {
 				if err := waitForFsxWindowsFileSystemAliasDeleted(conn, identifier, alias.(string)); err != nil {
-					return fmt.Errorf("Error waiting for FSX Windows filesystem alias (%s) to delete: %w", identifier, err)
+					return fmt.Errorf("Error waiting for FSX Windows filesystem (%s) alias (%s) to delete: %w", identifier, alias.(string), err)
 				}
 			}
 		}
 	}
-
-	// var addedAliases []*string
-
-	// for _, newAliasValue := range newAliasValues {
-	// 	exists := false
-
-	// 	for _, oldAliasValue := range oldAliasValues {
-	// 		if oldAliasValue == newAliasValue {
-	// 			exists = true
-	// 			break
-	// 		}
-	// 	}
-
-	// 	if !exists {
-	// 		addedAliases = append(addedAliases, newAliasValue)
-	// 	}
-	// }
 
 	return nil
 }

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -85,6 +85,7 @@ func TestAccAWSFsxWindowsFileSystem_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`file-system/fs-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_backup_retention_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_backups", "false"),
 					resource.TestMatchResourceAttr(resourceName, "daily_automatic_backup_start_time", regexp.MustCompile(`^\d\d:\d\d$`)),
@@ -140,6 +141,7 @@ func TestAccAWSFsxWindowsFileSystem_singleAz2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`file-system/fs-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_backup_retention_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_backups", "false"),
 					resource.TestMatchResourceAttr(resourceName, "daily_automatic_backup_start_time", regexp.MustCompile(`^\d\d:\d\d$`)),
@@ -219,6 +221,7 @@ func TestAccAWSFsxWindowsFileSystem_multiAz(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`file-system/fs-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_backup_retention_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_backups", "false"),
 					resource.TestMatchResourceAttr(resourceName, "daily_automatic_backup_start_time", regexp.MustCompile(`^\d\d:\d\d$`)),
@@ -268,6 +271,55 @@ func TestAccAWSFsxWindowsFileSystem_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsFsxWindowsFileSystem(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSFsxWindowsFileSystem_Aliases(t *testing.T) {
+	var filesystem1, filesystem2, filesystem3 fsx.FileSystem
+	resourceName := "aws_fsx_windows_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(fsx.EndpointsID, t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFsxWindowsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsFsxWindowsFileSystemConfigAliases1("filesystem1.domain.name.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem1.domain.name.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"security_group_ids",
+					"skip_final_backup",
+				},
+			},
+			{
+				Config: testAccAwsFsxWindowsFileSystemConfigAliases2("filesystem1.domain.name.com", "filesystem2.domain.name.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem2),
+					testAccCheckFsxWindowsFileSystemNotRecreated(&filesystem1, &filesystem2),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem1.domain.name.com"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.1", "filesystem2.domain.name.com"),
+				),
+			},
+			{
+				Config: testAccAwsFsxWindowsFileSystemConfigAliases1("filesystem2.domain.name.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem3),
+					testAccCheckFsxWindowsFileSystemNotRecreated(&filesystem2, &filesystem3),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem2.domain.name.com"),
+				),
 			},
 		},
 	})
@@ -859,6 +911,39 @@ resource "aws_directory_service_directory" "test" {
   }
 }
 `
+}
+
+func testAccAwsFsxWindowsFileSystemConfigAliases1(alias1 string) string {
+	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
+resource "aws_fsx_windows_file_system" "test" {
+  active_directory_id = aws_directory_service_directory.test.id
+  skip_final_backup   = true
+  storage_capacity    = 32
+  subnet_ids          = [aws_subnet.test1.id]
+  throughput_capacity = 8
+
+  aliases = [
+	%[1]q
+  ]
+}
+`, alias1)
+}
+
+func testAccAwsFsxWindowsFileSystemConfigAliases2(alias1, alias2 string) string {
+	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
+resource "aws_fsx_windows_file_system" "test" {
+  active_directory_id = aws_directory_service_directory.test.id
+  skip_final_backup   = true
+  storage_capacity    = 32
+  subnet_ids          = [aws_subnet.test1.id]
+  throughput_capacity = 8
+
+  aliases = [
+	%[1]q
+	%[2]q
+  ]
+}
+`, alias1, alias2)
 }
 
 func testAccAwsFsxWindowsFileSystemConfigAutomaticBackupRetentionDays(automaticBackupRetentionDays int) string {

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -915,12 +915,12 @@ resource "aws_directory_service_directory" "test" {
 }
 
 func testAccAwsFsxWindowsFileSystemConfigAliases1(alias1 string) string {
-	return fmt.Sprintf(`
+	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
 resource "aws_fsx_windows_file_system" "test" {
-  active_directory_id = "d-92677185a7"
+	active_directory_id = aws_directory_service_directory.test.id
   skip_final_backup   = true
   storage_capacity    = 32
-  subnet_ids          = ["subnet-060ab259c291fa28c"]
+  subnet_ids          = [aws_subnet.test1.id]
   throughput_capacity = 8
 
   aliases = [%[1]q]
@@ -929,12 +929,12 @@ resource "aws_fsx_windows_file_system" "test" {
 }
 
 func testAccAwsFsxWindowsFileSystemConfigAliases2(alias1, alias2 string) string {
-	return fmt.Sprintf(`
+	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
 resource "aws_fsx_windows_file_system" "test" {
-  active_directory_id = "d-92677185a7"
+  active_directory_id = aws_directory_service_directory.test.id
   skip_final_backup   = true
   storage_capacity    = 32
-  subnet_ids          = ["subnet-060ab259c291fa28c"]
+  subnet_ids          = [aws_subnet.test1.id]
   throughput_capacity = 8
 
   aliases = [%[1]q, %[2]q]

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -276,7 +276,7 @@ func TestAccAWSFsxWindowsFileSystem_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSFsxWindowsFileSystem_Aliases(t *testing.T) {
+func TestAccAWSFsxWindowsFileSystem_aliases(t *testing.T) {
 	var filesystem1, filesystem2, filesystem3 fsx.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
 
@@ -286,11 +286,11 @@ func TestAccAWSFsxWindowsFileSystem_Aliases(t *testing.T) {
 		CheckDestroy: testAccCheckFsxWindowsFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigAliases1("filesystem1.domain.name.com"),
+				Config: testAccAwsFsxWindowsFileSystemConfigAliases1("filesystem1.example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "aliases.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem1.domain.name.com"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem1.example.com"),
 				),
 			},
 			{
@@ -303,22 +303,22 @@ func TestAccAWSFsxWindowsFileSystem_Aliases(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigAliases2("filesystem1.domain.name.com", "filesystem2.domain.name.com"),
+				Config: testAccAwsFsxWindowsFileSystemConfigAliases2("filesystem2.example.com", "filesystem3.example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem2),
 					testAccCheckFsxWindowsFileSystemNotRecreated(&filesystem1, &filesystem2),
 					resource.TestCheckResourceAttr(resourceName, "aliases.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem1.domain.name.com"),
-					resource.TestCheckResourceAttr(resourceName, "aliases.1", "filesystem2.domain.name.com"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem2.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.1", "filesystem3.example.com"),
 				),
 			},
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigAliases1("filesystem2.domain.name.com"),
+				Config: testAccAwsFsxWindowsFileSystemConfigAliases1("filesystem3.example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem3),
 					testAccCheckFsxWindowsFileSystemNotRecreated(&filesystem2, &filesystem3),
 					resource.TestCheckResourceAttr(resourceName, "aliases.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem2.domain.name.com"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.0", "filesystem3.example.com"),
 				),
 			},
 		},
@@ -914,12 +914,12 @@ resource "aws_directory_service_directory" "test" {
 }
 
 func testAccAwsFsxWindowsFileSystemConfigAliases1(alias1 string) string {
-	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_fsx_windows_file_system" "test" {
-  active_directory_id = aws_directory_service_directory.test.id
+  active_directory_id = "d-92677185a7"
   skip_final_backup   = true
   storage_capacity    = 32
-  subnet_ids          = [aws_subnet.test1.id]
+  subnet_ids          = ["subnet-060ab259c291fa28c"]
   throughput_capacity = 8
 
   aliases = [
@@ -930,16 +930,16 @@ resource "aws_fsx_windows_file_system" "test" {
 }
 
 func testAccAwsFsxWindowsFileSystemConfigAliases2(alias1, alias2 string) string {
-	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_fsx_windows_file_system" "test" {
-  active_directory_id = aws_directory_service_directory.test.id
+  active_directory_id = "d-92677185a7"
   skip_final_backup   = true
   storage_capacity    = 32
-  subnet_ids          = [aws_subnet.test1.id]
+  subnet_ids          = ["subnet-060ab259c291fa28c"]
   throughput_capacity = 8
 
   aliases = [
-	%[1]q
+	%[1]q,
 	%[2]q
   ]
 }

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -922,9 +922,7 @@ resource "aws_fsx_windows_file_system" "test" {
   subnet_ids          = ["subnet-060ab259c291fa28c"]
   throughput_capacity = 8
 
-  aliases = [
-	%[1]q
-  ]
+  aliases = [%[1]q]
 }
 `, alias1)
 }
@@ -938,10 +936,7 @@ resource "aws_fsx_windows_file_system" "test" {
   subnet_ids          = ["subnet-060ab259c291fa28c"]
   throughput_capacity = 8
 
-  aliases = [
-	%[1]q,
-	%[2]q
-  ]
+  aliases = [%[1]q, %[2]q]
 }
 `, alias1, alias2)
 }

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -282,6 +282,7 @@ func TestAccAWSFsxWindowsFileSystem_aliases(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(fsx.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, fsx.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFsxWindowsFileSystemDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -917,7 +917,7 @@ resource "aws_directory_service_directory" "test" {
 func testAccAwsFsxWindowsFileSystemConfigAliases1(alias1 string) string {
 	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
 resource "aws_fsx_windows_file_system" "test" {
-	active_directory_id = aws_directory_service_directory.test.id
+  active_directory_id = aws_directory_service_directory.test.id
   skip_final_backup   = true
   storage_capacity    = 32
   subnet_ids          = [aws_subnet.test1.id]

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,12 +5,19 @@ go 1.15
 require (
 	github.com/bflad/tfproviderdocs v0.9.1
 	github.com/client9/misspell v0.3.4
+<<<<<<< HEAD
 	github.com/golangci/golangci-lint v1.39.0
 	github.com/hashicorp/go-changelog v0.0.0-20201005170154-56335215ce3a
 	github.com/hashicorp/go-getter v1.5.2 // indirect
 	github.com/katbyte/terrafmt v0.3.0
 	github.com/pavius/impi v0.0.3
 	github.com/terraform-linters/tflint v0.28.1
+=======
+	github.com/golangci/golangci-lint v1.33.0
+	github.com/katbyte/terrafmt v0.2.1-0.20200913185704-5ff4421407b4
+	github.com/pavius/impi v0.0.3 // indirect
+	github.com/terraform-linters/tflint v0.20.3
+>>>>>>> 9c419a56f (Updating tools)
 )
 
 replace github.com/katbyte/terrafmt => github.com/gdavison/terrafmt v0.3.1-0.20210204054728-84242796be99

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,19 +5,12 @@ go 1.15
 require (
 	github.com/bflad/tfproviderdocs v0.9.1
 	github.com/client9/misspell v0.3.4
-<<<<<<< HEAD
 	github.com/golangci/golangci-lint v1.39.0
 	github.com/hashicorp/go-changelog v0.0.0-20201005170154-56335215ce3a
 	github.com/hashicorp/go-getter v1.5.2 // indirect
 	github.com/katbyte/terrafmt v0.3.0
 	github.com/pavius/impi v0.0.3
 	github.com/terraform-linters/tflint v0.28.1
-=======
-	github.com/golangci/golangci-lint v1.33.0
-	github.com/katbyte/terrafmt v0.2.1-0.20200913185704-5ff4421407b4
-	github.com/pavius/impi v0.0.3 // indirect
-	github.com/terraform-linters/tflint v0.20.3
->>>>>>> 9c419a56f (Updating tools)
 )
 
 replace github.com/katbyte/terrafmt => github.com/gdavison/terrafmt v0.3.1-0.20210204054728-84242796be99

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `subnet_ids` - (Required) A list of IDs for the subnets that the file system will be accessible from. To specify more than a single subnet set `deployment_type` to `MULTI_AZ_1`.
 * `throughput_capacity` - (Required) Throughput (megabytes per second) of the file system in power of 2 increments. Minimum of `8` and maximum of `2048`.
 * `active_directory_id` - (Optional) The ID for an existing Microsoft Active Directory instance that the file system should join when it's created. Cannot be specified with `self_managed_active_directory`.
+* `aliases` - (Optional) An array DNS alias names that you want to associate with the Amazon FSx file system.  For more information, see [Working with DNS Aliases](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/managing-dns-aliases.html)
 * `automatic_backup_retention_days` - (Optional) The number of days to retain automatic backups. Minimum of `0` and maximum of `90`. Defaults to `7`. Set to `0` to disable.
 * `copy_tags_to_backups` - (Optional) A boolean flag indicating whether tags on the file system should be copied to backups. Defaults to `false`.
 * `daily_automatic_backup_start_time` - (Optional) The preferred time (in `HH:MM` format) to take daily automatic backups, in the UTC time zone.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16548
Supersedes #16683

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSFsxWindowsFileSystem_aliases (2000.94s)
```
