### PR TITLE
r/sagemaker_device_fleet - new resource

### DIFF
--- a/.changelog/20058.txt
+++ b/.changelog/20058.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sagemaker_device_fleet
+```

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -91,12 +91,22 @@ func DeviceFleetByName(conn *sagemaker.SageMaker, id string) (*sagemaker.Describ
 	}
 
 	output, err := conn.DescribeDeviceFleet(input)
+	if tfawserr.ErrMessageContains(err, "ValidationException", "No devicefleet with name") {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
 	if output == nil {
-		return nil, nil
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
 	}
 
 	return output, nil

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -83,6 +83,25 @@ func ImageVersionByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Desc
 	return output, nil
 }
 
+// DeviceFleetByName returns the Device Fleet corresponding to the specified Device Fleet name.
+// Returns nil if no Device Fleet is found.
+func DeviceFleetByName(conn *sagemaker.SageMaker, id string) (*sagemaker.DescribeDeviceFleetOutput, error) {
+	input := &sagemaker.DescribeDeviceFleetInput{
+		DeviceFleetName: aws.String(id),
+	}
+
+	output, err := conn.DescribeDeviceFleet(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output, nil
+}
+
 // DomainByName returns the domain corresponding to the specified domain id.
 // Returns nil if no domain is found.
 func DomainByName(conn *sagemaker.SageMaker, domainID string) (*sagemaker.DescribeDomainOutput, error) {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1003,6 +1003,7 @@ func Provider() *schema.Provider {
 			"aws_sagemaker_app":                                       resourceAwsSagemakerApp(),
 			"aws_sagemaker_app_image_config":                          resourceAwsSagemakerAppImageConfig(),
 			"aws_sagemaker_code_repository":                           resourceAwsSagemakerCodeRepository(),
+			"aws_sagemaker_device_fleet":                              resourceAwsSagemakerDeviceFleet(),
 			"aws_sagemaker_domain":                                    resourceAwsSagemakerDomain(),
 			"aws_sagemaker_endpoint":                                  resourceAwsSagemakerEndpoint(),
 			"aws_sagemaker_endpoint_configuration":                    resourceAwsSagemakerEndpointConfiguration(),

--- a/aws/resource_aws_sagemaker_device_fleet.go
+++ b/aws/resource_aws_sagemaker_device_fleet.go
@@ -1,0 +1,238 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+)
+
+func resourceAwsSagemakerDeviceFleet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerDeviceFleetCreate,
+		Read:   resourceAwsSagemakerDeviceFleetRead,
+		Update: resourceAwsSagemakerDeviceFleetUpdate,
+		Delete: resourceAwsSagemakerDeviceFleetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 800),
+			},
+			"device_fleet_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,62}$`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+				),
+			},
+			"iot_role_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"output_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_key_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
+						"s3_output_location": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1024),
+						},
+					},
+				},
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsSagemakerDeviceFleetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	name := d.Get("device_fleet_name").(string)
+	input := &sagemaker.CreateDeviceFleetInput{
+		DeviceFleetName: aws.String(name),
+		OutputConfig:    expandSagemakerFeatureDeviceFleetOutputConfig(d.Get("output_config").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("role_arn"); ok {
+		input.RoleArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
+	}
+
+	_, err := retryOnAwsCode("ValidationException", func() (interface{}, error) {
+		return conn.CreateDeviceFleet(input)
+	})
+	if err != nil {
+		return fmt.Errorf("error creating SageMaker Device Fleet %s: %w", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceAwsSagemakerDeviceFleetRead(d, meta)
+}
+
+func resourceAwsSagemakerDeviceFleetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	deviceFleet, err := finder.DeviceFleetByName(conn, d.Id())
+	if err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "does not exist") {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find SageMaker DeviceFleet (%s); removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("error reading SageMaker DeviceFleet (%s): %w", d.Id(), err)
+
+	}
+
+	arn := aws.StringValue(deviceFleet.DeviceFleetArn)
+	d.Set("deviceFleet_name", deviceFleet.DeviceFleetName)
+	d.Set("arn", arn)
+	d.Set("role_arn", deviceFleet.RoleArn)
+	d.Set("description", deviceFleet.Description)
+	d.Set("iot_role_alias", deviceFleet.IotRoleAlias)
+
+	if err := d.Set("output_config", flattenSagemakerFeatureDeviceFleetOutputConfig(deviceFleet.OutputConfig)); err != nil {
+		return fmt.Errorf("error setting output_config for Sagemaker Device Fleet (%s): %w", d.Id(), err)
+	}
+
+	tags, err := keyvaluetags.SagemakerListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for SageMaker DeviceFleet (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerDeviceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	if d.HasChangeExcept("tags") {
+
+		input := &sagemaker.UpdateDeviceFleetInput{
+			DeviceFleetName: aws.String(d.Id()),
+		}
+
+		if d.HasChange("description") {
+			input.Description = aws.String(d.Get("description").(string))
+		}
+
+		if d.HasChange("role_arn") {
+			input.RoleArn = aws.String(d.Get("role_arn").(string))
+		}
+
+		if d.HasChange("output_config") {
+			input.OutputConfig = expandSagemakerFeatureDeviceFleetOutputConfig(d.Get("output_config").([]interface{}))
+		}
+
+		log.Printf("[DEBUG] sagemaker DeviceFleet update config: %#v", *input)
+		_, err := conn.UpdateDeviceFleet(input)
+		if err != nil {
+			return fmt.Errorf("error updating SageMaker Device Fleet: %w", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.SagemakerUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating SageMaker Device Fleet (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSagemakerDeviceFleetRead(d, meta)
+}
+
+func resourceAwsSagemakerDeviceFleetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.DeleteDeviceFleetInput{
+		DeviceFleetName: aws.String(d.Id()),
+	}
+
+	if _, err := conn.DeleteDeviceFleet(input); err != nil {
+		if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "No Device Fleet with the name") {
+			return nil
+		}
+		return fmt.Errorf("error deleting SageMaker Device Fleet (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandSagemakerFeatureDeviceFleetOutputConfig(l []interface{}) *sagemaker.EdgeOutputConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.EdgeOutputConfig{
+		S3OutputLocation: aws.String(m["s3_output_location"].(string)),
+	}
+
+	if v, ok := m["kms_key_id"].(string); ok && v != "" {
+		config.KmsKeyId = aws.String(m["kms_key_id"].(string))
+	}
+
+	return config
+}
+
+func flattenSagemakerFeatureDeviceFleetOutputConfig(config *sagemaker.EdgeOutputConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"s3_output_location": aws.StringValue(config.S3OutputLocation),
+	}
+
+	if config.KmsKeyId != nil {
+		m["kms_key_id"] = aws.StringValue(config.KmsKeyId)
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/resource_aws_sagemaker_device_fleet.go
+++ b/aws/resource_aws_sagemaker_device_fleet.go
@@ -77,6 +77,7 @@ func resourceAwsSagemakerDeviceFleet() *schema.Resource {
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
 		},
+		CustomizeDiff: SetTagsDiff,
 	}
 }
 

--- a/aws/resource_aws_sagemaker_device_fleet.go
+++ b/aws/resource_aws_sagemaker_device_fleet.go
@@ -182,7 +182,7 @@ func resourceAwsSagemakerDeviceFleetUpdate(d *schema.ResourceData, meta interfac
 			input.Description = aws.String(d.Get("description").(string))
 		}
 
-		log.Printf("[DEBUG] sagemaker DeviceFleet update config: %#v", *input)
+		log.Printf("[DEBUG] sagemaker DeviceFleet update config: %s", input.String())
 		_, err := conn.UpdateDeviceFleet(input)
 		if err != nil {
 			return fmt.Errorf("error updating SageMaker Device Fleet: %w", err)

--- a/aws/resource_aws_sagemaker_device_fleet_test.go
+++ b/aws/resource_aws_sagemaker_device_fleet_test.go
@@ -60,7 +60,7 @@ func testSweepSagemakerDeviceFleets(region string) error {
 }
 
 func TestAccAWSSagemakerDeviceFleet_basic(t *testing.T) {
-	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	var deviceFleet sagemaker.DescribeDeviceFleetOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_device_fleet.test"
 
@@ -73,7 +73,7 @@ func TestAccAWSSagemakerDeviceFleet_basic(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDeviceFleetBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "device_fleet_name", rName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("device-fleet/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "output_config.#", "1"),
@@ -91,7 +91,7 @@ func TestAccAWSSagemakerDeviceFleet_basic(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDeviceFleet_description(t *testing.T) {
-	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	var deviceFleet sagemaker.DescribeDeviceFleetOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_device_fleet.test"
 
@@ -102,9 +102,9 @@ func TestAccAWSSagemakerDeviceFleet_description(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerDeviceFleetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerDeviceFleetDescription(rName),
+				Config: testAccAWSSagemakerDeviceFleetDescription(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 				),
 			},
@@ -114,17 +114,10 @@ func TestAccAWSSagemakerDeviceFleet_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSSagemakerDeviceFleetBasicConfig(rName),
+				Config: testAccAWSSagemakerDeviceFleetDescription(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
-				),
-			},
-			{
-				Config: testAccAWSSagemakerDeviceFleetDescription(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
-					resource.TestCheckResourceAttr(resourceName, "description", rName),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
 				),
 			},
 		},
@@ -132,7 +125,7 @@ func TestAccAWSSagemakerDeviceFleet_description(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDeviceFleet_tags(t *testing.T) {
-	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	var deviceFleet sagemaker.DescribeDeviceFleetOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_device_fleet.test"
 
@@ -145,7 +138,7 @@ func TestAccAWSSagemakerDeviceFleet_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDeviceFleetConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -158,7 +151,7 @@ func TestAccAWSSagemakerDeviceFleet_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDeviceFleetConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -167,7 +160,7 @@ func TestAccAWSSagemakerDeviceFleet_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDeviceFleetConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -177,7 +170,7 @@ func TestAccAWSSagemakerDeviceFleet_tags(t *testing.T) {
 }
 
 func TestAccAWSSagemakerDeviceFleet_disappears(t *testing.T) {
-	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	var deviceFleet sagemaker.DescribeDeviceFleetOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_device_fleet.test"
 
@@ -190,7 +183,7 @@ func TestAccAWSSagemakerDeviceFleet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerDeviceFleetBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerDeviceFleet(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -296,18 +289,18 @@ resource "aws_sagemaker_device_fleet" "test" {
 `, rName)
 }
 
-func testAccAWSSagemakerDeviceFleetDescription(rName string) string {
+func testAccAWSSagemakerDeviceFleetDescription(rName, desc string) string {
 	return testAccAWSSagemakerDeviceFleetConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device_fleet" "test" {
   device_fleet_name  = %[1]q
   role_arn           = aws_iam_role.test.arn
-  description        = %[1]q
+  description        = %[2]q
 
   output_config {
     s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
   }
 }
-`, rName)
+`, rName, desc)
 }
 
 func testAccAWSSagemakerDeviceFleetConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/aws/resource_aws_sagemaker_device_fleet_test.go
+++ b/aws/resource_aws_sagemaker_device_fleet_test.go
@@ -203,7 +203,7 @@ func testAccCheckAWSSagemakerDeviceFleetDestroy(s *terraform.State) error {
 
 		deviceFleet, err := finder.DeviceFleetByName(conn, rs.Primary.ID)
 		if err != nil {
-			return nil
+			return fmt.Errorf("error reading Sagemaker Device Fleet (%s): %w", rs.Primary.ID, err)
 		}
 
 		if aws.StringValue(deviceFleet.DeviceFleetName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_device_fleet_test.go
+++ b/aws/resource_aws_sagemaker_device_fleet_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -203,6 +204,9 @@ func testAccCheckAWSSagemakerDeviceFleetDestroy(s *terraform.State) error {
 
 		deviceFleet, err := finder.DeviceFleetByName(conn, rs.Primary.ID)
 		if err != nil {
+			if tfawserr.ErrMessageContains(err, "ValidationException", "No devicefleet with name") {
+				continue
+			}
 			return fmt.Errorf("error reading Sagemaker Device Fleet (%s): %w", rs.Primary.ID, err)
 		}
 

--- a/aws/resource_aws_sagemaker_device_fleet_test.go
+++ b/aws/resource_aws_sagemaker_device_fleet_test.go
@@ -1,0 +1,344 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_device_fleet", &resource.Sweeper{
+		Name: "aws_sagemaker_device_fleet",
+		F:    testSweepSagemakerDeviceFleets,
+	})
+}
+
+func testSweepSagemakerDeviceFleets(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	err = conn.ListDeviceFleetsPages(&sagemaker.ListDeviceFleetsInput{}, func(page *sagemaker.ListDeviceFleetsOutput, lastPage bool) bool {
+		for _, deviceFleet := range page.DeviceFleetSummaries {
+			name := aws.StringValue(deviceFleet.DeviceFleetName)
+
+			input := &sagemaker.DeleteDeviceFleetInput{
+				DeviceFleetName: deviceFleet.DeviceFleetName,
+			}
+
+			log.Printf("[INFO] Deleting SageMaker Device Fleet: %s", name)
+			if _, err := conn.DeleteDeviceFleet(input); err != nil {
+				log.Printf("[ERROR] Error deleting SageMaker Device Fleet (%s): %s", name, err)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker Device Fleet sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving SageMaker Device Fleets: %w", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerDeviceFleet_basic(t *testing.T) {
+	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_device_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDeviceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDeviceFleetBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "device_fleet_name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("device-fleet/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "output_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "output_config.0.s3_output_location", fmt.Sprintf("s3://%s/prefix/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerDeviceFleet_description(t *testing.T) {
+	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_device_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDeviceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDeviceFleetDescription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "description", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerDeviceFleetBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerDeviceFleetDescription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "description", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerDeviceFleet_tags(t *testing.T) {
+	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_device_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDeviceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDeviceFleetConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerDeviceFleetConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerDeviceFleetConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerDeviceFleet_disappears(t *testing.T) {
+	var device_fleet sagemaker.DescribeDeviceFleetOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_device_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerDeviceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerDeviceFleetBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &device_fleet),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerDeviceFleet(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerDeviceFleetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_device_fleet" {
+			continue
+		}
+
+		deviceFleet, err := finder.DeviceFleetByName(conn, rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+
+		if aws.StringValue(deviceFleet.DeviceFleetName) == rs.Primary.ID {
+			return fmt.Errorf("sagemaker Device Fleet %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSagemakerDeviceFleetExists(n string, device_fleet *sagemaker.DescribeDeviceFleetOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker Device Fleet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		resp, err := finder.DeviceFleetByName(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*device_fleet = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSSagemakerDeviceFleetConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  acl           = "private"
+  force_destroy = true
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "test2" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSIoTFullAccess"
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDeviceFleetBasicConfig(rName string) string {
+	return testAccAWSSagemakerDeviceFleetConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_device_fleet" "test" {
+  device_fleet_name = %[1]q
+  role_arn          = aws_iam_role.test.arn
+
+  output_config {
+    s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test, aws_iam_role_policy_attachment.test2]
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDeviceFleetDescription(rName string) string {
+	return testAccAWSSagemakerDeviceFleetConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_device_fleet" "test" {
+  device_fleet_name  = %[1]q
+  role_arn           = aws_iam_role.test.arn
+  description        = %[1]q
+
+  output_config {
+    s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
+  }
+}
+`, rName)
+}
+
+func testAccAWSSagemakerDeviceFleetConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSSagemakerDeviceFleetConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_device_fleet" "test" {
+  device_fleet_name = %[1]q
+  role_arn          = aws_iam_role.test.arn
+
+  output_config {
+    s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSSagemakerDeviceFleetConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSSagemakerDeviceFleetConfigBase(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_device_fleet" "test" {
+  device_fleet_name = %[1]q
+  role_arn          = aws_iam_role.test.arn
+
+  output_config {
+    s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_sagemaker_device_fleet_test.go
+++ b/aws/resource_aws_sagemaker_device_fleet_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -205,11 +205,12 @@ func testAccCheckAWSSagemakerDeviceFleetDestroy(s *terraform.State) error {
 		}
 
 		deviceFleet, err := finder.DeviceFleetByName(conn, rs.Primary.ID)
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, "ValidationException", "No devicefleet with name") {
-				continue
-			}
-			return fmt.Errorf("error reading Sagemaker Device Fleet (%s): %w", rs.Primary.ID, err)
+			return err
 		}
 
 		if aws.StringValue(deviceFleet.DeviceFleetName) == rs.Primary.ID {

--- a/aws/resource_aws_sagemaker_device_fleet_test.go
+++ b/aws/resource_aws_sagemaker_device_fleet_test.go
@@ -76,6 +76,7 @@ func TestAccAWSSagemakerDeviceFleet_basic(t *testing.T) {
 					testAccCheckAWSSagemakerDeviceFleetExists(resourceName, &deviceFleet),
 					resource.TestCheckResourceAttr(resourceName, "device_fleet_name", rName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("device-fleet/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "output_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "output_config.0.s3_output_location", fmt.Sprintf("s3://%s/prefix/", rName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -292,9 +293,9 @@ resource "aws_sagemaker_device_fleet" "test" {
 func testAccAWSSagemakerDeviceFleetDescription(rName, desc string) string {
 	return testAccAWSSagemakerDeviceFleetConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_device_fleet" "test" {
-  device_fleet_name  = %[1]q
-  role_arn           = aws_iam_role.test.arn
-  description        = %[2]q
+  device_fleet_name = %[1]q
+  role_arn          = aws_iam_role.test.arn
+  description       = %[2]q
 
   output_config {
     s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"

--- a/website/docs/r/sagemaker_device_fleet.html.markdown
+++ b/website/docs/r/sagemaker_device_fleet.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_device_fleet"
+description: |-
+  Provides a Sagemaker Device Fleet resource.
+---
+
+# Resource: aws_sagemaker_device_fleet
+
+Provides a Sagemaker Device Fleet resource.
+
+## Example Usage
+
+### Basic usage
+
+```terraform
+resource "aws_sagemaker_device_fleet" "example" {
+  device_fleet_name = "example"
+  role_arn          = aws_iam_role.test.arn
+
+  output_config {
+    s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `device_fleet_name` - (Required) The name of the Device Fleet (must be unique).
+* `role_arn` - (Required) The Amazon Resource Name (ARN) that has access to AWS Internet of Things (IoT).
+* `output_config` - (Required) Specifies details about the repository. see [Output Config](#output-config) details below.
+* `description` - (Optional) A description of the fleet.
+* `enable_iot_role_alias` - (Optional) Whether to create an AWS IoT Role Alias during device fleet creation. The name of the role alias generated will match this pattern: "SageMakerEdge-{DeviceFleetName}".
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Output Config
+
+* `s3_output_location` - (Required) The Amazon Simple Storage (S3) bucker URI.
+* `kms_key_id` - (Optional) The AWS Key Management Service (AWS KMS) key that Amazon SageMaker uses to encrypt data on the storage volume after compilation job. If you don't provide a KMS key ID, Amazon SageMaker uses the default KMS key for Amazon S3 for your role's account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the Device Fleet.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Device Fleet.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Sagemaker Device Fleets can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_sagemaker_device_fleet.example my-fleet
+```

--- a/website/docs/r/sagemaker_device_fleet.html.markdown
+++ b/website/docs/r/sagemaker_device_fleet.html.markdown
@@ -20,7 +20,7 @@ resource "aws_sagemaker_device_fleet" "example" {
   role_arn          = aws_iam_role.test.arn
 
   output_config {
-    s3_output_location = "s3://${aws_s3_bucket.test.bucket}/prefix/"
+    s3_output_location = "s3://${aws_s3_bucket.example.bucket}/prefix/"
   }
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerDeviceFleet_'
--- PASS: TestAccAWSSagemakerDeviceFleet_disappears (66.25s)
--- PASS: TestAccAWSSagemakerDeviceFleet_basic (73.51s)
--- PASS: TestAccAWSSagemakerDeviceFleet_description (139.28s)
--- PASS: TestAccAWSSagemakerDeviceFleet_tags (219.07s)
```
