### PR TITLE
resource/aws_acm_certificate: Correctly handle SAN entries that match `domain_name`

### DIFF
--- a/.changelog/19790.txt
+++ b/.changelog/19790.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_acm_certificate: Correctly handle SAN entries that match domain_name
+```

--- a/.changelog/19790.txt
+++ b/.changelog/19790.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_acm_certificate: Correctly handle SAN entries that match domain_name
-```

--- a/.changelog/20073.txt
+++ b/.changelog/20073.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_acm_certificate: Correctly handle SAN entries that match `domain_name`
+```

--- a/.changelog/20073.txt
+++ b/.changelog/20073.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_acm_certificate: Correctly handle SAN entries that match `domain_name`
 ```
+
+```release-note:enhancement
+resource/aws_acm_certificate_validation: Increase default reasource Create (certificate issuance) timeout to 75 minutes
+```

--- a/.changelog/20073.txt
+++ b/.changelog/20073.txt
@@ -3,5 +3,5 @@ resource/aws_acm_certificate: Correctly handle SAN entries that match `domain_na
 ```
 
 ```release-note:enhancement
-resource/aws_acm_certificate_validation: Increase default reasource Create (certificate issuance) timeout to 75 minutes
+resource/aws_acm_certificate_validation: Increase default resource Create (certificate issuance) timeout to 75 minutes
 ```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -204,6 +204,19 @@ func ResourceCertificate() *schema.Resource {
 					}
 				}
 
+				// ACM automatically adds the domain_name value to the list of SANs. Mimic ACM's behavior
+				// so that the user doesn't need to explicitly set it themselves.
+				if diff.HasChange("domain_name") || diff.HasChange("subject_alternative_names") {
+					domain_name := diff.Get("domain_name").(string)
+
+					if sanSet, ok := diff.Get("subject_alternative_names").(*schema.Set); ok {
+						sanSet.Add(domain_name)
+						if err := diff.SetNew("subject_alternative_names", sanSet); err != nil {
+							return fmt.Errorf("error setting new subject_alternative_names diff: %w", err)
+						}
+					}
+				}
+
 				return nil
 			},
 			verify.SetTagsDiff,
@@ -338,7 +351,7 @@ func resourceCertificateRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("arn", resp.Certificate.CertificateArn)
 		d.Set("certificate_authority_arn", resp.Certificate.CertificateAuthorityArn)
 
-		if err := d.Set("subject_alternative_names", cleanUpSubjectAlternativeNames(resp.Certificate)); err != nil {
+		if err := d.Set("subject_alternative_names", flattenSubjectAlternativeNames(resp.Certificate)); err != nil {
 			return resource.NonRetryableError(err)
 		}
 
@@ -434,13 +447,11 @@ func resourceCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceCertificateRead(d, meta)
 }
 
-func cleanUpSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
+func flattenSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
 	sans := cert.SubjectAlternativeNames
 	vs := make([]string, 0)
 	for _, v := range sans {
-		if aws.StringValue(v) != aws.StringValue(cert.DomainName) {
-			vs = append(vs, aws.StringValue(v))
-		}
+		vs = append(vs, aws.StringValue(v))
 	}
 	return vs
 }

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -52,9 +52,10 @@ func ResourceCertificate() *schema.Resource {
 				Computed: true,
 			},
 			"certificate_authority_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 			"certificate_body": {
 				Type:     schema.TypeString,
@@ -109,13 +110,10 @@ func ResourceCertificate() *schema.Resource {
 						"certificate_transparency_logging_preference": {
 							Type:          schema.TypeString,
 							Optional:      true,
-							Default:       acm.CertificateTransparencyLoggingPreferenceEnabled,
 							ForceNew:      true,
+							Default:       acm.CertificateTransparencyLoggingPreferenceEnabled,
+							ValidateFunc:  validation.StringInSlice(acm.CertificateTransparencyLoggingPreference_Values(), false),
 							ConflictsWith: []string{"private_key", "certificate_body", "certificate_chain"},
-							ValidateFunc: validation.StringInSlice([]string{
-								acm.CertificateTransparencyLoggingPreferenceEnabled,
-								acm.CertificateTransparencyLoggingPreferenceDisabled,
-							}, false),
 						},
 					},
 				},
@@ -174,7 +172,7 @@ func ResourceCertificate() *schema.Resource {
 		CustomizeDiff: customdiff.Sequence(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 				// Attempt to calculate the domain validation options based on domains present in domain_name and subject_alternative_names
-				if diff.Get("validation_method").(string) == "DNS" && (diff.HasChange("domain_name") || diff.HasChange("subject_alternative_names")) {
+				if diff.Get("validation_method").(string) == acm.ValidationMethodDns && (diff.HasChange("domain_name") || diff.HasChange("subject_alternative_names")) {
 					domainValidationOptionsList := []interface{}{map[string]interface{}{
 						// AWS Provider 3.0 -- plan-time validation prevents "domain_name"
 						// argument to accept a string with trailing period; thus, trim of trailing period

--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -197,7 +197,7 @@ func TestAccACMCertificateDataSource_keyTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(4096)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, acctest.RandomDomain().String())
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -30,13 +30,15 @@ func TestAccACMCertificate_emailValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAcmCertificateConfig(domain, acm.ValidationMethodEmail),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
-					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", domain),
+					acctest.CheckResourceAttrGreaterThanValue(resourceName, "validation_emails.#", "0"),
 					resource.TestMatchResourceAttr(resourceName, "validation_emails.0", regexp.MustCompile(`^[^@]+@.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodEmail),
 				),
@@ -74,7 +76,8 @@ func TestAccACMCertificate_dnsValidation(t *testing.T) {
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
-					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", domain),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),
@@ -111,7 +114,8 @@ func TestAccACMCertificate_root(t *testing.T) {
 						"resource_record_type": "CNAME",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusPendingValidation),
-					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "validation_method", acm.ValidationMethodDns),
 				),

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -139,7 +139,7 @@ func TestAccACMCertificate_privateCert(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_privateCert(commonName.String(), certificateDomainName),
+				Config: testAccAcmCertificatePrivateCertConfig(commonName.String(), certificateDomainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
@@ -195,7 +195,7 @@ func TestAccACMCertificate_rootAndWildcardSan(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(rootDomain, strconv.Quote(wildcardDomain), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateSubjectAlternativeNamesConfig(rootDomain, strconv.Quote(wildcardDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
@@ -237,7 +237,7 @@ func TestAccACMCertificate_SubjectAlternativeNames_emptyString(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(""), acm.ValidationMethodDns),
+				Config:      testAccAcmCertificateSubjectAlternativeNamesConfig(domain, strconv.Quote(""), acm.ValidationMethodDns),
 				ExpectError: regexp.MustCompile(`expected length`),
 			},
 		},
@@ -258,7 +258,7 @@ func TestAccACMCertificate_San_single(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateSubjectAlternativeNamesConfig(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
@@ -304,7 +304,7 @@ func TestAccACMCertificate_San_multiple(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, fmt.Sprintf("%q, %q", sanDomain1, sanDomain2), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateSubjectAlternativeNamesConfig(domain, fmt.Sprintf("%q, %q", sanDomain1, sanDomain2), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
@@ -354,7 +354,7 @@ func TestAccACMCertificate_San_trailingPeriod(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateSubjectAlternativeNamesConfig(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile(`certificate/.+`)),
@@ -399,7 +399,7 @@ func TestAccACMCertificate_San_matches_domain(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateSubjectAlternativeNamesConfig(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile(`certificate/.+`)),
@@ -482,7 +482,7 @@ func TestAccACMCertificate_wildcardAndRootSan(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(wildcardDomain, strconv.Quote(rootDomain), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateSubjectAlternativeNamesConfig(wildcardDomain, strconv.Quote(rootDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
@@ -525,7 +525,7 @@ func TestAccACMCertificate_disableCTLogging(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfig_disableCTLogging(rootDomain, acm.ValidationMethodDns),
+				Config: testAccAcmCertificateDisableCTLoggingConfig(rootDomain, acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
@@ -574,7 +574,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfigPrivateKey(certificate, key, caCertificate),
+				Config: testAccAcmCertificatePrivateKeyConfig(certificate, key, caCertificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -582,7 +582,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAcmCertificateConfigPrivateKey(newCertificate, key, newCaCertificate),
+				Config: testAccAcmCertificatePrivateKeyConfig(newCertificate, key, newCaCertificate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -590,7 +590,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAcmCertificateConfigPrivateKeyWithoutChain(withoutChainDomain),
+				Config: testAccAcmCertificatePrivateKeyWithoutChainConfig(withoutChainDomain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -620,7 +620,7 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) { // Reference: http
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcmCertificateConfigPrivateKeyWithoutChain("1.2.3.4"),
+				Config: testAccAcmCertificatePrivateKeyWithoutChainConfig("1.2.3.4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", ""),
@@ -752,7 +752,7 @@ resource "aws_acm_certificate" "test" {
 `, domainName, validationMethod)
 }
 
-func testAccAcmCertificateConfig_privateCert(commonName, certificateDomainName string) string {
+func testAccAcmCertificatePrivateCertConfig(commonName, certificateDomainName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
@@ -775,7 +775,7 @@ resource "aws_acm_certificate" "test" {
 `, commonName, certificateDomainName)
 }
 
-func testAccAcmCertificateConfig_subjectAlternativeNames(domainName, subjectAlternativeNames, validationMethod string) string {
+func testAccAcmCertificateSubjectAlternativeNamesConfig(domainName, subjectAlternativeNames, validationMethod string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   domain_name               = %[1]q
@@ -785,7 +785,7 @@ resource "aws_acm_certificate" "test" {
 `, domainName, subjectAlternativeNames, validationMethod)
 }
 
-func testAccAcmCertificateConfigPrivateKeyWithoutChain(commonName string) string {
+func testAccAcmCertificatePrivateKeyWithoutChainConfig(commonName string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, commonName)
 
@@ -824,7 +824,7 @@ resource "aws_acm_certificate" "test" {
 `, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key), tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAcmCertificateConfigPrivateKey(certificate, privateKey, chain string) string {
+func testAccAcmCertificatePrivateKeyConfig(certificate, privateKey, chain string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   certificate_body  = "%[1]s"
@@ -834,11 +834,12 @@ resource "aws_acm_certificate" "test" {
 `, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(privateKey), acctest.TLSPEMEscapeNewlines(chain))
 }
 
-func testAccAcmCertificateConfig_disableCTLogging(domainName, validationMethod string) string {
+func testAccAcmCertificateDisableCTLoggingConfig(domainName, validationMethod string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
-  domain_name       = "%s"
-  validation_method = "%s"
+  domain_name       = %[1]q
+  validation_method = %[2]q
+
   options {
     certificate_transparency_logging_preference = "DISABLED"
   }

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -22,6 +22,10 @@ func ResourceCertificateValidation() *schema.Resource {
 		Read:   resourceCertificateValidationRead,
 		Delete: resourceCertificateValidationDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(75 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"certificate_arn": {
 				Type:     schema.TypeString,
@@ -35,9 +39,6 @@ func ResourceCertificateValidation() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(45 * time.Minute),
 		},
 	}
 }

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -1,6 +1,7 @@
 package acm
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -20,7 +20,7 @@ func ResourceCertificateValidation() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceCertificateValidationCreate,
 		Read:   resourceCertificateValidationRead,
-		Delete: resourceCertificateValidationDelete,
+		Delete: schema.Noop,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(75 * time.Minute),
@@ -37,180 +37,142 @@ func ResourceCertificateValidation() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 		},
 	}
 }
 
 func resourceCertificateValidationCreate(d *schema.ResourceData, meta interface{}) error {
-	certificate_arn := d.Get("certificate_arn").(string)
-
 	conn := meta.(*conns.AWSClient).ACMConn
-	params := &acm.DescribeCertificateInput{
-		CertificateArn: aws.String(certificate_arn),
-	}
 
-	resp, err := conn.DescribeCertificate(params)
+	arn := d.Get("certificate_arn").(string)
+	certificate, err := FindCertificateByARN(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("Error describing certificate: %w", err)
+		return fmt.Errorf("reading ACM Certificate (%s): %w", arn, err)
 	}
 
-	if resp == nil || resp.Certificate == nil {
-		return fmt.Errorf("Error describing certificate: empty output")
+	if v := aws.StringValue(certificate.Type); v != acm.CertificateTypeAmazonIssued {
+		return fmt.Errorf("ACM Certificate (%s) has type %s, no validation necessary", arn, v)
 	}
 
-	if aws.StringValue(resp.Certificate.Type) != acm.CertificateTypeAmazonIssued {
-		return fmt.Errorf("Certificate %s has type %s, no validation necessary", aws.StringValue(resp.Certificate.CertificateArn), aws.StringValue(resp.Certificate.Status))
-	}
+	if v, ok := d.GetOk("validation_record_fqdns"); ok && v.(*schema.Set).Len() > 0 {
+		fqdns := make(map[string]*acm.DomainValidation)
 
-	if validation_record_fqdns, ok := d.GetOk("validation_record_fqdns"); ok {
-		err := resourceCertificateCheckValidationRecords(validation_record_fqdns.(*schema.Set).List(), resp.Certificate, conn)
-		if err != nil {
-			return err
-		}
-	} else {
-		log.Printf("[INFO] No validation_record_fqdns set, skipping check")
-	}
-
-	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		resp, err := conn.DescribeCertificate(params)
-
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %w", err))
-		}
-
-		if aws.StringValue(resp.Certificate.Status) != acm.CertificateStatusIssued {
-			return resource.RetryableError(fmt.Errorf("Expected certificate to be issued but was in state %s", aws.StringValue(resp.Certificate.Status)))
-		}
-
-		log.Printf("[INFO] ACM Certificate validation for %s done, certificate was issued", certificate_arn)
-		if err := resourceCertificateValidationRead(d, meta); err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		resp, err = conn.DescribeCertificate(params)
-		if aws.StringValue(resp.Certificate.Status) != acm.CertificateStatusIssued {
-			return fmt.Errorf("Expected certificate to be issued but was in state %s", aws.StringValue(resp.Certificate.Status))
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("Error describing created certificate: %w", err)
-	}
-	return nil
-}
-
-func resourceCertificateCheckValidationRecords(validationRecordFqdns []interface{}, cert *acm.CertificateDetail, conn *acm.ACM) error {
-	expectedFqdns := make(map[string]*acm.DomainValidation)
-
-	if len(cert.DomainValidationOptions) == 0 {
-		input := &acm.DescribeCertificateInput{
-			CertificateArn: cert.CertificateArn,
-		}
-		var err error
-		var output *acm.DescribeCertificateOutput
-		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-			log.Printf("[DEBUG] Certificate domain validation options empty for %s, retrying", aws.StringValue(cert.CertificateArn))
-			output, err = conn.DescribeCertificate(input)
-			if err != nil {
-				return resource.NonRetryableError(err)
+		for _, domainValidation := range certificate.DomainValidationOptions {
+			if v := aws.StringValue(domainValidation.ValidationMethod); v != acm.ValidationMethodDns {
+				return fmt.Errorf("validation_record_fqdns is not valid for %s validation", v)
 			}
-			if len(output.Certificate.DomainValidationOptions) == 0 {
-				return resource.RetryableError(fmt.Errorf("Certificate domain validation options empty for %s", aws.StringValue(cert.CertificateArn)))
-			}
-			cert = output.Certificate
-			return nil
-		})
-		if tfresource.TimedOut(err) {
-			output, err = conn.DescribeCertificate(input)
-			if err != nil {
-				return fmt.Errorf("Error describing ACM certificate: %w", err)
-			}
-			if len(output.Certificate.DomainValidationOptions) == 0 {
-				return fmt.Errorf("Certificate domain validation options empty for %s", aws.StringValue(cert.CertificateArn))
+
+			if v := domainValidation.ResourceRecord; v != nil {
+				if v := aws.StringValue(v.Name); v != "" {
+					fqdns[strings.TrimSuffix(v, ".")] = domainValidation
+				}
 			}
 		}
-		if err != nil {
-			return fmt.Errorf("Error checking certificate domain validation options: %w", err)
-		}
-		if output == nil || output.Certificate == nil {
-			return fmt.Errorf("Error checking certificate domain validation options: empty output")
+
+		for _, v := range v.(*schema.Set).List() {
+			delete(fqdns, strings.TrimSuffix(v.(string), "."))
 		}
 
-		cert = output.Certificate
-	}
-	for _, v := range cert.DomainValidationOptions {
-		if v.ValidationMethod != nil {
-			if aws.StringValue(v.ValidationMethod) != acm.ValidationMethodDns {
-				return fmt.Errorf("validation_record_fqdns is only valid for DNS validation")
+		if len(fqdns) > 0 {
+			var errs *multierror.Error
+
+			for fqdn, domainValidation := range fqdns {
+				errs = multierror.Append(errs, fmt.Errorf("missing %s DNS validation record: %s", aws.StringValue(domainValidation.DomainName), fqdn))
 			}
-			if v.ResourceRecord != nil && aws.StringValue(v.ResourceRecord.Name) != "" {
-				newExpectedFqdn := strings.TrimSuffix(aws.StringValue(v.ResourceRecord.Name), ".")
-				expectedFqdns[newExpectedFqdn] = v
-			}
-		} else if len(v.ValidationEmails) > 0 {
-			// ACM API sometimes is not sending ValidationMethod for EMAIL validation
-			return fmt.Errorf("validation_record_fqdns is only valid for DNS validation")
+
+			return errs
 		}
 	}
 
-	for _, v := range validationRecordFqdns {
-		delete(expectedFqdns, strings.TrimSuffix(v.(string), "."))
+	if _, err := waitCertificateIssued(conn, arn, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("waiting for ACM Certificate (%s) to be issued: %w", arn, err)
 	}
 
-	if len(expectedFqdns) > 0 {
-		var errors error
-		for expectedFqdn, domainValidation := range expectedFqdns {
-			errors = multierror.Append(errors, fmt.Errorf("missing %s DNS validation record: %s", aws.StringValue(domainValidation.DomainName), expectedFqdn))
-		}
-		return errors
-	}
+	d.SetId(arn)
 
-	return nil
+	return resourceCertificateValidationRead(d, meta)
 }
 
 func resourceCertificateValidationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ACMConn
 
-	params := &acm.DescribeCertificateInput{
-		CertificateArn: aws.String(d.Get("certificate_arn").(string)),
-	}
+	certificate, err := FindCertificateValidationByARN(conn, d.Id())
 
-	resp, err := conn.DescribeCertificate(params)
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, acm.ErrCodeResourceNotFoundException) {
-		log.Printf("[WARN] ACM Certificate (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ACM Certificate %s not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error describing ACM Certificate (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading ACM Certificate (%s): %w", d.Id(), err)
 	}
 
-	if resp == nil || resp.Certificate == nil {
-		return fmt.Errorf("error describing ACM Certificate (%s): empty response", d.Id())
-	}
-
-	if status := aws.StringValue(resp.Certificate.Status); status != acm.CertificateStatusIssued {
-		if d.IsNewResource() {
-			return fmt.Errorf("ACM Certificate (%s) status not issued: %s", d.Id(), status)
-		}
-
-		log.Printf("[WARN] ACM Certificate (%s) status not issued (%s), removing from state", d.Id(), status)
-		d.SetId("")
-		return nil
-	}
-
-	d.SetId(aws.TimeValue(resp.Certificate.IssuedAt).String())
+	d.Set("certificate_arn", certificate.CertificateArn)
 
 	return nil
 }
 
-func resourceCertificateValidationDelete(d *schema.ResourceData, meta interface{}) error {
-	// No need to do anything, certificate will be deleted when acm_certificate is deleted
-	return nil
+func FindCertificateValidationByARN(conn *acm.ACM, arn string) (*acm.CertificateDetail, error) {
+	output, err := FindCertificateByARN(conn, arn)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status := aws.StringValue(output.Status); status != acm.CertificateStatusIssued {
+		return nil, &resource.NotFoundError{
+			Message:     status,
+			LastRequest: arn,
+		}
+	}
+
+	return output, nil
+}
+
+func statusCertificate(conn *acm.ACM, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		// Don't call FindCertificateByARN as it maps useful status codes to NotFoundError.
+		input := &acm.DescribeCertificateInput{
+			CertificateArn: aws.String(arn),
+		}
+
+		output, err := findCertificate(conn, input)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func waitCertificateIssued(conn *acm.ACM, arn string, timeout time.Duration) (*acm.CertificateDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{acm.CertificateStatusPendingValidation},
+		Target:  []string{acm.CertificateStatusIssued},
+		Refresh: statusCertificate(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*acm.CertificateDetail); ok {
+		switch aws.StringValue(output.Status) {
+		case acm.CertificateStatusFailed:
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.FailureReason)))
+		case acm.CertificateStatusRevoked:
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.RevocationReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
 }

--- a/internal/service/acm/certificate_validation_test.go
+++ b/internal/service/acm/certificate_validation_test.go
@@ -49,8 +49,8 @@ func TestAccACMCertificateValidation_timeout(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAcmCertificateValidation_timeout(domain),
-				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
+				Config:      testAccAcmCertificateValidationTimeoutConfig(domain),
+				ExpectError: regexp.MustCompile(`timeout while waiting for state to become 'ISSUED' \(last state: 'PENDING_VALIDATION'`),
 			},
 		},
 	})
@@ -284,7 +284,7 @@ resource "aws_acm_certificate_validation" "test" {
 `, domainName, rootZoneDomain)
 }
 
-func testAccAcmCertificateValidation_timeout(domainName string) string {
+func testAccAcmCertificateValidationTimeoutConfig(domainName string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   domain_name       = %[1]q

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -144,4 +144,4 @@ In addition to all arguments above, the following attributes are exported:
 `acm_certificate_validation` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
 configuration options:
 
-- `create` - (Default `45m`) How long to wait for a certificate to be issued.
+- `create` - (Default `75m`) How long to wait for a certificate to be issued.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
AWS automatically adds a SAN entry that matches the `domain_name` value. This entry
was being deleted in order to avoid spurious diffs where user's config didn't include
the `domain_name` value in `subject_alternative_names`.

This change reverses the logic so as to better reflect the actual state of a certificate
in ACM; all SANs are now tracked in Terraform state, including the default SAN that AWS
adds. If a user hasn't specified the `domain_name` entry in `subject_alternative_names`
we add it for them to avoid spurious diffs.

Closes #19790.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/9338.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAcmCertificate -timeout 180m
=== RUN   TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== PAUSE TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== RUN   TestAccAWSAcmCertificateDataSource_KeyTypes
=== PAUSE TestAccAWSAcmCertificateDataSource_KeyTypes
=== RUN   TestAccAWSAcmCertificate_emailValidation
=== PAUSE TestAccAWSAcmCertificate_emailValidation
=== RUN   TestAccAWSAcmCertificate_dnsValidation
=== PAUSE TestAccAWSAcmCertificate_dnsValidation
=== RUN   TestAccAWSAcmCertificate_root
=== PAUSE TestAccAWSAcmCertificate_root
=== RUN   TestAccAWSAcmCertificate_privateCert
=== PAUSE TestAccAWSAcmCertificate_privateCert
=== RUN   TestAccAWSAcmCertificate_root_TrailingPeriod
=== PAUSE TestAccAWSAcmCertificate_root_TrailingPeriod
=== RUN   TestAccAWSAcmCertificate_rootAndWildcardSan
=== PAUSE TestAccAWSAcmCertificate_rootAndWildcardSan
=== RUN   TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString
=== PAUSE TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString
=== RUN   TestAccAWSAcmCertificate_san_single
=== PAUSE TestAccAWSAcmCertificate_san_single
=== RUN   TestAccAWSAcmCertificate_san_multiple
=== PAUSE TestAccAWSAcmCertificate_san_multiple
=== RUN   TestAccAWSAcmCertificate_san_TrailingPeriod
=== PAUSE TestAccAWSAcmCertificate_san_TrailingPeriod
=== RUN   TestAccAWSAcmCertificate_san_matches_domain
=== PAUSE TestAccAWSAcmCertificate_san_matches_domain
=== RUN   TestAccAWSAcmCertificate_wildcard
=== PAUSE TestAccAWSAcmCertificate_wildcard
=== RUN   TestAccAWSAcmCertificate_wildcardAndRootSan
=== PAUSE TestAccAWSAcmCertificate_wildcardAndRootSan
=== RUN   TestAccAWSAcmCertificate_disableCTLogging
=== PAUSE TestAccAWSAcmCertificate_disableCTLogging
=== RUN   TestAccAWSAcmCertificate_tags
=== PAUSE TestAccAWSAcmCertificate_tags
=== RUN   TestAccAWSAcmCertificate_imported_DomainName
=== PAUSE TestAccAWSAcmCertificate_imported_DomainName
=== RUN   TestAccAWSAcmCertificate_imported_IpAddress
=== PAUSE TestAccAWSAcmCertificate_imported_IpAddress
=== RUN   TestAccAWSAcmCertificate_PrivateKey_Tags
=== PAUSE TestAccAWSAcmCertificate_PrivateKey_Tags
=== RUN   TestAccAWSAcmCertificateValidation_basic
=== PAUSE TestAccAWSAcmCertificateValidation_basic
=== RUN   TestAccAWSAcmCertificateValidation_timeout
=== PAUSE TestAccAWSAcmCertificateValidation_timeout
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdns
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdns
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
=== CONT  TestAccAWSAcmCertificate_wildcardAndRootSan
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
=== CONT  TestAccAWSAcmCertificate_imported_IpAddress
=== CONT  TestAccAWSAcmCertificate_root_TrailingPeriod
=== CONT  TestAccAWSAcmCertificateValidation_basic
=== CONT  TestAccAWSAcmCertificateDataSource_KeyTypes
=== CONT  TestAccAWSAcmCertificate_imported_DomainName
=== CONT  TestAccAWSAcmCertificate_emailValidation
=== CONT  TestAccAWSAcmCertificate_tags
=== CONT  TestAccAWSAcmCertificate_PrivateKey_Tags
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdns
=== CONT  TestAccAWSAcmCertificateValidation_timeout
=== CONT  TestAccAWSAcmCertificate_disableCTLogging
=== CONT  TestAccAWSAcmCertificateDataSource_noMatchReturnsError
--- PASS: TestAccAWSAcmCertificate_root_TrailingPeriod (5.68s)
=== CONT  TestAccAWSAcmCertificate_wildcard
=== CONT  TestAccAWSAcmCertificate_san_matches_domain
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (23.81s)
=== CONT  TestAccAWSAcmCertificate_san_TrailingPeriod
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail (25.57s)
=== CONT  TestAccAWSAcmCertificate_san_multiple
--- PASS: TestAccAWSAcmCertificateValidation_timeout (28.62s)
=== CONT  TestAccAWSAcmCertificate_san_single
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (31.55s)
=== CONT  TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (32.29s)
=== CONT  TestAccAWSAcmCertificate_rootAndWildcardSan
--- PASS: TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString (1.94s)
=== CONT  TestAccAWSAcmCertificate_root
--- PASS: TestAccAWSAcmCertificate_disableCTLogging (36.91s)
=== CONT  TestAccAWSAcmCertificate_privateCert
--- PASS: TestAccAWSAcmCertificate_emailValidation (37.05s)
=== CONT  TestAccAWSAcmCertificate_dnsValidation
--- PASS: TestAccAWSAcmCertificate_wildcard (31.57s)
--- PASS: TestAccAWSAcmCertificate_wildcardAndRootSan (39.67s)
--- PASS: TestAccAWSAcmCertificate_san_matches_domain (32.78s)
--- PASS: TestAccAWSAcmCertificate_PrivateKey_Tags (48.60s)
--- PASS: TestAccAWSAcmCertificate_san_TrailingPeriod (27.79s)
--- PASS: TestAccAWSAcmCertificate_san_multiple (26.77s)
--- PASS: TestAccAWSAcmCertificate_san_single (25.88s)
--- PASS: TestAccAWSAcmCertificate_root (25.04s)
--- PASS: TestAccAWSAcmCertificate_rootAndWildcardSan (26.17s)
--- PASS: TestAccAWSAcmCertificate_dnsValidation (22.75s)
--- PASS: TestAccAWSAcmCertificate_privateCert (24.19s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (64.36s)
--- PASS: TestAccAWSAcmCertificate_tags (71.86s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdns (122.27s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (122.63s)
--- PASS: TestAccAWSAcmCertificateValidation_basic (124.80s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (351.82s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (352.29s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (352.99s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (393.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
```
