### PR TITLE
Add include_null_and_empty to kinesis_settings

### DIFF
--- a/.changelog/20084.txt
+++ b/.changelog/20084.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Add include_null_and_empty kinesis setting
+```

--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -379,7 +379,7 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			MessageFormat:        aws.String(d.Get("kinesis_settings.0.message_format").(string)),
 			ServiceAccessRoleArn: aws.String(d.Get("kinesis_settings.0.service_access_role_arn").(string)),
 			StreamArn:            aws.String(d.Get("kinesis_settings.0.stream_arn").(string)),
-			InludeNullAndEmpty:   aws.Bool(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
+			IncludeNullAndEmpty:  aws.Bool(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
 		}
 	case "mongodb":
 		request.MongoDbSettings = &dms.MongoDbSettings{
@@ -615,7 +615,7 @@ func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 			request.KinesisSettings = &dms.KinesisSettings{
 				ServiceAccessRoleArn: aws.String(d.Get("kinesis_settings.0.service_access_role_arn").(string)),
 				StreamArn:            aws.String(d.Get("kinesis_settings.0.stream_arn").(string)),
-				InludeNullAndEmpty:   aws.String(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
+				IncludeNullAndEmpty:  aws.Bool(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
 			}
 			request.EngineName = aws.String(d.Get("engine_name").(string)) // Must be included (should be 'kinesis')
 			hasChanges = true

--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -379,7 +379,7 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			MessageFormat:        aws.String(d.Get("kinesis_settings.0.message_format").(string)),
 			ServiceAccessRoleArn: aws.String(d.Get("kinesis_settings.0.service_access_role_arn").(string)),
 			StreamArn:            aws.String(d.Get("kinesis_settings.0.stream_arn").(string)),
-			InludeNullAndEmpty:   aws.String(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
+			InludeNullAndEmpty:   aws.Bool(d.Get("kinesis_settings.0.include_null_and_empty").(bool)),
 		}
 	case "mongodb":
 		request.MongoDbSettings = &dms.MongoDbSettings{

--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -193,6 +193,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 						"include_null_and_empty": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 					},
 				},

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -98,6 +98,7 @@ The `kinesis_settings` configuration block supports the following arguments:
 * `message_format` - (Optional) Output format for the records created. Defaults to `json`. Valid values are `json` and `json_unformatted` (a single line with no tab).
 * `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to write to the Kinesis data stream.
 * `stream_arn` - (Optional) Amazon Resource Name (ARN) of the Kinesis data stream.
+* `include_null_and_empty` - (Optional) Include NULL and empty columns for records migrated to the endpoint. The default is false.
 
 ### mongodb_settings Arguments
 


### PR DESCRIPTION
Closes #20083

Output from acceptance testing:

I am not very familiar with go and am not sure what changes this requires to resource_aws_dms_endpoint_test.go. I'm unable to test it myself, but if this looks correct I will commit it:

```
func TestAccAwsDmsEndpoint_Kinesis(t *testing.T) {
	resourceName := "aws_dms_endpoint.dms_endpoint"
	randId := acctest.RandString(8) + "-kinesis"

	resource.ParallelTest(t, resource.TestCase{
		PreCheck:     func() { testAccPreCheck(t) },
		ErrorCheck:   testAccErrorCheck(t, dms.EndpointsID),
		Providers:    testAccProviders,
		CheckDestroy: dmsEndpointDestroy,
		Steps: []resource.TestStep{
			{
				Config: dmsEndpointKinesisConfig(randId),
				Check: resource.ComposeTestCheckFunc(
					checkDmsEndpointExists(resourceName),
					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.#", "1"),
					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.message_format", "json"),
					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.stream_arn", "aws_kinesis_stream.stream1", "arn"),
					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.include_null_and_empty", "aws_kinesis_stream.stream1", "true"),
				),
			},
			{
				ResourceName:            resourceName,
				ImportState:             true,
				ImportStateVerify:       true,
				ImportStateVerifyIgnore: []string{"password"},
			},
			{
				Config: dmsEndpointKinesisConfigUpdate(randId),
				Check: resource.ComposeTestCheckFunc(
					checkDmsEndpointExists(resourceName),
					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.#", "1"),
					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.message_format", "json"),
					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.stream_arn", "aws_kinesis_stream.stream2", "arn"),
					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.include_null_and_empty", "aws_kinesis_stream.stream1", "false"),
				),
			},
		},
	})
}
