### PR TITLE
[WIP] Add multi_model_config setting to resource_aws_sagemaker_model resource

### DIFF
--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -60,11 +60,16 @@ The `primary_container` and `container` block both support:
 * `container_hostname` - (Optional) The DNS host name for the container.
 * `environment` - (Optional) Environment variables for the Docker container.
    A list of key value pairs.
-* `image_config` - (Optional) Specifies whether the model container is in Amazon ECR or a private Docker registry accessible from your Amazon Virtual Private Cloud (VPC). For more information see [Using a Private Docker Registry for Real-Time Inference Containers](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-containers-inference-private.html). see [Image Config](#image-config).
+* `image_config` - (Optional) Specifies whether the model container is in Amazon ECR or a private Docker registry accessible from your Amazon Virtual Private Cloud (VPC). For more information see [Using a Private Docker Registry for Real-Time Inference Containers](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-containers-inference-private.html). Also see [Image Config](#image-config).
+* `multi_model_config` - (Optional) Specifies optional configuration for the multi-model endpoint. For more information see [Create a Multi-Model Endpoint](https://docs.aws.amazon.com/sagemaker/latest/dg/create-multi-model-endpoint.html). Also see [Multi model config](#multi-model-config).
 
 ### Image Config
 
 * `repository_access_mode` - (Required) Specifies whether the model container is in Amazon ECR or a private Docker registry accessible from your Amazon Virtual Private Cloud (VPC). Allowed values are: `Platform` and `Vpc`.
+
+### Multi model Config
+
+* `model_cache_setting` - (Required) Specifies whether the multi-model endpoint is configured to cache Docker images. Allowed values are: `Enabled` (default) and `Disabled`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- This is required to toggle model cache settings for multi-model endpoints.
- This change would force a new resource_aws_sagemaker_model resource

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Output from acceptance testing:
`terraform plan` output...

```  # aws_sagemaker_model.model must be replaced
-/+ resource "aws_sagemaker_model" "model" {
      ~ arn                      = "arn:aws:sagemaker:<region>:<account_id>:model/<model_name>" -> (known after apply)
      - enable_network_isolation = false -> null
      ~ id                       = "<model_name>" -> (known after apply)
        name                     = "<model_name>"
        # (2 unchanged attributes hidden)

      ~ primary_container {
          - environment    = {} -> null
            # (3 unchanged attributes hidden)

          - multi_model_config { # forces replacement
              - model_cache_setting = "Enabled" -> null
            }
        }

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.```
