### PR TITLE
add import documentation for aws_cloudfront_cache_policy

### DIFF
--- a/website/docs/r/cloudfront_cache_policy.html.markdown
+++ b/website/docs/r/cloudfront_cache_policy.html.markdown
@@ -91,3 +91,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `etag` - The current version of the cache policy.
 * `id` - The identifier for the cache policy.
+
+## Import
+
+Cloudfront Cache Policies can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_cloudfront_cache_policy.policy 658327ea-f89d-4fab-a63d-7e88639e58f6
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This pull request add import documentation for `aws_cloudfront_cache_policy`, since you can import the policy by its ID into the Terraform state. 
