### PR TITLE
docs/r/lex_intent: add name in example usage

### DIFF
--- a/website/docs/r/lex_intent.html.markdown
+++ b/website/docs/r/lex_intent.html.markdown
@@ -25,6 +25,7 @@ resource "aws_lex_intent" "order_flowers_intent" {
   }
 
   create_version = false
+  name           = "OrderFlowers"
   description    = "Intent to order a bouquet of flowers for pick up"
 
   fulfillment_activity {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```

### Problem fixed
- `name` is the required attribute in `lex_intent`, hence we should include it in Example Usage code block.