### PR TITLE
fix: Remove sns_platform_application custom diff

### DIFF
--- a/aws/resource_aws_sns_platform_application_test.go
+++ b/aws/resource_aws_sns_platform_application_test.go
@@ -216,22 +216,6 @@ func TestAccAWSSnsPlatformApplication_basic(t *testing.T) {
 				CheckDestroy: testAccCheckAWSSNSPlatformApplicationDestroy,
 				Steps: []resource.TestStep{
 					{
-						Config: testAccAwsSnsPlatformApplicationConfig_basic(name, &testAccAwsSnsPlatformApplicationPlatform{
-							Name:       "APNS",
-							Credential: strconv.Quote("NOTEMPTY"),
-							Principal:  strconv.Quote(""),
-						}),
-						ExpectError: regexp.MustCompile(`platform_principal is required when platform =`),
-					},
-					{
-						Config: testAccAwsSnsPlatformApplicationConfig_basic(name, &testAccAwsSnsPlatformApplicationPlatform{
-							Name:       "APNS_SANDBOX",
-							Credential: strconv.Quote("NOTEMPTY"),
-							Principal:  strconv.Quote(""),
-						}),
-						ExpectError: regexp.MustCompile(`platform_principal is required when platform =`),
-					},
-					{
 						Config: testAccAwsSnsPlatformApplicationConfig_basic(name, platform),
 						Check: resource.ComposeTestCheckFunc(
 							testAccCheckAwsSnsPlatformApplicationExists(resourceName),


### PR DESCRIPTION
This makes sure that when planning for APNS with platform_principal coming from a to-be computed field e.g. (data.aws_secretsmanager_secret_version) the plan won't break with the following:
```
platform_principal is required when platform = APNS
```
It is a drawback as it removes the early validation but AWS's API
should be able to double check if someone sends something missing

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTARGS='-run=TestAccAWSSnsPlatformApplication_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSnsPlatformApplication_basic -timeout 180m
=== RUN   TestAccAWSSnsPlatformApplication_basic
    resource_aws_sns_platform_application_test.go:123: no SNS Platform Application environment variables found
--- SKIP: TestAccAWSSnsPlatformApplication_basic (0.00s)
=== RUN   TestAccAWSSnsPlatformApplication_basicAttributes
    resource_aws_sns_platform_application_test.go:123: no SNS Platform Application environment variables found
--- SKIP: TestAccAWSSnsPlatformApplication_basicAttributes (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.071s
```

note that the SNS check got skipped because I only have access to APNS and it uses p12 file which is in binary format so I cannot use file or encode it with base64 then decode because terraform only accepts utf-8 for `file` and `base64decode` functions.
please, let me know if i could test it somehow or if it had to be done somewhat differently.