### PR TITLE
Remove incorrect reference to IAM policy in aws_ecr_lifecycle_policy website docs

### DIFF
--- a/website/docs/r/ecr_lifecycle_policy.html.markdown
+++ b/website/docs/r/ecr_lifecycle_policy.html.markdown
@@ -85,7 +85,7 @@ EOF
 The following arguments are supported:
 
 * `repository` - (Required) Name of the repository to apply the policy.
-* `policy` - (Required) The policy document. This is a JSON formatted string. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+* `policy` - (Required) The policy document. This is a JSON formatted string. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The documentation for the "policy" attribute of aws_ecr_lifecycle_policy incorrectly links out to an IAM policy tutorial which has nothing to do with this resource. (The attribute uses a JSON body, and has an attribute name of "policy", but otherwise has nothing to do with the IAM policies that the second sentence of the attribute description links to.)

The first sentence already links to the correct upstream documentation and this is an obscure enough resource there are no other Hashicorp "learn" links to put in its place, so I've simply removed it.

This only affects documentation; there is no corresponding bug or sample code to reproduce.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
