### PR TITLE
enhancement - aws_rds_global_cluster data source

### DIFF
--- a/.changelog/20170.txt
+++ b/.changelog/20170.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_rds_global_cluster
+```

--- a/aws/data_source_aws_rds_global_cluster.go
+++ b/aws/data_source_aws_rds_global_cluster.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsRdsGlobalCluster() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRdsGlobalClusterRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deletion_protection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"force_destroy": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"global_cluster_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"global_cluster_members": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"db_cluster_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_writer": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"global_cluster_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_db_cluster_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRdsGlobalClusterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	globalClusterIdentifier := d.Get("global_cluster_identifier").(string)
+
+	params := &rds.DescribeGlobalClustersInput{
+		GlobalClusterIdentifier: aws.String(globalClusterIdentifier),
+	}
+	log.Printf("[DEBUG] Reading Global RDS Cluster: %s", params)
+	resp, err := conn.DescribeGlobalClusters(params)
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving Global RDS cluster: %w", err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("Error retrieving Global RDS cluster: empty response for: %s", params)
+	}
+
+	var globalCluster *rds.GlobalCluster
+	for _, c := range resp.GlobalClusters {
+		if aws.StringValue(c.GlobalClusterIdentifier) == globalClusterIdentifier {
+			globalCluster = c
+			break
+		}
+	}
+
+	if globalCluster == nil {
+		return fmt.Errorf("Error retrieving Global RDS cluster: cluster not found in response for: %s", params)
+	}
+
+	d.SetId(aws.StringValue(globalCluster.GlobalClusterIdentifier))
+
+	d.Set("arn", globalCluster.GlobalClusterArn)
+	d.Set("database_name", globalCluster.DatabaseName)
+	d.Set("deletion_protection", globalCluster.DeletionProtection)
+	d.Set("engine", globalCluster.Engine)
+	d.Set("engine_version", globalCluster.EngineVersion)
+	d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
+
+	var gcmList []interface{}
+	for _, gcm := range globalCluster.GlobalClusterMembers {
+		gcmMap := map[string]interface{}{
+			"db_cluster_arn": aws.StringValue(gcm.DBClusterArn),
+			"is_writer":      aws.BoolValue(gcm.IsWriter),
+		}
+
+		gcmList = append(gcmList, gcmMap)
+	}
+	if err := d.Set("global_cluster_members", gcmList); err != nil {
+		return fmt.Errorf("error setting global_cluster_members: %w", err)
+	}
+
+	if err := d.Set("global_cluster_members", flattenRdsGlobalClusterMembers(globalCluster.GlobalClusterMembers)); err != nil {
+		return fmt.Errorf("error setting global_cluster_members: %w", err)
+	}
+
+	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)
+	d.Set("storage_encrypted", globalCluster.StorageEncrypted)
+
+	return nil
+}

--- a/aws/data_source_aws_rds_global_cluster_test.go
+++ b/aws/data_source_aws_rds_global_cluster_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAccDataSourceAWSRDSGlobalCluster_basic(t *testing.T) {
+	var providers []*schema.Provider
+	globalClusterName := fmt.Sprintf("testaccawsrdsglobalcluster-basic-%s", acctest.RandString(10))
+	dataSourceName := "data.aws_rds_global_cluster.test"
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ErrorCheck:        testAccErrorCheck(t, rds.EndpointsID),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRdsGlobalClusterConfigBasic(globalClusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "database_name", resourceName, "database_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "deletion_protection", resourceName, "deletion_protection"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine", resourceName, "engine"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_version", resourceName, "engine_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_identifier", resourceName, "global_cluster_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_members", resourceName, "global_cluster_members"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_resource_id", resourceName, "global_cluster_resource_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "storage_encrypted", resourceName, "storage_encrypted"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRdsGlobalClusterConfigBasic(globalClusterName string) string {
+	return composeConfig(
+		testAccMultipleRegionProviderConfig(2),
+		fmt.Sprintf(`
+
+data "aws_region" "alternate" {
+	provider = "awsalternate"
+}
+	
+data "aws_region" "current" {}
+
+resource "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = "%[1]s"
+	engine                    = "aurora-postgresql"
+	engine_version            = "12.4"
+	database_name             = "example_db"
+}
+
+resource "aws_rds_cluster" "primary" {
+	engine                    = aws_rds_global_cluster.test.engine
+	engine_version            = aws_rds_global_cluster.test.engine_version
+	cluster_identifier        = "test-primary-cluster"
+	master_username           = "username"
+	master_password           = "somepass123"
+	database_name             = "example_db"
+	global_cluster_identifier = aws_rds_global_cluster.test.id
+	db_subnet_group_name      = "test"
+	skip_final_snapshot       = true
+	
+	depends_on = [
+		aws_rds_global_cluster.test
+	]
+}
+
+resource "aws_rds_cluster_instance" "primary" {
+	identifier           = "test-primary-cluster-instance"
+	cluster_identifier   = aws_rds_cluster.primary.id
+	instance_class       = "db.r4.large"
+	db_subnet_group_name = "test"
+	engine               = aws_rds_global_cluster.test.engine
+	engine_version       = aws_rds_global_cluster.test.engine_version
+	
+	depends_on = [
+		aws_rds_cluster.primary
+	]
+}
+
+resource "aws_rds_cluster" "secondary" {
+	provider                  = "awsalternate"
+	engine                    = aws_rds_global_cluster.test.engine
+	engine_version            = aws_rds_global_cluster.test.engine_version
+	cluster_identifier        = "test-secondary-cluster"
+	global_cluster_identifier = aws_rds_global_cluster.test.id
+	replication_source_identifier = aws_rds_cluster.primary.arn
+	source_region 			  = data.aws_region.alternate.name
+	db_subnet_group_name      = "test"
+	skip_final_snapshot       = true
+
+	depends_on = [
+		aws_rds_cluster_instance.primary
+	]
+}
+
+resource "aws_rds_cluster_instance" "secondary" {
+	provider             = "awsalternate"
+	identifier           = "test-secondary-cluster-instance"
+	cluster_identifier   = aws_rds_cluster.secondary.id
+	instance_class       = "db.r4.large"
+	db_subnet_group_name = "test"
+	engine               = aws_rds_global_cluster.test.engine
+	engine_version       = aws_rds_global_cluster.test.engine_version
+  
+	depends_on = [
+		aws_rds_cluster.secondary
+	]
+}
+
+data "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+}
+`, globalClusterName))
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -369,6 +369,7 @@ func Provider() *schema.Provider {
 			"aws_rds_certificate":                            dataSourceAwsRdsCertificate(),
 			"aws_rds_cluster":                                dataSourceAwsRdsCluster(),
 			"aws_rds_engine_version":                         dataSourceAwsRdsEngineVersion(),
+			"aws_rds_global_cluster":                         dataSourceAwsRdsGlobalCluster(),
 			"aws_rds_orderable_db_instance":                  dataSourceAwsRdsOrderableDbInstance(),
 			"aws_redshift_cluster":                           dataSourceAwsRedshiftCluster(),
 			"aws_redshift_orderable_cluster":                 dataSourceAwsRedshiftOrderableCluster(),

--- a/website/docs/d/rds_global_cluster.html.markdown
+++ b/website/docs/d/rds_global_cluster.html.markdown
@@ -1,0 +1,102 @@
+---
+subcategory: "RDS"
+layout: "aws"
+page_title: "AWS: aws_rds_global_cluster"
+description: |-
+  Provides an RDS global cluster data source.
+---
+
+# Data Source: aws_rds_global_cluster
+
+Provides information about an RDS global cluster.
+
+## Example Usage
+
+```terraform
+data "aws_region" "alternate" {
+	provider = "awsalternate"
+}
+	
+data "aws_region" "current" {}
+
+resource "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = "%[1]s"
+	engine                    = "aurora-postgresql"
+	engine_version            = "12.4"
+	database_name             = "example_db"
+}
+
+resource "aws_rds_cluster" "primary" {
+	engine                    = aws_rds_global_cluster.test.engine
+	engine_version            = aws_rds_global_cluster.test.engine_version
+	cluster_identifier        = "test-primary-cluster"
+	master_username           = "username"
+	master_password           = "somepass123"
+	database_name             = "example_db"
+	global_cluster_identifier = aws_rds_global_cluster.test.id
+	db_subnet_group_name      = "test"
+	skip_final_snapshot       = true
+	
+	depends_on = [
+		aws_rds_global_cluster.test
+	]
+}
+
+resource "aws_rds_cluster_instance" "primary" {
+	identifier           = "test-primary-cluster-instance"
+	cluster_identifier   = aws_rds_cluster.primary.id
+	instance_class       = "db.r4.large"
+	db_subnet_group_name = "test"
+	engine               = aws_rds_global_cluster.test.engine
+	engine_version       = aws_rds_global_cluster.test.engine_version
+	
+	depends_on = [
+		aws_rds_cluster.primary
+	]
+}
+
+resource "aws_rds_cluster" "secondary" {
+	provider                  = "awsalternate"
+	engine                    = aws_rds_global_cluster.test.engine
+	engine_version            = aws_rds_global_cluster.test.engine_version
+	cluster_identifier        = "test-secondary-cluster"
+	global_cluster_identifier = aws_rds_global_cluster.test.id
+	replication_source_identifier = aws_rds_cluster.primary.arn
+	source_region 			  = data.aws_region.alternate.name
+	db_subnet_group_name      = "test"
+	skip_final_snapshot       = true
+
+	depends_on = [
+		aws_rds_cluster_instance.primary
+	]
+}
+
+resource "aws_rds_cluster_instance" "secondary" {
+	provider             = "awsalternate"
+	identifier           = "test-secondary-cluster-instance"
+	cluster_identifier   = aws_rds_cluster.secondary.id
+	instance_class       = "db.r4.large"
+	db_subnet_group_name = "test"
+	engine               = aws_rds_global_cluster.test.engine
+	engine_version       = aws_rds_global_cluster.test.engine_version
+  
+	depends_on = [
+		aws_rds_cluster.secondary
+	]
+}
+
+data "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `global_cluster_identifier` - (Required) The global cluster identifier of the RDS global cluster.
+
+## Attributes Reference
+
+See the [RDS Global Cluster Resource](/docs/providers/aws/r/rds_global_cluster.html) for details on the
+returned attributes - they are identical.


### PR DESCRIPTION
This is for a brand new data source `aws_rds_global_cluster`. 
It will allow end users to read the contents of a global cluster if need be.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes 
* #20170 

Output from acceptance testing:

```
$ AWS_DEFAULT_REGION=us-west-2 \
AWS_ALTERNATE_REGION=us-east-1 \
AWS_PROFILE=MAIN_PROFILE_NAME \
AWS_ALTERNATE_PROFILE=ALTERNATE_PROFILE_NAME \
make testacc TESTARGS='-run=TestAccDataSourceAWSRDSGlobalCluster_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSRDSGlobalCluster_basic -timeout 180m
=== RUN   TestAccDataSourceAWSRDSGlobalCluster_basic
=== PAUSE TestAccDataSourceAWSRDSGlobalCluster_basic
=== CONT  TestAccDataSourceAWSRDSGlobalCluster_basic
--- PASS: TestAccDataSourceAWSRDSGlobalCluster_basic (1990.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1996.015s
```
