### PR TITLE
fix: add the attribute "environment_id" to aws_appconfig_environment

### DIFF
--- a/aws/resource_aws_appconfig_environment.go
+++ b/aws/resource_aws_appconfig_environment.go
@@ -32,6 +32,10 @@ func resourceAwsAppconfigEnvironment() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z0-9]{4,7}`), ""),
 			},
+			"environment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -110,6 +114,7 @@ func resourceAwsAppconfigEnvironmentCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error creating AppConfig Environment for Application (%s): empty response", appId)
 	}
 
+	d.Set("environment_id", environment.Id)
 	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(environment.Id), aws.StringValue(environment.ApplicationId)))
 
 	return resourceAwsAppconfigEnvironmentRead(d, meta)
@@ -148,6 +153,7 @@ func resourceAwsAppconfigEnvironmentRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("application_id", output.ApplicationId)
+	d.Set("environment_id", output.Id)
 	d.Set("description", output.Description)
 	d.Set("name", output.Name)
 	d.Set("state", output.State)

--- a/website/docs/r/appconfig_environment.html.markdown
+++ b/website/docs/r/appconfig_environment.html.markdown
@@ -61,6 +61,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the AppConfig Environment.
 * `id` - The AppConfig environment ID and application ID separated by a colon (`:`).
+* `environment_id` - The AppConfig environment ID.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11973 #19307

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSAppConfigEnvironment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppConfigEnvironment -timeout 180m
=== RUN   TestAccAWSAppConfigEnvironment_basic
=== PAUSE TestAccAWSAppConfigEnvironment_basic
=== RUN   TestAccAWSAppConfigEnvironment_disappears
=== PAUSE TestAccAWSAppConfigEnvironment_disappears
=== RUN   TestAccAWSAppConfigEnvironment_updateName
=== PAUSE TestAccAWSAppConfigEnvironment_updateName
=== RUN   TestAccAWSAppConfigEnvironment_updateDescription
=== PAUSE TestAccAWSAppConfigEnvironment_updateDescription
=== RUN   TestAccAWSAppConfigEnvironment_Monitors
=== PAUSE TestAccAWSAppConfigEnvironment_Monitors
=== RUN   TestAccAWSAppConfigEnvironment_MultipleEnvironments
=== PAUSE TestAccAWSAppConfigEnvironment_MultipleEnvironments
=== RUN   TestAccAWSAppConfigEnvironment_Tags
=== PAUSE TestAccAWSAppConfigEnvironment_Tags
=== CONT  TestAccAWSAppConfigEnvironment_basic
=== CONT  TestAccAWSAppConfigEnvironment_Monitors
=== CONT  TestAccAWSAppConfigEnvironment_MultipleEnvironments
=== CONT  TestAccAWSAppConfigEnvironment_disappears
=== CONT  TestAccAWSAppConfigEnvironment_Tags
=== CONT  TestAccAWSAppConfigEnvironment_updateName
=== CONT  TestAccAWSAppConfigEnvironment_updateDescription
--- PASS: TestAccAWSAppConfigEnvironment_disappears (85.40s)
--- PASS: TestAccAWSAppConfigEnvironment_basic (102.00s)
--- PASS: TestAccAWSAppConfigEnvironment_updateName (141.55s)
--- PASS: TestAccAWSAppConfigEnvironment_MultipleEnvironments (164.41s)
--- PASS: TestAccAWSAppConfigEnvironment_Tags (178.14s)
--- PASS: TestAccAWSAppConfigEnvironment_updateDescription (186.54s)
--- PASS: TestAccAWSAppConfigEnvironment_Monitors (204.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	206.613s
```

Add the attribute `environment_id` to `aws_appconfig_environment`.