### PR TITLE
Updates dependency direction between Client VPN and Directory Service Directory

### DIFF
--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -21,6 +21,7 @@ func init() {
 		F:    testSweepDirectoryServiceDirectories,
 		Dependencies: []string{
 			"aws_db_instance",
+			"aws_ec2_client_vpn_endpoint",
 			"aws_fsx_windows_file_system",
 			"aws_workspaces_directory",
 		},

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -29,7 +29,6 @@ func init() {
 		Name: "aws_ec2_client_vpn_endpoint",
 		F:    testSweepEc2ClientVpnEndpoints,
 		Dependencies: []string{
-			"aws_directory_service_directory",
 			"aws_ec2_client_vpn_network_association",
 		},
 	})

--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -19,9 +19,6 @@ func init() {
 	resource.AddTestSweepers("aws_ec2_client_vpn_network_association", &resource.Sweeper{
 		Name: "aws_ec2_client_vpn_network_association",
 		F:    testSweepEc2ClientVpnNetworkAssociations,
-		Dependencies: []string{
-			"aws_directory_service_directory",
-		},
 	})
 }
 


### PR DESCRIPTION
The Client VPN resource can depend on a Directory Service Directory, so the Client VPN must be destroyed first. The sweepers have the wrong direction for the dependency.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make sweep SWEEPARGS=-sweep-run=aws_directory_service_directory

...
2021/07/14 12:30:36 Sweeper Tests ran successfully:
	- aws_workspaces_workspace
	- aws_workspaces_directory
	- aws_db_instance
	- aws_ec2_client_vpn_network_association
	- aws_ec2_client_vpn_endpoint
	- aws_fsx_windows_file_system
	- aws_directory_service_directory
```
