### PR TITLE
Pass context that can cancel wait on terraform provider signal.

### DIFF
--- a/aws/internal/service/eks/waiter/waiter.go
+++ b/aws/internal/service/eks/waiter/waiter.go
@@ -181,7 +181,7 @@ func FargateProfileDeleted(conn *eks.EKS, clusterName, fargateProfileName string
 	return nil, err
 }
 
-func NodegroupCreated(conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
+func NodegroupCreated(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.NodegroupStatusCreating},
 		Target:  []string{eks.NodegroupStatusActive},
@@ -189,7 +189,7 @@ func NodegroupCreated(conn *eks.EKS, clusterName, nodeGroupName string, timeout 
 		Timeout: timeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*eks.Nodegroup); ok {
 		return output, err
@@ -198,7 +198,7 @@ func NodegroupCreated(conn *eks.EKS, clusterName, nodeGroupName string, timeout 
 	return nil, err
 }
 
-func NodegroupDeleted(conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
+func NodegroupDeleted(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName string, timeout time.Duration) (*eks.Nodegroup, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.NodegroupStatusActive, eks.NodegroupStatusDeleting},
 		Target:  []string{},
@@ -215,7 +215,7 @@ func NodegroupDeleted(conn *eks.EKS, clusterName, nodeGroupName string, timeout 
 	return nil, err
 }
 
-func NodegroupUpdateSuccessful(conn *eks.EKS, clusterName, nodeGroupName, id string, timeout time.Duration) (*eks.Update, error) {
+func NodegroupUpdateSuccessful(ctx context.Context, conn *eks.EKS, clusterName, nodeGroupName, id string, timeout time.Duration) (*eks.Update, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},
 		Target:  []string{eks.UpdateStatusSuccessful},

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"fmt"
+	"context"
 	"log"
 	"reflect"
 	"time"
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -22,10 +23,10 @@ import (
 
 func resourceAwsEksNodeGroup() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAwsEksNodeGroupCreate,
-		Read:   resourceAwsEksNodeGroupRead,
-		Update: resourceAwsEksNodeGroupUpdate,
-		Delete: resourceAwsEksNodeGroupDelete,
+		CreateContext: resourceAwsEksNodeGroupCreate,
+		ReadContext:   resourceAwsEksNodeGroupRead,
+		UpdateContext: resourceAwsEksNodeGroupUpdate,
+		DeleteContext: resourceAwsEksNodeGroupDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -255,7 +256,7 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 	}
 }
 
-func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEksNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*AWSClient).eksconn
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
@@ -323,21 +324,21 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 	_, err := conn.CreateNodegroup(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EKS Node Group (%s): %w", id, err)
+		return diag.Errorf("error creating EKS Node Group (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
-	_, err = waiter.NodegroupCreated(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutCreate))
+	_, err = waiter.NodegroupCreated(ctx, conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EKS Node Groupe (%s) to create: %w", d.Id(), err)
+		return diag.Errorf("error waiting for EKS Node Group (%s) to create: %s", d.Id(), err)
 	}
 
-	return resourceAwsEksNodeGroupRead(d, meta)
+	return resourceAwsEksNodeGroupRead(ctx, d, meta)
 }
 
-func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEksNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*AWSClient).eksconn
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
@@ -345,7 +346,7 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	nodeGroup, err := finder.NodegroupByClusterNameAndNodegroupName(conn, clusterName, nodeGroupName)
@@ -357,7 +358,7 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading EKS Node Group (%s): %w", d.Id(), err)
+		return diag.Errorf("error reading EKS Node Group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("ami_type", nodeGroup.AmiType)
@@ -367,15 +368,15 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("disk_size", nodeGroup.DiskSize)
 
 	if err := d.Set("instance_types", aws.StringValueSlice(nodeGroup.InstanceTypes)); err != nil {
-		return fmt.Errorf("error setting instance_types: %w", err)
+		return diag.Errorf("error setting instance_types: %s", err)
 	}
 
 	if err := d.Set("labels", aws.StringValueMap(nodeGroup.Labels)); err != nil {
-		return fmt.Errorf("error setting labels: %w", err)
+		return diag.Errorf("error setting labels: %s", err)
 	}
 
 	if err := d.Set("launch_template", flattenEksLaunchTemplateSpecification(nodeGroup.LaunchTemplate)); err != nil {
-		return fmt.Errorf("error setting launch_template: %w", err)
+		return diag.Errorf("error setting launch_template: %s", err)
 	}
 
 	d.Set("node_group_name", nodeGroup.NodegroupName)
@@ -384,25 +385,25 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("release_version", nodeGroup.ReleaseVersion)
 
 	if err := d.Set("remote_access", flattenEksRemoteAccessConfig(nodeGroup.RemoteAccess)); err != nil {
-		return fmt.Errorf("error setting remote_access: %w", err)
+		return diag.Errorf("error setting remote_access: %s", err)
 	}
 
 	if err := d.Set("resources", flattenEksNodeGroupResources(nodeGroup.Resources)); err != nil {
-		return fmt.Errorf("error setting resources: %w", err)
+		return diag.Errorf("error setting resources: %s", err)
 	}
 
 	if err := d.Set("scaling_config", flattenEksNodeGroupScalingConfig(nodeGroup.ScalingConfig)); err != nil {
-		return fmt.Errorf("error setting scaling_config: %w", err)
+		return diag.Errorf("error setting scaling_config: %s", err)
 	}
 
 	d.Set("status", nodeGroup.Status)
 
 	if err := d.Set("subnet_ids", aws.StringValueSlice(nodeGroup.Subnets)); err != nil {
-		return fmt.Errorf("error setting subnets: %w", err)
+		return diag.Errorf("error setting subnets: %s", err)
 	}
 
 	if err := d.Set("taint", flattenEksTaints(nodeGroup.Taints)); err != nil {
-		return fmt.Errorf("error setting taint: %w", err)
+		return diag.Errorf("error setting taint: %s", err)
 	}
 
 	d.Set("version", nodeGroup.Version)
@@ -411,23 +412,23 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return diag.Errorf("error setting tags: %s", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return diag.Errorf("error setting tags_all: %s", err)
 	}
 
 	return nil
 }
 
-func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEksNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*AWSClient).eksconn
 
 	clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	// Do any version update first.
@@ -470,15 +471,15 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		output, err := conn.UpdateNodegroupVersion(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating EKS Node Group (%s) version: %w", d.Id(), err)
+			return diag.Errorf("error updating EKS Node Group (%s) version: %s", d.Id(), err)
 		}
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		_, err = waiter.NodegroupUpdateSuccessful(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.NodegroupUpdateSuccessful(ctx, conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
-			return fmt.Errorf("error waiting for EKS Node Group (%s) version update (%s): %w", d.Id(), updateID, err)
+			return diag.Errorf("error waiting for EKS Node Group (%s) version update (%s): %s", d.Id(), updateID, err)
 		}
 	}
 
@@ -502,35 +503,35 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		output, err := conn.UpdateNodegroupConfig(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating EKS Node Group (%s) config: %w", d.Id(), err)
+			return diag.Errorf("error updating EKS Node Group (%s) config: %s", d.Id(), err)
 		}
 
 		updateID := aws.StringValue(output.Update.Id)
 
-		_, err = waiter.NodegroupUpdateSuccessful(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+		_, err = waiter.NodegroupUpdateSuccessful(ctx, conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
-			return fmt.Errorf("error waiting for EKS Node Group (%s) config update (%s): %w", d.Id(), updateID, err)
+			return diag.Errorf("error waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
 		}
 	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := keyvaluetags.EksUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %w", err)
+			return diag.Errorf("error updating tags: %s", err)
 		}
 	}
 
-	return resourceAwsEksNodeGroupRead(d, meta)
+	return resourceAwsEksNodeGroupRead(ctx, d, meta)
 }
 
-func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEksNodeGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*AWSClient).eksconn
 
 	clusterName, nodeGroupName, err := tfeks.NodeGroupParseResourceID(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Deleting EKS Node Group: %s", d.Id())
@@ -544,13 +545,13 @@ func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting EKS Node Group (%s): %w", d.Id(), err)
+		return diag.Errorf("error deleting EKS Node Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = waiter.NodegroupDeleted(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete))
+	_, err = waiter.NodegroupDeleted(ctx, conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EKS Node Group (%s) to delete: %w", d.Id(), err)
+		return diag.Errorf("error waiting for EKS Node Group (%s) to delete: %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Relates #4177.

Output from acceptance testing:

It seems that acceptance tests aren't passing for what seems to be unrelated concerns.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEksNodeGroup_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_* -timeout 180m
=== RUN   TestAccAWSEksNodeGroup_basic
=== PAUSE TestAccAWSEksNodeGroup_basic
=== RUN   TestAccAWSEksNodeGroup_Name_Generated
=== PAUSE TestAccAWSEksNodeGroup_Name_Generated
=== RUN   TestAccAWSEksNodeGroup_NamePrefix
=== PAUSE TestAccAWSEksNodeGroup_NamePrefix
=== RUN   TestAccAWSEksNodeGroup_disappears
=== PAUSE TestAccAWSEksNodeGroup_disappears
=== RUN   TestAccAWSEksNodeGroup_AmiType
=== PAUSE TestAccAWSEksNodeGroup_AmiType
=== RUN   TestAccAWSEksNodeGroup_CapacityType_Spot
=== PAUSE TestAccAWSEksNodeGroup_CapacityType_Spot
=== RUN   TestAccAWSEksNodeGroup_DiskSize
=== PAUSE TestAccAWSEksNodeGroup_DiskSize
=== RUN   TestAccAWSEksNodeGroup_ForceUpdateVersion
=== PAUSE TestAccAWSEksNodeGroup_ForceUpdateVersion
=== RUN   TestAccAWSEksNodeGroup_InstanceTypes_Multiple
=== PAUSE TestAccAWSEksNodeGroup_InstanceTypes_Multiple
=== RUN   TestAccAWSEksNodeGroup_InstanceTypes_Single
=== PAUSE TestAccAWSEksNodeGroup_InstanceTypes_Single
=== RUN   TestAccAWSEksNodeGroup_Labels
=== PAUSE TestAccAWSEksNodeGroup_Labels
=== RUN   TestAccAWSEksNodeGroup_LaunchTemplate_Id
=== PAUSE TestAccAWSEksNodeGroup_LaunchTemplate_Id
=== RUN   TestAccAWSEksNodeGroup_LaunchTemplate_Name
=== PAUSE TestAccAWSEksNodeGroup_LaunchTemplate_Name
=== RUN   TestAccAWSEksNodeGroup_LaunchTemplate_Version
=== PAUSE TestAccAWSEksNodeGroup_LaunchTemplate_Version
=== RUN   TestAccAWSEksNodeGroup_ReleaseVersion
=== PAUSE TestAccAWSEksNodeGroup_ReleaseVersion
=== RUN   TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey
=== PAUSE TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey
=== RUN   TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds
=== PAUSE TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds
=== RUN   TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize
=== PAUSE TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize
=== RUN   TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
=== PAUSE TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
=== RUN   TestAccAWSEksNodeGroup_ScalingConfig_MinSize
=== PAUSE TestAccAWSEksNodeGroup_ScalingConfig_MinSize
=== RUN   TestAccAWSEksNodeGroup_ScalingConfig_Zero_DesiredSize_MinSize
=== PAUSE TestAccAWSEksNodeGroup_ScalingConfig_Zero_DesiredSize_MinSize
=== RUN   TestAccAWSEksNodeGroup_Tags
=== PAUSE TestAccAWSEksNodeGroup_Tags
=== RUN   TestAccAWSEksNodeGroup_Taints
=== PAUSE TestAccAWSEksNodeGroup_Taints
=== RUN   TestAccAWSEksNodeGroup_Version
=== PAUSE TestAccAWSEksNodeGroup_Version
=== CONT  TestAccAWSEksNodeGroup_basic
=== CONT  TestAccAWSEksNodeGroup_LaunchTemplate_Version
=== CONT  TestAccAWSEksNodeGroup_ScalingConfig_Zero_DesiredSize_MinSize
=== CONT  TestAccAWSEksNodeGroup_ReleaseVersion
=== CONT  TestAccAWSEksNodeGroup_ScalingConfig_MinSize
=== CONT  TestAccAWSEksNodeGroup_DiskSize
=== CONT  TestAccAWSEksNodeGroup_CapacityType_Spot
=== CONT  TestAccAWSEksNodeGroup_Version
=== CONT  TestAccAWSEksNodeGroup_NamePrefix
=== CONT  TestAccAWSEksNodeGroup_ForceUpdateVersion
=== CONT  TestAccAWSEksNodeGroup_ScalingConfig_MaxSize
=== CONT  TestAccAWSEksNodeGroup_Name_Generated
=== CONT  TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize
=== CONT  TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds
=== CONT  TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey
=== CONT  TestAccAWSEksNodeGroup_basic
    provider_test.go:239: at least one environment variable of [AWS_PROFILE AWS_ACCESS_KEY_ID AWS_CONTAINER_CREDENTIALS_FULL_URI] must be set. Usage: credentials for running acceptance testing
=== CONT  TestAccAWSEksNodeGroup_AmiType
--- FAIL: TestAccAWSEksNodeGroup_basic (0.00s)
=== CONT  TestAccAWSEksNodeGroup_LaunchTemplate_Id
=== CONT  TestAccAWSEksNodeGroup_disappears
--- FAIL: TestAccAWSEksNodeGroup_LaunchTemplate_Id (0.00s)
=== CONT  TestAccAWSEksNodeGroup_Taints
--- FAIL: TestAccAWSEksNodeGroup_AmiType (0.00s)
=== CONT  TestAccAWSEksNodeGroup_Tags
--- FAIL: TestAccAWSEksNodeGroup_Taints (0.00s)
--- FAIL: TestAccAWSEksNodeGroup_LaunchTemplate_Version (0.00s)
panic: interface conversion: interface {} is nil, not *aws.AWSClient [recovered]
	panic: interface conversion: interface {} is nil, not *aws.AWSClient

goroutine 51 [running]:
testing.tRunner.func1.2(0x831e180, 0xc0002fc090)
	/usr/local/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc0024c6600)
	/usr/local/go/src/testing/testing.go:1146 +0x4b6
panic(0x831e180, 0xc0002fc090)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/terraform-providers/terraform-provider-aws/aws.testAccPreCheckAWSEks(0xc0024c6600)
	/Users/joe/code/terraform-provider-aws/aws/resource_aws_eks_cluster_test.go:675 +0x1cc
github.com/terraform-providers/terraform-provider-aws/aws.TestAccAWSEksNodeGroup_AmiType.func1()
	/Users/joe/code/terraform-provider-aws/aws/resource_aws_eks_node_group_test.go:228 +0x3d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.Test(0xa2e8ed8, 0xc0024c6600, 0x0, 0xc0024ce1d0, 0xc0002fc060, 0x0, 0x0, 0xc002441cb0, 0x0, 0x0, ...)
	/Users/joe/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/resource/testing.go:551 +0x4e2
github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.ParallelTest(0xa2e8ed8, 0xc0024c6600, 0x0, 0xc0024ce1d0, 0x0, 0x0, 0x0, 0xc002441cb0, 0x0, 0x0, ...)
	/Users/joe/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/resource/testing.go:504 +0xa5
github.com/terraform-providers/terraform-provider-aws/aws.TestAccAWSEksNodeGroup_AmiType(0xc0024c6600)
	/Users/joe/code/terraform-provider-aws/aws/resource_aws_eks_node_group_test.go:227 +0x545
testing.tRunner(0xc0024c6600, 0x97152e8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	2.615s
FAIL
make: *** [testacc] Error 1
...
```
