### PR TITLE
workflow/change name of org scoped token to conform to new naming guidelines

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -12,4 +12,4 @@ jobs:
       with:
         project: AWS Provider Working Board
         column: Open Maintainer PR
-        repo-token: ${{ secrets.GITHUB_ACTIONS_TOKEN}}
+        repo-token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           github_done_column_id: 11513756
           github_release_name: ${{ github.event.release.tag_name }}
-          github_token: ${{ secrets.GITHUB_ACTIONS_TOKEN }}
+          github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
   changelog-newversion:
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/team_slack_bot.yml
+++ b/.github/workflows/team_slack_bot.yml
@@ -13,7 +13,7 @@ jobs:
     - name: open-pr-stats
       uses: breathingdust/github-team-slackbot@v17
       with:
-        github_token: ${{ secrets.GITHUB_ACTIONS_TOKEN}}
+        github_token: ${{ secrets.ORGSCOPED_GITHUB_TOKEN}}
         org: hashicorp
         repo: terraform-provider-aws
         team_slug: terraform-aws


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

We need to update this token but are currently unable to as restrictions to not allow secret names to be updated if they start with `GITHUB_`. Renaming this secret to all us to update it.
