### PR TITLE
r/glue_crawler - s3 sample size

### DIFF
--- a/.changelog/20203.txt
+++ b/.changelog/20203.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_crawler: Add `sample_size` argument in `s3_target` block.
+```

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -79,15 +79,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"schema_change_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "1" && new == "0" {
-						return true
-					}
-					return false
-				},
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				MaxItems:         1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"delete_behavior": {
@@ -238,15 +233,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				ValidateFunc: validation.StringIsJSON,
 			},
 			"lineage_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "1" && new == "0" {
-						return true
-					}
-					return false
-				},
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"crawler_lineage_settings": {
@@ -259,15 +249,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				},
 			},
 			"recrawl_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "1" && new == "0" {
-						return true
-					}
-					return false
-				},
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"recrawl_behavior": {
@@ -408,16 +393,14 @@ func updateCrawlerInput(d *schema.ResourceData, crawlerName string) (*glue.Updat
 
 	crawlerInput.TablePrefix = aws.String(d.Get("table_prefix").(string))
 
-	if configuration, ok := d.GetOk("configuration"); ok {
-		crawlerInput.Configuration = aws.String(configuration.(string))
-	}
-
 	if v, ok := d.GetOk("configuration"); ok {
 		configuration, err := structure.NormalizeJsonString(v)
 		if err != nil {
 			return nil, fmt.Errorf("Configuration contains an invalid JSON: %v", err)
 		}
 		crawlerInput.Configuration = aws.String(configuration)
+	} else {
+		crawlerInput.Configuration = aws.String("")
 	}
 
 	if securityConfiguration, ok := d.GetOk("security_configuration"); ok {
@@ -534,7 +517,7 @@ func expandGlueS3Target(cfg map[string]interface{}) *glue.S3Target {
 		target.Exclusions = expandStringList(v.([]interface{}))
 	}
 
-	if v, ok := cfg["sample_size"]; ok {
+	if v, ok := cfg["sample_size"]; ok && v.(int) > 0 {
 		target.SampleSize = aws.Int64(int64(v.(int)))
 	}
 

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2605,8 +2605,8 @@ resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
   database_name = aws_glue_catalog_database.test.name
-  name = %[1]q
-  role = aws_iam_role.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
 
   s3_target {
     sample_size = %[2]d

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -990,6 +990,13 @@ func TestAccAWSGlueCrawler_Configuration(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccGlueCrawlerConfig_Configuration(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
+				),
+			},
 		},
 	})
 }
@@ -2598,8 +2605,8 @@ resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
   database_name = aws_glue_catalog_database.test.name
-  name          =  %[1]q
-  role          = aws_iam_role.test.name
+  name =  %[1]q
+  role = aws_iam_role.test.name
 
   s3_target {
     sample_size = %[2]d

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -2605,7 +2605,7 @@ resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
   database_name = aws_glue_catalog_database.test.name
-  name =  %[1]q
+  name = %[1]q
   role = aws_iam_role.test.name
 
   s3_target {

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -168,6 +168,7 @@ The following arguments are supported:
 * `path` - (Required) The path to the Amazon S3 target.
 * `connection_name` - (Optional) The name of a connection which allows crawler to access data in S3 within a VPC.
 * `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
+* `sample_size` - (Optional)  Sets the number of files in each leaf folder to be crawled when crawling ample files in a dataset. If not set, all the files are crawled. A valid value is an integer between 1 and 249.
 
 ### Catalog Target
 

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -168,7 +168,7 @@ The following arguments are supported:
 * `path` - (Required) The path to the Amazon S3 target.
 * `connection_name` - (Optional) The name of a connection which allows crawler to access data in S3 within a VPC.
 * `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
-* `sample_size` - (Optional)  Sets the number of files in each leaf folder to be crawled when crawling ample files in a dataset. If not set, all the files are crawled. A valid value is an integer between 1 and 249.
+* `sample_size` - (Optional)  Sets the number of files in each leaf folder to be crawled when crawling sample files in a dataset. If not set, all the files are crawled. A valid value is an integer between 1 and 249.
 
 ### Catalog Target
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20177
Closes #18174

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCrawler_'
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (56.98s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (59.48s)
--- PASS: TestAccAWSGlueCrawler_disappears (65.08s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (80.63s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (131.69s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (148.54s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget (148.54s)
--- PASS: TestAccAWSGlueCrawler_Description (149.07s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (150.05s)
--- PASS: TestAccAWSGlueCrawler_Configuration (150.29s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (153.17s)
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (158.23s)
--- PASS: TestAccAWSGlueCrawler_Schedule (197.96s)
--- PASS: TestAccAWSGlueCrawler_RemoveTablePrefix (146.95s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (206.54s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (207.00s)
--- PASS: TestAccAWSGlueCrawler_recrawlPolicy (208.01s)
--- PASS: TestAccAWSGlueCrawler_Tags (210.34s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget_multiple (211.36s)
--- PASS: TestAccAWSGlueCrawler_mongoDBTarget_scan_all (211.42s)
--- PASS: TestAccAWSGlueCrawler_lineageConfig (211.67s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (149.02s)
--- PASS: TestAccAWSGlueCrawler_S3Target_ConnectionName (90.00s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanRate (184.81s)
--- PASS: TestAccAWSGlueCrawler_S3Target (125.84s)
--- PASS: TestAccAWSGlueCrawler_S3Target_SampleSize (128.82s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (135.05s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget (157.83s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (178.16s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget_Multiple (256.74s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanAll (171.32s)
```
