### PR TITLE
Remove misleading wording

### DIFF
--- a/website/docs/r/route53_vpc_association_authorization.html.markdown
+++ b/website/docs/r/route53_vpc_association_authorization.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Route53"
 layout: "aws"
 page_title: "AWS: aws_route53_vpc_association_authorization"
 description: |-
-  Authorizes a VPC in a peer account to be associated with a local Route53 Hosted Zone
+  Authorizes a VPC in a different account to be associated with a local Route53 Hosted Zone
 ---
 
 # Resource: aws_route53_vpc_association_authorization
 
-Authorizes a VPC in a peer account to be associated with a local Route53 Hosted Zone.
+Authorizes a VPC in a different account to be associated with a local Route53 Hosted Zone.
 
 ## Example Usage
 


### PR DESCRIPTION
Peering isn't actually a requirement: https://docs.aws.amazon.com/cli/latest/reference/route53/create-vpc-association-authorization.html
