### PR TITLE
sweeper: Allow assuming IAM Role

### DIFF
--- a/aws/internal/envvar/consts.go
+++ b/aws/internal/envvar/consts.go
@@ -48,3 +48,19 @@ const (
 	// An inline assume role policy is then used to deny actions for the test
 	TfAccAssumeRoleArn = "TF_ACC_ASSUME_ROLE_ARN"
 )
+
+// Custom environment variables used for assuming a role with resource sweepers
+const (
+	// The ARN of the IAM Role to assume
+	TfAwsAssumeRoleARN = "TF_AWS_ASSUME_ROLE_ARN"
+
+	// The duration in seconds the IAM role will be assumed.
+	// Defaults to 1 hour (3600) instead of the SDK default of 15 minutes.
+	TfAwsAssumeRoleDuration = "TF_AWS_ASSUME_ROLE_DURATION"
+
+	// An External ID to pass to the assumed role
+	TfAwsAssumeRoleExternalID = "TF_AWS_ASSUME_ROLE_EXTERNAL_ID"
+
+	// A session name for the assumed role
+	TfAwsAssumeRoleSessionName = "TF_AWS_ASSUME_ROLE_SESSION_NAME"
+)

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -83,7 +83,7 @@ func iamRoleNameFilter(name string) bool {
 		"ssm_role",
 		"ssm-role",
 		"test",
-		"tf",
+		"tf-acc",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(name, prefix) {

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -1133,6 +1133,13 @@ To run a specific resource sweeper:
 $ SWEEPARGS=-sweep-run=aws_example_thing make sweep
 ```
 
+To run sweepers with an assumed role, use the following additional environment variables:
+
+* `TF_AWS_ASSUME_ROLE_ARN` - Required.
+* `TF_AWS_ASSUME_ROLE_DURATION` - Optional, defaults to 1 hour (3600).
+* `TF_AWS_ASSUME_ROLE_EXTERNAL_ID` - Optional.
+* `TF_AWS_ASSUME_ROLE_SESSION_NAME` - Optional.
+
 ### Writing Test Sweepers
 
 The first step is to initialize the resource into the test sweeper framework:


### PR DESCRIPTION
Allows assuming an IAM Role in the sweeper framework rather than using an external tool.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_AWS_ASSUME_ROLE_ARN=arn:aws:iam::123456789012:role/sweeper TF_AWS_ASSUME_ROLE_EXTERNAL_ID=abc123 TF_AWS_ASSUME_ROLE_SESSION_NAME=xyz098  make sweep SWEEPARGS=-sweep-run=aws_eks_addon

2021/07/15 15:02:21 [DEBUG] Running Sweepers for region (us-east-1):
2021/07/15 15:02:21 [DEBUG] Running Sweeper (aws_eks_addon) in region (us-east-1)
2021/07/15 15:02:21 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2021/07/15 15:02:21 [INFO] Attempting to AssumeRole arn:aws:iam::123456789012:role/sweeper (SessionName: "xyz098", ExternalId: "abc123")
2021/07/15 15:02:21 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/07/15 15:02:23 Sweeper Tests ran successfully:
	- aws_eks_addon
```
