### PR TITLE
Use engine_version and engine_version_actual for aws_db_instance

### DIFF
--- a/.changelog/20207.txt
+++ b/.changelog/20207.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Use engine_version and engine_version_actual to set and track engine versions
+```

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -41,32 +40,6 @@ func suppressEquivalentTypeStringBoolean(k, old, new string, d *schema.ResourceD
 //  * The operator's configuration omits the optional configuration block
 func suppressMissingOptionalConfigurationBlock(k, old, new string, d *schema.ResourceData) bool {
 	return old == "1" && new == "0"
-}
-
-// Suppresses minor version changes to the db_instance engine_version attribute
-func suppressAwsDbEngineVersionDiffs(k, old, new string, d *schema.ResourceData) bool {
-	// First check if the old/new values are nil.
-	// If both are nil, we have no state to compare the values with, so register a diff.
-	// This populates the attribute field during a plan/apply with fresh state, allowing
-	// the attribute to still be used in future resources.
-	// See https://github.com/hashicorp/terraform/issues/11881
-	if old == "" && new == "" {
-		return false
-	}
-
-	if v, ok := d.GetOk("auto_minor_version_upgrade"); ok {
-		if v.(bool) {
-			// If we're set to auto upgrade minor versions
-			// ignore a minor version diff between versions
-			if strings.HasPrefix(old, new) {
-				log.Printf("[DEBUG] Ignoring minor version diff")
-				return true
-			}
-		}
-	}
-
-	// Throw a diff by default
-	return false
 }
 
 func suppressEquivalentJsonDiffs(k, old, new string, d *schema.ResourceData) bool {

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1975,8 +1975,5 @@ func expandRestoreToPointInTime(l []interface{}) *rds.RestoreDBInstanceToPointIn
 func dbSetResourceDataEngineVersionFromInstance(d *schema.ResourceData, c *rds.DBInstance) {
 	oldVersion := d.Get("engine_version").(string)
 	newVersion := aws.StringValue(c.EngineVersion)
-	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != string([]byte(newVersion)[0:len(oldVersion)+1]) {
-		d.Set("engine_version", newVersion)
-	}
-	d.Set("engine_version_actual", newVersion)
+	compareActualEngineVersion(d, oldVersion, newVersion)
 }

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -190,10 +190,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				},
 			},
 			"engine_version": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: suppressAwsDbEngineVersionDiffs,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"engine_version_actual": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"final_snapshot_identifier": {
 				Type:     schema.TypeString,
@@ -1377,7 +1380,6 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("username", v.MasterUsername)
 	d.Set("deletion_protection", v.DeletionProtection)
 	d.Set("engine", v.Engine)
-	d.Set("engine_version", v.EngineVersion)
 	d.Set("allocated_storage", v.AllocatedStorage)
 	d.Set("iops", v.Iops)
 	d.Set("copy_tags_to_snapshot", v.CopyTagsToSnapshot)
@@ -1405,6 +1407,8 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("character_set_name", v.CharacterSetName)
 	d.Set("nchar_character_set_name", v.NcharCharacterSetName)
 	d.Set("timezone", v.Timezone)
+
+	dbSetResourceDataEngineVersionFromInstance(d, v)
 
 	if len(v.DBParameterGroups) > 0 {
 		d.Set("parameter_group_name", v.DBParameterGroups[0].DBParameterGroupName)
@@ -1966,4 +1970,13 @@ func expandRestoreToPointInTime(l []interface{}) *rds.RestoreDBInstanceToPointIn
 	}
 
 	return input
+}
+
+func dbSetResourceDataEngineVersionFromInstance(d *schema.ResourceData, c *rds.DBInstance) {
+	oldVersion := d.Get("engine_version").(string)
+	newVersion := aws.StringValue(c.EngineVersion)
+	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != string([]byte(newVersion)[0:len(oldVersion)+1]) {
+		d.Set("engine_version", newVersion)
+	}
+	d.Set("engine_version_actual", newVersion)
 }

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -3610,10 +3610,14 @@ resource "aws_db_instance" "bar" {
 
 func testAccAWSDBInstanceConfig_MajorVersionOnly(engine, engineVersion string) string {
 	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
+locals {
+  engine = %[1]q
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage       = 10
   backup_retention_period = 0
-  engine                  = %[1]q
+  engine                  = local.engine
   engine_version          = %[2]q
   instance_class          = "db.r4.large"
   name                    = "baz"

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -116,6 +116,39 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_OnlyMajorVersion(t *testing.T) {
+	var dbInstance1 rds.DBInstance
+	resourceName := "aws_db_instance.test"
+	engine := "mysql"
+	engineVersion1 := "5.6"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, rds.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_MajorVersionOnly(engine, engineVersion1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
+					resource.TestCheckResourceAttr(resourceName, "engine", engine),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", engineVersion1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"engine_version",
+					"password",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSDBInstance_namePrefix(t *testing.T) {
 	var v rds.DBInstance
 
@@ -3573,6 +3606,28 @@ resource "aws_db_instance" "bar" {
   maintenance_window = "Fri:09:00-Fri:09:30"
 }
 `)
+}
+
+func testAccAWSDBInstanceConfig_MajorVersionOnly(engine, engineVersion string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
+resource "aws_db_instance" "test" {
+  allocated_storage       = 10
+  backup_retention_period = 0
+  engine                  = %[1]q
+  engine_version          = %[2]q
+  instance_class          = "db.r4.large"
+  name                    = "baz"
+  parameter_group_name    = "default.mysql5.6"
+  password                = "barbarbarbar"
+  skip_final_snapshot     = true
+  username                = "foo"
+
+  # Maintenance Window is stored in lower case in the API, though not strictly
+  # documented. Terraform will downcase this to match (as opposed to throw a
+  # validation error).
+  maintenance_window = "Fri:09:00-Fri:09:30"
+}
+`, engine, engineVersion))
 }
 
 func testAccAWSDBInstanceConfig_namePrefix() string {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -116,8 +116,8 @@ For information on the difference between the available Aurora MySQL engines
 see [Comparison between Aurora MySQL 1 and Aurora MySQL 2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Updates.20180206.html)
 in the Amazon RDS User Guide.
 * `engine_version` - (Optional) The engine version to use. If `auto_minor_version_upgrade`
-is enabled, you can provide a prefix of the version such as `5.7` (for `5.7.10`) and
-this attribute will ignore differences in the patch version automatically (e.g. `5.7.17`).
+is enabled, you can provide a prefix of the version such as `5.7` (for `5.7.10`).
+The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
 Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
@@ -282,7 +282,7 @@ DB instance.
 * `domain_iam_role_name` - The name of the IAM role to be used when making API calls to the Directory Service.
 * `endpoint` - The connection endpoint in `address:port` format.
 * `engine` - The database engine.
-* `engine_version` - The database engine version.
+* `engine_version_actual` - The running version of the database.
 * `hosted_zone_id` - The canonical hosted zone ID of the DB instance (to be used
 in a Route 53 Alias record).
 * `id` - The RDS instance ID.


### PR DESCRIPTION
Instead of suppressing diffs to allow for using less specific `engine_version`s, allow `engine_version` to be less specific, and keep the actual engine version in `engine_version_actual`.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #20211.
Closes #19240.
Closes #14277.

Output from acceptance testing:


```
=== RUN   TestAccAWSDBInstance_basic
=== PAUSE TestAccAWSDBInstance_basic
=== RUN   TestAccAWSDBInstance_OnlyMajorVersion
=== PAUSE TestAccAWSDBInstance_OnlyMajorVersion
=== RUN   TestAccAWSDBInstance_namePrefix
=== PAUSE TestAccAWSDBInstance_namePrefix
=== RUN   TestAccAWSDBInstance_generatedName
=== PAUSE TestAccAWSDBInstance_generatedName
=== RUN   TestAccAWSDBInstance_kmsKey
=== PAUSE TestAccAWSDBInstance_kmsKey
=== RUN   TestAccAWSDBInstance_subnetGroup
=== PAUSE TestAccAWSDBInstance_subnetGroup
=== RUN   TestAccAWSDBInstance_optionGroup
=== PAUSE TestAccAWSDBInstance_optionGroup
=== RUN   TestAccAWSDBInstance_iamAuth
=== PAUSE TestAccAWSDBInstance_iamAuth
=== RUN   TestAccAWSDBInstance_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_DbSubnetGroupName
=== PAUSE TestAccAWSDBInstance_DbSubnetGroupName
=== RUN   TestAccAWSDBInstance_DbSubnetGroupName_RamShared
=== PAUSE TestAccAWSDBInstance_DbSubnetGroupName_RamShared
=== RUN   TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_DeletionProtection
=== PAUSE TestAccAWSDBInstance_DeletionProtection
=== RUN   TestAccAWSDBInstance_FinalSnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_FinalSnapshotIdentifier
=== RUN   TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
=== PAUSE TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
=== RUN   TestAccAWSDBInstance_IsAlreadyBeingDeleted
=== PAUSE TestAccAWSDBInstance_IsAlreadyBeingDeleted
=== RUN   TestAccAWSDBInstance_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_Password
=== PAUSE TestAccAWSDBInstance_Password
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection
    provider_test.go:57: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Port
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Port
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier
=== RUN   TestAccAWSDBInstance_S3Import
=== PAUSE TestAccAWSDBInstance_S3Import
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier
=== RUN   TestAccAWSDBInstance_SnapshotIdentifierRemoved
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifierRemoved
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Port
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Port
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset
    provider_test.go:57: To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/5959
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== RUN   TestAccAWSDBInstance_MonitoringInterval
=== PAUSE TestAccAWSDBInstance_MonitoringInterval
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== RUN   TestAccAWSDBInstance_separateIopsUpdate
=== PAUSE TestAccAWSDBInstance_separateIopsUpdate
=== RUN   TestAccAWSDBInstance_portUpdate
=== PAUSE TestAccAWSDBInstance_portUpdate
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
=== PAUSE TestAccAWSDBInstance_MSSQL_TZ
=== RUN   TestAccAWSDBInstance_MSSQL_Domain
=== PAUSE TestAccAWSDBInstance_MSSQL_Domain
=== RUN   TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== PAUSE TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== RUN   TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== PAUSE TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== RUN   TestAccAWSDBInstance_MinorVersion
=== PAUSE TestAccAWSDBInstance_MinorVersion
=== RUN   TestAccAWSDBInstance_ec2Classic
=== PAUSE TestAccAWSDBInstance_ec2Classic
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== PAUSE TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== RUN   TestAccAWSDBInstance_NoDeleteAutomatedBackups
=== PAUSE TestAccAWSDBInstance_NoDeleteAutomatedBackups
=== RUN   TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled
=== PAUSE TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled
=== RUN   TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled
=== PAUSE TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled
=== RUN   TestAccAWSDBInstance_PerformanceInsightsKmsKeyId
=== PAUSE TestAccAWSDBInstance_PerformanceInsightsKmsKeyId
=== RUN   TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod
=== PAUSE TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== RUN   TestAccAWSDBInstance_CACertificateIdentifier
=== PAUSE TestAccAWSDBInstance_CACertificateIdentifier
=== RUN   TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier
=== PAUSE TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier
=== RUN   TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID
=== PAUSE TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID
=== CONT  TestAccAWSDBInstance_basic
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== CONT  TestAccAWSDBInstance_MSSQL_TZ
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== CONT  TestAccAWSDBInstance_portUpdate
=== CONT  TestAccAWSDBInstance_separateIopsUpdate
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== CONT  TestAccAWSDBInstance_MonitoringInterval
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
--- PASS: TestAccAWSDBInstance_portUpdate (519.28s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifierRemoved
--- PASS: TestAccAWSDBInstance_basic (570.76s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
--- PASS: TestAccAWSDBInstance_separateIopsUpdate (765.17s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (789.29s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (846.10s)
=== CONT  TestAccAWSDBInstance_S3Import
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (915.78s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1006.38s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1149.08s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1155.88s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1189.88s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1190.10s)
=== CONT  TestAccAWSDBInstance_NoDeleteAutomatedBackups
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1200.16s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Port
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1343.55s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Tags
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1384.57s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Port
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1531.05s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1548.31s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1568.69s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1630.31s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1088.35s)
=== CONT  TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID
--- FAIL: TestAccAWSDBInstance_S3Import (834.80s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
--- PASS: TestAccAWSDBInstance_SnapshotIdentifierRemoved (1242.46s)
=== CONT  TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (978.38s)
=== CONT  TestAccAWSDBInstance_CACertificateIdentifier
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1814.42s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds (1063.19s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (726.90s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1169.81s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName (979.08s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
--- PASS: TestAccAWSDBInstance_CACertificateIdentifier (400.90s)
=== CONT  TestAccAWSDBInstance_PerformanceInsightsKmsKeyId
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1036.49s)
=== CONT  TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1099.66s)
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1150.87s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1314.83s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1365.81s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (1582.43s)
=== CONT  TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2609.36s)
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (439.70s)
=== CONT  TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled
--- PASS: TestAccAWSDBInstance_RestoreToPointInTime_SourceResourceID (1280.13s)
=== CONT  TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1440.51s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (535.76s)
=== CONT  TestAccAWSDBInstance_DeletionProtection
--- PASS: TestAccAWSDBInstance_RestoreToPointInTime_SourceIdentifier (1302.52s)
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1541.07s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1138.60s)
=== CONT  TestAccAWSDBInstance_Password
--- PASS: TestAccAWSDBInstance_PerformanceInsightsKmsKeyId (1117.29s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (728.02s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1583.12s)
=== CONT  TestAccAWSDBInstance_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1481.85s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1767.81s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1351.34s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
--- PASS: TestAccAWSDBInstance_DeletionProtection (522.48s)
=== CONT  TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
--- PASS: TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (913.95s)
=== CONT  TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod (955.23s)
=== CONT  TestAccAWSDBInstance_IsAlreadyBeingDeleted
--- PASS: TestAccAWSDBInstance_Password (454.93s)
=== CONT  TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (740.13s)
=== CONT  TestAccAWSDBInstance_FinalSnapshotIdentifier
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2261.68s)
=== CONT  TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (2073.34s)
=== CONT  TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (605.38s)
=== CONT  TestAccAWSDBInstance_DbSubnetGroupName
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL (941.53s)
=== CONT  TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_generatedName (353.89s)
=== CONT  TestAccAWSDBInstance_DbSubnetGroupName_RamShared
    provider_test.go:714: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (0.03s)
=== CONT  TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1540.24s)
=== CONT  TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (506.65s)
=== CONT  TestAccAWSDBInstance_ec2Classic
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (542.99s)
=== CONT  TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_optionGroup (580.45s)
=== CONT  TestAccAWSDBInstance_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds (433.43s)
=== CONT  TestAccAWSDBInstance_OnlyMajorVersion
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1279.71s)
=== CONT  TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1797.03s)
=== CONT  TestAccAWSDBInstance_MSSQL_Domain
--- PASS: TestAccAWSDBInstance_kmsKey (449.81s)
=== CONT  TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName (475.30s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (2007.06s)
--- PASS: TestAccAWSDBInstance_iamAuth (477.58s)
--- PASS: TestAccAWSDBInstance_ec2Classic (472.63s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (857.17s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1292.43s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (503.83s)
--- PASS: TestAccAWSDBInstance_MinorVersion (558.44s)
--- PASS: TestAccAWSDBInstance_OnlyMajorVersion (437.40s)
--- PASS: TestAccAWSDBInstance_subnetGroup (947.41s)
--- PASS: TestAccAWSDBInstance_namePrefix (448.26s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1440.46s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (1947.30s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1499.04s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1649.98s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1846.34s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (2018.54s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4779.57s)
<Removed skips and known failures>
```
