### PR TITLE
[AWS DMS] - Fix broken link for extra_connection_attributes

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
 * `engine_name` - (Required) The type of engine for the endpoint. Can be one of `aurora | aurora-postgresql| azuredb | db2 | docdb | dynamodb | elasticsearch | kafka | kinesis | mariadb | mongodb | mysql | oracle | postgres | redshift | s3 | sqlserver | sybase`.
-* `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.RDSPostgreSQL).
+* `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.ConnectionAttrib).
 * `kafka_settings` - (Optional) Configuration block with Kafka settings. Detailed below.
 * `kinesis_settings` - (Optional) Configuration block with Kinesis settings. Detailed below.
 * `kms_key_arn` - (Required when `engine_name` is `mongodb`, optional otherwise) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
 * `engine_name` - (Required) The type of engine for the endpoint. Can be one of `aurora | aurora-postgresql| azuredb | db2 | docdb | dynamodb | elasticsearch | kafka | kinesis | mariadb | mongodb | mysql | oracle | postgres | redshift | s3 | sqlserver | sybase`.
-* `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
+* `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html#CHAP_Source.PostgreSQL.RDSPostgreSQL).
 * `kafka_settings` - (Optional) Configuration block with Kafka settings. Detailed below.
 * `kinesis_settings` - (Optional) Configuration block with Kinesis settings. Detailed below.
 * `kms_key_arn` - (Required when `engine_name` is `mongodb`, optional otherwise) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.


### PR DESCRIPTION
Fixes a broken link for `extra_connection_attributes` for the Database Migration Service docs. This link points towards some PostgreSQL connection parameters whereas the previous pointed to the home DMS page without any documentation.