### PR TITLE
Add support for username attribute on auth blocks of aws_db_proxy

### DIFF
--- a/aws/resource_aws_db_proxy.go
+++ b/aws/resource_aws_db_proxy.go
@@ -101,6 +101,10 @@ func resourceAwsDbProxy() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validateArn,
 						},
+						"username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -220,6 +224,10 @@ func expandDbProxyAuth(l []interface{}) []*rds.UserAuthConfig {
 			userAuthConfig.SecretArn = aws.String(v)
 		}
 
+		if v, ok := m["username"].(string); ok && v != "" {
+			userAuthConfig.UserName = aws.String(v)
+		}
+
 		userAuthConfigs = append(userAuthConfigs, userAuthConfig)
 	}
 
@@ -233,6 +241,7 @@ func flattenDbProxyAuth(userAuthConfig *rds.UserAuthConfigInfo) map[string]inter
 	m["description"] = aws.StringValue(userAuthConfig.Description)
 	m["iam_auth"] = aws.StringValue(userAuthConfig.IAMAuth)
 	m["secret_arn"] = aws.StringValue(userAuthConfig.SecretArn)
+	m["username"] = aws.StringValue(userAuthConfig.UserName)
 
 	return m
 }

--- a/aws/resource_aws_db_proxy_default_target_group_test.go
+++ b/aws/resource_aws_db_proxy_default_target_group_test.go
@@ -366,6 +366,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 
   tags = {

--- a/aws/resource_aws_db_proxy_endpoint_test.go
+++ b/aws/resource_aws_db_proxy_endpoint_test.go
@@ -381,6 +381,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName)

--- a/aws/resource_aws_db_proxy_target_test.go
+++ b/aws/resource_aws_db_proxy_target_test.go
@@ -196,6 +196,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 
   tags = {

--- a/aws/resource_aws_db_proxy_test.go
+++ b/aws/resource_aws_db_proxy_test.go
@@ -86,6 +86,7 @@ func TestAccAWSDBProxy_basic(t *testing.T) {
 						"auth_scheme": "SECRETS",
 						"description": "test",
 						"iam_auth":    "DISABLED",
+						"username":    "test",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "debug_logging", "false"),
 					resource.TestCheckResourceAttr(resourceName, "idle_client_timeout", "1800"),
@@ -667,6 +668,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 
   tags = {
@@ -695,6 +697,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName, nName)
@@ -719,6 +722,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName, debugLogging)
@@ -743,6 +747,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName, idleClientTimeout)
@@ -767,6 +772,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName, requireTls)
@@ -790,6 +796,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 
@@ -826,6 +833,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 
@@ -855,6 +863,7 @@ resource "aws_db_proxy" "test" {
     description = "%[2]s"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName, description)
@@ -880,6 +889,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "%[2]s"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 }
 `, rName, iamAuth)
@@ -904,6 +914,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test2.arn
+    username    = "test
   }
 }
 
@@ -917,6 +928,32 @@ resource "aws_secretsmanager_secret_version" "test2" {
   secret_string = "{\"username\":\"db_user\",\"password\":\"db_user_password\"}"
 }
 `, rName, nName)
+}
+
+func testAccAWSDBProxyConfigAuthUsername(rName, iamAuth string) string {
+	return testAccAWSDBProxyConfigBase(rName) + fmt.Sprintf(`
+resource "aws_db_proxy" "test" {
+  depends_on = [
+    aws_secretsmanager_secret_version.test,
+    aws_iam_role_policy.test
+  ]
+
+  name                   = "%[1]s"
+  engine_family          = "MYSQL"
+  role_arn               = aws_iam_role.test.arn
+  require_tls            = true
+  vpc_security_group_ids = [aws_security_group.test.id]
+  vpc_subnet_ids         = aws_subnet.test.*.id
+
+  auth {
+    auth_scheme = "SECRETS"
+    description = "test"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "%[2]s"
+  }
+}
+`, rName, iamAuth)
 }
 
 func testAccAWSDBProxyConfigTags(rName, key, value string) string {
@@ -938,6 +975,7 @@ resource "aws_db_proxy" "test" {
     description = "test"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.test.arn
+    username    = "test"
   }
 
   tags = {

--- a/website/docs/r/db_proxy.html.markdown
+++ b/website/docs/r/db_proxy.html.markdown
@@ -28,6 +28,7 @@ resource "aws_db_proxy" "example" {
     description = "example"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.example.arn
+    username    = "example"
   }
 
   tags = {

--- a/website/docs/r/db_proxy_default_target_group.html.markdown
+++ b/website/docs/r/db_proxy_default_target_group.html.markdown
@@ -30,6 +30,7 @@ resource "aws_db_proxy" "example" {
     description = "example"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.example.arn
+    username    = "example"
   }
 
   tags = {

--- a/website/docs/r/db_proxy_target.html.markdown
+++ b/website/docs/r/db_proxy_target.html.markdown
@@ -28,6 +28,7 @@ resource "aws_db_proxy" "example" {
     description = "example"
     iam_auth    = "DISABLED"
     secret_arn  = aws_secretsmanager_secret.example.arn
+    username    = "example"
   }
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #20204

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDBProxy'

# TODO - our dev account has reached VPC capacity so was unable to run the tests
```
