### PR TITLE
Use engine_version and engine_version_actual for aws_rds_cluster and rds_cluster_instance

### DIFF
--- a/.changelog/20211.txt
+++ b/.changelog/20211.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_rds_cluster: Use engine_version and engine_version_actual to set and track engine versions
+```
+
+```release-note:enhancement
+resource/aws_rds_cluster_instance: Use engine_version and engine_version_actual to set and track engine versions
+```

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -1506,6 +1506,10 @@ func waitForRDSClusterDeletion(conn *rds.RDS, id string, timeout time.Duration) 
 func rdsClusterSetResourceDataEngineVersionFromCluster(d *schema.ResourceData, c *rds.DBCluster) {
 	oldVersion := d.Get("engine_version").(string)
 	newVersion := aws.StringValue(c.EngineVersion)
+	compareActualEngineVersion(d, oldVersion, newVersion)
+}
+
+func compareActualEngineVersion(d *schema.ResourceData, oldVersion string, newVersion string) {
 	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != string([]byte(newVersion)[0:len(oldVersion)+1]) {
 		d.Set("engine_version", newVersion)
 	}

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -668,8 +668,5 @@ var resourceAwsRdsClusterInstanceDeletePendingStates = []string{
 func rdsClusterSetResourceDataEngineVersionFromClusterInstance(d *schema.ResourceData, c *rds.DBInstance) {
 	oldVersion := d.Get("engine_version").(string)
 	newVersion := aws.StringValue(c.EngineVersion)
-	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != string([]byte(newVersion)[0:len(oldVersion)+1]) {
-		d.Set("engine_version", newVersion)
-	}
-	d.Set("engine_version_actual", newVersion)
+	compareActualEngineVersion(d, oldVersion, newVersion)
 }

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -116,9 +116,9 @@ The following arguments are supported:
 * `deletion_protection` - (Optional) If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
 * `enable_http_endpoint` - (Optional) Enable HTTP endpoint (data API). Only valid when `engine_mode` is set to `serverless`.
 * `enabled_cloudwatch_logs_exports` - (Optional) Set of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: `audit`, `error`, `general`, `slowquery`, `postgresql` (PostgreSQL).
-* `engine_mode` - (Optional) The database engine mode. Valid values: `global` (only valid for Aurora MySQL 1.21 and earlier), `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`. See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.html) for limitations when using `serverless`.
-* `engine_version` - (Optional) The database engine version. Updating this argument results in an outage. See the [Aurora MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.html) and [Aurora Postgres](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.html) documentation for your configured engine to determine this value. For example with Aurora MySQL 2, a potential value for this argument is `5.7.mysql_aurora.2.03.2`.
 * `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `aurora`. Valid Values: `aurora`, `aurora-mysql`, `aurora-postgresql`
+* `engine_mode` - (Optional) The database engine mode. Valid values: `global` (only valid for Aurora MySQL 1.21 and earlier), `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`. See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.html) for limitations when using `serverless`.
+* `engine_version` - (Optional) The database engine version. Updating this argument results in an outage. See the [Aurora MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.html) and [Aurora Postgres](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.html) documentation for your configured engine to determine this value. For example with Aurora MySQL 2, a potential value for this argument is `5.7.mysql_aurora.2.03.2`. The value can contain a partial version where supported by the API. The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot when this DB cluster is deleted. If omitted, no final snapshot will be made.
 * `global_cluster_identifier` - (Optional) The global cluster identifier specified on [`aws_rds_global_cluster`](/docs/providers/aws/r/rds_global_cluster.html).
 * `iam_database_authentication_enabled` - (Optional) Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Please see [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html) for availability and limitations.
@@ -236,7 +236,7 @@ In addition to all arguments above, the following attributes are exported:
 * `reader_endpoint` - A read-only endpoint for the Aurora cluster, automatically
 load-balanced across replicas
 * `engine` - The database engine
-* `engine_version` - The database engine version
+* `engine_version_actual` - The running version of the database.
 * `database_name` - The database name
 * `port` - The database port
 * `master_username` - The master username for the database

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -97,7 +97,7 @@ In addition to all arguments above, the following attributes are exported:
 * `availability_zone` - The availability zone of the instance
 * `endpoint` - The DNS address for this instance. May not be writable
 * `engine` - The database engine
-* `engine_version` - The database engine version
+* `engine_version_actual` - The database engine version
 * `port` - The database port
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `kms_key_id` - The ARN for the KMS encryption key if one is set to the cluster.


### PR DESCRIPTION
Instead of suppressing diffs to allow for using less specific `engine_version`s, allow `engine_version` to be less specific, and keep the actual engine version in `engine_version_actual`.

Relates #20207 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

```
=== RUN   TestAccAWSRDSCluster_basic
=== PAUSE TestAccAWSRDSCluster_basic
=== RUN   TestAccAWSRDSCluster_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSRDSCluster_AllowMajorVersionUpgrade
=== RUN   TestAccAWSRDSCluster_OnlyMajorVersion
=== PAUSE TestAccAWSRDSCluster_OnlyMajorVersion
=== RUN   TestAccAWSRDSCluster_AvailabilityZones
=== PAUSE TestAccAWSRDSCluster_AvailabilityZones
=== RUN   TestAccAWSRDSCluster_BacktrackWindow
=== PAUSE TestAccAWSRDSCluster_BacktrackWindow
=== RUN   TestAccAWSRDSCluster_ClusterIdentifierPrefix
=== PAUSE TestAccAWSRDSCluster_ClusterIdentifierPrefix
=== RUN   TestAccAWSRDSCluster_DbSubnetGroupName
=== PAUSE TestAccAWSRDSCluster_DbSubnetGroupName
=== RUN   TestAccAWSRDSCluster_s3Restore
=== PAUSE TestAccAWSRDSCluster_s3Restore
=== RUN   TestAccAWSRDSCluster_PointInTimeRestore
=== PAUSE TestAccAWSRDSCluster_PointInTimeRestore
=== RUN   TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports
=== PAUSE TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports
=== RUN   TestAccAWSRDSCluster_generatedName
=== PAUSE TestAccAWSRDSCluster_generatedName
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
=== PAUSE TestAccAWSRDSCluster_takeFinalSnapshot
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
=== PAUSE TestAccAWSRDSCluster_missingUserNameCausesError
=== RUN   TestAccAWSRDSCluster_Tags
=== PAUSE TestAccAWSRDSCluster_Tags
=== RUN   TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL
=== PAUSE TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL
=== RUN   TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql
=== PAUSE TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql
=== RUN   TestAccAWSRDSCluster_updateIamRoles
=== PAUSE TestAccAWSRDSCluster_updateIamRoles
=== RUN   TestAccAWSRDSCluster_kmsKey
=== PAUSE TestAccAWSRDSCluster_kmsKey
=== RUN   TestAccAWSRDSCluster_encrypted
=== PAUSE TestAccAWSRDSCluster_encrypted
=== RUN   TestAccAWSRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccAWSRDSCluster_copyTagsToSnapshot
=== RUN   TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId
=== PAUSE TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId
=== RUN   TestAccAWSRDSCluster_backupsUpdate
=== PAUSE TestAccAWSRDSCluster_backupsUpdate
=== RUN   TestAccAWSRDSCluster_iamAuth
=== PAUSE TestAccAWSRDSCluster_iamAuth
=== RUN   TestAccAWSRDSCluster_DeletionProtection
=== PAUSE TestAccAWSRDSCluster_DeletionProtection
=== RUN   TestAccAWSRDSCluster_EngineMode
=== PAUSE TestAccAWSRDSCluster_EngineMode
=== RUN   TestAccAWSRDSCluster_EngineMode_Global
=== PAUSE TestAccAWSRDSCluster_EngineMode_Global
=== RUN   TestAccAWSRDSCluster_EngineMode_Multimaster
=== PAUSE TestAccAWSRDSCluster_EngineMode_Multimaster
=== RUN   TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== PAUSE TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== RUN   TestAccAWSRDSCluster_EngineVersion
=== PAUSE TestAccAWSRDSCluster_EngineVersion
=== RUN   TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== PAUSE TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier
=== RUN   TestAccAWSRDSCluster_Port
=== PAUSE TestAccAWSRDSCluster_Port
=== RUN   TestAccAWSRDSCluster_ScalingConfiguration
=== PAUSE TestAccAWSRDSCluster_ScalingConfiguration
=== RUN   TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity
=== PAUSE TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_KmsKeyId
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_KmsKeyId
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== RUN   TestAccAWSRDSCluster_EnableHttpEndpoint
=== PAUSE TestAccAWSRDSCluster_EnableHttpEndpoint
=== CONT  TestAccAWSRDSCluster_basic
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== CONT  TestAccAWSRDSCluster_backupsUpdate
=== CONT  TestAccAWSRDSCluster_Port
=== CONT  TestAccAWSRDSCluster_EnableHttpEndpoint
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_KmsKeyId
=== CONT  TestAccAWSRDSCluster_takeFinalSnapshot
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove
--- PASS: TestAccAWSRDSCluster_Port (163.21s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (168.33s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (168.86s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (172.79s)
=== CONT  TestAccAWSRDSCluster_EngineMode_ParallelQuery
--- PASS: TestAccAWSRDSCluster_basic (172.87s)
=== CONT  TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (174.31s)
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global
--- PASS: TestAccAWSRDSCluster_backupsUpdate (203.38s)
=== CONT  TestAccAWSRDSCluster_EngineVersion
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (326.98s)
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (167.83s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (186.15s)
=== CONT  TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_KmsKeyId (375.08s)
=== CONT  TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (416.30s)
=== CONT  TestAccAWSRDSCluster_EngineMode
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (419.98s)
=== CONT  TestAccAWSRDSCluster_DeletionProtection
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (425.81s)
=== CONT  TestAccAWSRDSCluster_EngineMode_Multimaster
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (435.94s)
=== CONT  TestAccAWSRDSCluster_ScalingConfiguration
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (436.10s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (439.54s)
=== CONT  TestAccAWSRDSCluster_iamAuth
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (445.17s)
=== CONT  TestAccAWSRDSCluster_copyTagsToSnapshot
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (445.69s)
=== CONT  TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (446.07s)
=== CONT  TestAccAWSRDSCluster_EngineMode_Global
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (227.83s)
=== CONT  TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (398.48s)
=== CONT  TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_iamAuth (127.50s)
=== CONT  TestAccAWSRDSCluster_Tags
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (146.63s)
=== CONT  TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (5.91s)
=== CONT  TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL
--- PASS: TestAccAWSRDSCluster_DeletionProtection (190.44s)
=== CONT  TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (441.81s)
=== CONT  TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (448.55s)
=== CONT  TestAccAWSRDSCluster_DbSubnetGroupName
--- PASS: TestAccAWSRDSCluster_kmsKey (170.21s)
=== CONT  TestAccAWSRDSCluster_AvailabilityZones
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (189.30s)
=== CONT  TestAccAWSRDSCluster_OnlyMajorVersion
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity (281.12s)
=== CONT  TestAccAWSRDSCluster_PointInTimeRestore
--- PASS: TestAccAWSRDSCluster_EngineVersion (452.37s)
=== CONT  TestAccAWSRDSCluster_s3Restore
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (251.72s)
=== CONT  TestAccAWSRDSCluster_ClusterIdentifierPrefix
--- PASS: TestAccAWSRDSCluster_encrypted (148.28s)
=== CONT  TestAccAWSRDSCluster_BacktrackWindow
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (146.87s)
=== CONT  TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (148.72s)
=== CONT  TestAccAWSRDSCluster_AllowMajorVersionUpgrade
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (333.09s)
--- PASS: TestAccAWSRDSCluster_Tags (212.15s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql (168.74s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL (210.75s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (360.38s)
--- PASS: TestAccAWSRDSCluster_EngineMode (387.94s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (215.70s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (169.01s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (527.56s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (199.41s)
--- PASS: TestAccAWSRDSCluster_generatedName (148.05s)
--- PASS: TestAccAWSRDSCluster_PointInTimeRestore_EnabledCloudwatchLogsExports (372.55s)

```
