### PR TITLE
Add elasticache user and user_group resources

### DIFF
--- a/.changelog/20215.txt
+++ b/.changelog/20215.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_elasticache_user
+```
+
+```release-note:new-resource
+aws_elasticache_user_group
+```

--- a/aws/internal/service/elasticache/finder/finder.go
+++ b/aws/internal/service/elasticache/finder/finder.go
@@ -179,3 +179,55 @@ func GlobalReplicationGroupMemberByID(conn *elasticache.ElastiCache, globalRepli
 		Message: fmt.Sprintf("Replication Group (%s) not found in Global Replication Group (%s)", id, globalReplicationGroupID),
 	}
 }
+
+func ElastiCacheUserById(conn *elasticache.ElastiCache, userID string) (*elasticache.User, error) {
+	input := &elasticache.DescribeUsersInput{
+		UserId: aws.String(userID),
+	}
+	out, err := conn.DescribeUsers(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(out.Users) {
+	case 0:
+		return nil, &resource.NotFoundError{
+			Message: "empty result",
+		}
+	case 1:
+		if aws.StringValue(out.Users[0].Status) != "active" {
+			return nil, &resource.NotFoundError{
+				Message: "empty result",
+			}
+		}
+		return out.Users[0], nil
+	default:
+		return nil, &resource.NotFoundError{
+			Message: "too many results",
+		}
+	}
+}
+
+func ElastiCacheUserGroupById(conn *elasticache.ElastiCache, groupID string) (*elasticache.UserGroup, error) {
+	input := &elasticache.DescribeUserGroupsInput{
+		UserGroupId: aws.String(groupID),
+	}
+	out, err := conn.DescribeUserGroups(input)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(out.UserGroups) {
+	case 0:
+		return nil, &resource.NotFoundError{
+			Message: "empty result",
+		}
+	case 1:
+		return out.UserGroups[0], nil
+	default:
+		return nil, &resource.NotFoundError{
+			Message: "too many results",
+		}
+	}
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -743,6 +743,8 @@ func Provider() *schema.Provider {
 			"aws_elasticache_replication_group":                       resourceAwsElasticacheReplicationGroup(),
 			"aws_elasticache_security_group":                          resourceAwsElasticacheSecurityGroup(),
 			"aws_elasticache_subnet_group":                            resourceAwsElasticacheSubnetGroup(),
+			"aws_elasticache_user":                                    resourceAwsElasticacheUser(),
+			"aws_elasticache_user_group":                              resourceAwsElasticacheUserGroup(),
 			"aws_elastic_beanstalk_application":                       resourceAwsElasticBeanstalkApplication(),
 			"aws_elastic_beanstalk_application_version":               resourceAwsElasticBeanstalkApplicationVersion(),
 			"aws_elastic_beanstalk_configuration_template":            resourceAwsElasticBeanstalkConfigurationTemplate(),

--- a/aws/resource_aws_elasticache_user.go
+++ b/aws/resource_aws_elasticache_user.go
@@ -121,11 +121,11 @@ func resourceAwsElasticacheUserRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error describing ElastiCache User (%s): %w", d.Id(), err)
 	}
 
-	d.Set("access_string", aws.StringValue(resp.AccessString))
-	d.Set("engine", aws.StringValue(resp.Engine))
-	d.Set("user_id", aws.StringValue(resp.UserId))
-	d.Set("user_name", aws.StringValue(resp.UserName))
-	d.Set("arn", aws.StringValue(resp.ARN))
+	d.Set("access_string", resp.AccessString)
+	d.Set("engine", resp.Engine)
+	d.Set("user_id", resp.UserId)
+	d.Set("user_name", resp.UserName)
+	d.Set("arn", resp.ARN)
 
 	// Tags are currently only supported in AWS Commercial.
 	if meta.(*AWSClient).partition == endpoints.AwsPartitionID {

--- a/aws/resource_aws_elasticache_user.go
+++ b/aws/resource_aws_elasticache_user.go
@@ -1,0 +1,217 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsElasticacheUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElasticacheUserCreate,
+		Read:   resourceAwsElasticacheUserRead,
+		Update: resourceAwsElasticacheUserUpdate,
+		Delete: resourceAwsElasticacheUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: SetTagsDiff,
+
+		Schema: map[string]*schema.Schema{
+			"access_string": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"engine": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"REDIS"}, false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
+			},
+			"no_password_required": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"passwords": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 2,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+			"user_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsElasticacheUserCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &elasticache.CreateUserInput{
+		AccessString:       aws.String(d.Get("access_string").(string)),
+		Engine:             aws.String(d.Get("engine").(string)),
+		NoPasswordRequired: aws.Bool(d.Get("no_password_required").(bool)),
+		UserId:             aws.String(d.Get("user_id").(string)),
+		UserName:           aws.String(d.Get("user_name").(string)),
+	}
+
+	if v, ok := d.GetOk("passwords"); ok {
+		input.Passwords = expandStringSet(v.(*schema.Set))
+	}
+
+	// Tags are currently only supported in AWS Commercial.
+	if len(tags) > 0 && meta.(*AWSClient).partition == endpoints.AwsPartitionID {
+		input.Tags = tags.IgnoreAws().ElasticacheTags()
+	}
+
+	out, err := conn.CreateUser(input)
+	if err != nil {
+		return fmt.Errorf("error creating ElastiCache User: %w", err)
+	}
+
+	d.SetId(aws.StringValue(out.UserId))
+
+	return resourceAwsElasticacheUserRead(d, meta)
+
+}
+
+func resourceAwsElasticacheUserRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	resp, err := finder.ElastiCacheUserById(conn, d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		d.SetId("")
+		log.Printf("[DEBUG] ElastiCache User (%s) not found", d.Id())
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing ElastiCache User (%s): %w", d.Id(), err)
+	}
+
+	d.Set("access_string", aws.StringValue(resp.AccessString))
+	d.Set("engine", aws.StringValue(resp.Engine))
+	d.Set("user_id", aws.StringValue(resp.UserId))
+	d.Set("user_name", aws.StringValue(resp.UserName))
+	d.Set("arn", aws.StringValue(resp.ARN))
+
+	// Tags are currently only supported in AWS Commercial.
+	if meta.(*AWSClient).partition == endpoints.AwsPartitionID {
+		tags, err := keyvaluetags.ElasticacheListTags(conn, aws.StringValue(resp.ARN))
+
+		if err != nil {
+			return fmt.Errorf("error listing tags for ElastiCache User (%s): %w", aws.StringValue(resp.ARN), err)
+		}
+
+		tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+		//lintignore:AWSR002
+		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %w", err)
+		}
+
+		if err := d.Set("tags_all", tags.Map()); err != nil {
+			return fmt.Errorf("error setting tags_all: %w", err)
+		}
+	} else {
+		d.Set("tags", nil)
+		d.Set("tags_all", nil)
+	}
+
+	return nil
+}
+
+func resourceAwsElasticacheUserUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	hasChange := false
+
+	if d.HasChangeExcept("tags_all") {
+		req := &elasticache.ModifyUserInput{
+			UserId: aws.String(d.Get("user_id").(string)),
+		}
+
+		if d.HasChange("access_string") {
+			req.AccessString = aws.String(d.Get("access_string").(string))
+			hasChange = true
+		}
+
+		if d.HasChange("no_password_required") {
+			req.NoPasswordRequired = aws.Bool(d.Get("no_password_required").(bool))
+			hasChange = true
+		}
+
+		if d.HasChange("password") {
+			req.Passwords = expandStringSet(d.Get("password").(*schema.Set))
+			hasChange = true
+		}
+
+		if hasChange {
+			_, err := conn.ModifyUser(req)
+			if err != nil {
+				return fmt.Errorf("error updating ElastiCache User (%q): %w", d.Id(), err)
+			}
+		}
+
+	}
+
+	// Tags are currently only supported in AWS Commercial.
+	if d.HasChange("tags_all") && meta.(*AWSClient).partition == endpoints.AwsPartitionID {
+		o, n := d.GetChange("tags_all")
+
+		if err := keyvaluetags.ElasticacheUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating ElastiCache User (%s) tags: %w", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceAwsElasticacheUserRead(d, meta)
+}
+
+func resourceAwsElasticacheUserDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	input := &elasticache.DeleteUserInput{
+		UserId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteUser(input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserNotFoundFault) {
+			return nil
+		}
+		return fmt.Errorf("ElastiCache User cannot be deleted: %w", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_elasticache_user_group.go
+++ b/aws/resource_aws_elasticache_user_group.go
@@ -125,8 +125,8 @@ func resourceAwsElasticacheUserGroupRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error describing ElastiCache User Group (%s): %w", d.Id(), err)
 	}
 
-	d.Set("arn", aws.StringValue(resp.ARN))
-	d.Set("engine", aws.StringValue(resp.Engine))
+	d.Set("arn", resp.ARN)
+	d.Set("engine", resp.Engine)
 	d.Set("user_ids", resp.UserIds)
 	d.Set("user_group_id", resp.UserGroupId)
 

--- a/aws/resource_aws_elasticache_user_group.go
+++ b/aws/resource_aws_elasticache_user_group.go
@@ -1,0 +1,268 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsElasticacheUserGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElasticacheUserGroupCreate,
+		Read:   resourceAwsElasticacheUserGroupRead,
+		Update: resourceAwsElasticacheUserGroupUpdate,
+		Delete: resourceAwsElasticacheUserGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: SetTagsDiff,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"engine": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"REDIS"}, false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+			"user_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+var resourceAwsElasticacheUserGroupPendingStates = []string{
+	"creating",
+	"modifying",
+}
+
+func resourceAwsElasticacheUserGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &elasticache.CreateUserGroupInput{
+		Engine:      aws.String(d.Get("engine").(string)),
+		UserGroupId: aws.String(d.Get("user_group_id").(string)),
+	}
+
+	if v, ok := d.GetOk("user_ids"); ok {
+		input.UserIds = expandStringSet(v.(*schema.Set))
+	}
+
+	// Tags are currently only supported in AWS Commercial.
+	if len(tags) > 0 && meta.(*AWSClient).partition == endpoints.AwsPartitionID {
+		input.Tags = tags.IgnoreAws().ElasticacheTags()
+	}
+
+	out, err := conn.CreateUserGroup(input)
+	if err != nil {
+		return fmt.Errorf("error creating ElastiCache User Group: %w", err)
+	}
+
+	d.SetId(aws.StringValue(out.UserGroupId))
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    resourceAwsElasticacheUserGroupPendingStates,
+		Target:     []string{"active"},
+		Refresh:    resourceAwsElasticacheUserGroupStateRefreshFunc(d.Get("user_group_id").(string), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second, // Wait 30 secs before starting
+	}
+
+	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error creating ElastiCache User Group: %w", err)
+	}
+
+	return resourceAwsElasticacheUserGroupRead(d, meta)
+
+}
+
+func resourceAwsElasticacheUserGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	resp, err := finder.ElastiCacheUserGroupById(conn, d.Id())
+	if !d.IsNewResource() && (tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault)) {
+		d.SetId("")
+		log.Printf("[DEBUG] ElastiCache User Group (%s) not found", d.Id())
+		return nil
+	}
+
+	if err != nil && !tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
+		return fmt.Errorf("error describing ElastiCache User Group (%s): %w", d.Id(), err)
+	}
+
+	d.Set("arn", aws.StringValue(resp.ARN))
+	d.Set("engine", aws.StringValue(resp.Engine))
+	d.Set("user_ids", resp.UserIds)
+	d.Set("user_group_id", resp.UserGroupId)
+
+	// Tags are currently only supported in AWS Commercial.
+	if meta.(*AWSClient).partition == endpoints.AwsPartitionID {
+		tags, err := keyvaluetags.ElasticacheListTags(conn, aws.StringValue(resp.ARN))
+
+		if err != nil {
+			return fmt.Errorf("error listing tags for ElastiCache User (%s): %w", aws.StringValue(resp.ARN), err)
+		}
+
+		tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+		//lintignore:AWSR002
+		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+			return fmt.Errorf("error setting tags: %w", err)
+		}
+
+		if err := d.Set("tags_all", tags.Map()); err != nil {
+			return fmt.Errorf("error setting tags_all: %w", err)
+		}
+	} else {
+		d.Set("tags", nil)
+		d.Set("tags_all", nil)
+	}
+
+	return nil
+}
+
+func resourceAwsElasticacheUserGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+	hasChange := false
+
+	if d.HasChangeExcept("tags_all") {
+		req := &elasticache.ModifyUserGroupInput{
+			UserGroupId: aws.String(d.Get("user_group_id").(string)),
+		}
+
+		if d.HasChange("user_ids") {
+			o, n := d.GetChange("user_ids")
+			usersRemove := o.(*schema.Set).Difference(n.(*schema.Set))
+			usersAdd := n.(*schema.Set).Difference(o.(*schema.Set))
+
+			if usersAdd.Len() > 0 {
+				req.UserIdsToAdd = expandStringSet(usersAdd)
+				hasChange = true
+			}
+			if usersRemove.Len() > 0 {
+				req.UserIdsToRemove = expandStringSet(usersRemove)
+				hasChange = true
+			}
+		}
+
+		if hasChange {
+			_, err := conn.ModifyUserGroup(req)
+			if err != nil {
+				return fmt.Errorf("error updating ElastiCache User Group (%q): %w", d.Id(), err)
+			}
+			stateConf := &resource.StateChangeConf{
+				Pending:    resourceAwsElasticacheUserGroupPendingStates,
+				Target:     []string{"active"},
+				Refresh:    resourceAwsElasticacheUserGroupStateRefreshFunc(d.Get("user_group_id").(string), conn),
+				Timeout:    d.Timeout(schema.TimeoutCreate),
+				MinTimeout: 10 * time.Second,
+				Delay:      30 * time.Second, // Wait 30 secs before starting
+			}
+
+			log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
+			_, err = stateConf.WaitForState()
+			if err != nil {
+				return fmt.Errorf("error updating ElastiCache User Group (%q): %w", d.Id(), err)
+			}
+		}
+	}
+
+	// Tags are currently only supported in AWS Commercial.
+	if d.HasChange("tags_all") && meta.(*AWSClient).partition == endpoints.AwsPartitionID {
+		o, n := d.GetChange("tags_all")
+
+		if err := keyvaluetags.ElasticacheUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating ElastiCache User Group (%s) tags: %w", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceAwsElasticacheUserGroupRead(d, meta)
+}
+
+func resourceAwsElasticacheUserGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticacheconn
+
+	input := &elasticache.DeleteUserGroupInput{
+		UserGroupId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteUserGroup(input)
+	if err != nil && !tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
+		return fmt.Errorf("error deleting ElastiCache User Group: %w", err)
+	}
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting"},
+		Target:     []string{},
+		Refresh:    resourceAwsElasticacheUserGroupStateRefreshFunc(d.Get("user_group_id").(string), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second, // Wait 30 secs before starting
+	}
+
+	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeInvalidUserGroupStateFault) {
+			return nil
+		}
+		return fmt.Errorf("ElastiCache User Group cannot be deleted: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsElasticacheUserGroupStateRefreshFunc(id string, conn *elasticache.ElastiCache) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		v, err := finder.ElastiCacheUserGroupById(conn, id)
+
+		if err != nil {
+			log.Printf("Error on retrieving ElastiCache User Group when waiting: %s", err)
+			return nil, "", err
+		}
+
+		if v == nil {
+			return nil, "", nil
+		}
+
+		if v.Status != nil {
+			log.Printf("[DEBUG] ElastiCache User Group status for instance %s: %s", id, *v.Status)
+		}
+
+		return v, *v.Status, nil
+	}
+}

--- a/aws/resource_aws_elasticache_user_group_test.go
+++ b/aws/resource_aws_elasticache_user_group_test.go
@@ -205,16 +205,16 @@ func testAccAWSElasticacheUserGroupConfigBasic(rName string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
-	user_name     = "default"
-	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-	engine        = "REDIS"
-	passwords     = [ "password123456789" ]
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
 }
 
 resource "aws_elasticache_user_group" "test" {
   user_group_id = %[1]q
-	engine        = "REDIS"
-	user_ids      = [ aws_elasticache_user.test.user_id ]
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id]
 }
 `, rName))
 }
@@ -223,24 +223,24 @@ func testAccAWSElasticacheUserGroupConfigMultiple(rName string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
-	user_name     = "default"
-	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-	engine        = "REDIS"
-	passwords     = [ "password123456789" ]
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
 }
 
 resource "aws_elasticache_user" "test2" {
   user_id       = "%[1]s-2"
-	user_name     = "username1"
-	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-	engine        = "REDIS"
-	passwords     = [ "password123456789" ]
+  user_name     = "username1"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
 }
 
 resource "aws_elasticache_user_group" "test" {
   user_group_id = %[1]q
-	engine        = "REDIS"
-	user_ids      = [ aws_elasticache_user.test.user_id, aws_elasticache_user.test2.user_id ]
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id, aws_elasticache_user.test2.user_id]
 }
 `, rName))
 }
@@ -249,20 +249,20 @@ func testAccAWSElasticacheUserGroupConfigTags(rName, tagKey, tagValue string) st
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
-	user_name     = "default"
-	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-	engine        = "REDIS"
-	passwords     = [ "password123456789" ]
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
 }
 
 resource "aws_elasticache_user_group" "test" {
   user_group_id = %[1]q
-	engine        = "REDIS"
-	user_ids      = [ aws_elasticache_user.test.user_id ]
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id]
 
-	tags = {
-		%[2]s = %[3]q
-	}
+  tags = {
+    %[2]s = %[3]q
+  }
 }
 `, rName, tagKey, tagValue))
 }

--- a/aws/resource_aws_elasticache_user_group_test.go
+++ b/aws/resource_aws_elasticache_user_group_test.go
@@ -1,0 +1,268 @@
+package aws
+
+import (
+	//"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+)
+
+func TestAccAWSElasticacheUserGroup_basic(t *testing.T) {
+	var userGroup elasticache.UserGroup
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheUserGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserGroupConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheUserGroup_update(t *testing.T) {
+	var userGroup elasticache.UserGroup
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheUserGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserGroupConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheUserGroupConfigMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheUserGroupConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheUserGroup_tags(t *testing.T) {
+	var userGroup elasticache.UserGroup
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheUserGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserGroupConfigTags(rName, "tagKey", "tagVal"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tagKey", "tagVal"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheUserGroupConfigTags(rName, "tagKey", "tagVal2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tagKey", "tagVal2"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheUserGroupConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheUserGroup_disappears(t *testing.T) {
+	var userGroup elasticache.UserGroup
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserGroupConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserGroupExists(resourceName, &userGroup),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsElasticacheUserGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSElasticacheUserGroupDestroy(s *terraform.State) error {
+	return testAccCheckAWSElasticacheUserGroupDestroyWithProvider(s, testAccProvider)
+}
+
+func testAccCheckAWSElasticacheUserGroupDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*AWSClient).elasticacheconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticache_user_group" {
+			continue
+		}
+
+		_, err := finder.ElastiCacheUserGroupById(conn, rs.Primary.ID)
+		if err != nil {
+			if isAWSErr(err, elasticache.ErrCodeUserGroupNotFoundFault, "") {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSElasticacheUserGroupExists(n string, v *elasticache.UserGroup) resource.TestCheckFunc {
+	return testAccCheckAWSElasticacheUserGroupExistsWithProvider(n, v, func() *schema.Provider { return testAccProvider })
+}
+
+func testAccCheckAWSElasticacheUserGroupExistsWithProvider(n string, v *elasticache.UserGroup, providerF func() *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ElastiCache User Group ID is set")
+		}
+
+		provider := providerF()
+		conn := provider.Meta().(*AWSClient).elasticacheconn
+		resp, err := finder.ElastiCacheUserGroupById(conn, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("ElastiCache User Group (%s) not found: %w", rs.Primary.ID, err)
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSElasticacheUserGroupConfigBasic(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[1]q
+	user_name     = "default"
+	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+	engine        = "REDIS"
+	passwords     = [ "password123456789" ]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[1]q
+	engine        = "REDIS"
+	user_ids      = [ aws_elasticache_user.test.user_id ]
+}
+`, rName))
+}
+
+func testAccAWSElasticacheUserGroupConfigMultiple(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[1]q
+	user_name     = "default"
+	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+	engine        = "REDIS"
+	passwords     = [ "password123456789" ]
+}
+
+resource "aws_elasticache_user" "test2" {
+  user_id       = "%[1]s-2"
+	user_name     = "username1"
+	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+	engine        = "REDIS"
+	passwords     = [ "password123456789" ]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[1]q
+	engine        = "REDIS"
+	user_ids      = [ aws_elasticache_user.test.user_id, aws_elasticache_user.test2.user_id ]
+}
+`, rName))
+}
+
+func testAccAWSElasticacheUserGroupConfigTags(rName, tagKey, tagValue string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[1]q
+	user_name     = "default"
+	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+	engine        = "REDIS"
+	passwords     = [ "password123456789" ]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[1]q
+	engine        = "REDIS"
+	user_ids      = [ aws_elasticache_user.test.user_id ]
+
+	tags = {
+		%[2]s = %[3]q
+	}
+}
+`, rName, tagKey, tagValue))
+}

--- a/aws/resource_aws_elasticache_user_test.go
+++ b/aws/resource_aws_elasticache_user_test.go
@@ -1,0 +1,203 @@
+package aws
+
+import (
+	//"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/elasticache/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func TestAccAWSElasticacheUser_basic(t *testing.T) {
+	var user elasticache.User
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserExists(resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "no_password_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "username1"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"no_password_required",
+					"passwords",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheUser_tags(t *testing.T) {
+	var user elasticache.User
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserConfigTags(rName, "tagKey", "tagVal"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserExists(resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "no_password_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "username1"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tagKey", "tagVal"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheUserConfigTags(rName, "tagKey", "tagVal2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserExists(resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "no_password_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "username1"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tagKey", "tagVal2"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheUserConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserExists(resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "no_password_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "username1"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheUser_disappears(t *testing.T) {
+	var user elasticache.User
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheUserConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheUserExists(resourceName, &user),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsElasticacheUser(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSElasticacheUserDestroy(s *terraform.State) error {
+	return testAccCheckAWSElasticacheUserDestroyWithProvider(s, testAccProvider)
+}
+
+func testAccCheckAWSElasticacheUserDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*AWSClient).elasticacheconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elasticache_user" {
+			continue
+		}
+
+		_, err := finder.ElastiCacheUserById(conn, rs.Primary.ID)
+		if err != nil {
+			if tfresource.NotFound(err) {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSElasticacheUserExists(n string, v *elasticache.User) resource.TestCheckFunc {
+	return testAccCheckAWSElasticacheUserExistsWithProvider(n, v, func() *schema.Provider { return testAccProvider })
+}
+
+func testAccCheckAWSElasticacheUserExistsWithProvider(n string, v *elasticache.User, providerF func() *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ElastiCache User ID is set")
+		}
+
+		provider := providerF()
+		conn := provider.Meta().(*AWSClient).elasticacheconn
+		resp, err := finder.ElastiCacheUserById(conn, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("ElastiCache User (%s) not found: %w", rs.Primary.ID, err)
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSElasticacheUserConfigBasic(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[1]q
+	user_name     = "username1"
+	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+	engine        = "REDIS"
+	passwords     = [ "password123456789" ]
+}
+`, rName))
+}
+
+func testAccAWSElasticacheUserConfigTags(rName, tagKey, tagValue string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[1]q
+	user_name     = "username1"
+	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+	engine        = "REDIS"
+	passwords     = [ "password123456789" ]
+
+	tags = {
+		%[2]s = %[3]q
+	}
+}
+`, rName, tagKey, tagValue))
+}

--- a/aws/resource_aws_elasticache_user_test.go
+++ b/aws/resource_aws_elasticache_user_test.go
@@ -178,10 +178,10 @@ func testAccAWSElasticacheUserConfigBasic(rName string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
-	user_name     = "username1"
-	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-	engine        = "REDIS"
-	passwords     = [ "password123456789" ]
+  user_name     = "username1"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
 }
 `, rName))
 }
@@ -190,14 +190,14 @@ func testAccAWSElasticacheUserConfigTags(rName, tagKey, tagValue string) string 
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
-	user_name     = "username1"
-	access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-	engine        = "REDIS"
-	passwords     = [ "password123456789" ]
+  user_name     = "username1"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
 
-	tags = {
-		%[2]s = %[3]q
-	}
+  tags = {
+    %[2]s = %[3]q
+  }
 }
 `, rName, tagKey, tagValue))
 }

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_user"
+description: |-
+  Provides an ElastiCache user.
+---
+
+# Resource: aws_elasticache_user
+
+Provides an ElastiCache user resource.
+
+## Example Usage
+
+```terraform
+resource "aws_elasticache_user" "test" {
+  user_id       = "testUserId"
+  user_name     = "testUserName"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `access_string` - (Required) Access permissions string used for this user.
+* `engine` - (Required) The current supported value is `REDIS`.
+* `user_id` - (Required) The ID of the user.
+* `user_name` - (Required) The username of the user.
+
+The following arguments are optional:
+
+* `no_password_required` - (Optional) Indicates a password is not required for this user.
+* `passwords` - (Optional) Passwords used for this user. You can create up to two passwords for each user.
+* `tags` - (Optional) A list of tags to be added to this resource. A tag is a key-value pair.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the created ElastiCache User.
+
+## Import
+
+ElastiCache users can be imported using the `user_id`, e.g.
+
+```
+$ terraform import aws_elasticache_user.my_user userId1
+```

--- a/website/docs/r/elasticache_user_group.html.markdown
+++ b/website/docs/r/elasticache_user_group.html.markdown
@@ -22,9 +22,9 @@ resource "aws_elasticache_user" "test" {
 }
 
 resource "aws_elasticache_user_group" "test" {
-  engine = "REDIS"
+  engine        = "REDIS"
   user_group_id = "userGroupId"
-  user_ids = [aws_elasticache_user.test.user_id]
+  user_ids      = [aws_elasticache_user.test.user_id]
 }
 ```
 
@@ -38,6 +38,12 @@ The following arguments are required:
 The following arguments are optional:
 
 * `user_ids` - (Optional) The list of user IDs that belong to the user group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The IP group identifier.
 
 ## Import
 

--- a/website/docs/r/elasticache_user_group.html.markdown
+++ b/website/docs/r/elasticache_user_group.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_user_group"
+description: |-
+  Provides an ElastiCache user group.
+---
+
+# Resource: aws_elasticache_user_group
+
+Provides an ElastiCache user group resource.
+
+## Example Usage
+
+```terraform
+resource "aws_elasticache_user" "test" {
+  user_id       = "testUserId"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  engine = "REDIS"
+  user_group_id = "userGroupId"
+  user_ids = [aws_elasticache_user.test.user_id]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `engine` - (Required) The current supported value is `REDIS`.
+* `user_group_id` - (Required) The ID of the user group.
+
+The following arguments are optional:
+
+* `user_ids` - (Optional) The list of user IDs that belong to the user group.
+
+## Import
+
+ElastiCache user groups can be imported using the `user_group_id`, e.g.
+
+```
+$ terraform import aws_elasticache_user_group.my_user_group userGoupId1
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #16327

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheUser -timeout 180m
=== RUN   TestAccAWSElasticacheUserGroup_basic
=== PAUSE TestAccAWSElasticacheUserGroup_basic
=== RUN   TestAccAWSElasticacheUserGroup_update
=== PAUSE TestAccAWSElasticacheUserGroup_update
=== RUN   TestAccAWSElasticacheUserGroup_tags
=== PAUSE TestAccAWSElasticacheUserGroup_tags
=== RUN   TestAccAWSElasticacheUserGroup_disappears
=== PAUSE TestAccAWSElasticacheUserGroup_disappears
=== RUN   TestAccAWSElasticacheUser_basic
=== PAUSE TestAccAWSElasticacheUser_basic
=== RUN   TestAccAWSElasticacheUser_tags
=== PAUSE TestAccAWSElasticacheUser_tags
=== RUN   TestAccAWSElasticacheUser_disappears
=== PAUSE TestAccAWSElasticacheUser_disappears
=== CONT  TestAccAWSElasticacheUserGroup_basic
=== CONT  TestAccAWSElasticacheUser_basic
=== CONT  TestAccAWSElasticacheUser_disappears
=== CONT  TestAccAWSElasticacheUserGroup_tags
=== CONT  TestAccAWSElasticacheUserGroup_disappears
=== CONT  TestAccAWSElasticacheUser_tags
=== CONT  TestAccAWSElasticacheUserGroup_update
--- PASS: TestAccAWSElasticacheUser_disappears (15.28s)
--- PASS: TestAccAWSElasticacheUser_basic (17.44s)
--- PASS: TestAccAWSElasticacheUser_tags (39.51s)
--- PASS: TestAccAWSElasticacheUserGroup_tags (483.47s)
--- PASS: TestAccAWSElasticacheUserGroup_basic (489.94s)
--- PASS: TestAccAWSElasticacheUserGroup_disappears (497.05s)
--- PASS: TestAccAWSElasticacheUserGroup_update (1088.31s)
PASS
```
