### PR TITLE
Leave parameters in existing case

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -698,14 +698,14 @@ func flattenParameters(list []*rds.Parameter) []map[string]interface{} {
 	for _, i := range list {
 		if i.ParameterName != nil {
 			r := make(map[string]interface{})
-			r["name"] = strings.ToLower(*i.ParameterName)
+			r["name"] = *i.ParameterName
 			// Default empty string, guard against nil parameter values
 			r["value"] = ""
 			if i.ParameterValue != nil {
-				r["value"] = strings.ToLower(*i.ParameterValue)
+				r["value"] = *i.ParameterValue
 			}
 			if i.ApplyMethod != nil {
-				r["apply_method"] = strings.ToLower(*i.ApplyMethod)
+				r["apply_method"] = *i.ApplyMethod
 			}
 
 			result = append(result, r)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -698,15 +698,9 @@ func flattenParameters(list []*rds.Parameter) []map[string]interface{} {
 	for _, i := range list {
 		if i.ParameterName != nil {
 			r := make(map[string]interface{})
-			r["name"] = *i.ParameterName
-			// Default empty string, guard against nil parameter values
-			r["value"] = ""
-			if i.ParameterValue != nil {
-				r["value"] = *i.ParameterValue
-			}
-			if i.ApplyMethod != nil {
-				r["apply_method"] = *i.ApplyMethod
-			}
+			r["name"] = aws.StringValue(i.ParameterName)
+			r["value"] = aws.StringValue(i.ParameterValue)
+			r["apply_method"] = aws.StringValue(i.ApplyMethod)
 
 			result = append(result, r)
 		}

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -658,8 +658,9 @@ func TestFlattenParameters(t *testing.T) {
 			},
 			Output: []map[string]interface{}{
 				{
-					"name":  "character_set_client",
-					"value": "utf8",
+					"name":         "character_set_client",
+					"value":        "utf8",
+					"apply_method": "",
 				},
 			},
 		},


### PR DESCRIPTION
Don't change the case of parameters. Changing the case can result in unwanted diffs and inability to update values.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates https://github.com/hashicorp/terraform-provider-aws/issues/15583

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBClusterParameterGroup_ -timeout 180m
=== RUN   TestAccAWSDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDBClusterParameterGroup_basic
=== RUN   TestAccAWSDBClusterParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBClusterParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDBClusterParameterGroup_only
=== PAUSE TestAccAWSDBClusterParameterGroup_only
=== RUN   TestAccAWSDBClusterParameterGroup_updateParameters
=== PAUSE TestAccAWSDBClusterParameterGroup_updateParameters
=== CONT  TestAccAWSDBClusterParameterGroup_basic
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_updateParameters
=== CONT  TestAccAWSDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDBClusterParameterGroup_withApplyMethod
=== CONT  TestAccAWSDBClusterParameterGroup_only
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (16.65s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (20.58s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (20.97s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (22.62s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (22.66s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (22.98s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (23.18s)
--- PASS: TestAccAWSDBClusterParameterGroup_updateParameters (35.61s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (66.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	66.839s
```
