### PR TITLE
Update rds_global_cluster.html.markdown - fix non-working MySQL Global Cluster example

### DIFF
--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -38,6 +38,8 @@ resource "aws_rds_cluster" "primary" {
 
 resource "aws_rds_cluster_instance" "primary" {
   provider             = aws.primary
+  engine               = aws_rds_global_cluster.example.engine
+  engine_version       = aws_rds_global_cluster.example.engine_version
   identifier           = "test-primary-cluster-instance"
   cluster_identifier   = aws_rds_cluster.primary.id
   instance_class       = "db.r4.large"
@@ -55,6 +57,8 @@ resource "aws_rds_cluster" "secondary" {
 
 resource "aws_rds_cluster_instance" "secondary" {
   provider             = aws.secondary
+  engine               = aws_rds_global_cluster.example.engine
+  engine_version       = aws_rds_global_cluster.example.engine_version
   identifier           = "test-secondary-cluster-instance"
   cluster_identifier   = aws_rds_cluster.secondary.id
   instance_class       = "db.r4.large"


### PR DESCRIPTION
Updated the MySQL Global Cluster example to work around an issue where the engine parameters for the individual cluster instances are not inherited from the cluster and must be explicitly defined again. Without this fix the published example would not build with AWS Provider 3.49 and engine _5.7.mysql_aurora.2.10.0_, resulting in:

`Error: error creating RDS Cluster (my-cluster-pri) Instance: InvalidParameterCombination: Cannot find version 5.7.mysql_aurora.2.10.0 for aurora`

The cluster in the other region will then also fail with:
`Error: error creating RDS cluster: InvalidParameterValue: The parameter MasterUsername must be provided and must not be blank.`

These two separate errors from the separate clusters then confound troubleshooting because it's not clear which is cause and which is effect. The second error is in fact spurious and only occurs because the primary cluster failed to build. Adding the explicit engine parameters to the cluster instances results in a successful build.

This issue was reported in 2019 via #10585, and a solved by @alexwlchan
https://github.com/hashicorp/terraform-provider-aws/issues/10585#issuecomment-558804101




<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
