### PR TITLE
Implements `d.IsNewResource()` Check in Read functions for OpsWorks Layers and API Gateway (v1) resources

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -305,29 +305,29 @@ rules:
 
   - id: helper-schema-ResourceData-SetId-empty-without-IsNewResource-check
     languages: [go]
-    message: Calling `d.SetId("")` should ensure `!d.IsNewResource()` is checked first
+    message: Calling `d.SetId("")` should ensure `!d.IsNewResource()` is also checked
     paths:
-      exclude:
-        - aws/resource_aws_api_gateway_*.go
-        - aws/resource_aws_apigatewayv2_*.go
-        - aws/resource_aws_app_cookie_stickiness_policy.go
-        - aws/resource_aws_appautoscaling_*.go
-        - aws/resource_aws_appsync_*.go
-        - aws/resource_aws_athena_*.go
-        - aws/resource_aws_autoscaling_*.go
-        - aws/resource_aws_autoscalingplans_scaling_plan.go
-        - aws/resource_aws_[b-ce-g]*.go
-        - aws/resource_aws_d[a-df-z]*.go
-        - aws/resource_aws_devicefarm*.go
-        - aws/resource_aws_i*.go
-        - aws/resource_aws_[k-r]*.go
-        - aws/resource_aws_s[a-df-z3]*.go
-        - aws/resource_aws_se[d-z]*.go
-        - aws/resource_aws_sec[a-t]*.go
-        - aws/resource_aws_securityhub*.go
-        - aws/resource_aws_[t-x]*.go
       include:
-        - aws/resource*.go
+        - internal/service
+      exclude:
+        - "*_data_source.go"
+        - internal/service/apigateway
+        - internal/service/apigatewayv2
+        - internal/service/appautoscaling
+        - internal/service/appsync
+        - internal/service/athena
+        - internal/service/autoscaling
+        - internal/service/autoscalingplans/scaling_plan.go
+        - internal/service/[b-ce-g]*
+        - internal/service/d[a-df-z]*
+        - internal/service/devicefarm
+        - internal/service/i*
+        - internal/service/[k-r]*
+        - internal/service/s[a-df-z3]*
+        - internal/service/se[d-z]*
+        - internal/service/sec[a-t]*
+        - internal/service/securityhub
+        - internal/service/[t-x]*
     patterns:
       - pattern-either:
         - pattern: |

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -310,8 +310,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - "*_data_source.go"
-        - internal/service/apigateway
+        - internal/service/**/*_data_source.go
         - internal/service/apigatewayv2
         - internal/service/appautoscaling
         - internal/service/appsync

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -47,7 +47,7 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 	details, err := conn.DescribeWorkspaceWithContext(ctx, &prometheusservice.DescribeWorkspaceInput{
 		WorkspaceId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, prometheusservice.ErrCodeResourceNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] Prometheus Workspace (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigateway/api_key.go
+++ b/internal/service/apigateway/api_key.go
@@ -109,13 +109,13 @@ func resourceAPIKeyRead(d *schema.ResourceData, meta interface{}) error {
 		IncludeValue: aws.Bool(true),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway API Key (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 
-		return err
+		return fmt.Errorf("error reading API Gateway API Key (%s): %w", d.Id(), err)
 	}
 
 	tags := KeyValueTags(apiKey.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/apigateway/authorizer.go
+++ b/internal/service/apigateway/authorizer.go
@@ -172,12 +172,12 @@ func resourceAuthorizerRead(d *schema.ResourceData, meta interface{}) error {
 
 	authorizer, err := conn.GetAuthorizer(&input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] No API Gateway Authorizer found: %s", input)
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
+			log.Printf("[WARN] API Gateway Authorizer (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Authorizer (%s): %w", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Authorizer: %s", authorizer)
 

--- a/internal/service/apigateway/base_path_mapping.go
+++ b/internal/service/apigateway/base_path_mapping.go
@@ -161,13 +161,13 @@ func resourceBasePathMappingRead(d *schema.ResourceData, meta interface{}) error
 		BasePath:   aws.String(basePath),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Base Path Mapping (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Gateway base path mapping: %s", err)
+		return fmt.Errorf("error reading API Gateway Base Path Mapping (%s): %w", d.Id(), err)
 	}
 
 	mappingBasePath := aws.StringValue(mapping.BasePath)

--- a/internal/service/apigateway/client_certificate.go
+++ b/internal/service/apigateway/client_certificate.go
@@ -86,14 +86,13 @@ func resourceClientCertificateRead(d *schema.ResourceData, meta interface{}) err
 	}
 	out, err := conn.GetClientCertificate(&input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] API Gateway Client Certificate %s not found, removing", d.Id())
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
+			log.Printf("[WARN] API Gateway Client Certificate (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Client Certificate (%s): %w", d.Id(), err)
 	}
-	log.Printf("[DEBUG] Received API Gateway Client Certificate: %s", out)
 
 	tags := KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -114,12 +114,12 @@ func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
 		DeploymentId: aws.String(d.Id()),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Deployment (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Deployment (%s): %w", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Deployment: %s", out)
 	d.Set("description", out.Description)

--- a/internal/service/apigateway/documentation_part.go
+++ b/internal/service/apigateway/documentation_part.go
@@ -104,15 +104,13 @@ func resourceDocumentationPartRead(d *schema.ResourceData, meta interface{}) err
 		RestApiId:           aws.String(apiId),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Documentation Part (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Documentation Part (%s): %w", d.Id(), err)
 	}
-
-	log.Printf("[DEBUG] Received API Gateway Documentation Part: %s", docPart)
 
 	d.Set("rest_api_id", apiId)
 	d.Set("location", flattenApiGatewayDocumentationPartLocation(docPart.Location))

--- a/internal/service/apigateway/documentation_version.go
+++ b/internal/service/apigateway/documentation_version.go
@@ -86,7 +86,7 @@ func resourceDocumentationVersionRead(d *schema.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Documentation Version (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Documentation Version (%s): %w", d.Id(), err)
 	}
 
 	d.Set("rest_api_id", apiId)

--- a/internal/service/apigateway/documentation_version.go
+++ b/internal/service/apigateway/documentation_version.go
@@ -81,12 +81,12 @@ func resourceDocumentationVersionRead(d *schema.ResourceData, meta interface{}) 
 		RestApiId:            aws.String(apiId),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Documentation Version (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Documentation Version (%s): %s", d.Id(), err)
 	}
 
 	d.Set("rest_api_id", apiId)

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -246,13 +246,12 @@ func resourceDomainNameRead(d *schema.ResourceData, meta interface{}) error {
 		DomainName: aws.String(d.Id()),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Domain Name (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-
-		return err
+		return fmt.Errorf("error reading API Gateway Domain Name (%s): %s", d.Id(), err)
 	}
 
 	tags := KeyValueTags(domainName.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -251,7 +251,7 @@ func resourceDomainNameRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Domain Name (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Domain Name (%s): %w", d.Id(), err)
 	}
 
 	tags := KeyValueTags(domainName.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/apigateway/gateway_response.go
+++ b/internal/service/apigateway/gateway_response.go
@@ -116,12 +116,12 @@ func resourceGatewayResponseRead(d *schema.ResourceData, meta interface{}) error
 		ResponseType: aws.String(d.Get("response_type").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Gateway Response (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Response (%s): %s", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Gateway Response: %s", gatewayResponse)

--- a/internal/service/apigateway/gateway_response.go
+++ b/internal/service/apigateway/gateway_response.go
@@ -121,7 +121,7 @@ func resourceGatewayResponseRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Response (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Response (%s): %w", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Gateway Response: %s", gatewayResponse)

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -259,12 +259,12 @@ func resourceIntegrationRead(d *schema.ResourceData, meta interface{}) error {
 		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Integration (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Integration (%s): %s", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Integration: %s", integration)
 

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -264,7 +264,7 @@ func resourceIntegrationRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Integration (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Integration (%s): %w", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Integration: %s", integration)
 

--- a/internal/service/apigateway/integration_response.go
+++ b/internal/service/apigateway/integration_response.go
@@ -143,12 +143,12 @@ func resourceIntegrationResponseRead(d *schema.ResourceData, meta interface{}) e
 		StatusCode: aws.String(d.Get("status_code").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Integration Response (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Integration Response (%s): %s", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Integration Response: %s", integrationResponse)

--- a/internal/service/apigateway/integration_response.go
+++ b/internal/service/apigateway/integration_response.go
@@ -148,7 +148,7 @@ func resourceIntegrationResponseRead(d *schema.ResourceData, meta interface{}) e
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Integration Response (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Integration Response (%s): %w", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Integration Response: %s", integrationResponse)

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -173,12 +173,12 @@ func resourceMethodRead(d *schema.ResourceData, meta interface{}) error {
 		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Method (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Method (%s): %s", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Method: %s", out)
 

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -178,7 +178,7 @@ func resourceMethodRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Method (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Method (%s): %w", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Method: %s", out)
 

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -136,12 +136,12 @@ func resourceMethodResponseRead(d *schema.ResourceData, meta interface{}) error 
 		StatusCode: aws.String(d.Get("status_code").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] API Gateway Response (%s) not found, removing from state", d.Id())
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
+			log.Printf("[WARN] API Gateway Method Response (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Method Response (%s): %s", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Method Response: %s", methodResponse)

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -141,7 +141,7 @@ func resourceMethodResponseRead(d *schema.ResourceData, meta interface{}) error 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Method Response (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Method Response (%s): %w", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Method Response: %s", methodResponse)

--- a/internal/service/apigateway/model.go
+++ b/internal/service/apigateway/model.go
@@ -119,12 +119,12 @@ func resourceModelRead(d *schema.ResourceData, meta interface{}) error {
 		RestApiId: aws.String(d.Get("rest_api_id").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Model (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Model (%s): %s", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Model: %s", out)
 

--- a/internal/service/apigateway/model.go
+++ b/internal/service/apigateway/model.go
@@ -124,7 +124,7 @@ func resourceModelRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Model (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Model (%s): %w", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Received API Gateway Model: %s", out)
 

--- a/internal/service/apigateway/request_validator.go
+++ b/internal/service/apigateway/request_validator.go
@@ -94,7 +94,7 @@ func resourceRequestValidatorRead(d *schema.ResourceData, meta interface{}) erro
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Request Validator (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Request Validator (%s): %w", d.Id(), err)
 	}
 
 	d.Set("name", out.Name)

--- a/internal/service/apigateway/request_validator.go
+++ b/internal/service/apigateway/request_validator.go
@@ -89,12 +89,12 @@ func resourceRequestValidatorRead(d *schema.ResourceData, meta interface{}) erro
 
 	out, err := conn.GetRequestValidator(&input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Request Validator (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Request Validator (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", out.Name)

--- a/internal/service/apigateway/resource.go
+++ b/internal/service/apigateway/resource.go
@@ -87,12 +87,12 @@ func resourceResourceRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Resource (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Resource (%s): %s", d.Id(), err)
 	}
 
 	d.Set("parent_id", resource.ParentId)

--- a/internal/service/apigateway/resource.go
+++ b/internal/service/apigateway/resource.go
@@ -92,7 +92,7 @@ func resourceResourceRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading API Gateway Resource (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading API Gateway Resource (%s): %w", d.Id(), err)
 	}
 
 	d.Set("parent_id", resource.ParentId)

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -338,7 +338,7 @@ func resourceRestAPIRead(d *schema.ResourceData, meta interface{}) error {
 	api, err := conn.GetRestApi(&apigateway.GetRestApiInput{
 		RestApiId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 		log.Printf("[WARN] API Gateway (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigateway/rest_api_policy.go
+++ b/internal/service/apigateway/rest_api_policy.go
@@ -80,7 +80,7 @@ func resourceRestAPIPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	api, err := conn.GetRestApi(&apigateway.GetRestApiInput{
 		RestApiId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 		log.Printf("[WARN] API Gateway REST API Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigateway/stage.go
+++ b/internal/service/apigateway/stage.go
@@ -220,7 +220,7 @@ func resourceStageRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	stage, err := conn.GetStage(&input)
 
-	if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 		log.Printf("[WARN] API Gateway Stage (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigateway/usage_plan.go
+++ b/internal/service/apigateway/usage_plan.go
@@ -225,12 +225,12 @@ func resourceUsagePlanRead(d *schema.ResourceData, meta interface{}) error {
 		UsagePlanId: aws.String(d.Id()),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Usage Plan (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Usage Plan (%s): %w", d.Id(), err)
 	}
 
 	tags := KeyValueTags(up.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/apigateway/usage_plan_key.go
+++ b/internal/service/apigateway/usage_plan_key.go
@@ -94,12 +94,12 @@ func resourceUsagePlanKeyRead(d *schema.ResourceData, meta interface{}) error {
 		KeyId:       aws.String(d.Get("key_id").(string)),
 	})
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] API Gateway Usage Plan Key (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading API Gateway Usage Plan Key (%s): %w", d.Id(), err)
 	}
 
 	d.Set("name", up.Name)

--- a/internal/service/apigateway/vpc_link.go
+++ b/internal/service/apigateway/vpc_link.go
@@ -93,7 +93,7 @@ func resourceVPCLinkRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.GetVpcLink(input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apigateway.ErrCodeNotFoundException) {
 			log.Printf("[WARN] VPC Link %s not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -161,12 +161,7 @@ func resourceVPCLinkUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	_, err := conn.UpdateVpcLink(input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, apigateway.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] VPC Link %s not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error updating API Gateway VPC Link (%s): %w", d.Id(), err)
 	}
 
 	if err := waitAPIGatewayVPCLinkAvailable(conn, d.Id()); err != nil {

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -288,11 +288,11 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, meta interface{}) erro
 
 	resp, err := conn.DescribeLayers(req)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, opsworks.ErrCodeResourceNotFoundException, "") {
+		if !d.IsNewResource() && tfawserr.ErrMessageContains(err, opsworks.ErrCodeResourceNotFoundException, "") {
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading OpsWorks layer (%s): %w", d.Id(), err)
 	}
 
 	layer := resp.Layers[0]
@@ -317,7 +317,7 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, meta interface{}) erro
 	} else {
 		policy, err := structure.NormalizeJsonString(*layer.CustomJson)
 		if err != nil {
-			return fmt.Errorf("policy contains an invalid JSON: %s", err)
+			return fmt.Errorf("policy contains an invalid JSON: %w", err)
 		}
 		d.Set("custom_json", policy)
 	}
@@ -355,7 +355,7 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, meta interface{}) erro
 	tags, err := ListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Opsworks Layer (%s): %s", arn, err)
+		return fmt.Errorf("error listing tags for Opsworks Layer (%s): %w", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -439,7 +439,7 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, meta interface{}) er
 
 	if len(tags) > 0 {
 		if err := UpdateTags(conn, arn, nil, tags); err != nil {
-			return fmt.Errorf("error updating Opsworks stack (%s) tags: %s", arn, err)
+			return fmt.Errorf("error updating Opsworks stack (%s) tags: %w", arn, err)
 		}
 	}
 
@@ -519,7 +519,7 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, meta interface{}) er
 
 		arn := d.Get("arn").(string)
 		if err := UpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating Opsworks Layer (%s) tags: %s", arn, err)
+			return fmt.Errorf("error updating Opsworks Layer (%s) tags: %w", arn, err)
 		}
 	}
 

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -227,8 +228,10 @@ func TestAccOpsWorksStack_classicEndpoints(t *testing.T) {
 	rInt := sdkacctest.RandInt()
 	var opsstack opsworks.Stack
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckRegion(t, "us-west-2") }, //lintignore:AWSAT003
+	// This test cannot be parallel with other tests, because it changes the provider region in a non-standard way
+	// https://github.com/hashicorp/terraform-provider-aws/issues/21887
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckRegion(t, endpoints.UsWest2RegionID) },
 		ErrorCheck:   acctest.ErrorCheck(t, opsworks.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckStackDestroy,
@@ -251,7 +254,6 @@ func TestAccOpsWorksStack_classicEndpoints(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccCheckStackRecreated(t *testing.T, before, after *opsworks.Stack) resource.TestCheckFunc {
@@ -470,8 +472,7 @@ func testAccCheckCreateStackAttributes(stackName string) resource.TestCheckFunc 
 	)
 }
 
-func testAccCheckStackExists(
-	n string, vpc bool, opsstack *opsworks.Stack) resource.TestCheckFunc {
+func testAccCheckStackExists(n string, vpc bool, opsstack *opsworks.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {


### PR DESCRIPTION
Implements `d.IsNewResource()` Check in Read functions for OpsWorks Layers and API Gateway (v1) resources

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16796

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayDomainName\|TestAccAWSAPIGatewayIntegration\|TestAccAWSAPIGatewayApiKey\|TestAccAWSAPIGatewayRequestValidator\|TestAccAWSAPIGatewayStage\|TestAccAWSAPIGatewayUsagePlanKey\|TestAccAWSAPIGatewayDocumentationVersion\|TestAccAWSAPIGatewayRestApi\|TestAccAWSAPIGatewayBasePathMapping\|TestAccAWSAPIGatewayIntegrationResponse\|TestAccAWSAPIGatewayMethodResponse\|TestAccAWSAPIGatewayMethodSettings\|TestAccAWSAPIGatewayDeployment\|TestAccAWSAPIGatewayModel\|TestAccAWSAPIGatewayGatewayResponse\|TestAccAWSAPIGatewayMethod\|TestAccAWSAPIGatewayUsagePlan\|TestAccAWSAPIGatewayDocumentationPart\|TestAccAWSAPIGatewayVpcLink\|TestAccAWSAPIGatewayRestApiPolicy\|TestAccAWSAPIGatewayAuthorizer\|TestAccAWSAPIGatewayClientCertificate\|TestAccAWSAPIGatewayResource'

--- PASS: TestDecodeApiGatewayBasePathMappingId (0.00s)
--- PASS: TestAccAWSAPIGatewayApiKey_disappears (43.81s)
--- PASS: TestAccAWSAPIGatewayApiKey_Value (53.24s)
--- PASS: TestAccAWSAPIGatewayApiKey_basic (56.82s)
--- PASS: TestAccAWSAPIGatewayClientCertificate_disappears (51.45s)
--- PASS: TestAccAWSAPIGatewayClientCertificate_basic (97.35s)
--- PASS: TestAccAWSAPIGatewayApiKey_Description (102.59s)
--- PASS: TestAccAWSAPIGatewayApiKey_Enabled (104.70s)
--- PASS: TestAccAWSAPIGatewayDeployment_disappears_RestApi (57.40s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_authTypeValidation (117.02s)
--- PASS: TestAccAWSAPIGatewayClientCertificate_tags (128.68s)
--- PASS: TestAccAWSAPIGatewayApiKey_Tags (132.80s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_basic (146.27s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageDescription (44.60s)
--- PASS: TestAccAWSAPIGatewayDeployment_Description (81.09s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_disappears (182.36s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (205.38s)
--- PASS: TestAccAWSAPIGatewayDeployment_Variables (92.52s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateArn (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateName (0.00s)
--- PASS: TestAccAWSAPIGatewayDomainName_RegionalCertificateArn (18.55s)
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateName (0.00s)
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_disappears (36.26s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_updates (247.17s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_disappears (274.23s)
--- SKIP: TestAccAWSAPIGatewayDomainName_MutualTlsAuthentication (0.00s)
--- PASS: TestAccAWSAPIGatewayDomainName_SecurityPolicy (76.05s)
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_allFields (122.72s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (27.00s)
--- PASS: TestAccAWSAPIGatewayDomainName_Tags (99.84s)
--- PASS: TestAccAWSAPIGatewayDeployment_Triggers (262.92s)
--- PASS: TestAccAWSAPIGatewayDomainName_disappears (123.26s)
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (18.36s)
--- PASS: TestAccAWSAPIGatewayDeployment_basic (365.41s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito (459.60s)
--- PASS: TestAccAWSAPIGatewayIntegration_TlsConfig_InsecureSkipVerification (63.87s)
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (35.53s)
--- PASS: TestAccAWSAPIGatewayMethodResponse_disappears (27.38s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthType (578.32s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (57.80s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (27.27s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (32.60s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (57.65s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (32.51s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (39.22s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (745.66s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (32.55s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (38.67s)
--- PASS: TestAccAWSAPIGatewayIntegration_basic (492.92s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (26.04s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimitDisabledByDefault (28.42s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (30.08s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_disappears (39.25s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito_authorizerCredentials (1012.07s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_method (881.63s)
--- PASS: TestAccAWSAPIGatewayMethod_cognitoauthorizer (34.62s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_basic (957.58s)
--- PASS: TestAccAWSAPIGatewayMethod_disappears (23.80s)
--- PASS: TestAccAWSAPIGatewayGatewayResponse_basic (836.96s)
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (212.84s)
--- PASS: TestAccAWSAPIGatewayModel_disappears (15.34s)
--- FAIL: TestAccAWSAPIGatewayIntegration_integrationType (866.08s)
--- PASS: TestAccAWSAPIGatewayRequestValidator_disappears (23.57s)
--- PASS: TestAccAWSAPIGatewayRequestValidator_basic (68.02s)
--- PASS: TestAccAWSAPIGatewayResource_update (22.82s)
--- PASS: TestAccAWSAPIGatewayResource_disappears (33.85s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimitDisabledByDefault (580.95s)
--- PASS: TestAccAWSAPIGatewayIntegration_disappears (975.57s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (732.58s)
--- PASS: TestAccAWSAPIGatewayRestApiPolicy_disappears_restApi (55.08s)
--- PASS: TestAccAWSAPIGatewayRestApi_tags (32.87s)
--- PASS: TestAccAWSAPIGatewayGatewayResponse_disappears (1242.78s)
--- PASS: TestAccAWSAPIGatewayRestApiPolicy_basic (227.96s)
--- PASS: TestAccAWSAPIGatewayRestApi_basic (128.75s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (22.30s)
--- PASS: TestAccAWSAPIGatewayRestApi_ApiKeySource (34.21s)
--- PASS: TestAccAWSAPIGatewayRestApi_ApiKeySource_OverrideBody (86.55s)
--- PASS: TestAccAWSAPIGatewayResource_basic (430.13s)
--- PASS: TestAccAWSAPIGatewayRestApi_disappears (211.55s)
--- PASS: TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_OverrideBody (54.53s)
--- PASS: TestAccAWSAPIGatewayRestApi_Body (30.53s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_zero_ttl (1808.92s)
--- PASS: TestAccAWSAPIGatewayRestApi_Description_OverrideBody (41.85s)
--- PASS: TestAccAWSAPIGatewayRestApi_Description_SetByBody (19.80s)
--- PASS: TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint (34.20s)
--- PASS: TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_OverrideBody (33.95s)
--- PASS: TestAccAWSAPIGatewayRestApi_DisableExecuteApiEndpoint_SetByBody (27.33s)
--- PASS: TestAccAWSAPIGatewayRestApiPolicy_disappears (624.31s)
--- PASS: TestAccAWSAPIGatewayRestApi_Description (237.31s)
--- PASS: TestAccAWSAPIGatewayMethod_basic (1073.10s)
--- PASS: TestAccAWSAPIGatewayRestApi_BinaryMediaTypes (343.26s)
--- PASS: TestAccAWSAPIGatewayMethod_OperationName (967.77s)
--- PASS: TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_SetByBody (20.56s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_disappears (1828.73s)
--- PASS: TestAccAWSAPIGatewayRestApi_BinaryMediaTypes_SetByBody (441.50s)
--- PASS: TestAccAWSAPIGatewayRestApi_Parameters (30.51s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_SetByBody (173.20s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds_OverrideBody (206.15s)
--- PASS: TestAccAWSAPIGatewayRestApi_Policy_SetByBody (23.59s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VpcEndpointIds (263.97s)
--- PASS: TestAccAWSAPIGatewayStage_disappears_ReferencingDeployment (44.02s)
--- PASS: TestAccAWSAPIGatewayRestApi_MinimumCompressionSize (241.15s)
--- PASS: TestAccAWSAPIGatewayModel_basic (1226.44s)
--- PASS: TestAccAWSAPIGatewayRestApi_Policy (186.31s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (815.52s)
--- PASS: TestAccAWSAPIGatewayRestApi_ApiKeySource_SetByBody (782.94s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (33.91s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL (2497.23s)
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_KeyId_Concurrency (133.32s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings (224.01s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (58.47s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings_kinesis (334.71s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (51.44s)
--- PASS: TestAccAWSAPIGatewayRestApi_Policy_OverrideBody (479.14s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages_multiple (25.02s)
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_basic (2552.51s)
--- PASS: TestAccAWSAPIGatewayRestApi_Name_OverrideBody (659.39s)
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_basic (462.14s)
--- PASS: TestAccAWSAPIGatewayStage_basic (605.03s)
--- PASS: TestAccAWSAPIGatewayRestApi_MinimumCompressionSize_OverrideBody (808.65s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (371.38s)
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (2558.87s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (447.07s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_responseHeader (2846.23s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (345.81s)
--- PASS: TestAccAWSAPIGatewayStage_disappears (813.48s)
--- PASS: TestAccAWSAPIGatewayMethod_customrequestvalidator (2038.27s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_disappears (2958.94s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName_EmptyString (3034.89s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_disappears (497.65s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName (3131.95s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (776.63s)
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_disappears (1001.26s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (2848.82s)
--- FAIL: TestAccAWSAPIGatewayVpcLink_basic (815.56s)
--- FAIL: TestAccAWSAPIGatewayVpcLink_tags (815.13s)
--- FAIL: TestAccAWSAPIGatewayVpcLink_disappears (855.12s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_tags (1292.06s)
```

The failed tests are addressed by #20316