### PR TITLE
Ignore error caused by IAM propagation during lambda event source mapping creation

### DIFF
--- a/.changelog/20229.txt
+++ b/.changelog/20229.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+aws/resource_aws_lambda_event_source_mapping: Ignore `InvalidParameterValueException` error caused by IAM propagation when creating lambda event source mapping with kinesis streamstream
+```

--- a/.changelog/20229.txt
+++ b/.changelog/20229.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-aws/resource_aws_lambda_event_source_mapping: Ignore `InvalidParameterValueException` error caused by IAM propagation when creating lambda event source mapping with kinesis streamstream
+aws/resource_aws_lambda_event_source_mapping: Ignore `InvalidParameterValueException` error caused by IAM propagation when creating Lambda event source mapping with Kinesis stream source
 ```

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -388,7 +388,7 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 			return resource.RetryableError(err)
 		}
 
-		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "Please ensure the role can perform") {
+		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "ensure the role can perform") {
 			return resource.RetryableError(err)
 		}
 

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -388,6 +388,10 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 			return resource.RetryableError(err)
 		}
 
+		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "Please ensure the role can perform") {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

As part of change in this pull request https://github.com/hashicorp/terraform-provider-aws/issues/14042, the lambda event source mapping creation behaviour has changed from ignoring all `InvalidParameterValueException` to ignoring a subset of `InvalidParameterValueException` error caused by IAM propagation. 

The new whitelist does not cover all edge cases. This causes the following error when creating a lambda event source on a new lambda function and execution role.

```
╷
│ Error: error creating Lambda Event Source Mapping (KINESIS STREAM ARN): InvalidParameterValueException: Cannot access stream KINESIS STREAM ARN. Please ensure the role can perform the GetRecords, GetShardIterator, DescribeStream, ListShards, and ListStreams Actions on your stream in IAM.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "REQUEST ID"
│   },
│   Message_: "Cannot access stream KINESIS STREAM ARN. Please ensure the role can perform the GetRecords, GetShardIterator, DescribeStream, ListShards, and ListStreams Actions on your stream in IAM.",
│   Type: "User"
│ }
│ 
```

I can see we have another pull request here https://github.com/hashicorp/terraform-provider-aws/pull/19425 fixing an similar issue https://github.com/hashicorp/terraform-provider-aws/issues/14042
