### PR TITLE
Add status to aws_acm_certificate data source attributes

### DIFF
--- a/.changelog/20232.txt
+++ b/.changelog/20232.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_acm_certificate: Add status attribute
+```

--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -28,6 +28,10 @@ func dataSourceAwsAcmCertificate() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"key_types": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -170,6 +174,7 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(aws.StringValue(matchedCertificate.CertificateArn))
 	d.Set("arn", matchedCertificate.CertificateArn)
+	d.Set("status", matchedCertificate.Status)
 
 	tags, err := keyvaluetags.AcmListTags(conn, aws.StringValue(matchedCertificate.CertificateArn))
 

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -45,6 +45,7 @@ func TestAccAWSAcmCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
 				),
 			},
 			{
@@ -52,6 +53,7 @@ func TestAccAWSAcmCertificateDataSource_singleIssued(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
 				),
 			},
 			{

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -49,5 +49,5 @@ data "aws_acm_certificate" "rsa_4096" {
 
 * `arn` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
 * `id` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
-* `status` - Status of the found certificate
+* `status` - Status of the found certificate.
 * `tags` - A mapping of tags for the resource.

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -49,5 +49,5 @@ data "aws_acm_certificate" "rsa_4096" {
 
 * `arn` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
 * `id` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
+* `status` - Status of the found certificate
 * `tags` - A mapping of tags for the resource.
-


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

I added the status of a certificate to the `aws_acm_certificate` data source attributes. Since I'm unable to validate certificates automatically (I have to ask someone else to set the validation DNS records), I have to create the certificate in terraform, do the validation externally, and use the certificate in terraform when it's issued. So I have to check the status of an existing certificate, but the data source currently only allows to filter on status. If your filter contains multiple statuses (e.g. `["ISSUED", "PENDING_VALIDATION"]`), there is no way to get the actual status.

### Output from acceptance testing

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificateDataSource_singleIssued'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAcmCertificateDataSource_singleIssued -timeout 180m
=== RUN   TestAccAWSAcmCertificateDataSource_singleIssued
=== PAUSE TestAccAWSAcmCertificateDataSource_singleIssued
=== CONT  TestAccAWSAcmCertificateDataSource_singleIssued
--- PASS: TestAccAWSAcmCertificateDataSource_singleIssued (67.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	67.526s
```
