### PR TITLE
aws_storagegateway_smb_file_share: Add `bucket_region`, `oplocks_enabled` and `vpc_endpoint_dns_name` arguments

### DIFF
--- a/.changelog/20234.txt
+++ b/.changelog/20234.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_storagegateway_smb_file_share: Add `bucket_region`, `oplocks_enabled` and `vpc_endpoint_dns_name` arguments
+```

--- a/aws/internal/service/storagegateway/enum.go
+++ b/aws/internal/service/storagegateway/enum.go
@@ -1,0 +1,29 @@
+package storagegateway
+
+const (
+	AuthenticationActiveDirectory = "ActiveDirectory"
+	AuthenticationGuestAccess     = "GuestAccess"
+)
+
+func Authentication_Values() []string {
+	return []string{
+		AuthenticationActiveDirectory,
+		AuthenticationGuestAccess,
+	}
+}
+
+const (
+	DefaultStorageClassS3IntelligentTiering = "S3_INTELLIGENT_TIERING"
+	DefaultStorageClassS3OneZoneIA          = "S3_ONEZONE_IA"
+	DefaultStorageClassS3Standard           = "S3_STANDARD"
+	DefaultStorageClassS3StandardIA         = "S3_STANDARD_IA"
+)
+
+func DefaultStorageClass_Values() []string {
+	return []string{
+		DefaultStorageClassS3IntelligentTiering,
+		DefaultStorageClassS3OneZoneIA,
+		DefaultStorageClassS3Standard,
+		DefaultStorageClassS3StandardIA,
+	}
+}

--- a/aws/internal/service/storagegateway/enum.go
+++ b/aws/internal/service/storagegateway/enum.go
@@ -27,3 +27,11 @@ func DefaultStorageClass_Values() []string {
 		DefaultStorageClassS3StandardIA,
 	}
 }
+
+const (
+	FileShareStatusAvailable     = "AVAILABLE"
+	FileShareStatusCreating      = "CREATING"
+	FileShareStatusDeleting      = "DELETING"
+	FileShareStatusForceDeleting = "FORCE_DELETING"
+	FileShareStatusUpdating      = "UPDATING"
+)

--- a/aws/internal/service/storagegateway/errors.go
+++ b/aws/internal/service/storagegateway/errors.go
@@ -1,0 +1,43 @@
+package storagegateway
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+)
+
+// OperationErrCodeEquals returns true if the error matches all these conditions:
+//  * err is of type awserr.Error and represents storagegateway.InternalServerError or storagegateway.InvalidGatewayRequestException
+//  * Error_.ErrorCode equals one of the passed codes
+// See https://docs.aws.amazon.com/storagegateway/latest/userguide/AWSStorageGatewayAPI.html#APIErrorResponses for details.
+func OperationErrCodeEquals(err error, codes ...string) bool {
+	if tfawserr.ErrCodeEquals(err, storagegateway.ErrCodeInternalServerError) {
+		var inner *storagegateway.InternalServerError
+
+		if ok := errors.As(err, &inner); ok {
+			if err := inner.Error_; err != nil {
+				for _, code := range codes {
+					if aws.StringValue(err.ErrorCode) == code {
+						return true
+					}
+				}
+			}
+		}
+	} else if tfawserr.ErrCodeEquals(err, storagegateway.ErrCodeInvalidGatewayRequestException) {
+		var inner *storagegateway.InvalidGatewayRequestException
+
+		if ok := errors.As(err, &inner); ok {
+			if err := inner.Error_; err != nil {
+				for _, code := range codes {
+					if aws.StringValue(err.ErrorCode) == code {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/aws/internal/service/storagegateway/errors.go
+++ b/aws/internal/service/storagegateway/errors.go
@@ -5,39 +5,24 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 )
 
-// OperationErrCodeEquals returns true if the error matches all these conditions:
-//  * err is of type awserr.Error and represents storagegateway.InternalServerError or storagegateway.InvalidGatewayRequestException
-//  * Error_.ErrorCode equals one of the passed codes
+const (
+	OperationErrCodeFileShareNotFound = "FileShareNotFound"
+)
+
+// OperationErrorCode returns the operation error code from the specified error:
+//  * err is of type awserr.Error and represents a storagegateway.InternalServerError or storagegateway.InvalidGatewayRequestException
+//  * Error_ is not nil
 // See https://docs.aws.amazon.com/storagegateway/latest/userguide/AWSStorageGatewayAPI.html#APIErrorResponses for details.
-func OperationErrCodeEquals(err error, codes ...string) bool {
-	if tfawserr.ErrCodeEquals(err, storagegateway.ErrCodeInternalServerError) {
-		var inner *storagegateway.InternalServerError
-
-		if ok := errors.As(err, &inner); ok {
-			if err := inner.Error_; err != nil {
-				for _, code := range codes {
-					if aws.StringValue(err.ErrorCode) == code {
-						return true
-					}
-				}
-			}
-		}
-	} else if tfawserr.ErrCodeEquals(err, storagegateway.ErrCodeInvalidGatewayRequestException) {
-		var inner *storagegateway.InvalidGatewayRequestException
-
-		if ok := errors.As(err, &inner); ok {
-			if err := inner.Error_; err != nil {
-				for _, code := range codes {
-					if aws.StringValue(err.ErrorCode) == code {
-						return true
-					}
-				}
-			}
-		}
+func OperationErrorCode(err error) string {
+	if inner := (*storagegateway.InternalServerError)(nil); errors.As(err, &inner) && inner.Error_ != nil {
+		return aws.StringValue(inner.Error_.ErrorCode)
 	}
 
-	return false
+	if inner := (*storagegateway.InvalidGatewayRequestException)(nil); errors.As(err, &inner) && inner.Error_ != nil {
+		return aws.StringValue(inner.Error_.ErrorCode)
+	}
+
+	return ""
 }

--- a/aws/internal/service/storagegateway/finder/finder.go
+++ b/aws/internal/service/storagegateway/finder/finder.go
@@ -3,6 +3,8 @@ package finder
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfstoragegateway "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/storagegateway"
 )
 
 func LocalDiskByDiskId(conn *storagegateway.StorageGateway, gatewayARN string, diskID string) (*storagegateway.Disk, error) {
@@ -78,4 +80,35 @@ func UploadBufferDisk(conn *storagegateway.StorageGateway, gatewayARN string, di
 	}
 
 	return result, err
+}
+
+func SMBFileShareByARN(conn *storagegateway.StorageGateway, arn string) (*storagegateway.SMBFileShareInfo, error) {
+	input := &storagegateway.DescribeSMBFileSharesInput{
+		FileShareARNList: aws.StringSlice([]string{arn}),
+	}
+
+	output, err := conn.DescribeSMBFileShares(input)
+
+	if tfstoragegateway.OperationErrorCode(err) == tfstoragegateway.OperationErrCodeFileShareNotFound {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	// TODO Check for multiple results.
+	// TODO https://github.com/hashicorp/terraform-provider-aws/pull/17613.
+
+	return output.SMBFileShareInfoList[0], nil
 }

--- a/aws/internal/service/storagegateway/waiter/status.go
+++ b/aws/internal/service/storagegateway/waiter/status.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/storagegateway/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -111,27 +113,18 @@ func NfsFileShareStatus(conn *storagegateway.StorageGateway, fileShareArn string
 	}
 }
 
-func SmbFileShareStatus(conn *storagegateway.StorageGateway, fileShareArn string) resource.StateRefreshFunc {
+func SMBFileShareStatus(conn *storagegateway.StorageGateway, arn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &storagegateway.DescribeSMBFileSharesInput{
-			FileShareARNList: []*string{aws.String(fileShareArn)},
+		output, err := finder.SMBFileShareByARN(conn, arn)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
-		log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %s", input)
-		output, err := conn.DescribeSMBFileShares(input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
-				return nil, SmbFileShareStatusNotFound, nil
-			}
-			return nil, SmbFileShareStatusUnknown, fmt.Errorf("error reading Storage Gateway SMB File Share: %w", err)
+			return nil, "", err
 		}
 
-		if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {
-			return nil, SmbFileShareStatusNotFound, nil
-		}
-
-		fileshare := output.SMBFileShareInfoList[0]
-
-		return fileshare, aws.StringValue(fileshare.FileShareStatus), nil
+		return output, aws.StringValue(output.FileShareStatus), nil
 	}
 }

--- a/aws/internal/service/storagegateway/waiter/waiter.go
+++ b/aws/internal/service/storagegateway/waiter/waiter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfstoragegateway "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/storagegateway"
 )
 
 const (
@@ -111,12 +112,11 @@ func NfsFileShareDeleted(conn *storagegateway.StorageGateway, fileShareArn strin
 	return nil, err
 }
 
-// SmbFileShareAvailable waits for a SMB File Share to return Available
-func SmbFileShareAvailable(conn *storagegateway.StorageGateway, fileShareArn string, timeout time.Duration) (*storagegateway.SMBFileShareInfo, error) {
+func SMBFileShareCreated(conn *storagegateway.StorageGateway, arn string, timeout time.Duration) (*storagegateway.SMBFileShareInfo, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"CREATING", "UPDATING"},
-		Target:  []string{"AVAILABLE"},
-		Refresh: SmbFileShareStatus(conn, fileShareArn),
+		Pending: []string{tfstoragegateway.FileShareStatusCreating},
+		Target:  []string{tfstoragegateway.FileShareStatusAvailable},
+		Refresh: SMBFileShareStatus(conn, arn),
 		Timeout: timeout,
 		Delay:   SmbFileShareAvailableDelay,
 	}
@@ -130,14 +130,32 @@ func SmbFileShareAvailable(conn *storagegateway.StorageGateway, fileShareArn str
 	return nil, err
 }
 
-func SmbFileShareDeleted(conn *storagegateway.StorageGateway, fileShareArn string, timeout time.Duration) (*storagegateway.SMBFileShareInfo, error) {
+func SMBFileShareDeleted(conn *storagegateway.StorageGateway, arn string, timeout time.Duration) (*storagegateway.SMBFileShareInfo, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:        []string{"AVAILABLE", "DELETING", "FORCE_DELETING"},
+		Pending:        []string{tfstoragegateway.FileShareStatusAvailable, tfstoragegateway.FileShareStatusDeleting, tfstoragegateway.FileShareStatusForceDeleting},
 		Target:         []string{},
-		Refresh:        SmbFileShareStatus(conn, fileShareArn),
+		Refresh:        SMBFileShareStatus(conn, arn),
 		Timeout:        timeout,
 		Delay:          SmbFileShareDeletedDelay,
 		NotFoundChecks: 1,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*storagegateway.SMBFileShareInfo); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func SMBFileShareUpdated(conn *storagegateway.StorageGateway, arn string, timeout time.Duration) (*storagegateway.SMBFileShareInfo, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{tfstoragegateway.FileShareStatusUpdating},
+		Target:  []string{tfstoragegateway.FileShareStatusAvailable},
+		Refresh: SMBFileShareStatus(conn, arn),
+		Timeout: timeout,
+		Delay:   SmbFileShareAvailableDelay,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -104,11 +104,27 @@ func resourceAwsStorageGatewaySmbFileShare() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},
+			"vpc_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"bucket_region": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"vpc_endpoint"},
+			},
 			"object_acl": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      storagegateway.ObjectACLPrivate,
 				ValidateFunc: validation.StringInSlice(storagegateway.ObjectACL_Values(), false),
+			},
+			"oplocks_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
 			},
 			"cache_attributes": {
 				Type:     schema.TypeList,
@@ -201,7 +217,10 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 		InvalidUserList:      expandStringSet(d.Get("invalid_user_list").(*schema.Set)),
 		KMSEncrypted:         aws.Bool(d.Get("kms_encrypted").(bool)),
 		LocationARN:          aws.String(d.Get("location_arn").(string)),
+		VPCEndpointDNSName:   aws.String(d.Get("vpc_endpoint").(string)),
+		BucketRegion:         aws.String(d.Get("bucket_region").(string)),
 		ObjectACL:            aws.String(d.Get("object_acl").(string)),
+		OplocksEnabled:       aws.Bool(d.Get("oplocks_enabled").(bool)),
 		ReadOnly:             aws.Bool(d.Get("read_only").(bool)),
 		RequesterPays:        aws.Bool(d.Get("requester_pays").(bool)),
 		Role:                 aws.String(d.Get("role_arn").(string)),
@@ -303,7 +322,10 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 	d.Set("kms_encrypted", fileshare.KMSEncrypted)
 	d.Set("kms_key_arn", fileshare.KMSKey)
 	d.Set("location_arn", fileshare.LocationARN)
+	d.Set("vpc_endpoint", fileshare.VPCEndpointDNSName)
+	d.Set("bucket_region", fileshare.BucketRegion)
 	d.Set("object_acl", fileshare.ObjectACL)
+	d.Set("oplocks_enabled", fileshare.OplocksEnabled)
 	d.Set("path", fileshare.Path)
 	d.Set("read_only", fileshare.ReadOnly)
 	d.Set("requester_pays", fileshare.RequesterPays)
@@ -346,7 +368,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 	}
 
 	if d.HasChanges("admin_user_list", "default_storage_class", "guess_mime_type_enabled", "invalid_user_list",
-		"kms_encrypted", "object_acl", "read_only", "requester_pays", "requester_pays",
+		"kms_encrypted", "object_acl", "oplocks_enabled", "read_only", "requester_pays", "requester_pays",
 		"valid_user_list", "kms_key_arn", "audit_destination_arn", "smb_acl_enabled", "cache_attributes",
 		"case_sensitivity", "file_share_name", "notification_policy", "access_based_enumeration") {
 		input := &storagegateway.UpdateSMBFileShareInput{
@@ -356,6 +378,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 			InvalidUserList:        expandStringSet(d.Get("invalid_user_list").(*schema.Set)),
 			KMSEncrypted:           aws.Bool(d.Get("kms_encrypted").(bool)),
 			ObjectACL:              aws.String(d.Get("object_acl").(string)),
+			OplocksEnabled:         aws.Bool(d.Get("oplocks_enabled").(bool)),
 			ReadOnly:               aws.Bool(d.Get("read_only").(bool)),
 			RequesterPays:          aws.Bool(d.Get("requester_pays").(bool)),
 			ValidUserList:          expandStringSet(d.Get("valid_user_list").(*schema.Set)),

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -206,14 +206,17 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &storagegateway.CreateSMBFileShareInput{
-		ClientToken: aws.String(resource.UniqueId()),
-		GatewayARN:  aws.String(d.Get("gateway_arn").(string)),
-		LocationARN: aws.String(d.Get("location_arn").(string)),
-		Role:        aws.String(d.Get("role_arn").(string)),
-	}
-
-	if v, ok := d.GetOk("access_based_enumeration"); ok {
-		input.AccessBasedEnumeration = aws.Bool(v.(bool))
+		AccessBasedEnumeration: aws.Bool(d.Get("access_based_enumeration").(bool)),
+		ClientToken:            aws.String(resource.UniqueId()),
+		GatewayARN:             aws.String(d.Get("gateway_arn").(string)),
+		GuessMIMETypeEnabled:   aws.Bool(d.Get("guess_mime_type_enabled").(bool)),
+		KMSEncrypted:           aws.Bool(d.Get("kms_encrypted").(bool)),
+		LocationARN:            aws.String(d.Get("location_arn").(string)),
+		OplocksEnabled:         aws.Bool(d.Get("oplocks_enabled").(bool)),
+		ReadOnly:               aws.Bool(d.Get("read_only").(bool)),
+		RequesterPays:          aws.Bool(d.Get("requester_pays").(bool)),
+		Role:                   aws.String(d.Get("role_arn").(string)),
+		SMBACLEnabled:          aws.Bool(d.Get("smb_acl_enabled").(bool)),
 	}
 
 	if v, ok := d.GetOk("admin_user_list"); ok && v.(*schema.Set).Len() > 0 {
@@ -248,16 +251,8 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 		input.FileShareName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("guess_mime_type_enabled"); ok {
-		input.GuessMIMETypeEnabled = aws.Bool(v.(bool))
-	}
-
 	if v, ok := d.GetOk("invalid_user_list"); ok && v.(*schema.Set).Len() > 0 {
 		input.InvalidUserList = expandStringSet(v.(*schema.Set))
-	}
-
-	if v, ok := d.GetOk("kms_encrypted"); ok {
-		input.KMSEncrypted = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("kms_key_arn"); ok {
@@ -270,22 +265,6 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 
 	if v, ok := d.GetOk("object_acl"); ok {
 		input.ObjectACL = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("oplocks_enabled"); ok {
-		input.OplocksEnabled = aws.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("read_only"); ok {
-		input.ReadOnly = aws.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("requester_pays"); ok {
-		input.RequesterPays = aws.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("smb_acl_enabled"); ok {
-		input.SMBACLEnabled = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("valid_user_list"); ok && v.(*schema.Set).Len() > 0 {
@@ -388,11 +367,14 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &storagegateway.UpdateSMBFileShareInput{
-			FileShareARN: aws.String(d.Id()),
-		}
-
-		if d.HasChange("access_based_enumeration") {
-			input.AccessBasedEnumeration = aws.Bool(d.Get("access_based_enumeration").(bool))
+			AccessBasedEnumeration: aws.Bool(d.Get("access_based_enumeration").(bool)),
+			FileShareARN:           aws.String(d.Id()),
+			GuessMIMETypeEnabled:   aws.Bool(d.Get("guess_mime_type_enabled").(bool)),
+			KMSEncrypted:           aws.Bool(d.Get("kms_encrypted").(bool)),
+			OplocksEnabled:         aws.Bool(d.Get("oplocks_enabled").(bool)),
+			ReadOnly:               aws.Bool(d.Get("read_only").(bool)),
+			RequesterPays:          aws.Bool(d.Get("requester_pays").(bool)),
+			SMBACLEnabled:          aws.Bool(d.Get("smb_acl_enabled").(bool)),
 		}
 
 		if d.HasChange("admin_user_list") {
@@ -419,16 +401,8 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 			input.FileShareName = aws.String(d.Get("file_share_name").(string))
 		}
 
-		if d.HasChange("guess_mime_type_enabled") {
-			input.GuessMIMETypeEnabled = aws.Bool(d.Get("guess_mime_type_enabled").(bool))
-		}
-
 		if d.HasChange("kms_key_arn") {
 			input.KMSKey = aws.String(d.Get("kms_key_arn").(string))
-		}
-
-		if d.HasChange("kms_encrypted") {
-			input.KMSEncrypted = aws.Bool(d.Get("kms_encrypted").(bool))
 		}
 
 		if d.HasChange("invalid_user_list") {
@@ -441,22 +415,6 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 
 		if d.HasChange("object_acl") {
 			input.ObjectACL = aws.String(d.Get("object_acl").(string))
-		}
-
-		if d.HasChange("oplocks_enabled") {
-			input.OplocksEnabled = aws.Bool(d.Get("oplocks_enabled").(bool))
-		}
-
-		if d.HasChange("read_only") {
-			input.ReadOnly = aws.Bool(d.Get("read_only").(bool))
-		}
-
-		if d.HasChange("requester_pays") {
-			input.RequesterPays = aws.Bool(d.Get("requester_pays").(bool))
-		}
-
-		if d.HasChange("smb_acl_enabled") {
-			input.SMBACLEnabled = aws.Bool(d.Get("smb_acl_enabled").(bool))
 		}
 
 		if d.HasChange("valid_user_list") {

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -401,7 +401,8 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 			input.FileShareName = aws.String(d.Get("file_share_name").(string))
 		}
 
-		if d.HasChange("kms_key_arn") {
+		// This value can only be set when KMSEncrypted is true.
+		if d.HasChange("kms_key_arn") && d.Get("kms_encrypted").(bool) {
 			input.KMSKey = aws.String(d.Get("kms_key_arn").(string))
 		}
 

--- a/aws/resource_aws_storagegateway_smb_file_share_test.go
+++ b/aws/resource_aws_storagegateway_smb_file_share_test.go
@@ -1108,11 +1108,11 @@ func testAccAWSStorageGatewaySmbFileShareConfig_OpLocksEnabled(rName string, opL
 	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
-  authentication          = "GuestAccess"
-  gateway_arn             = aws_storagegateway_gateway.test.arn
-  oplocks_enabled         = %t
-  location_arn            = aws_s3_bucket.test.arn
-  role_arn                = aws_iam_role.test.arn
+  authentication  = "GuestAccess"
+  gateway_arn     = aws_storagegateway_gateway.test.arn
+  oplocks_enabled = %t
+  location_arn    = aws_s3_bucket.test.arn
+  role_arn        = aws_iam_role.test.arn
 }
 `, opLocksEnabled))
 }

--- a/aws/resource_aws_storagegateway_smb_file_share_test.go
+++ b/aws/resource_aws_storagegateway_smb_file_share_test.go
@@ -918,7 +918,7 @@ func testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName string, smbFil
 }
 
 func testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain string) string {
-	return testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName, domain), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -965,11 +965,11 @@ resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName string) string {
-	return testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "smbguestpassword") + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "smbguestpassword"), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %q
 
@@ -1016,33 +1016,33 @@ resource "aws_s3_bucket" "test" {
   bucket        = %q
   force_destroy = true
 }
-`, rName, rName)
+`, rName, rName))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_Authentication_ActiveDirectory(rName, domain string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + `
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), `
 resource "aws_storagegateway_smb_file_share" "test" {
   authentication = "ActiveDirectory"
   gateway_arn    = aws_storagegateway_gateway.test.arn
   location_arn   = aws_s3_bucket.test.arn
   role_arn       = aws_iam_role.test.arn
 }
-`
+`)
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_Authentication_GuestAccess(rName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), `
 resource "aws_storagegateway_smb_file_share" "test" {
   authentication = "GuestAccess"
   gateway_arn    = aws_storagegateway_gateway.test.arn
   location_arn   = aws_s3_bucket.test.arn
   role_arn       = aws_iam_role.test.arn
 }
-`
+`)
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfigAccessBasedEnumeration(rName string, enabled bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   authentication           = "GuestAccess"
   gateway_arn              = aws_storagegateway_gateway.test.arn
@@ -1050,11 +1050,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn                 = aws_iam_role.test.arn
   access_based_enumeration = %[1]t
 }
-`, enabled)
+`, enabled))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfigNotificationPolicy(rName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), `
 resource "aws_storagegateway_smb_file_share" "test" {
   authentication      = "GuestAccess"
   gateway_arn         = aws_storagegateway_gateway.test.arn
@@ -1062,11 +1062,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn            = aws_iam_role.test.arn
   notification_policy = "{\"Upload\": {\"SettlingTimeInSeconds\": 60}}"
 }
-`
+`)
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_DefaultStorageClass(rName, defaultStorageClass string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication        = "GuestAccess"
@@ -1075,11 +1075,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn          = aws_s3_bucket.test.arn
   role_arn              = aws_iam_role.test.arn
 }
-`, defaultStorageClass)
+`, defaultStorageClass))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_FileShareName(rName, fileShareName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication  = "GuestAccess"
@@ -1088,11 +1088,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn    = aws_s3_bucket.test.arn
   role_arn        = aws_iam_role.test.arn
 }
-`, fileShareName)
+`, fileShareName))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_GuessMIMETypeEnabled(rName string, guessMimeTypeEnabled bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication          = "GuestAccess"
@@ -1101,11 +1101,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn            = aws_s3_bucket.test.arn
   role_arn                = aws_iam_role.test.arn
 }
-`, guessMimeTypeEnabled)
+`, guessMimeTypeEnabled))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_OpLocksEnabled(rName string, opLocksEnabled bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication          = "GuestAccess"
@@ -1114,11 +1114,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn            = aws_s3_bucket.test.arn
   role_arn                = aws_iam_role.test.arn
 }
-`, opLocksEnabled)
+`, opLocksEnabled))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Single(rName, domain, invalidUser1 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Must be ActiveDirectory
   authentication    = "ActiveDirectory"
@@ -1127,11 +1127,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn      = aws_s3_bucket.test.arn
   role_arn          = aws_iam_role.test.arn
 }
-`, invalidUser1)
+`, invalidUser1))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Multiple(rName, domain, invalidUser1, invalidUser2 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Must be ActiveDirectory
   authentication    = "ActiveDirectory"
@@ -1140,11 +1140,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn      = aws_s3_bucket.test.arn
   role_arn          = aws_iam_role.test.arn
 }
-`, invalidUser1, invalidUser2)
+`, invalidUser1, invalidUser2))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_KMSEncrypted(rName string, kmsEncrypted bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1153,11 +1153,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn   = aws_s3_bucket.test.arn
   role_arn       = aws_iam_role.test.arn
 }
-`, kmsEncrypted)
+`, kmsEncrypted))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_KMSKeyArn(rName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), `
 resource "aws_kms_key" "test" {
   count = 2
 
@@ -1174,11 +1174,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn   = aws_s3_bucket.test.arn
   role_arn       = aws_iam_role.test.arn
 }
-`
+`)
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_KMSKeyArn_Update(rName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), `
 resource "aws_kms_key" "test" {
   count = 2
 
@@ -1195,11 +1195,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   location_arn   = aws_s3_bucket.test.arn
   role_arn       = aws_iam_role.test.arn
 }
-`
+`)
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_ObjectACL(rName, objectACL string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1208,11 +1208,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   object_acl     = %q
   role_arn       = aws_iam_role.test.arn
 }
-`, objectACL)
+`, objectACL))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_ReadOnly(rName string, readOnly bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1221,11 +1221,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   read_only      = %t
   role_arn       = aws_iam_role.test.arn
 }
-`, readOnly)
+`, readOnly))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_RequesterPays(rName string, requesterPays bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1234,11 +1234,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   requester_pays = %t
   role_arn       = aws_iam_role.test.arn
 }
-`, requesterPays)
+`, requesterPays))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Single(rName, domain, validUser1 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Must be ActiveDirectory
   authentication  = "ActiveDirectory"
@@ -1247,11 +1247,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn        = aws_iam_role.test.arn
   valid_user_list = [%q]
 }
-`, validUser1)
+`, validUser1))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Multiple(rName, domain, validUser1, validUser2 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Must be ActiveDirectory
   authentication  = "ActiveDirectory"
@@ -1260,11 +1260,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn        = aws_iam_role.test.arn
   valid_user_list = [%q, %q]
 }
-`, validUser1, validUser2)
+`, validUser1, validUser2))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Single(rName, domain, adminUser1 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Must be ActiveDirectory
   authentication  = "ActiveDirectory"
@@ -1273,11 +1273,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn        = aws_iam_role.test.arn
   admin_user_list = [%q]
 }
-`, adminUser1)
+`, adminUser1))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Multiple(rName, domain, adminUser1, adminUser2 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Must be ActiveDirectory
   authentication  = "ActiveDirectory"
@@ -1286,11 +1286,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn        = aws_iam_role.test.arn
   admin_user_list = [%q, %q]
 }
-`, adminUser1, adminUser2)
+`, adminUser1, adminUser2))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1302,11 +1302,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
     %q = %q
   }
 }
-`, tagKey1, tagValue1)
+`, tagKey1, tagValue1))
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1319,11 +1319,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
     %q = %q
   }
 }
-`, tagKey1, tagValue1, tagKey2, tagValue2)
+`, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccAWSStorageGatewaySmbFileShareSMBACLConfig(rName, domain string, enabled bool) string {
-	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName, domain), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   authentication  = "ActiveDirectory"
   gateway_arn     = aws_storagegateway_gateway.test.arn
@@ -1331,11 +1331,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn        = aws_iam_role.test.arn
   smb_acl_enabled = %[1]t
 }
-`, enabled)
+`, enabled))
 }
 
 func testAccAWSStorageGatewaySmbFileShareAuditDestinationConfig(rName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -1348,11 +1348,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn              = aws_iam_role.test.arn
   audit_destination_arn = aws_cloudwatch_log_group.test.arn
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSStorageGatewaySmbFileShareAuditDestinationUpdatedConfig(rName string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -1369,11 +1369,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn              = aws_iam_role.test.arn
   audit_destination_arn = aws_cloudwatch_log_group.test2.arn
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSStorageGatewaySmbFileShareCacheAttributesConfig(rName string, timeout int) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication = "GuestAccess"
@@ -1385,11 +1385,11 @@ resource "aws_storagegateway_smb_file_share" "test" {
     cache_stale_timeout_in_seconds = %[1]d
   }
 }
-`, timeout)
+`, timeout))
 }
 
 func testAccAWSStorageGatewaySmbFileShareCaseSensitivityConfig(rName, option string) string {
-	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication   = "GuestAccess"
@@ -1398,5 +1398,5 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn         = aws_iam_role.test.arn
   case_sensitivity = %[1]q
 }
-`, option)
+`, option))
 }

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -44,8 +44,8 @@ The following arguments are supported:
 
 * `gateway_arn` - (Required) Amazon Resource Name (ARN) of the file gateway.
 * `location_arn` - (Required) The ARN of the backed storage used for storing file data.
-* `vpc_endpoint` - (Optional) The DNS name of the VPC endpoint for S3 private link.
-* `bucket_region` - (Optional) The region of the S3 buck used by the file share. Required when specifying a `vpc_endpoint`.
+* `vpc_endpoint_dns_name` - (Optional) The DNS name of the VPC endpoint for S3 private link.
+* `bucket_region` - (Optional) The region of the S3 buck used by the file share. Required when specifying a `vpc_endpoint_dns_name`.
 * `role_arn` - (Required) The ARN of the AWS Identity and Access Management (IAM) role that a file gateway assumes when it accesses the underlying storage.
 * `admin_user_list` - (Optional) A list of users in the Active Directory that have admin access to the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `authentication` - (Optional) The authentication method that users use to access the file share. Defaults to `ActiveDirectory`. Valid values: `ActiveDirectory`, `GuestAccess`.

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 * `gateway_arn` - (Required) Amazon Resource Name (ARN) of the file gateway.
 * `location_arn` - (Required) The ARN of the backed storage used for storing file data.
+* `vpc_endpoint` - (Optional) The DNS name of the VPC endpoint for S3 private link.
+* `bucket_region` - (Optional) The region of the S3 buck used by the file share. Required when specifying a `vpc_endpoint`.
 * `role_arn` - (Required) The ARN of the AWS Identity and Access Management (IAM) role that a file gateway assumes when it accesses the underlying storage.
 * `admin_user_list` - (Optional) A list of users in the Active Directory that have admin access to the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `authentication` - (Optional) The authentication method that users use to access the file share. Defaults to `ActiveDirectory`. Valid values: `ActiveDirectory`, `GuestAccess`.
@@ -55,6 +57,7 @@ The following arguments are supported:
 * `kms_encrypted` - (Optional) Boolean value if `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Defaults to `false`.
 * `kms_key_arn` - (Optional) Amazon Resource Name (ARN) for KMS key used for Amazon S3 server side encryption. This value can only be set when `kms_encrypted` is true.
 * `object_acl` - (Optional) Access Control List permission for S3 bucket objects. Defaults to `private`.
+* `oplocks_enabled` - (Optional) Boolean to indicate Opportunistic lock (oplock) status. Defaults to `true`.
 * `cache_attributes` - (Optional) Refresh cache information. see [Cache Attributes](#cache_attributes) for more details.
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.


### PR DESCRIPTION
Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request