### PR TITLE
Improve documentation for EventBridge oauth flow

### DIFF
--- a/website/docs/r/cloudwatch_event_connection.html.markdown
+++ b/website/docs/r/cloudwatch_event_connection.html.markdown
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_event_connection" "test" {
 resource "aws_cloudwatch_event_connection" "test" {
   name               = "ngrok-connection"
   description        = "A connection description"
-  authorization_type = "BASIC"
+  authorization_type = "OAUTH_CLIENT_CREDENTIALS"
 
   auth_parameters {
     oauth {
@@ -160,7 +160,7 @@ The following arguments are supported:
 
 `oauth` support the following:
 
-* `authorization_endpoint` - (Required) A username for the authorization.
+* `authorization_endpoint` - (Required) The URL to the authorization endpoint.
 * `http_method` - (Required) A password for the authorization. Created and stored in AWS Secrets Manager.
 * `client_parameters` - (Required) Contains the client parameters for OAuth authorization. Contains the following two parameters.
     * `client_id` - (Required) The client ID for the credentials to use for authorization. Created and stored in AWS Secrets Manager.


### PR DESCRIPTION
authorization_type was listed as BASIC for oauth flow, and authorization_endpoint is a URL not a username.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
