### PR TITLE
Ensure resource attribute options are coherent

### DIFF
--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `enabled` - (Optional) If true, the rule will be enabled
 * `recipients` - (Optional) A list of email addresses
 * `scan_enabled` - (Optional) If true, incoming emails will be scanned for spam and viruses
-* `tls_policy` - (Optional) Require or Optional
+* `tls_policy` - (Optional) `Require` or `Optional`
 * `add_header_action` - (Optional) A list of Add Header Action blocks. Documented below.
 * `bounce_action` - (Optional) A list of Bounce Action blocks. Documented below.
 * `lambda_action` - (Optional) A list of Lambda Action blocks. Documented below.
@@ -71,7 +71,7 @@ Bounce actions support the following:
 Lambda actions support the following:
 
 * `function_arn` - (Required) The ARN of the Lambda function to invoke
-* `invocation_type` - (Optional) Event or RequestResponse
+* `invocation_type` - (Optional) `Event` or `RequestResponse`
 * `topic_arn` - (Optional) The ARN of an SNS topic to notify
 * `position` - (Required) The position of the action in the receipt rule
 


### PR DESCRIPTION
In order to make the options for attributes of  the `aws_ses_receipt_rule` more visible they should be in `code blocks` as per conventions in other docs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
