### PR TITLE
r/servicecat_provisioned_product: Increase timeouts

### DIFF
--- a/.changelog/20254.txt
+++ b/.changelog/20254.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_servicecatalog_provisioned_product: Increase timeouts to align with CloudFormation (30 min.)
+```

--- a/aws/internal/service/servicecatalog/waiter/waiter.go
+++ b/aws/internal/service/servicecatalog/waiter/waiter.go
@@ -43,8 +43,9 @@ const (
 
 	LaunchPathsReadyTimeout = 3 * time.Minute
 
-	ProvisionedProductReadyTimeout  = 3 * time.Minute
-	ProvisionedProductDeleteTimeout = 3 * time.Minute
+	ProvisionedProductReadyTimeout  = 30 * time.Minute
+	ProvisionedProductUpdateTimeout = 30 * time.Minute
+	ProvisionedProductDeleteTimeout = 30 * time.Minute
 
 	RecordReadyTimeout = 3 * time.Minute
 

--- a/aws/internal/service/servicecatalog/waiter/waiter.go
+++ b/aws/internal/service/servicecatalog/waiter/waiter.go
@@ -47,7 +47,7 @@ const (
 	ProvisionedProductUpdateTimeout = 30 * time.Minute
 	ProvisionedProductDeleteTimeout = 30 * time.Minute
 
-	RecordReadyTimeout = 3 * time.Minute
+	RecordReadyTimeout = 30 * time.Minute
 
 	PortfolioConstraintsReadyTimeout = 3 * time.Minute
 

--- a/aws/resource_aws_servicecatalog_provisioned_product.go
+++ b/aws/resource_aws_servicecatalog_provisioned_product.go
@@ -28,6 +28,12 @@ func resourceAwsServiceCatalogProvisionedProduct() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(waiter.ProvisionedProductReadyTimeout),
+			Update: schema.DefaultTimeout(waiter.ProvisionedProductUpdateTimeout),
+			Delete: schema.DefaultTimeout(waiter.ProvisionedProductDeleteTimeout),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"accept_language": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20253

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSServiceCatalogProvisionedProduct_basic (159.59s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSServiceCatalogProvisionedProduct_basic (164.62s)
```