### PR TITLE
Remove hardcoded email addresses

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -532,15 +532,10 @@ rules:
 
   - id: email-address
     languages: [go]
-    message: Use default email address or generate a random email address. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#hardcoded-ssh-key
+    message: Use default email address or generate a random email address. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#hardcoded-email-addresses
     paths:
       include:
         - aws/
-      exclude:
-        - aws/internal/generators
-        - aws/internal/keyvaluetags/generators
-        - "**/list_pages_gen.go"
-        - awsproviderlint/vendor/
     patterns:
       - pattern-regex: '[-_A-Za-z0-9.+]+@([-A-Za-z0-9]+\.)(com|net|org)'
       - pattern-not-regex: 'no-reply@hashicorp\.com'

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -530,6 +530,23 @@ rules:
             fmt.Println(...)
     severity: WARNING
 
+  - id: email-address
+    languages: [go]
+    message: Use default email address or generate a random email address. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#hardcoded-ssh-key
+    paths:
+      include:
+        - aws/
+      exclude:
+        - aws/internal/generators
+        - aws/internal/keyvaluetags/generators
+        - "**/list_pages_gen.go"
+        - awsproviderlint/vendor/
+    patterns:
+      - pattern-regex: '[-_A-Za-z0-9.+]+@([-A-Za-z0-9]+\.)(com|net|org)'
+      - pattern-not-regex: 'no-reply@hashicorp\.com'
+      - pattern-inside: '($X : string)'
+    severity: WARNING
+
   - id: ssh-key
     languages: [go]
     message: Generate random SSH keys using acctest.RandSSHKeyPair() or RandSSHKeyPairSize(). https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#hardcoded-ssh-key

--- a/aws/data_source_aws_servicecatalog_launch_paths_test.go
+++ b/aws/data_source_aws_servicecatalog_launch_paths_test.go
@@ -13,7 +13,9 @@ func TestAccAWSServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_servicecatalog_launch_paths.test"
 	resourceNameProduct := "aws_servicecatalog_product.test"
 	resourceNamePortfolio := "aws_servicecatalog_portfolio.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -21,7 +23,7 @@ func TestAccAWSServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName),
+				Config: testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName, domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "accept_language", "en"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "product_id", resourceNameProduct, "id"),
@@ -34,7 +36,7 @@ func TestAccAWSServiceCatalogLaunchPathsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName string) string {
+func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName, domain, email string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
   name = %[1]q
@@ -69,8 +71,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = "supportbeskrivning"
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[3]q
+  support_url         = %[2]q
 
   provisioning_artifact_parameters {
     description          = "artefaktbeskrivning"
@@ -122,11 +124,11 @@ resource "aws_servicecatalog_principal_portfolio_association" "test" {
   portfolio_id  = aws_servicecatalog_portfolio.test.id
   principal_arn = data.aws_iam_session_context.current.issuer_arn
 }
-`, rName)
+`, rName, domain, email)
 }
 
-func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName string) string {
-	return composeConfig(testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName), `
+func testAccAWSServiceCatalogLaunchPathsDataSourceConfig_basic(rName, domain, email string) string {
+	return composeConfig(testAccAWSServiceCatalogLaunchPathsDataSourceConfig_base(rName, domain, email), `
 data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }

--- a/aws/data_source_aws_servicecatalog_product_test.go
+++ b/aws/data_source_aws_servicecatalog_product_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
@@ -11,7 +12,9 @@ import (
 func TestAccAWSServiceCatalogProductDataSource_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 	dataSourceName := "data.aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,7 +23,7 @@ func TestAccAWSServiceCatalogProductDataSource_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductDataSourceConfig_basic(rName, "beskrivning", "supportbeskrivning"),
+				Config: testAccAWSServiceCatalogProductDataSourceConfig_basic(rName, "beskrivning", "supportbeskrivning", domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_time", dataSourceName, "created_time"),
@@ -45,7 +48,9 @@ func TestAccAWSServiceCatalogProductDataSource_basic(t *testing.T) {
 func TestAccAWSServiceCatalogProductDataSource_physicalID(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
 	dataSourceName := "data.aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,7 +59,7 @@ func TestAccAWSServiceCatalogProductDataSource_physicalID(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductDataSourceConfig_physicalID(rName),
+				Config: testAccAWSServiceCatalogProductDataSourceConfig_physicalID(rName, domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_time", dataSourceName, "created_time"),
@@ -76,16 +81,16 @@ func TestAccAWSServiceCatalogProductDataSource_physicalID(t *testing.T) {
 	})
 }
 
-func testAccAWSServiceCatalogProductDataSourceConfig_basic(rName, description, supportDescription string) string {
-	return composeConfig(testAccAWSServiceCatalogProductConfig_basic(rName, description, supportDescription), `
+func testAccAWSServiceCatalogProductDataSourceConfig_basic(rName, description, supportDescription, domain, email string) string {
+	return composeConfig(testAccAWSServiceCatalogProductConfig_basic(rName, description, supportDescription, domain, email), `
 data "aws_servicecatalog_product" "test" {
   id = aws_servicecatalog_product.test.id
 }
 `)
 }
 
-func testAccAWSServiceCatalogProductDataSourceConfig_physicalID(rName string) string {
-	return composeConfig(testAccAWSServiceCatalogProductConfig_physicalID(rName), `
+func testAccAWSServiceCatalogProductDataSourceConfig_physicalID(rName, domain, email string) string {
+	return composeConfig(testAccAWSServiceCatalogProductConfig_physicalID(rName, domain, email), `
 data "aws_servicecatalog_product" "test" {
   id = aws_servicecatalog_product.test.id
 }

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -2338,3 +2338,9 @@ func testAccRandomDomain() domainName {
 // testAccDefaultEmailAddress is the default email address to set as a
 // resource or data source parameter for acceptance tests.
 const testAccDefaultEmailAddress = "no-reply@hashicorp.com"
+
+// testAccRandomEmailAddress generates a random email address in the form
+// "tf-acc-test-<random>@<domain>"
+func testAccRandomEmailAddress(domainName string) string {
+	return fmt.Sprintf("%s@%s", acctest.RandomWithPrefix("tf-acc-test"), domainName)
+}

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -196,10 +196,15 @@ func TestAccAWSBudgetsBudget_notification(t *testing.T) {
 		testAccAWSBudgetsBudgetNotificationConfigDefaults(),
 	}
 
+	domain := testAccRandomDomainName()
+	address1 := testAccRandomEmailAddress(domain)
+	address2 := testAccRandomEmailAddress(domain)
+	address3 := testAccRandomEmailAddress(domain)
+
 	noEmails := []string{}
-	oneEmail := []string{"test@example.com"}
-	oneOtherEmail := []string{"bar@example.com"}
-	twoEmails := []string{"bar@example.com", "baz@example.com"}
+	oneEmail := []string{address1}
+	oneOtherEmail := []string{address2}
+	twoEmails := []string{address2, address3}
 	noTopics := []string{}
 	oneTopic := []string{"${aws_sns_topic.budget_notifications.arn}"}
 
@@ -665,8 +670,17 @@ resource "aws_budgets_budget" "test" {
   time_unit         = "%s"
     %s
 }
-`, aws.StringValue(budgetConfig.BudgetName), aws.StringValue(budgetConfig.BudgetType), aws.StringValue(budgetConfig.BudgetLimit.Amount), aws.StringValue(budgetConfig.BudgetLimit.Unit), aws.BoolValue(budgetConfig.CostTypes.IncludeTax), aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription), aws.BoolValue(budgetConfig.CostTypes.UseBlended), timePeriodStart, timePeriodEnd, aws.StringValue(budgetConfig.TimeUnit), strings.Join(notificationStrings, "\n"))
-
+`, aws.StringValue(budgetConfig.BudgetName),
+		aws.StringValue(budgetConfig.BudgetType),
+		aws.StringValue(budgetConfig.BudgetLimit.Amount),
+		aws.StringValue(budgetConfig.BudgetLimit.Unit),
+		aws.BoolValue(budgetConfig.CostTypes.IncludeTax),
+		aws.BoolValue(budgetConfig.CostTypes.IncludeSubscription),
+		aws.BoolValue(budgetConfig.CostTypes.UseBlended),
+		timePeriodStart,
+		timePeriodEnd,
+		aws.StringValue(budgetConfig.TimeUnit),
+		strings.Join(notificationStrings, "\n"))
 }
 
 func testAccAWSBudgetsBudgetConfigNotificationSnippet(notification budgets.Notification, emails []string, topics []string) string {
@@ -689,5 +703,10 @@ notification {
   subscriber_sns_topic_arns  = [%s]
   comparison_operator        = "%s"
 }
-`, aws.Float64Value(notification.Threshold), aws.StringValue(notification.ThresholdType), aws.StringValue(notification.NotificationType), strings.Join(quotedEMails, ","), strings.Join(quotedTopics, ","), aws.StringValue(notification.ComparisonOperator))
+`, aws.Float64Value(notification.Threshold),
+		aws.StringValue(notification.ThresholdType),
+		aws.StringValue(notification.NotificationType),
+		strings.Join(quotedEMails, ","),
+		strings.Join(quotedTopics, ","),
+		aws.StringValue(notification.ComparisonOperator))
 }

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -18,6 +18,8 @@ func TestAccAWSCodeBuildWebhook_Bitbucket(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codebuild_webhook.test"
 
+	sourceLocation := testAccAWSCodeBuildBitbucketSourceLocationFromEnv()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
 		ErrorCheck:   testAccErrorCheck(t, codebuild.EndpointsID),
@@ -25,7 +27,7 @@ func TestAccAWSCodeBuildWebhook_Bitbucket(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeBuildWebhookConfig_Bitbucket(rName),
+				Config: testAccAWSCodeBuildWebhookConfig_Bitbucket(rName, sourceLocation),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildWebhookExists(resourceName, &webhook),
 					resource.TestCheckResourceAttr(resourceName, "branch_filter", ""),
@@ -287,8 +289,9 @@ func testAccCheckAWSCodeBuildWebhookExists(name string, webhook *codebuild.Webho
 	}
 }
 
-func testAccAWSCodeBuildWebhookConfig_Bitbucket(rName string) string {
-	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName) + `
+func testAccAWSCodeBuildWebhookConfig_Bitbucket(rName, sourceLocation string) string {
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName, sourceLocation), `
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
 }

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -432,7 +432,7 @@ func TestAccAWSBeanstalkEnv_settingWithJsonValue(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvSettingJsonValue(rName, publicKey),
+				Config: testAccBeanstalkEnvSettingJsonValue(rName, publicKey, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvExists(resourceName, &app),
 				),
@@ -1545,7 +1545,7 @@ resource "aws_elastic_beanstalk_environment" "test" {
 `, rName)
 }
 
-func testAccBeanstalkEnvSettingJsonValue(rName, publicKey string) string {
+func testAccBeanstalkEnvSettingJsonValue(rName, publicKey, email string) string {
 	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sqs_queue" "test" {
   name = %[1]q
@@ -1607,7 +1607,7 @@ resource "aws_elastic_beanstalk_environment" "test" {
   setting {
     namespace = "aws:elasticbeanstalk:sns:topics"
     name      = "Notification Endpoint"
-    value     = "example@example.com"
+    value     = %[3]q
   }
 
   setting {
@@ -1727,5 +1727,5 @@ resource "aws_elastic_beanstalk_environment" "test" {
 EOF
   }
 }
-`, rName, publicKey)
+`, rName, publicKey, email)
 }

--- a/aws/resource_aws_guardduty_member_test.go
+++ b/aws/resource_aws_guardduty_member_test.go
@@ -13,7 +13,6 @@ import (
 func testAccAwsGuardDutyMember_basic(t *testing.T) {
 	resourceName := "aws_guardduty_member.test"
 	accountID := "111111111111"
-	email := "required@example.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,12 +21,12 @@ func testAccAwsGuardDutyMember_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsGuardDutyMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGuardDutyMemberConfig_basic(accountID, email),
+				Config: testAccGuardDutyMemberConfig_basic(accountID, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsGuardDutyMemberExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
 					resource.TestCheckResourceAttrSet(resourceName, "detector_id"),
-					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "email", testAccDefaultEmailAddress),
 					resource.TestCheckResourceAttr(resourceName, "relationship_status", "Created"),
 				),
 			},

--- a/aws/resource_aws_macie2_member_test.go
+++ b/aws/resource_aws_macie2_member_test.go
@@ -26,7 +26,6 @@ func testAccAwsMacie2Member_basic(t *testing.T) {
 	var providers []*schema.Provider
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
-	email := "required@example.com"
 	dataSourceAlternate := "data.aws_caller_identity.member"
 
 	resource.Test(t, resource.TestCase{
@@ -39,7 +38,7 @@ func testAccAwsMacie2Member_basic(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsMacieMemberConfigBasic(email),
+				Config: testAccAwsMacieMemberConfigBasic(testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
 					resource.TestCheckResourceAttr(resourceName, "relationship_status", macie2.RelationshipStatusCreated),
@@ -52,7 +51,7 @@ func testAccAwsMacie2Member_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccAwsMacieMemberConfigBasic(email),
+				Config:            testAccAwsMacieMemberConfigBasic(testAccDefaultEmailAddress),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -65,7 +64,6 @@ func testAccAwsMacie2Member_disappears(t *testing.T) {
 	var providers []*schema.Provider
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
-	email := "required@example.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -77,7 +75,7 @@ func testAccAwsMacie2Member_disappears(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsMacieMemberConfigBasic(email),
+				Config: testAccAwsMacieMemberConfigBasic(testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsMacie2Member(), resourceName),
@@ -257,7 +255,6 @@ func testAccAwsMacie2Member_withTags(t *testing.T) {
 	var providers []*schema.Provider
 	var macie2Output macie2.GetMemberOutput
 	resourceName := "aws_macie2_member.member"
-	email := "required@example.com"
 	dataSourceAlternate := "data.aws_caller_identity.member"
 
 	resource.Test(t, resource.TestCase{
@@ -270,7 +267,7 @@ func testAccAwsMacie2Member_withTags(t *testing.T) {
 		ErrorCheck:        testAccErrorCheck(t, macie2.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsMacieMemberConfigWithTags(email),
+				Config: testAccAwsMacieMemberConfigWithTags(testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMacie2MemberExists(resourceName, &macie2Output),
 					testAccCheckResourceAttrRfc3339(resourceName, "invited_at"),

--- a/aws/resource_aws_quicksight_user_test.go
+++ b/aws/resource_aws_quicksight_user_test.go
@@ -205,5 +205,5 @@ resource "aws_quicksight_user" %[1]q {
 }
 
 func testAccAWSQuickSightUserConfig(rName string) string {
-	return testAccAWSQuickSightUserConfigWithEmail(rName, "fakeemail@example.com")
+	return testAccAWSQuickSightUserConfigWithEmail(rName, testAccDefaultEmailAddress)
 }

--- a/aws/resource_aws_securityhub_invite_accepter_test.go
+++ b/aws/resource_aws_securityhub_invite_accepter_test.go
@@ -26,13 +26,13 @@ func testAccAWSSecurityHubInviteAccepter_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSSecurityHubInviteAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityHubInviteAccepterConfig_basic(),
+				Config: testAccAWSSecurityHubInviteAccepterConfig_basic(testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityHubInviteAccepterExists(resourceName),
 				),
 			},
 			{
-				Config:            testAccAWSSecurityHubInviteAccepterConfig_basic(),
+				Config:            testAccAWSSecurityHubInviteAccepterConfig_basic(testAccDefaultEmailAddress),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -93,9 +93,10 @@ func testAccCheckAWSSecurityHubInviteAccepterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSSecurityHubInviteAccepterConfig_basic() string {
+func testAccAWSSecurityHubInviteAccepterConfig_basic(email string) string {
 	return composeConfig(
-		testAccAlternateAccountProviderConfig(), `
+		testAccAlternateAccountProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_securityhub_invite_accepter" "test" {
   master_id = aws_securityhub_member.source.master_id
 
@@ -106,7 +107,7 @@ resource "aws_securityhub_member" "source" {
   provider = awsalternate
 
   account_id = data.aws_caller_identity.test.account_id
-  email      = "example@example.com"
+  email      = %[1]q
   invite     = true
 
   depends_on = [aws_securityhub_account.source]
@@ -119,5 +120,5 @@ resource "aws_securityhub_account" "source" {
 }
 
 data "aws_caller_identity" "test" {}
-`)
+`, email))
 }

--- a/aws/resource_aws_securityhub_member_test.go
+++ b/aws/resource_aws_securityhub_member_test.go
@@ -23,7 +23,7 @@ func testAccAWSSecurityHubMember_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityHubMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityHubMemberConfig_basic("111111111111", "example@example.com"),
+				Config: testAccAWSSecurityHubMemberConfig_basic("111111111111", testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityHubMemberExists(resourceName, &member),
 				),
@@ -48,7 +48,7 @@ func testAccAWSSecurityHubMember_invite(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityHubMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityHubMemberConfig_invite("111111111111", "example@example.com", true),
+				Config: testAccAWSSecurityHubMemberConfig_invite("111111111111", testAccDefaultEmailAddress, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityHubMemberExists(resourceName, &member),
 					resource.TestCheckResourceAttr(resourceName, "member_status", "Invited"),
@@ -131,8 +131,8 @@ resource "aws_securityhub_account" "example" {}
 
 resource "aws_securityhub_member" "example" {
   depends_on = [aws_securityhub_account.example]
-  account_id = "%s"
-  email      = "%s"
+  account_id = %[1]q
+  email      = %[2]q
 }
 `, accountId, email)
 }
@@ -143,9 +143,9 @@ resource "aws_securityhub_account" "example" {}
 
 resource "aws_securityhub_member" "example" {
   depends_on = [aws_securityhub_account.example]
-  account_id = "%s"
-  email      = "%s"
-  invite     = %t
+  account_id = %[1]q
+  email      = %[2]q
+  invite     = %[3]t
 }
 `, accountId, email, invite)
 }

--- a/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
+++ b/aws/resource_aws_servicecatalog_product_portfolio_association_test.go
@@ -123,6 +123,8 @@ func TestAccAWSServiceCatalogProductPortfolioAssociation_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_product_portfolio_association.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -130,7 +132,7 @@ func TestAccAWSServiceCatalogProductPortfolioAssociation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductPortfolioAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName),
+				Config: testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName, domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductPortfolioAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "portfolio_id", "aws_servicecatalog_portfolio.test", "id"),
@@ -150,6 +152,8 @@ func TestAccAWSServiceCatalogProductPortfolioAssociation_disappears(t *testing.T
 	resourceName := "aws_servicecatalog_product_portfolio_association.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -157,7 +161,7 @@ func TestAccAWSServiceCatalogProductPortfolioAssociation_disappears(t *testing.T
 		CheckDestroy: testAccCheckAwsServiceCatalogProductPortfolioAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName),
+				Config: testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName, domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductPortfolioAssociationExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogProductPortfolioAssociation(), resourceName),
@@ -222,7 +226,7 @@ func testAccCheckAwsServiceCatalogProductPortfolioAssociationExists(resourceName
 	}
 }
 
-func testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName string) string {
+func testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName, domain, email string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
   name = %[1]q
@@ -257,8 +261,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = "supportbeskrivning"
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[3]q
+  support_url         = %[2]q
 
   provisioning_artifact_parameters {
     description          = "artefaktbeskrivning"
@@ -276,11 +280,11 @@ resource "aws_servicecatalog_portfolio" "test" {
   name          = %[1]q
   provider_name = %[1]q
 }
-`, rName)
+`, rName, domain, email)
 }
 
-func testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName string) string {
-	return composeConfig(testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName), `
+func testAccAWSServiceCatalogProductPortfolioAssociationConfig_basic(rName, domain, email string) string {
+	return composeConfig(testAccAWSServiceCatalogProductPortfolioAssociationConfig_base(rName, domain, email), `
 resource "aws_servicecatalog_product_portfolio_association" "test" {
   portfolio_id = aws_servicecatalog_portfolio.test.id
   product_id   = aws_servicecatalog_product.test.id

--- a/aws/resource_aws_servicecatalog_product_test.go
+++ b/aws/resource_aws_servicecatalog_product_test.go
@@ -81,7 +81,9 @@ func testSweepServiceCatalogProducts(region string) error {
 
 func TestAccAWSServiceCatalogProduct_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -90,7 +92,7 @@ func TestAccAWSServiceCatalogProduct_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "beskrivning", "supportbeskrivning"),
+				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "beskrivning", "supportbeskrivning", domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "catalog", regexp.MustCompile(`product/prod-.*`)),
@@ -109,8 +111,8 @@ func TestAccAWSServiceCatalogProduct_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provisioning_artifact_parameters.0.type", servicecatalog.ProvisioningArtifactTypeCloudFormationTemplate),
 					resource.TestCheckResourceAttr(resourceName, "status", waiter.StatusCreated),
 					resource.TestCheckResourceAttr(resourceName, "support_description", "supportbeskrivning"),
-					resource.TestCheckResourceAttr(resourceName, "support_email", "support@example.com"),
-					resource.TestCheckResourceAttr(resourceName, "support_url", "http://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "support_email", testAccDefaultEmailAddress),
+					resource.TestCheckResourceAttr(resourceName, "support_url", domain),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", servicecatalog.ProductTypeCloudFormationTemplate),
@@ -131,7 +133,9 @@ func TestAccAWSServiceCatalogProduct_basic(t *testing.T) {
 
 func TestAccAWSServiceCatalogProduct_disappears(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -140,7 +144,7 @@ func TestAccAWSServiceCatalogProduct_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductConfig_basic(rName, rName, rName),
+				Config: testAccAWSServiceCatalogProductConfig_basic(rName, rName, rName, domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogProduct(), resourceName),
@@ -153,7 +157,9 @@ func TestAccAWSServiceCatalogProduct_disappears(t *testing.T) {
 
 func TestAccAWSServiceCatalogProduct_update(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -162,7 +168,7 @@ func TestAccAWSServiceCatalogProduct_update(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "beskrivning", "supportbeskrivning"),
+				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "beskrivning", "supportbeskrivning", domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "beskrivning"),
@@ -172,7 +178,7 @@ func TestAccAWSServiceCatalogProduct_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "ny beskrivning", "ny supportbeskrivning"),
+				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "ny beskrivning", "ny supportbeskrivning", domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "ny beskrivning"),
@@ -187,7 +193,9 @@ func TestAccAWSServiceCatalogProduct_update(t *testing.T) {
 
 func TestAccAWSServiceCatalogProduct_updateTags(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -196,7 +204,7 @@ func TestAccAWSServiceCatalogProduct_updateTags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "beskrivning", "supportbeskrivning"),
+				Config: testAccAWSServiceCatalogProductConfig_basic(rName, "beskrivning", "supportbeskrivning", domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -204,7 +212,7 @@ func TestAccAWSServiceCatalogProduct_updateTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSServiceCatalogProductConfig_updateTags(rName, "beskrivning", "supportbeskrivning"),
+				Config: testAccAWSServiceCatalogProductConfig_updateTags(rName, "beskrivning", "supportbeskrivning", domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -218,7 +226,9 @@ func TestAccAWSServiceCatalogProduct_updateTags(t *testing.T) {
 
 func TestAccAWSServiceCatalogProduct_physicalID(t *testing.T) {
 	resourceName := "aws_servicecatalog_product.test"
+
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -227,7 +237,7 @@ func TestAccAWSServiceCatalogProduct_physicalID(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProductDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProductConfig_physicalID(rName),
+				Config: testAccAWSServiceCatalogProductConfig_physicalID(rName, domain, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProductExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "catalog", regexp.MustCompile(`product/prod-.*`)),
@@ -348,7 +358,7 @@ resource "aws_s3_bucket_object" "test" {
 `, rName)
 }
 
-func testAccAWSServiceCatalogProductConfig_basic(rName, description, supportDescription string) string {
+func testAccAWSServiceCatalogProductConfig_basic(rName, description, supportDescription, domain, email string) string {
 	return composeConfig(testAccAWSServiceCatalogProductConfigTemplateURLBase(rName), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -359,8 +369,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = %[3]q
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[5]q
+  support_url         = %[4]q
 
   provisioning_artifact_parameters {
     description                 = "artefaktbeskrivning"
@@ -374,10 +384,10 @@ resource "aws_servicecatalog_product" "test" {
     Name = %[1]q
   }
 }
-`, rName, description, supportDescription))
+`, rName, description, supportDescription, domain, email))
 }
 
-func testAccAWSServiceCatalogProductConfig_updateTags(rName, description, supportDescription string) string {
+func testAccAWSServiceCatalogProductConfig_updateTags(rName, description, supportDescription, domain, email string) string {
 	return composeConfig(testAccAWSServiceCatalogProductConfigTemplateURLBase(rName), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -388,8 +398,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = %[3]q
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[5]q
+  support_url         = %[4]q
 
   provisioning_artifact_parameters {
     description                 = "artefaktbeskrivning"
@@ -404,10 +414,10 @@ resource "aws_servicecatalog_product" "test" {
     Environment = "natural"
   }
 }
-`, rName, description, supportDescription))
+`, rName, description, supportDescription, domain, email))
 }
 
-func testAccAWSServiceCatalogProductConfig_physicalID(rName string) string {
+func testAccAWSServiceCatalogProductConfig_physicalID(rName, domain, email string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
   name = %[1]q
@@ -442,8 +452,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = "supportbeskrivning"
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[3]q
+  support_url         = %[2]q
 
   provisioning_artifact_parameters {
     description          = "artefaktbeskrivning"
@@ -456,5 +466,5 @@ resource "aws_servicecatalog_product" "test" {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName, domain, email)
 }

--- a/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
+++ b/aws/resource_aws_servicecatalog_provisioning_artifact_test.go
@@ -109,6 +109,8 @@ func TestAccAWSServiceCatalogProvisioningArtifact_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -116,7 +118,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName),
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
@@ -149,6 +151,8 @@ func TestAccAWSServiceCatalogProvisioningArtifact_disappears(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -156,7 +160,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName),
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceCatalogProvisioningArtifact(), resourceName),
@@ -171,6 +175,8 @@ func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -178,7 +184,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName),
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
@@ -189,7 +195,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_update(rName),
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_update(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "accept_language", "jp"),
 					resource.TestCheckResourceAttr(resourceName, "active", "false"),
@@ -216,6 +222,8 @@ func TestAccAWSServiceCatalogProvisioningArtifact_physicalID(t *testing.T) {
 	resourceName := "aws_servicecatalog_provisioning_artifact.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -223,7 +231,7 @@ func TestAccAWSServiceCatalogProvisioningArtifact_physicalID(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceCatalogProvisioningArtifactDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName),
+				Config: testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "accept_language", tfservicecatalog.AcceptLanguageEnglish),
@@ -320,7 +328,7 @@ func testAccCheckAwsServiceCatalogProvisioningArtifactExists(resourceName string
 	}
 }
 
-func testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName string) string {
+func testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName, domain string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -362,8 +370,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = %[1]q
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[3]q
+  support_url         = %[2]q
 
   provisioning_artifact_parameters {
     description                 = "artefaktbeskrivning"
@@ -377,11 +385,11 @@ resource "aws_servicecatalog_product" "test" {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName, domain, testAccDefaultEmailAddress)
 }
 
-func testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName string) string {
-	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName), fmt.Sprintf(`
+func testAccAWSServiceCatalogProvisioningArtifactConfig_basic(rName, domain string) string {
+	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName, domain), fmt.Sprintf(`
 resource "aws_servicecatalog_provisioning_artifact" "test" {
   accept_language             = "en"
   active                      = true
@@ -396,8 +404,8 @@ resource "aws_servicecatalog_provisioning_artifact" "test" {
 `, rName))
 }
 
-func testAccAWSServiceCatalogProvisioningArtifactConfig_update(rName string) string {
-	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName), fmt.Sprintf(`
+func testAccAWSServiceCatalogProvisioningArtifactConfig_update(rName, domain string) string {
+	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigTemplateURLBase(rName, domain), fmt.Sprintf(`
 resource "aws_servicecatalog_provisioning_artifact" "test" {
   accept_language             = "jp"
   active                      = false
@@ -412,7 +420,7 @@ resource "aws_servicecatalog_provisioning_artifact" "test" {
 `, rName))
 }
 
-func testAccAWSServiceCatalogProvisioningArtifactConfigPhysicalIDBase(rName string) string {
+func testAccAWSServiceCatalogProvisioningArtifactConfigPhysicalIDBase(rName, domain string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "test" {
   name = %[1]q
@@ -447,8 +455,8 @@ resource "aws_servicecatalog_product" "test" {
   owner               = "ägare"
   type                = "CLOUD_FORMATION_TEMPLATE"
   support_description = "supportbeskrivning"
-  support_email       = "support@example.com"
-  support_url         = "http://example.com"
+  support_email       = %[3]q
+  support_url         = %[2]q
 
   provisioning_artifact_parameters {
     description          = "artefaktbeskrivning"
@@ -457,11 +465,11 @@ resource "aws_servicecatalog_product" "test" {
     type                 = "CLOUD_FORMATION_TEMPLATE"
   }
 }
-`, rName)
+`, rName, domain, testAccDefaultEmailAddress)
 }
 
-func testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName string) string {
-	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigPhysicalIDBase(rName), fmt.Sprintf(`
+func testAccAWSServiceCatalogProvisioningArtifactConfig_physicalID(rName, domain string) string {
+	return composeConfig(testAccAWSServiceCatalogProvisioningArtifactConfigPhysicalIDBase(rName, domain), fmt.Sprintf(`
 resource "aws_servicecatalog_provisioning_artifact" "test" {
   accept_language             = "en"
   active                      = true

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -29,7 +29,7 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSESReceiptRuleBasicConfig(rName),
+				Config: testAccAWSSESReceiptRuleBasicConfig(rName, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -43,7 +43,7 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stop_action.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "workmail_action.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "recipients.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "recipients.*", "test@example.com"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "recipients.*", testAccDefaultEmailAddress),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "scan_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tls_policy", "Require"),
@@ -335,7 +335,7 @@ func TestAccAWSSESReceiptRule_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSESReceiptRuleBasicConfig(rName),
+				Config: testAccAWSSESReceiptRuleBasicConfig(rName, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesReceiptRuleSet(), ruleSetResourceName),
@@ -343,7 +343,7 @@ func TestAccAWSSESReceiptRule_disappears(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccAWSSESReceiptRuleBasicConfig(rName),
+				Config: testAccAWSSESReceiptRuleBasicConfig(rName, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESReceiptRuleExists(resourceName, &rule),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesReceiptRule(), resourceName),
@@ -447,7 +447,7 @@ func testAccPreCheckSESReceiptRule(t *testing.T) {
 	}
 }
 
-func testAccAWSSESReceiptRuleBasicConfig(rName string) string {
+func testAccAWSSESReceiptRuleBasicConfig(rName, email string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
   rule_set_name = %[1]q
@@ -456,12 +456,12 @@ resource "aws_ses_receipt_rule_set" "test" {
 resource "aws_ses_receipt_rule" "test" {
   name          = %[1]q
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
+  recipients    = [%[2]q]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
 }
-`, rName)
+`, rName, email)
 }
 
 func testAccAWSSESReceiptRuleS3ActionConfig(rName string) string {
@@ -479,7 +479,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_ses_receipt_rule" "test" {
   name          = %[1]q
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
+  recipients    = [%[2]q]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
@@ -489,7 +489,7 @@ resource "aws_ses_receipt_rule" "test" {
     position    = 1
   }
 }
-`, rName)
+`, rName, testAccDefaultEmailAddress)
 }
 
 func testAccAWSSESReceiptRuleSNSActionConfig(rName string) string {
@@ -505,7 +505,7 @@ resource "aws_sns_topic" "test" {
 resource "aws_ses_receipt_rule" "test" {
   name          = %[1]q
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
+  recipients    = [%[2]q]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
@@ -515,7 +515,7 @@ resource "aws_ses_receipt_rule" "test" {
     position  = 1
   }
 }
-`, rName)
+`, rName, testAccDefaultEmailAddress)
 }
 
 func testAccAWSSESReceiptRuleSNSActionEncodingConfig(rName string) string {
@@ -531,7 +531,7 @@ resource "aws_sns_topic" "test" {
 resource "aws_ses_receipt_rule" "test" {
   name          = %[1]q
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
+  recipients    = [%[2]q]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
@@ -542,7 +542,7 @@ resource "aws_ses_receipt_rule" "test" {
     position  = 1
   }
 }
-`, rName)
+`, rName, testAccDefaultEmailAddress)
 }
 
 func testAccAWSSESReceiptRuleLambdaActionConfig(rName string) string {
@@ -587,7 +587,7 @@ resource "aws_lambda_permission" "test" {
 resource "aws_ses_receipt_rule" "test" {
   name          = %[1]q
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
+  recipients    = [%[2]q]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
@@ -599,7 +599,7 @@ resource "aws_ses_receipt_rule" "test" {
 
   depends_on = [aws_lambda_permission.test]
 }
-`, rName)
+`, rName, testAccDefaultEmailAddress)
 }
 
 func testAccAWSSESReceiptRuleStopActionConfig(rName string) string {
@@ -615,7 +615,7 @@ resource "aws_sns_topic" "test" {
 resource "aws_ses_receipt_rule" "test" {
   name          = %[1]q
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
-  recipients    = ["test@example.com"]
+  recipients    = [%[2]q]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"
@@ -626,7 +626,7 @@ resource "aws_ses_receipt_rule" "test" {
     position  = 1
   }
 }
-`, rName)
+`, rName, testAccDefaultEmailAddress)
 }
 
 func testAccAWSSESReceiptRuleOrderConfig(rName string) string {

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -389,13 +389,13 @@ func TestAccAWSSNSTopicSubscription_email(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSNSTopicSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSNSTopicSubscriptionEmailConfig(rName),
+				Config: testAccAWSSNSTopicSubscriptionEmailConfig(rName, testAccDefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicSubscriptionExists(resourceName, attributes),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", sns.ServiceName, regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
 					resource.TestCheckResourceAttr(resourceName, "confirmation_was_authenticated", "false"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
-					resource.TestCheckResourceAttr(resourceName, "endpoint", "invalid_email@example.com"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", testAccDefaultEmailAddress),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, "pending_confirmation", "true"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "email"),
@@ -603,8 +603,8 @@ func obfuscateEndpoint(t *testing.T, endpoint string) string {
 func TestObfuscateEndpointPassword(t *testing.T) {
 	checks := map[string]string{
 		"https://example.com/myroute":                   "https://example.com/myroute",
-		"https://username@example.com/myroute":          "https://username@example.com/myroute",
-		"https://username:password@example.com/myroute": "https://username:****@example.com/myroute",
+		"https://username@example.com/myroute":          "https://username@example.com/myroute",      // nosemgrep: email-address
+		"https://username:password@example.com/myroute": "https://username:****@example.com/myroute", // nosemgrep: email-address
 	}
 	for endpoint, expected := range checks {
 		out := obfuscateEndpoint(t, endpoint)
@@ -1040,7 +1040,7 @@ resource "aws_sns_topic_subscription" "test" {
 `, rName)
 }
 
-func testAccAWSSNSTopicSubscriptionEmailConfig(rName string) string {
+func testAccAWSSNSTopicSubscriptionEmailConfig(rName, email string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -1049,9 +1049,9 @@ resource "aws_sns_topic" "test" {
 resource "aws_sns_topic_subscription" "test" {
   topic_arn = aws_sns_topic.test.arn
   protocol  = "email"
-  endpoint  = "invalid_email@example.com"
+  endpoint  = %[2]q
 }
-`, rName)
+`, rName, email)
 }
 
 func testAccAWSSNSTopicSubscriptionConfig_firehose(rName string) string {

--- a/aws/resource_aws_transfer_ssh_key_test.go
+++ b/aws/resource_aws_transfer_ssh_key_test.go
@@ -92,7 +92,7 @@ func testAccCheckAWSTransferSshKeyDestroy(s *terraform.State) error {
 		}
 		serverID, userName, sshKeyID, err := decodeTransferSshKeyId(rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("error parsing Transfer SSH Public Key ID: %s", err)
+			return fmt.Errorf("error parsing Transfer SSH Public Key ID: %w", err)
 		}
 
 		describe, err := conn.DescribeUser(&transfer.DescribeUserInput{

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -173,7 +173,7 @@ func TestValidateCloudWatchEventBusNameOrARN(t *testing.T) {
 		"HelloWorl_d",
 		"hello-world",
 		"hello.World0125",
-		"aws.partner/mongodb.com/stitch.trigger/something",
+		"aws.partner/mongodb.com/stitch.trigger/something",        // nosemgrep: domain-names
 		"arn:aws:events:us-east-1:123456789012:event-bus/default", // lintignore:AWSAT003,AWSAT005
 	}
 	for _, v := range validNames {
@@ -1880,11 +1880,11 @@ func TestValidateOpenIdURL(t *testing.T) {
 		ErrCount int
 	}{
 		{
-			Value:    "http://wrong.scheme.com",
+			Value:    "http://wrong.scheme.com", // nosemgrep: domain-names
 			ErrCount: 1,
 		},
 		{
-			Value:    "ftp://wrong.scheme.co.uk",
+			Value:    "ftp://wrong.scheme.co.uk", // nosemgrep: domain-names
 			ErrCount: 1,
 		},
 		{
@@ -2036,7 +2036,7 @@ func TestValidateCognitoSupportedLoginProviders(t *testing.T) {
 	validValues := []string{
 		"foo",
 		"7346241598935552",
-		"123456789012.apps.googleusercontent.com",
+		"123456789012.apps.googleusercontent.com", // nosemgrep: domain-names
 		"foo_bar",
 		"foo;bar",
 		"foo/bar",

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -44,6 +44,7 @@
         - [Hardcoded Region](#hardcoded-region)
         - [Hardcoded Spot Price](#hardcoded-spot-price)
         - [Hardcoded SSH Keys](#hardcoded-ssh-keys)
+        - [Hardcoded Email Addresses](#hardcoded-email-addresses)
 
 Terraform includes an acceptance test harness that does most of the repetitive
 work involved in testing a resource. For additional information about testing
@@ -1577,6 +1578,7 @@ func TestAccAWSKeyPair_basic(t *testing.T) {
       },
     },
   })
+}
 
 func testAccAWSKeyPairConfig(rName, publicKey string) string {
 	return fmt.Sprintf(`
@@ -1585,5 +1587,66 @@ resource "aws_key_pair" "test" {
   public_key = %[2]q
 }
 `, rName, publicKey)
+}
+```
+
+#### Hardcoded Email Addresses
+
+- [ ] __Uses either testAccDefaultEmailAddress Constant or testAccRandomEmailAddress() Function__: Any hardcoded email addresses should replaced with either the constant `testAccDefaultEmailAddress` or the function `testAccRandomEmailAddress()`.
+
+Using `testAccDefaultEmailAddress` is preferred when using a single email address in an acceptance test.
+
+Here's an example using `testAccDefaultEmailAddress`
+
+```go
+func TestAccAWSSNSTopicSubscription_email(t *testing.T) {
+	...
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		...
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSNSTopicSubscriptionEmailConfig(rName, testAccDefaultEmailAddress),
+				Check: resource.ComposeTestCheckFunc(
+					...
+					resource.TestCheckResourceAttr(resourceName, "endpoint", testAccDefaultEmailAddress),
+				),
+			},
+		},
+	})
+}
+```
+
+Here's an example using `testAccRandomEmailAddress()`
+
+```go
+func TestAccAWSPinpointEmailChannel_basic(t *testing.T) {
+	...
+
+	domain := testAccRandomDomainName()
+	address1 := testAccRandomEmailAddress(domain)
+	address2 := testAccRandomEmailAddress(domain)
+
+	resource.ParallelTest(t, resource.TestCase{
+		...
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointEmailChannelConfig_FromAddress(domain, address1),
+				Check: resource.ComposeTestCheckFunc(
+					...
+					resource.TestCheckResourceAttr(resourceName, "from_address", address1),
+				),
+			},
+			{
+				Config: testAccAWSPinpointEmailChannelConfig_FromAddress(domain, address2),
+				Check: resource.ComposeTestCheckFunc(
+					...
+					resource.TestCheckResourceAttr(resourceName, "from_address", address2),
+				),
+			},
+		},
+	})
 }
 ```


### PR DESCRIPTION
Remove hardcoded email addresses

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19972

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject\|TestAccAWSQuickSightUser\|TestAccAWSServiceCatalogLaunchPathsDataSource\|TestAccAWSProvider\|TestAccAWSSESReceiptRule\|TestAccAWSServiceCatalogProduct\|TestAccAWSSNSTopicSubscription\|TestAccAWSBudgetsBudget\|TestAccAWSServiceCatalogProvisionedProduct\|TestAccAWSCodeBuildWebhook\|TestAccAWSBeanstalkEnv\|TestAccAWSServiceCatalogProductPortfolioAssociation\|TestAccAWSServiceCatalogProductDataSource\|TestAccAWSPinpointEmailChannel\|TestAccAWSServiceCatalogProvisioningArtifact'

--- PASS: TestAccAWSProvider_Region_AwsC2S (47.12s)
--- PASS: TestAccAWSProvider_Region_AwsChina (47.41s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (48.53s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (48.56s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (60.98s)
--- PASS: TestAccAWSProvider_DefaultAndIgnoreTags_EmptyConfigurationBlocks (61.34s)
--- PASS: TestAccAWSProvider_DefaultTags_EmptyConfigurationBlock (61.20s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (61.76s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (61.88s)
--- PASS: TestAccAWSProvider_DefaultTags_Tags_One (61.80s)
--- PASS: TestAccAWSProvider_Endpoints (62.18s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (62.56s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (62.93s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (63.84s)
--- PASS: TestAccAWSProvider_DefaultTags_Tags_Multiple (64.31s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (64.71s)
--- PASS: TestAccAWSProvider_DefaultTags_Tags_None (65.37s)
--- PASS: TestAccAWSServiceCatalogProductDataSource_basic (90.31s)
--- PASS: TestAccAWSProvider_Region_AwsSC2S (43.25s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (52.48s)
--- PASS: TestAccAWSBudgetsBudget_disappears (44.95s)
--- PASS: TestAccAWSServiceCatalogProductDataSource_physicalID (126.98s)
--- PASS: TestAccAWSBudgetsBudgetAction_disappears (77.73s)
--- PASS: TestAccAWSServiceCatalogLaunchPathsDataSource_basic (135.70s)
--- PASS: TestAccAWSBudgetsBudgetAction_basic (85.90s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (81.02s)
--- PASS: TestAccAWSCodeBuildProject_basic (89.27s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (91.24s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (87.39s)
--- PASS: TestAccAWSBudgetsBudget_prefix (109.99s)
--- PASS: TestAccAWSBudgetsBudget_basic (125.25s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (85.39s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (138.65s)
--- PASS: TestAccAWSCodeBuildProject_Description (138.30s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (140.59s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (185.71s)
--- PASS: TestAccAWSCodeBuildProject_BuildBatchConfig (146.43s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (192.66s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (147.43s)
--- PASS: TestAccAWSCodeBuildProject_Source_BuildStatusConfig_GitHubEnterprise (95.10s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (153.96s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (152.94s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (152.40s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (216.70s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (149.77s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (202.58s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (204.71s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (147.43s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (150.98s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (152.88s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (152.99s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (203.44s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (56.19s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (89.44s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (90.02s)
--- PASS: TestAccAWSCodeBuildProject_FileSystemLocations (310.44s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (92.53s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (90.51s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (90.35s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (88.34s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (137.39s)
--- PASS: TestAccAWSCodeBuildProject_WindowsServer2019Container (84.69s)
--- PASS: TestAccAWSBudgetsBudget_notification (355.38s)
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (85.61s)
--- PASS: TestAccAWSCodeBuildProject_Cache (368.66s)
--- PASS: TestAccAWSCodeBuildProject_Tags (137.23s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (141.77s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (144.98s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (148.28s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (152.50s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (154.51s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (150.15s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (152.24s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (203.71s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (152.27s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (155.20s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (151.33s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (100.55s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (156.73s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (151.69s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (150.37s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (97.04s)
--- FAIL: TestAccAWSCodeBuildWebhook_Bitbucket (54.26s)
--- FAIL: TestAccAWSCodeBuildWebhook_GitHub (53.10s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (154.26s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (150.96s)
--- FAIL: TestAccAWSCodeBuildWebhook_BranchFilter (53.77s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (153.31s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (153.25s)
--- FAIL: TestAccAWSCodeBuildWebhook_FilterGroup (47.56s)
--- PASS: TestAccAWSCodeBuildProject_ConcurrentBuildLimit (119.48s)
--- FAIL: TestAccAWSCodeBuildWebhook_GitHubEnterprise (87.81s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (106.46s)
--- PASS: TestAccAWSPinpointEmailChannel_noRole (38.14s)
--- PASS: TestAccAWSPinpointEmailChannel_disappears (37.95s)
--- PASS: TestAccAWSPinpointEmailChannel_configurationSet (41.34s)
--- PASS: TestAccAWSQuickSightUser_disappears (26.85s)
--- PASS: TestAccAWSQuickSightUser_basic (55.89s)
--- PASS: TestAccAWSQuickSightUser_withInvalidFormattedEmailStillWorks (53.98s)
--- PASS: TestAccAWSPinpointEmailChannel_basic (60.52s)
--- PASS: TestAccAWSServiceCatalogProduct_disappears (29.47s)
--- PASS: TestAccAWSServiceCatalogProduct_basic (36.06s)
--- PASS: TestAccAWSServiceCatalogProduct_update (49.44s)
--- PASS: TestAccAWSServiceCatalogProduct_updateTags (46.96s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_basic (37.19s)
--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_disappears (81.13s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_disappears (28.58s)
--- PASS: TestAccAWSServiceCatalogProductPortfolioAssociation_basic (90.63s)
--- PASS: TestAccAWSSESReceiptRuleSet_disappears (15.30s)
--- PASS: TestAccAWSSESReceiptRuleSet_basic (19.32s)
--- PASS: TestAccAWSServiceCatalogProduct_physicalID (79.07s)
--- PASS: TestAccAWSSESReceiptRule_basic (20.39s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (27.00s)
--- PASS: TestAccAWSSESReceiptRule_snsAction (24.93s)
--- PASS: TestAccAWSSESReceiptRule_snsActionEncoding (24.77s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_update (68.78s)
--- PASS: TestAccAWSSESReceiptRule_lambdaAction (54.14s)
--- PASS: TestAccAWSSESReceiptRule_actions (32.48s)
--- PASS: TestAccAWSSESReceiptRule_order (32.91s)
--- PASS: TestAccAWSSESReceiptRule_stopAction (33.09s)
--- PASS: TestAccAWSServiceCatalogProvisionedProduct_disappears (136.97s)
--- PASS: TestAccAWSServiceCatalogProvisionedProduct_basic (142.12s)
--- PASS: TestAccAWSServiceCatalogProvisioningArtifact_physicalID (93.22s)
--- PASS: TestAccAWSSESReceiptRule_disappears (61.69s)
--- PASS: TestAccAWSSNSTopicSubscription_basic (71.42s)
--- PASS: TestAccAWSSNSTopicSubscription_email (36.75s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (105.26s)
--- PASS: TestAccAWSServiceCatalogProvisionedProduct_tags (251.55s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (125.41s)
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (126.97s)
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (125.30s)
--- PASS: TestAccAWSSNSTopicSubscription_redrivePolicy (128.80s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (131.43s)
--- PASS: TestAccAWSSNSTopicSubscription_disappears (85.02s)
--- PASS: TestAccAWSBeanstalkEnv_resource (404.31s)
--- PASS: TestAccAWSSNSTopicSubscription_disappears_topic (66.32s)
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (412.63s)
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (402.59s)
--- PASS: TestAccAWSSNSTopicSubscription_firehose (143.51s)
--- PASS: TestAccAWSBeanstalkEnv_basic (490.88s)
--- PASS: TestAccAWSBeanstalkEnv_platformArn (459.73s)
--- PASS: TestAccAWSBeanstalkEnv_tier (570.61s)
--- PASS: TestAccAWSBeanstalkEnv_config (577.73s)
--- PASS: TestAccAWSBeanstalkEnv_version_label (594.22s)
--- PASS: TestAccAWSBeanstalkEnv_template_change (616.54s)
--- PASS: TestAccAWSBeanstalkEnv_tags (665.66s)
--- PASS: TestAccAWSBeanstalkEnv_settings_update (755.34s)
```

`TestAccAWSCodeBuildWebhook_*` failures are pre-existing