### PR TITLE
documentation update: link to AWS docs instead of static list

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -556,8 +556,9 @@ The arguments of `geo_restriction` are:
 
 * `minimum_protocol_version` - The minimum version of the SSL protocol that
     you want CloudFront to use for HTTPS connections. Can only be set if
-    `cloudfront_default_certificate = false`. One of `SSLv3`, `TLSv1`,
-    `TLSv1_2016`, `TLSv1.1_2016`, `TLSv1.2_2018` or `TLSv1.2_2019`. Default: `TLSv1`. **NOTE**:
+    `cloudfront_default_certificate = false`. See all possible values in
+    [this](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html)
+    table under "Security policy." Default: `TLSv1`. **NOTE**:
     If you are using a custom certificate (specified with `acm_certificate_arn`
     or `iam_certificate_id`), and have specified `sni-only` in
     `ssl_support_method`, `TLSv1` or later must be specified. If you have


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15194 

Replaces the static list of accepted values provided in the docs for cloudfront for `viewer_certificate`, `minimum_protocol_version` with a link to the AWS docs that has a table containing all values accepted by the API (and therefore terraform)