### PR TITLE
SecretsManager Secret Replication

### DIFF
--- a/.changelog/20293.txt
+++ b/.changelog/20293.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_secretsmanager_secret: Add replica support
+```

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -37,6 +37,11 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"force_overwrite_replica_secret": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"kms_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -73,6 +78,35 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 					validation.IntInSlice([]int{0}),
 				),
 			},
+			"replicas": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"last_accessed_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"rotation_enabled": {
 				Deprecated: "Use the aws_secretsmanager_secret_rotation resource instead",
 				Type:       schema.TypeBool,
@@ -99,45 +133,6 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 					},
 				},
 			},
-
-			"force_overwrite_replica_secret": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
-			"replica_regions": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"force_overwrite_replica_secret": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						"replica_region": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"region": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"kms_key_id": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
 		},
@@ -161,8 +156,9 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 	}
 
 	input := &secretsmanager.CreateSecretInput{
-		Description: aws.String(d.Get("description").(string)),
-		Name:        aws.String(secretName),
+		Description:                 aws.String(d.Get("description").(string)),
+		Name:                        aws.String(secretName),
+		ForceOverwriteReplicaSecret: aws.Bool(d.Get("force_overwrite_replica_secret").(bool)),
 	}
 
 	if len(tags) > 0 {
@@ -171,6 +167,10 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
 		input.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("replicas"); ok && v.(*schema.Set).Len() > 0 {
+		input.AddReplicaRegions = expandSecretsManagerSecretReplicas(v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] Creating Secrets Manager Secret: %s", input)
@@ -253,51 +253,6 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	if v := d.Get("replication_configuration"); v != nil {
-		input := secretsmanager.ReplicateSecretToRegionsInput{
-			SecretId: aws.String(d.Id()),
-		}
-
-		if v, ok := d.GetOk("force_overwrite_replica_secret"); ok {
-			input.ForceOverwriteReplicaSecret = aws.Bool(v.(bool))
-		}
-
-		var replicaRegions []*secretsmanager.ReplicaRegionType
-		if v := d.Get("replica_region"); v != nil {
-			for _, v := range v.(*schema.Set).List() {
-				replicaRegionResource := v.(map[string]interface{})
-
-				replicaRegion := secretsmanager.ReplicaRegionType{}
-				if v, ok := replicaRegionResource["region"]; ok && v.(string) != "" {
-
-					replicaRegion.Region = aws.String(v.(string))
-				}
-
-				if v, ok := d.GetOk("kms_key_id"); ok {
-					replicaRegion.KmsKeyId = aws.String(v.(string))
-				}
-
-				replicaRegions = append(replicaRegions, &replicaRegion)
-			}
-			input.AddReplicaRegions = replicaRegions
-		}
-
-		log.Printf("[DEBUG] Enabling Secrets Manager Secret Replication: %s", input)
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			_, err := conn.ReplicateSecretToRegions(&input)
-			if err != nil {
-				// AccessDeniedException: Secrets Manager cannot replicate the secret.
-				if isAWSErr(err, "AccessDeniedException", "") {
-					return resource.RetryableError(err)
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("error enabling Secrets Manager Secret %q replication: %w", d.Id(), err)
-		}
-	}
-
 	return resourceAwsSecretsManagerSecretRead(d, meta)
 }
 
@@ -351,6 +306,10 @@ func resourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interface{
 	d.Set("kms_key_id", output.KmsKeyId)
 	d.Set("name", output.Name)
 
+	if err := d.Set("replicas", flattenSecretsManagerSecretReplicas(output.ReplicationStatus)); err != nil {
+		return fmt.Errorf("error setting replicas: %w", err)
+	}
+
 	pIn := &secretsmanager.GetResourcePolicyInput{
 		SecretId: aws.String(d.Id()),
 	}
@@ -380,28 +339,10 @@ func resourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interface{
 		d.Set("rotation_rules", []interface{}{})
 	}
 
-<<<<<<< HEAD
 	tags := keyvaluetags.SecretsmanagerKeyValueTags(output.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-=======
-	if output.ReplicationStatus != nil && len(output.ReplicationStatus) > 0 {
-		replicationStatuses := make([]interface{}, len(output.ReplicationStatus))
-		for i, rs := range output.ReplicationStatus {
-			replicationStatus := map[string]interface{}{
-				"region":      aws.StringValue(rs.Region),
-				"kms_key_id":  aws.StringValue(rs.KmsKeyId),
-			}
-			replicationStatuses[i] = replicationStatus
-		}
-		if err := d.Set("replica_region", replicationStatuses); err != nil {
-			return fmt.Errorf("error setting replica_region: %s", err)
-		}
-	}
-
-	if err := d.Set("tags", keyvaluetags.SecretsmanagerKeyValueTags(output.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
->>>>>>> 95dac460e (First pass at implementation)
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
@@ -548,4 +489,96 @@ func resourceAwsSecretsManagerSecretDelete(d *schema.ResourceData, meta interfac
 	}
 
 	return nil
+}
+
+func expandSecretsManagerSecretReplica(tfMap map[string]interface{}) *secretsmanager.ReplicaRegionType {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &secretsmanager.ReplicaRegionType{}
+
+	if v, ok := tfMap["kms_key_id"].(string); ok && v != "" {
+		apiObject.KmsKeyId = aws.String(v)
+	}
+
+	if v, ok := tfMap["region"].(string); ok && v != "" {
+		apiObject.Region = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandSecretsManagerSecretReplicas(tfList []interface{}) []*secretsmanager.ReplicaRegionType {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*secretsmanager.ReplicaRegionType
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandSecretsManagerSecretReplica(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func flattenSecretsManagerSecretReplica(apiObject *secretsmanager.ReplicationStatusType) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.KmsKeyId; v != nil {
+		tfMap["kms_key_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.LastAccessedDate; v != nil {
+		tfMap["last_accessed_date"] = aws.TimeValue(v).Format(time.RFC3339)
+	}
+
+	if v := apiObject.Region; v != nil {
+		tfMap["region"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Status; v != nil {
+		tfMap["status"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.StatusMessage; v != nil {
+		tfMap["status_message"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenSecretsManagerSecretReplicas(apiObjects []*secretsmanager.ReplicationStatusType) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenSecretsManagerSecretReplica(apiObject))
+	}
+
+	return tfList
 }

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -99,6 +99,32 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 					},
 				},
 			},
+
+			"force_overwrite_replica_secret": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"replica_region": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"kms_key_id": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),
 		},
@@ -211,6 +237,14 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		}
 		if err != nil {
 			return fmt.Errorf("error enabling Secrets Manager Secret %q rotation: %w", d.Id(), err)
+		}
+	}
+
+	if v, ok := d.GetOk("") {
+		input := &secretsmanager.
+
+		if err != nil {
+			return fmt.Errorf("error replicatin Secrets Manager Secret")
 		}
 	}
 

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -99,7 +99,6 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 						"region": {
 							Type:     schema.TypeString,
 							Required: true,
-							Computed: true,
 						},
 						"status": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -95,7 +95,7 @@ func TestAccAwsSecretsManagerSecret_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 		},
 	})
@@ -124,7 +124,7 @@ func TestAccAwsSecretsManagerSecret_withNamePrefix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "name_prefix"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "name_prefix", "force_overwrite_replica_secret"},
 			},
 		},
 	})
@@ -159,7 +159,7 @@ func TestAccAwsSecretsManagerSecret_Description(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 		},
 	})
@@ -193,7 +193,7 @@ func TestAccAwsSecretsManagerSecret_OverwriteReplica(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 		},
 	})
@@ -228,7 +228,7 @@ func TestAccAwsSecretsManagerSecret_KmsKeyID(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 		},
 	})
@@ -264,7 +264,7 @@ func TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate(t *testing.T) 
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 		},
 	})
@@ -309,7 +309,7 @@ func TestAccAwsSecretsManagerSecret_RotationLambdaARN(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 			// Test removing rotation on resource update
 			{
@@ -363,7 +363,7 @@ func TestAccAwsSecretsManagerSecret_RotationRules(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 			// Test removing rotation rules on resource update
 			{
@@ -425,7 +425,7 @@ func TestAccAwsSecretsManagerSecret_Tags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days"},
+				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
 			},
 		},
 	})

--- a/website/docs/r/secretsmanager_secret.html.markdown
+++ b/website/docs/r/secretsmanager_secret.html.markdown
@@ -43,15 +43,21 @@ resource "aws_secretsmanager_secret" "rotation-example" {
 
 The following arguments are supported:
 
-* `name` - (Optional) Specifies the friendly name of the new secret. The secret name can consist of uppercase letters, lowercase letters, digits, and any of the following characters: `/_+=.@-` Conflicts with `name_prefix`.
+* `description` - (Optional) Description of the secret.
+* `kms_key_id` - (Optional) ARN or Id of the AWS KMS customer master key (CMK) to be used to encrypt the secret values in the versions stored in this secret. If you don't specify this value, then Secrets Manager defaults to using the AWS account's default CMK (the one named `aws/secretsmanager`). If the default KMS CMK with that name doesn't yet exist, then AWS Secrets Manager creates it for you automatically the first time.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-* `description` - (Optional) A description of the secret.
-* `kms_key_id` - (Optional) Specifies the ARN or Id of the AWS KMS customer master key (CMK) to be used to encrypt the secret values in the versions stored in this secret. If you don't specify this value, then Secrets Manager defaults to using the AWS account's default CMK (the one named `aws/secretsmanager`). If the default KMS CMK with that name doesn't yet exist, then AWS Secrets Manager creates it for you automatically the first time.
-* `policy` - (Optional) A valid JSON document representing a [resource policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html). For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
-* `recovery_window_in_days` - (Optional) Specifies the number of days that AWS Secrets Manager waits before it can delete the secret. This value can be `0` to force deletion without recovery or range from `7` to `30` days. The default value is `30`.
-* `rotation_lambda_arn` - (Optional, **DEPRECATED**) Specifies the ARN of the Lambda function that can rotate the secret. Use the `aws_secretsmanager_secret_rotation` resource to manage this configuration instead. As of version 2.67.0, removal of this configuration will no longer remove rotation due to supporting the new resource. Either import the new resource and remove the configuration or manually remove rotation.
-* `rotation_rules` - (Optional, **DEPRECATED**) A structure that defines the rotation configuration for this secret. Defined below. Use the `aws_secretsmanager_secret_rotation` resource to manage this configuration instead. As of version 2.67.0, removal of this configuration will no longer remove rotation due to supporting the new resource. Either import the new resource and remove the configuration or manually remove rotation.
-* `tags` - (Optional) Specifies a key-value map of user-defined tags that are attached to the secret. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `name` - (Optional) Friendly name of the new secret. The secret name can consist of uppercase letters, lowercase letters, digits, and any of the following characters: `/_+=.@-` Conflicts with `name_prefix`.
+* `policy` - (Optional) Valid JSON document representing a [resource policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html). For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
+* `recovery_window_in_days` - (Optional) Number of days that AWS Secrets Manager waits before it can delete the secret. This value can be `0` to force deletion without recovery or range from `7` to `30` days. The default value is `30`.
+* `replica` - (Optional) Configuration block to support secret replication. See details below.
+* `rotation_lambda_arn` - (Optional, **DEPRECATED**) ARN of the Lambda function that can rotate the secret. Use the `aws_secretsmanager_secret_rotation` resource to manage this configuration instead. As of version 2.67.0, removal of this configuration will no longer remove rotation due to supporting the new resource. Either import the new resource and remove the configuration or manually remove rotation.
+* `rotation_rules` - (Optional, **DEPRECATED**) Configuration block for the rotation configuration of this secret. Defined below. Use the `aws_secretsmanager_secret_rotation` resource to manage this configuration instead. As of version 2.67.0, removal of this configuration will no longer remove rotation due to supporting the new resource. Either import the new resource and remove the configuration or manually remove rotation.
+* `tags` - (Optional) Key-value map of user-defined tags that are attached to the secret. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### replica
+
+* `kms_key_id` - (Optional) ARN, Key ID, or Alias.
+* `region` - (Required) Region for replicating the secret.
 
 ### rotation_rules
 
@@ -61,10 +67,17 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Amazon Resource Name (ARN) of the secret.
-* `arn` - Amazon Resource Name (ARN) of the secret.
-* `rotation_enabled` - Specifies whether automatic rotation is enabled for this secret.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `id` - ARN of the secret.
+* `arn` - ARN of the secret.
+* `rotation_enabled` - Whether automatic rotation is enabled for this secret.
+* `replica` - Attributes of a replica are described below.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+### replica
+
+* `last_accessed_date` - Date that you last accessed the secret in the Region.
+* `status` - Status can be `InProgress`, `Failed`, or `InSync`.
+* `status_message` - Message such as `Replication succeeded` or `Secret with this name already exists in this region`.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18280 
Closes #17943

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (25.43s)
--- PASS: TestAccAwsSecretsManagerSecret_basic (25.71s)
--- PASS: TestAccAwsSecretsManagerSecret_basicReplica (27.40s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (37.34s)
--- FAIL: TestAccAwsSecretsManagerSecret_policy (39.13s) # pre-existing failure, unrelated to these changes
--- PASS: TestAccAwsSecretsManagerSecret_Description (39.37s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (45.47s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (60.60s)
--- PASS: TestAccAwsSecretsManagerSecret_overwriteReplica (64.59s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (65.90s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (78.11s)
```

Output from acceptance testing (GovCloud):

```
--- FAIL: TestAccAwsSecretsManagerSecret_overwriteReplica (2.32s) # test requires 3 regions, govcloud only has 2
--- PASS: TestAccAwsSecretsManagerSecret_basic (29.20s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (29.22s)
--- PASS: TestAccAwsSecretsManagerSecret_basicReplica (30.67s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (44.15s)
--- FAIL: TestAccAwsSecretsManagerSecret_policy (44.81s) # pre-existing failure, unrelated to these changes
--- PASS: TestAccAwsSecretsManagerSecret_Description (47.10s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (52.32s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (66.61s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (74.36s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (75.89s)
```
