### PR TITLE
sweeper/aws_cur_report_definition: Checks for region support

### DIFF
--- a/aws/cur_test.go
+++ b/aws/cur_test.go
@@ -97,3 +97,11 @@ func testAccGetCurRegion() string {
 
 	return testAccCurRegion
 }
+
+func testAccRegionSupportsCur(region, partition string) bool {
+	if rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), partition, costandusagereportservice.ServiceName); ok {
+		_, ok := rs[region]
+		return ok
+	}
+	return false
+}


### PR DESCRIPTION
In some regions where CUR was not supported, such as `us-east-2`, the error `RequestError` is returned, which will cause the sweeper to skip.

In other regions where it is not supported, such as `us-west-2`, the error is `ThrottlingException` instead.

This PR now checks for the existence of a CUR endpoint and skips if the region does not support CUR.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPARGS=-sweep-run=aws_cur_report_definition

2021/07/23 11:59:31 [DEBUG] Running Sweepers for region (us-east-1):
2021/07/23 11:59:31 [DEBUG] Running Sweeper (aws_cur_report_definition) in region (us-east-1)
2021/07/23 11:59:33 [DEBUG] Completed Sweeper (aws_cur_report_definition) in region (us-east-1) in 2.455980495s
2021/07/23 11:59:33 Completed Sweepers for region (us-east-1) in 2.456235699s
2021/07/23 11:59:33 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_cur_report_definition
2021/07/23 11:59:33 [DEBUG] Running Sweepers for region (us-east-2):
2021/07/23 11:59:33 [DEBUG] Running Sweeper (aws_cur_report_definition) in region (us-east-2)
2021/07/23 11:59:34 [WARN] Skipping Cost and Usage Report Definitions sweep for us-east-2: CUR not supported in this region
2021/07/23 11:59:34 [DEBUG] Completed Sweeper (aws_cur_report_definition) in region (us-east-2) in 1.284317519s
2021/07/23 11:59:34 Completed Sweepers for region (us-east-2) in 1.284335761s
2021/07/23 11:59:34 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_cur_report_definition
2021/07/23 11:59:34 [DEBUG] Running Sweepers for region (us-west-2):
2021/07/23 11:59:34 [DEBUG] Running Sweeper (aws_cur_report_definition) in region (us-west-2)
2021/07/23 11:59:36 [WARN] Skipping Cost and Usage Report Definitions sweep for us-west-2: CUR not supported in this region
2021/07/23 11:59:36 [DEBUG] Completed Sweeper (aws_cur_report_definition) in region (us-west-2) in 1.740692215s
2021/07/23 11:59:36 Completed Sweepers for region (us-west-2) in 1.740708271s
2021/07/23 11:59:36 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_cur_report_definition
```
