### PR TITLE
d/aws_lb: tags must be Computed

### DIFF
--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -150,7 +150,7 @@ func dataSourceAwsLb() *schema.Resource {
 				Computed: true,
 			},
 
-			"tags": tagsSchema(),
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6458.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTARGS='-run=TestAccDataSourceAWSLB_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLB_ -timeout 180m
=== RUN   TestAccDataSourceAWSLB_basic
=== PAUSE TestAccDataSourceAWSLB_basic
=== RUN   TestAccDataSourceAWSLB_outpost
=== PAUSE TestAccDataSourceAWSLB_outpost
=== RUN   TestAccDataSourceAWSLB_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLB_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLB_basic
=== CONT  TestAccDataSourceAWSLB_outpost
=== CONT  TestAccDataSourceAWSLB_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLB_outpost
    data_source_aws_outposts_outposts_test.go:67: skipping since no Outposts found
--- SKIP: TestAccDataSourceAWSLB_outpost (1.33s)
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (248.07s)
--- PASS: TestAccDataSourceAWSLB_basic (248.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	252.120s
```
