### PR TITLE
r/aws_api_gateway_model: suppress schema whitespace differences

### DIFF
--- a/.changelog/20299.txt
+++ b/.changelog/20299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+aws/resource_aws_api_gateway_model: Surpress whitespace differences between model schemas
+```

--- a/aws/resource_aws_api_gateway_model.go
+++ b/aws/resource_aws_api_gateway_model.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsApiGatewayModel() *schema.Resource {
@@ -65,6 +67,15 @@ func resourceAwsApiGatewayModel() *schema.Resource {
 			"schema": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 32768),
+					validation.StringIsJSON,
+				),
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"content_type": {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Resolves an issue with API Gateway Schema models being marked as having changed when differences solely consist of irrelevant characters such as whitespace.

Implementation ported from [aws/resource_aws_apigatewayv2_model.go](https://github.com/hashicorp/terraform-provider-aws/blob/main/aws/resource_aws_apigatewayv2_model.go#L50) which already handles this issue.
