### PR TITLE
d/aws_ec2_instance_type_offerings: Attributes are lists

### DIFF
--- a/aws/data_source_aws_ec2_instance_type_offerings.go
+++ b/aws/data_source_aws_ec2_instance_type_offerings.go
@@ -16,12 +16,12 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"filter": dataSourceFiltersSchema(),
 			"instance_types": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"locations": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -31,7 +31,7 @@ func dataSourceAwsEc2InstanceTypeOfferings() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(ec2.LocationType_Values(), false),
 			},
 			"location_types": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/website/docs/d/ec2_instance_type_offerings.html.markdown
+++ b/website/docs/d/ec2_instance_type_offerings.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - AWS Region.
-* `instance_types` - Set of EC2 Instance Types.
-* `locations` - Set of locations.
-* `location_types` - Set of location types.
+* `instance_types` - List of EC2 Instance Types.
+* `locations` - List of locations.
+* `location_types` - List of location types.
+
+Note that the indexes of Instance Type Offering instance types, locations and location types correspond.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16704.
Relates #17794.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTARGS='-run=TestAccAWSEc2InstanceTypeOfferingsDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2InstanceTypeOfferingsDataSource_ -timeout 180m
=== RUN   TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== PAUSE TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== RUN   TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
=== PAUSE TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
=== CONT  TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter
=== CONT  TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_Filter (10.50s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingsDataSource_LocationType (12.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	15.764s
```
