### PR TITLE
Remove hardcoded domain names from data source acceptance tests

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -530,6 +530,19 @@ rules:
             fmt.Println(...)
     severity: WARNING
 
+  - id: domain-names
+    languages: [go]
+    message: Domain names should be in the namespaces defined in RFC 6761 (https://datatracker.ietf.org/doc/html/rfc6761) as reserved for testing
+    paths:
+      include:
+    patterns:
+      - patterns:
+        - pattern-regex: '[\"`].*(?<!(example))\.(com|net|org)\b'
+        - pattern-regex: '[\"`].*(?<!(amazonaws))\.com\b'
+        - pattern-regex: '[\"`].*(?<!(awsapps))\.com'
+      - pattern-inside: '($X : string)'
+    severity: WARNING
+
   - id: email-address
     languages: [go]
     message: Use default email address or generate a random email address. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md#hardcoded-email-addresses

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -535,6 +535,7 @@ rules:
     message: Domain names should be in the namespaces defined in RFC 6761 (https://datatracker.ietf.org/doc/html/rfc6761) as reserved for testing
     paths:
       include:
+        - aws/data_source*.go
     patterns:
       - patterns:
         - pattern-regex: '[\"`].*(?<!(example))\.(com|net|org)\b'

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -536,6 +536,7 @@ rules:
     paths:
       include:
         - aws/data_source*.go
+        - aws/resource_aws_workspaces_*.go
     patterns:
       - patterns:
         - pattern-regex: '[\"`].*(?<!(example))\.(com|net|org)\b'

--- a/aws/data_source_aws_acmpca_certificate_test.go
+++ b/aws/data_source_aws_acmpca_certificate_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/acmpca"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceAwsAcmpcaCertificate_Basic(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_acmpca_certificate.test"
 	dataSourceName := "data.aws_acmpca_certificate.test"
+
+	domain := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -25,7 +25,7 @@ func TestAccDataSourceAwsAcmpcaCertificate_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`ResourceNotFoundException`),
 			},
 			{
-				Config: testAccDataSourceAwsAcmpcaCertificateConfig_ARN(rName),
+				Config: testAccDataSourceAwsAcmpcaCertificateConfig_ARN(domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "certificate", resourceName, "certificate"),
@@ -37,7 +37,7 @@ func TestAccDataSourceAwsAcmpcaCertificate_Basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAwsAcmpcaCertificateConfig_ARN(rName string) string {
+func testAccDataSourceAwsAcmpcaCertificateConfig_ARN(domain string) string {
 	return fmt.Sprintf(`
 data "aws_acmpca_certificate" "test" {
   arn                       = aws_acmpca_certificate.test.arn
@@ -66,13 +66,13 @@ resource "aws_acmpca_certificate_authority" "test" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "%[1]s.com"
+      common_name = %[1]q
     }
   }
 }
 
 data "aws_partition" "current" {}
-`, rName)
+`, domain)
 }
 
 const testAccDataSourceAwsAcmpcaCertificateConfig_NonExistent = `

--- a/aws/data_source_aws_directory_service_directory_test.go
+++ b/aws/data_source_aws_directory_service_directory_test.go
@@ -30,17 +30,19 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD(t *testing.T) {
 	resourceName := "aws_directory_service_directory.test-simple-ad"
 	dataSourceName := "data.aws_directory_service_directory.test-simple-ad"
 
+	domainName := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSDirectoryServiceSimpleDirectory(t) },
 		ErrorCheck: testAccErrorCheck(t, directoryservice.EndpointsID),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsDirectoryServiceDirectoryConfig_SimpleAD(alias),
+				Config: testAccDataSourceAwsDirectoryServiceDirectoryConfig_SimpleAD(alias, domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "type", directoryservice.DirectoryTypeSimpleAd),
 					resource.TestCheckResourceAttr(dataSourceName, "size", "Small"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", "tf-testacc-corp.neverland.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", domainName),
 					resource.TestCheckResourceAttr(dataSourceName, "description", "tf-testacc SimpleAD"),
 					resource.TestCheckResourceAttr(dataSourceName, "short_name", "corp"),
 					resource.TestCheckResourceAttr(dataSourceName, "alias", alias),
@@ -62,17 +64,19 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD(t *testing.T) {
 	resourceName := "aws_directory_service_directory.test-microsoft-ad"
 	dataSourceName := "data.aws_directory_service_directory.test-microsoft-ad"
 
+	domainName := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
 		ErrorCheck: testAccErrorCheck(t, directoryservice.EndpointsID),
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsDirectoryServiceDirectoryConfig_MicrosoftAD(alias),
+				Config: testAccDataSourceAwsDirectoryServiceDirectoryConfig_MicrosoftAD(alias, domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "type", directoryservice.DirectoryTypeMicrosoftAd),
 					resource.TestCheckResourceAttr(dataSourceName, "edition", "Standard"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", "tf-testacc-corp.neverland.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", domainName),
 					resource.TestCheckResourceAttr(dataSourceName, "description", "tf-testacc MicrosoftAD"),
 					resource.TestCheckResourceAttr(dataSourceName, "short_name", "corp"),
 					resource.TestCheckResourceAttr(dataSourceName, "alias", alias),
@@ -93,6 +97,8 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_connector(t *testing.T) {
 	resourceName := "aws_directory_service_directory.connector"
 	dataSourceName := "data.aws_directory_service_directory.test-ad-connector"
 
+	domainName := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -103,7 +109,7 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_connector(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDirectoryServiceDirectoryConfig_connector(),
+				Config: testAccDataSourceDirectoryServiceDirectoryConfig_connector(domainName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "connect_settings.0.connect_ips", resourceName, "connect_settings.0.connect_ips"),
 				),
@@ -150,17 +156,17 @@ resource "aws_subnet" "secondary" {
 `, adType))
 }
 
-func testAccDataSourceAwsDirectoryServiceDirectoryConfig_SimpleAD(alias string) string {
+func testAccDataSourceAwsDirectoryServiceDirectoryConfig_SimpleAD(alias, domain string) string {
 	return composeConfig(testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites("simple-ad"), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test-simple-ad" {
   type        = "SimpleAD"
   size        = "Small"
-  name        = "tf-testacc-corp.neverland.com"
+  name        = %[2]q
   description = "tf-testacc SimpleAD"
   short_name  = "corp"
   password    = "#S1ncerely"
 
-  alias      = %q
+  alias      = %[1]q
   enable_sso = false
 
   vpc_settings {
@@ -172,20 +178,20 @@ resource "aws_directory_service_directory" "test-simple-ad" {
 data "aws_directory_service_directory" "test-simple-ad" {
   directory_id = aws_directory_service_directory.test-simple-ad.id
 }
-`, alias))
+`, alias, domain))
 }
 
-func testAccDataSourceAwsDirectoryServiceDirectoryConfig_MicrosoftAD(alias string) string {
+func testAccDataSourceAwsDirectoryServiceDirectoryConfig_MicrosoftAD(alias, domain string) string {
 	return composeConfig(testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites("microsoft-ad"), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test-microsoft-ad" {
   type        = "MicrosoftAD"
   edition     = "Standard"
-  name        = "tf-testacc-corp.neverland.com"
+  name        = %[2]q
   description = "tf-testacc MicrosoftAD"
   short_name  = "corp"
   password    = "#S1ncerely"
 
-  alias      = %q
+  alias      = %[1]q
   enable_sso = false
 
   vpc_settings {
@@ -197,14 +203,15 @@ resource "aws_directory_service_directory" "test-microsoft-ad" {
 data "aws_directory_service_directory" "test-microsoft-ad" {
   directory_id = aws_directory_service_directory.test-microsoft-ad.id
 }
-`, alias))
+`, alias, domain))
 }
 
-func testAccDataSourceDirectoryServiceDirectoryConfig_connector() string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(),
-		`
+func testAccDataSourceDirectoryServiceDirectoryConfig_connector(domain string) string {
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_directory_service_directory" "test" {
-  name     = "corp.notexample.com"
+  name     = %[1]q
   password = "SuperSecretPassw0rd"
   size     = "Small"
 
@@ -215,7 +222,7 @@ resource "aws_directory_service_directory" "test" {
 }
 
 resource "aws_directory_service_directory" "connector" {
-  name     = "corp.notexample.com"
+  name     = %[1]q
   password = "SuperSecretPassw0rd"
   size     = "Small"
   type     = "ADConnector"
@@ -259,5 +266,5 @@ resource "aws_subnet" "test" {
 data "aws_directory_service_directory" "test-ad-connector" {
   directory_id = aws_directory_service_directory.connector.id
 }
-`)
+`, domain))
 }

--- a/aws/data_source_aws_servicecatalog_product_test.go
+++ b/aws/data_source_aws_servicecatalog_product_test.go
@@ -16,6 +16,8 @@ func TestAccAWSServiceCatalogProductDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -50,6 +52,8 @@ func TestAccAWSServiceCatalogProductDataSource_physicalID(t *testing.T) {
 	dataSourceName := "data.aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
+
 	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_servicecatalog_product_test.go
+++ b/aws/data_source_aws_servicecatalog_product_test.go
@@ -16,8 +16,6 @@ func TestAccAWSServiceCatalogProductDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
-	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, servicecatalog.EndpointsID),
@@ -52,8 +50,6 @@ func TestAccAWSServiceCatalogProductDataSource_physicalID(t *testing.T) {
 	dataSourceName := "data.aws_servicecatalog_product.test"
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
-
 	domain := fmt.Sprintf("http://%s", testAccRandomDomainName())
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_workspaces_directory_test.go
+++ b/aws/data_source_aws_workspaces_directory_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_directory.test"
 	dataSourceName := "data.aws_workspaces_directory.test"
@@ -26,7 +27,7 @@ func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsWorkspacesDirectoryConfig(rName),
+				Config: testAccDataSourceAwsWorkspacesDirectoryConfig(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "alias", resourceName, "alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "directory_id", resourceName, "directory_id"),
@@ -65,9 +66,9 @@ func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAwsWorkspacesDirectoryConfig(rName string) string {
+func testAccDataSourceAwsWorkspacesDirectoryConfig(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name   = "tf-testacc-workspaces-directory-%[1]s"

--- a/aws/data_source_aws_workspaces_workspace_test.go
+++ b/aws/data_source_aws_workspaces_workspace_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestAccDataSourceAwsWorkspacesWorkspace_byWorkspaceID(t *testing.T) {
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
+
 	dataSourceName := "data.aws_workspaces_workspace.test"
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -20,7 +22,7 @@ func TestAccDataSourceAwsWorkspacesWorkspace_byWorkspaceID(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceWorkspacesWorkspaceConfig_byWorkspaceID(rName),
+				Config: testAccDataSourceWorkspacesWorkspaceConfig_byWorkspaceID(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "directory_id", resourceName, "directory_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bundle_id", resourceName, "bundle_id"),
@@ -44,6 +46,8 @@ func TestAccDataSourceAwsWorkspacesWorkspace_byWorkspaceID(t *testing.T) {
 
 func TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName(t *testing.T) {
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
+
 	dataSourceName := "data.aws_workspaces_workspace.test"
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -53,7 +57,7 @@ func TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName(t *testing.T
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceWorkspacesWorkspaceConfig_byDirectoryID_userName(rName),
+				Config: testAccDataSourceWorkspacesWorkspaceConfig_byDirectoryID_userName(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "directory_id", resourceName, "directory_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bundle_id", resourceName, "bundle_id"),
@@ -89,9 +93,9 @@ func TestAccDataSourceAwsWorkspacesWorkspace_workspaceIDAndDirectoryIDConflict(t
 	})
 }
 
-func testAccDataSourceWorkspacesWorkspaceConfig_byWorkspaceID(rName string) string {
+func testAccDataSourceWorkspacesWorkspaceConfig_byWorkspaceID(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -117,9 +121,9 @@ data "aws_workspaces_workspace" "test" {
 `)
 }
 
-func testAccDataSourceWorkspacesWorkspaceConfig_byDirectoryID_userName(rName string) string {
+func testAccDataSourceWorkspacesWorkspaceConfig_byDirectoryID_userName(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -109,7 +109,7 @@ func TestAccAWSSpotInstanceRequest_KeyName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSpotInstanceRequestConfig_KeyName(rName, publicKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotInstanceRequestExists(resourceName, &sir),
 					resource.TestCheckResourceAttrPair(resourceName, "key_name", keyPairResourceName, "key_name"),
 				),

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -60,6 +60,8 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 	directoryResourceName := "aws_directory_service_directory.main"
 	iamRoleDataSourceName := "data.aws_iam_role.workspaces-default"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -72,7 +74,7 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfig(rName),
+				Config: testAccWorkspacesDirectoryConfig(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "alias", directoryResourceName, "alias"),
@@ -124,6 +126,8 @@ func TestAccAwsWorkspacesDirectory_disappears(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -136,7 +140,7 @@ func TestAccAwsWorkspacesDirectory_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfig(rName),
+				Config: testAccWorkspacesDirectoryConfig(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					testAccCheckAwsWorkspacesDirectoryDisappears(&v),
@@ -153,6 +157,8 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -165,7 +171,7 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfig_subnetIds(rName),
+				Config: testAccWorkspacesDirectoryConfig_subnetIds(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -186,6 +192,8 @@ func TestAccAwsWorkspacesDirectory_tags(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -198,7 +206,7 @@ func TestAccAwsWorkspacesDirectory_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfigTags1(rName, "key1", "value1"),
+				Config: testAccWorkspacesDirectoryConfigTags1(rName, domain, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -211,7 +219,7 @@ func TestAccAwsWorkspacesDirectory_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkspacesDirectoryConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccWorkspacesDirectoryConfigTags2(rName, domain, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -220,7 +228,7 @@ func TestAccAwsWorkspacesDirectory_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkspacesDirectoryConfigTags1(rName, "key2", "value2"),
+				Config: testAccWorkspacesDirectoryConfigTags1(rName, domain, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -237,6 +245,8 @@ func TestAccAwsWorkspacesDirectory_selfServicePermissions(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -249,7 +259,7 @@ func TestAccAwsWorkspacesDirectory_selfServicePermissions(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectory_selfServicePermissions(rName),
+				Config: testAccWorkspacesDirectory_selfServicePermissions(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.#", "1"),
@@ -270,6 +280,8 @@ func TestAccAwsWorkspacesDirectory_workspaceAccessProperties(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.main"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -282,7 +294,7 @@ func TestAccAwsWorkspacesDirectory_workspaceAccessProperties(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectory_workspaceAccessProperties(rName),
+				Config: testAccWorkspacesDirectory_workspaceAccessProperties(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "workspace_access_properties.#", "1"),
@@ -306,6 +318,8 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties(t *testing.T) {
 	resourceName := "aws_workspaces_directory.main"
 	resourceSecurityGroup := "aws_security_group.test"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -318,7 +332,7 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties(rName),
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
@@ -340,6 +354,8 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGro
 	resourceName := "aws_workspaces_directory.main"
 	resourceSecurityGroup := "aws_security_group.test"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -352,7 +368,7 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGro
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName),
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
@@ -361,7 +377,7 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGro
 				),
 			},
 			{
-				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Present(rName),
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Present(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
@@ -370,7 +386,7 @@ func TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGro
 				),
 			},
 			{
-				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName),
+				Config: testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "workspace_creation_properties.#", "1"),
@@ -389,6 +405,8 @@ func TestAccAwsWorkspacesDirectory_ipGroupIds(t *testing.T) {
 
 	resourceName := "aws_workspaces_directory.test"
 
+	domain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
 		ErrorCheck:   testAccErrorCheck(t, workspaces.EndpointsID),
@@ -396,7 +414,7 @@ func TestAccAwsWorkspacesDirectory_ipGroupIds(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesDirectoryConfig_ipGroupIds_create(rName),
+				Config: testAccWorkspacesDirectoryConfig_ipGroupIds_create(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ip_group_ids.#", "1"),
@@ -409,7 +427,7 @@ func TestAccAwsWorkspacesDirectory_ipGroupIds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkspacesDirectoryConfig_ipGroupIds_update(rName),
+				Config: testAccWorkspacesDirectoryConfig_ipGroupIds_update(rName, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "ip_group_ids.#", "2"),
@@ -784,7 +802,7 @@ func testAccPreCheckWorkspacesDirectory(t *testing.T) {
 	}
 }
 
-func testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName string) string {
+func testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain string) string {
 	return composeConfig(
 		testAccAvailableAZsNoOptInConfig(),
 		//lintignore:AWSAT003
@@ -829,7 +847,7 @@ resource "aws_subnet" "secondary" {
 
 resource "aws_directory_service_directory" "main" {
   size     = "Small"
-  name     = "tf-acctest.neverland.com"
+  name     = %[2]q
   password = "#S1ncerely"
 
   vpc_settings {
@@ -841,12 +859,12 @@ resource "aws_directory_service_directory" "main" {
     Name = "tf-testacc-workspaces-directory-%[1]s"
   }
 }
-`, rName))
+`, rName, domain))
 }
 
-func testAccWorkspacesDirectoryConfig(rName string) string {
+func testAccWorkspacesDirectoryConfig(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -862,9 +880,9 @@ data "aws_iam_role" "workspaces-default" {
 `, rName))
 }
 
-func testAccWorkspacesDirectory_selfServicePermissions(rName string) string {
+func testAccWorkspacesDirectory_selfServicePermissions(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -884,9 +902,9 @@ resource "aws_workspaces_directory" "main" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfig_subnetIds(rName string) string {
+func testAccWorkspacesDirectoryConfig_subnetIds(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -899,9 +917,9 @@ resource "aws_workspaces_directory" "main" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccWorkspacesDirectoryConfigTags1(rName, domain, tagKey1, tagValue1 string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -913,9 +931,9 @@ resource "aws_workspaces_directory" "main" {
 `, tagKey1, tagValue1))
 }
 
-func testAccWorkspacesDirectoryConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccWorkspacesDirectoryConfigTags2(rName, domain, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -928,9 +946,9 @@ resource "aws_workspaces_directory" "main" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccWorkspacesDirectory_workspaceAccessProperties(rName string) string {
+func testAccWorkspacesDirectory_workspaceAccessProperties(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -952,9 +970,9 @@ resource "aws_workspaces_directory" "main" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfig_workspaceCreationProperties(rName string) string {
+func testAccWorkspacesDirectoryConfig_workspaceCreationProperties(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name   = "tf-acctest-%[1]s"
@@ -979,9 +997,9 @@ resource "aws_workspaces_directory" "main" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName string) string {
+func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Absent(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = aws_directory_service_directory.main.id
@@ -999,9 +1017,9 @@ resource "aws_workspaces_directory" "main" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Present(rName string) string {
+func testAccWorkspacesDirectoryConfig_workspaceCreationProperties_customSecurityGroupId_defaultOu_Present(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_security_group" "test" {
   vpc_id = aws_vpc.main.id
@@ -1026,9 +1044,9 @@ resource "aws_workspaces_directory" "main" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfig_ipGroupIds_create(rName string) string {
+func testAccWorkspacesDirectoryConfig_ipGroupIds_create(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_ip_group" "test_alpha" {
   name = "%[1]s-alpha"
@@ -1048,9 +1066,9 @@ resource "aws_workspaces_directory" "test" {
 `, rName))
 }
 
-func testAccWorkspacesDirectoryConfig_ipGroupIds_update(rName string) string {
+func testAccWorkspacesDirectoryConfig_ipGroupIds_update(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_ip_group" "test_beta" {
   name = "%[1]s-beta"

--- a/aws/resource_aws_workspaces_ip_group_test.go
+++ b/aws/resource_aws_workspaces_ip_group_test.go
@@ -132,6 +132,7 @@ func TestAccAwsWorkspacesIpGroup_MultipleDirectories(t *testing.T) {
 	var d1, d2 workspaces.WorkspaceDirectory
 
 	ipGroupName := acctest.RandomWithPrefix("tf-acc-test")
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_ip_group.test"
 	directoryResourceName1 := "aws_workspaces_directory.test1"
@@ -144,7 +145,7 @@ func TestAccAwsWorkspacesIpGroup_MultipleDirectories(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesIpGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWorkspacesIpGroupConfigMultipleDirectories(ipGroupName),
+				Config: testAccAwsWorkspacesIpGroupConfigMultipleDirectories(ipGroupName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesIpGroupExists(resourceName, &v),
 					testAccCheckAwsWorkspacesDirectoryExists(directoryResourceName1, &d1),
@@ -288,12 +289,12 @@ resource "aws_workspaces_ip_group" "test" {
 `, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAwsWorkspacesIpGroupConfigMultipleDirectories(name string) string {
+func testAccAwsWorkspacesIpGroupConfigMultipleDirectories(name, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(name),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(name, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_ip_group" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_workspaces_directory" "test1" {

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -56,6 +56,7 @@ func testSweepWorkspacesWorkspace(region string) error {
 func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
 	var v workspaces.Workspace
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_workspace.test"
 	directoryResourceName := "aws_workspaces_directory.test"
@@ -74,7 +75,7 @@ func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Destroy: false,
-				Config:  testAccWorkspacesWorkspaceConfig(rName),
+				Config:  testAccWorkspacesWorkspaceConfig(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "directory_id", directoryResourceName, "id"),
@@ -106,6 +107,7 @@ func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
 func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 	var v1, v2, v3 workspaces.Workspace
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -121,7 +123,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesWorkspaceConfig_TagsA(rName),
+				Config: testAccWorkspacesWorkspaceConfig_TagsA(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -135,7 +137,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkspacesWorkspaceConfig_TagsB(rName),
+				Config: testAccWorkspacesWorkspaceConfig_TagsB(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -144,7 +146,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkspacesWorkspaceConfig_TagsC(rName),
+				Config: testAccWorkspacesWorkspaceConfig_TagsC(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -158,6 +160,7 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 func TestAccAwsWorkspacesWorkspace_workspaceProperties(t *testing.T) {
 	var v1, v2, v3 workspaces.Workspace
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -174,7 +177,7 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Destroy: false,
-				Config:  testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA(rName),
+				Config:  testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
@@ -191,7 +194,7 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName),
+				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
@@ -203,7 +206,7 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(rName),
+				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
@@ -225,6 +228,7 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn(t *te
 	var v1 workspaces.Workspace
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_workspaces_workspace.test"
+	domain := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -238,7 +242,7 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn(t *te
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName),
+				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
@@ -260,6 +264,7 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn(t *te
 
 func TestAccAwsWorkspacesWorkspace_validateRootVolumeSize(t *testing.T) {
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -268,7 +273,7 @@ func TestAccAwsWorkspacesWorkspace_validateRootVolumeSize(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(rName),
+				Config:      testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(rName, domain),
 				ExpectError: regexp.MustCompile(regexp.QuoteMeta("expected workspace_properties.0.root_volume_size_gib to be one of [80], got 90")),
 			},
 		},
@@ -277,6 +282,7 @@ func TestAccAwsWorkspacesWorkspace_validateRootVolumeSize(t *testing.T) {
 
 func TestAccAwsWorkspacesWorkspace_validateUserVolumeSize(t *testing.T) {
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -285,7 +291,7 @@ func TestAccAwsWorkspacesWorkspace_validateUserVolumeSize(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccWorkspacesWorkspaceConfig_validateUserVolumeSize(rName),
+				Config:      testAccWorkspacesWorkspaceConfig_validateUserVolumeSize(rName, domain),
 				ExpectError: regexp.MustCompile(regexp.QuoteMeta("workspace_properties.0.user_volume_size_gib to be one of [10 50], got 60")),
 			},
 		},
@@ -295,6 +301,7 @@ func TestAccAwsWorkspacesWorkspace_validateUserVolumeSize(t *testing.T) {
 func TestAccAwsWorkspacesWorkspace_recreate(t *testing.T) {
 	var v workspaces.Workspace
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -310,14 +317,14 @@ func TestAccAwsWorkspacesWorkspace_recreate(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspacesWorkspaceConfig(rName),
+				Config: testAccWorkspacesWorkspaceConfig(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v),
 				),
 			},
 			{
 				Taint:  []string{resourceName}, // Force workspace re-creation
-				Config: testAccWorkspacesWorkspaceConfig(rName),
+				Config: testAccWorkspacesWorkspaceConfig(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v),
 				),
@@ -329,6 +336,7 @@ func TestAccAwsWorkspacesWorkspace_recreate(t *testing.T) {
 func TestAccAwsWorkspacesWorkspace_timeout(t *testing.T) {
 	var v workspaces.Workspace
 	rName := acctest.RandString(8)
+	domain := testAccRandomDomainName()
 
 	resourceName := "aws_workspaces_workspace.test"
 
@@ -345,7 +353,7 @@ func TestAccAwsWorkspacesWorkspace_timeout(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Destroy: false,
-				Config:  testAccWorkspacesWorkspaceConfig_timeout(rName),
+				Config:  testAccWorkspacesWorkspaceConfig_timeout(rName, domain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsWorkspacesWorkspaceExists(resourceName, &v),
 				),
@@ -407,9 +415,9 @@ func testAccCheckAwsWorkspacesWorkspaceExists(n string, v *workspaces.Workspace)
 	}
 }
 
-func testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName string) string {
+func testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName),
+		testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 data "aws_workspaces_bundle" "test" {
   bundle_id = "wsb-bh8rsxt14" # Value with Windows 10 (English)
@@ -425,9 +433,9 @@ resource "aws_workspaces_directory" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig(rName string) string {
+func testAccWorkspacesWorkspaceConfig(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -444,9 +452,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_TagsA(rName string) string {
+func testAccWorkspacesWorkspaceConfig_TagsA(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -464,9 +472,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_TagsB(rName string) string {
+func testAccWorkspacesWorkspaceConfig_TagsB(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -484,9 +492,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_TagsC(rName string) string {
+func testAccWorkspacesWorkspaceConfig_TagsC(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -503,9 +511,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA(rName string) string {
+func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -528,9 +536,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName string) string {
+func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -552,9 +560,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(rName string) string {
+func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -574,9 +582,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(rName string) string {
+func testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -598,9 +606,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_validateUserVolumeSize(rName string) string {
+func testAccWorkspacesWorkspaceConfig_validateUserVolumeSize(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id
@@ -622,9 +630,9 @@ resource "aws_workspaces_workspace" "test" {
 `, rName))
 }
 
-func testAccWorkspacesWorkspaceConfig_timeout(rName string) string {
+func testAccWorkspacesWorkspaceConfig_timeout(rName, domain string) string {
 	return composeConfig(
-		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName),
+		testAccAwsWorkspacesWorkspaceConfig_Prerequisites(rName, domain),
 		fmt.Sprintf(`
 resource "aws_workspaces_workspace" "test" {
   bundle_id    = data.aws_workspaces_bundle.test.id


### PR DESCRIPTION
Removes hardcoded domain names from data source acceptance tests

### Community Note



<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19972

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsWorkspacesWorkspace\|TestAccAWSSpotInstanceRequest\|TestAccAwsWorkspacesIpGroup\|TestAccDataSourceAwsWorkspacesDirectory\|TestAccDataSourceAwsAcmpcaCertificate\|TestAccDataSourceAwsDirectoryServiceDirectory\|TestAccDataSourceAwsWorkspacesWorkspace\|TestAccAwsWorkspacesDirectory'

--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_workspaceIDAndDirectoryIDConflict (12.06s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent (13.00s)
--- PASS: TestAccDataSourceAwsAcmpcaCertificateAuthority_basic (39.17s)
--- PASS: TestAccDataSourceAwsAcmpcaCertificateAuthority_S3ObjectAcl (45.59s)
--- PASS: TestAccDataSourceAwsAcmpcaCertificate_Basic (47.09s)
--- PASS: TestAccAWSSpotInstanceRequest_basic (94.80s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (95.76s)
--- PASS: TestAccAWSSpotInstanceRequest_tags (127.66s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (134.56s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (139.42s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (161.37s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptFixDeprecated (123.87s)
--- PASS: TestAccAWSSpotInstanceRequest_disappears (311.15s)
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (356.99s)
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (360.46s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (349.89s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptHibernate (320.48s)
--- PASS: TestAccAWSSpotInstanceRequest_KeyName (380.11s)
--- FAIL: TestAccAwsWorkspacesDirectory_workspaceCreationProperties_customSecurityGroupId_defaultOu (16.02s)
--- PASS: TestExpandSelfServicePermissions (0.00s)
--- PASS: TestFlattenSelfServicePermissions (0.00s)
--- PASS: TestExpandWorkspaceAccessProperties (0.00s)
--- PASS: TestFlattenWorkspaceAccessProperties (0.00s)
--- PASS: TestExpandWorkspaceCreationProperties (0.00s)
--- PASS: TestFlattenWorkspaceCreationProperties (0.00s)
--- FAIL: TestAccAwsWorkspacesDirectory_selfServicePermissions (31.13s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (391.20s)
--- FAIL: TestAccAwsWorkspacesDirectory_workspaceCreationProperties (32.28s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptStop (351.10s)
--- PASS: TestAccAwsWorkspacesIpGroup_disappears (18.48s)
--- PASS: TestAccAwsWorkspacesIpGroup_basic (43.10s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptDeprecated (332.34s)
--- PASS: TestAccAwsWorkspacesIpGroup_tags (66.67s)
--- PASS: TestAccAwsWorkspacesWorkspace_validateRootVolumeSize (1.67s)
--- PASS: TestAccAwsWorkspacesWorkspace_validateUserVolumeSize (1.68s)
--- FAIL: TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn (57.51s)
--- FAIL: TestAccAwsWorkspacesWorkspace_tags (76.34s)
--- PASS: TestExpandWorkspaceProperties (0.00s)
--- PASS: TestFlattenWorkspaceProperties (0.00s)
--- FAIL: TestAccAwsWorkspacesWorkspace_workspaceProperties (66.95s)
--- FAIL: TestAccAwsWorkspacesWorkspace_timeout (14.51s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptUpdate (639.21s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptUpdateFromDeprecated (620.72s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD (786.74s)
--- PASS: TestAccAwsWorkspacesDirectory_disappears (717.07s)
--- PASS: TestAccAwsWorkspacesDirectory_basic (754.77s)
--- PASS: TestAccDataSourceAwsWorkspacesDirectory_basic (918.78s)
--- FAIL: TestAccAwsWorkspacesIpGroup_MultipleDirectories (547.40s)
--- PASS: TestAccAwsWorkspacesDirectory_subnetIds (770.97s)
--- PASS: TestAccAwsWorkspacesDirectory_tags (727.92s)
--- PASS: TestAccAwsWorkspacesDirectory_ipGroupIds (813.94s)
--- PASS: TestAccAwsWorkspacesDirectory_workspaceAccessProperties (1040.67s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_connector (1478.85s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD (1900.99s)
--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_byDirectoryID_userName (1942.29s)
--- PASS: TestAccDataSourceAwsWorkspacesWorkspace_byWorkspaceID (1998.48s)
--- PASS: TestAccAwsWorkspacesWorkspace_recreate (1890.84s)
--- PASS: TestAccAwsWorkspacesWorkspace_basic (2064.55s)
```

Workspaces acceptance test failures are due to resource limits on Directory Service