### PR TITLE
[WIP] Add resource aws_s3_bucket_intelligent_tiering_configuration

### DIFF
--- a/.changelog/20326.txt
+++ b/.changelog/20326.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_s3_bucket_intelligent_tiering_configuration
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ FEATURES:
 * **New Resource:** `aws_appconfig_environment` ([#19307](https://github.com/hashicorp/terraform-provider-aws/issues/19307))
 * **New Resource:** `aws_appconfig_hosted_configuration_version` ([#19324](https://github.com/hashicorp/terraform-provider-aws/issues/19324))
 * **New Resource:** `aws_config_organization_conformance_pack` ([#17298](https://github.com/hashicorp/terraform-provider-aws/issues/17298))
+* **New Resource:** `aws_securityhub_standards_control` ([#14714](https://github.com/hashicorp/terraform-provider-aws/issues/14714))
 
 ENHANCEMENTS:
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1034,6 +1034,7 @@ func Provider() *schema.Provider {
 			"aws_s3_bucket":                                           resourceAwsS3Bucket(),
 			"aws_s3_bucket_analytics_configuration":                   resourceAwsS3BucketAnalyticsConfiguration(),
 			"aws_s3_bucket_policy":                                    resourceAwsS3BucketPolicy(),
+			"aws_s3_bucket_intelligent_tiering_configuration":         resourceAwsS3IntelligentTieringConfiguration(),
 			"aws_s3_bucket_public_access_block":                       resourceAwsS3BucketPublicAccessBlock(),
 			"aws_s3_bucket_object":                                    resourceAwsS3BucketObject(),
 			"aws_s3_bucket_ownership_controls":                        resourceAwsS3BucketOwnershipControls(),

--- a/aws/resource_aws_s3_bucket_intelligent_tiering_configuration.go
+++ b/aws/resource_aws_s3_bucket_intelligent_tiering_configuration.go
@@ -1,0 +1,194 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsS3IntelligentTieringConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsS3IntelligentTieringConfigurationPut,
+		Read:   resourceAwsS3IntelligentTieringConfigurationRead,
+		Update: resourceAwsS3IntelligentTieringConfigurationPut,
+		Delete: resourceAwsS3IntelligentTieringConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": tagsSchema(),
+			"archive_configuration": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 2,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_tier": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"days": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsS3IntelligentTieringConfigurationPut(d *schema.ResourceData, meta interface{}) error {
+	s3conn := meta.(*AWSClient).s3conn
+
+	bucket := d.Get("bucket").(string)
+	config := d.Get("tiering_configuration").(*schema.Set).List()
+
+	id := d.Get("name").(string)
+
+	log.Printf("[DEBUG] S3 bucket: %s, put policy: %s", bucket, id)
+
+	params := &s3.PutBucketIntelligentTieringConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(id),
+		IntelligentTieringConfiguration: &s3.IntelligentTieringConfiguration{
+			Filter: &s3.IntelligentTieringFilter{
+				And: &s3.IntelligentTieringAndOperator{
+					Prefix: aws.String("test"),
+				},
+			},
+			Id:       aws.String(id),
+			Status:   aws.String("Enabled"),
+			Tierings: expandS3IntelligentTieringConfigurations(config),
+		},
+	}
+
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := s3conn.PutBucketIntelligentTieringConfiguration(params)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		_, err = s3conn.PutBucketIntelligentTieringConfiguration(params)
+	}
+	if err != nil {
+		return fmt.Errorf("Error putting Intelligent Tiering Configuration: %s", err)
+	}
+
+	d.SetId(bucket)
+
+	return resourceAwsS3IntelligentTieringConfigurationRead(d, meta)
+}
+
+func expandS3IntelligentTieringConfigurations(tfList []interface{}) []*s3.Tiering {
+	var apiObjects []*s3.Tiering
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandS3IntelligentTieringConfiguration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandS3IntelligentTieringConfiguration(tfMap map[string]interface{}) *s3.Tiering {
+	if len(tfMap) == 0 {
+		return nil
+	}
+
+	apiObject := &s3.Tiering{}
+
+	log.Printf("[DEBUG] This is the map: %s", tfMap)
+
+	if v, ok := tfMap["access_tier"].(string); ok && v != "" {
+		apiObject.AccessTier = aws.String(v)
+	}
+
+	if v, ok := tfMap["days"].(int); ok && v != 0 {
+		apiObject.Days = aws.Int64(int64(v))
+	}
+
+	log.Printf("[DEBUG] This is the apiObject: %s", apiObject)
+
+	return apiObject
+}
+
+func resourceAwsS3IntelligentTieringConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	s3conn := meta.(*AWSClient).s3conn
+
+	bucket := d.Get("bucket").(string)
+	id := d.Get("name").(string)
+
+	log.Printf("[DEBUG] S3 bucket policy, read for bucket: %s", bucket)
+	s3conn.GetBucketIntelligentTieringConfiguration(&s3.GetBucketIntelligentTieringConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(id),
+	})
+
+	// v := ""
+	// if err == nil && pol.IntelligentTieringConfiguration != nil {
+	// 	v = pol.IntelligentTieringConfiguration
+	// }
+	// if err := d.Set("id", v); err != nil {
+	// 	return err
+	// }
+	// if err := d.Set("bucket", d.Id()); err != nil {
+	// 	return err
+	// }
+
+	return nil
+}
+
+func resourceAwsS3IntelligentTieringConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+
+	s3conn := meta.(*AWSClient).s3conn
+
+	bucket := d.Get("bucket").(string)
+	id := d.Get("name").(string)
+
+	log.Printf("[DEBUG] S3 bucket: %s, delete policy", bucket)
+	_, err := s3conn.DeleteBucketIntelligentTieringConfiguration(&s3.DeleteBucketIntelligentTieringConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(id),
+	})
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoSuchBucket" {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Intelligent Tiering Configuration: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_s3_bucket_intelligent_tiering_configuration.go
+++ b/aws/resource_aws_s3_bucket_intelligent_tiering_configuration.go
@@ -62,7 +62,7 @@ func resourceAwsS3IntelligentTieringConfiguration() *schema.Resource {
 					},
 				},
 			},
-			"archive_configuration": {
+			"tier": {
 				Type:     schema.TypeSet,
 				Required: true,
 				MinItems: 1,
@@ -89,7 +89,7 @@ func resourceAwsS3IntelligentTieringConfigurationPut(d *schema.ResourceData, met
 	s3conn := meta.(*AWSClient).s3conn
 
 	bucket := d.Get("bucket").(string)
-	config := d.Get("archive_configuration").(*schema.Set).List()
+	config := d.Get("tier").(*schema.Set).List()
 	id := d.Get("name").(string)
 
 	log.Printf("[DEBUG] S3 bucket: %s, put intelligent tiering configuration: %s", bucket, id)
@@ -171,7 +171,7 @@ func resourceAwsS3IntelligentTieringConfigurationRead(d *schema.ResourceData, me
 		return fmt.Errorf("error setting filter: %w", err)
 	}
 
-	if err = d.Set("archive_configuration", flattenS3ArchiveConfiguration(output.IntelligentTieringConfiguration.Tierings)); err != nil {
+	if err = d.Set("tier", flattenS3ArchiveConfiguration(output.IntelligentTieringConfiguration.Tierings)); err != nil {
 		return fmt.Errorf("error setting storage class anyalytics: %w", err)
 	}
 

--- a/aws/resource_aws_s3_bucket_intelligent_tiering_configuration_test.go
+++ b/aws/resource_aws_s3_bucket_intelligent_tiering_configuration_test.go
@@ -2,23 +2,24 @@ package aws
 
 import (
 	"fmt"
-	"reflect"
+	// "reflect"
 	"regexp"
-	"sort"
-	"testing"
-	"time"
-
+	// "sort"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"testing"
+	"time"
 )
 
 func TestAccAWSS3BucketIntelligentTieringConfiguration_basic(t *testing.T) {
-	var ac s3.AnalyticsConfiguration
+	var itc s3.IntelligentTieringConfiguration
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+	accessTier := "DEEP_ARCHIVE_ACCESS"
+	accessTierDays := "180"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,13 +28,16 @@ func TestAccAWSS3BucketIntelligentTieringConfiguration_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSS3BucketAnalyticsConfiguration(rName, rName),
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationOneTier(rName, rName, accessTier, accessTierDays),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketAnalyticsConfigurationExists(resourceName, &ac),
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "archive_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tier.0.access_tier", accessTier),
+					resource.TestCheckResourceAttr(resourceName, "tier.0.days", accessTierDays),
 				),
 			},
 			{
@@ -45,6 +49,624 @@ func TestAccAWSS3BucketIntelligentTieringConfiguration_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketIntelligentTieringConfiguration_removed(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfiguration(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfiguration_removed(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationRemoved(rName, rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_updateBasic(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	originalITCName := acctest.RandomWithPrefix("tf-acc-test")
+	originalBucketName := acctest.RandomWithPrefix("tf-acc-test")
+	updatedITCName := acctest.RandomWithPrefix("tf-acc-test")
+	updatedBucketName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfiguration(originalITCName, originalBucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "name", originalITCName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tier.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfiguration(updatedITCName, originalBucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationRemoved(originalITCName, originalBucketName),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedITCName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tier.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationUpdateBucket(updatedITCName, originalBucketName, updatedBucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationRemoved(updatedITCName, originalBucketName),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedITCName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test_2", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tier.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Empty(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSS3BucketIntelligentTieringConfigurationWithEmptyFilter(rName, rName),
+				ExpectError: regexp.MustCompile(`one of .* must be specified`),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Prefix(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	rName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	prefix := fmt.Sprintf("prefix-%d/", rInt)
+	prefixUpdate := fmt.Sprintf("prefix-update-%d/", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefix(rName, rName, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefix),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefix(rName, rName, prefixUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefixUpdate),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_SingleTag(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	rName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	tag1 := fmt.Sprintf("tag-%d", rInt)
+	tag1Update := fmt.Sprintf("tag-update-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterSingleTag(rName, rName, tag1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag1", tag1),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterSingleTag(rName, rName, tag1Update),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag1", tag1Update),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_MultipleTags(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	rName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	tag1 := fmt.Sprintf("tag1-%d", rInt)
+	tag1Update := fmt.Sprintf("tag1-update-%d", rInt)
+	tag2 := fmt.Sprintf("tag2-%d", rInt)
+	tag2Update := fmt.Sprintf("tag2-update-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterMultipleTags(rName, rName, tag1, tag2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag1", tag1),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag2", tag2),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterMultipleTags(rName, rName, tag1Update, tag2Update),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag1", tag1Update),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag2", tag2Update),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_PrefixAndTags(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	rName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	prefix := fmt.Sprintf("prefix-%d/", rInt)
+	prefixUpdate := fmt.Sprintf("prefix-update-%d/", rInt)
+	tag1 := fmt.Sprintf("tag1-%d", rInt)
+	tag1Update := fmt.Sprintf("tag1-update-%d", rInt)
+	tag2 := fmt.Sprintf("tag2-%d", rInt)
+	tag2Update := fmt.Sprintf("tag2-update-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefixAndTags(rName, rName, prefix, tag1, tag2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefix),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag1", tag1),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag2", tag2),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefixAndTags(rName, rName, prefixUpdate, tag1Update, tag2Update),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", prefixUpdate),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag1", tag1Update),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.tags.tag2", tag2Update),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Remove(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	rName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	prefix := fmt.Sprintf("prefix-%d/", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefix(rName, rName, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfiguration(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithTier_Empty(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSS3BucketIntelligentTieringConfigurationWithEmptyTier(rName, rName),
+				ExpectError: regexp.MustCompile(`The argument "access_tier" is required, but no definition was found.`),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_Default(t *testing.T) {
+	var itc s3.IntelligentTieringConfiguration
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	accessTierOne := "DEEP_ARCHIVE_ACCESS"
+	accessTierDaysOne := "240"
+
+	accessTierTwo := "ARCHIVE_ACCESS"
+	accessTierDaysTwo := "120"
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketIntelligentTieringConfigurationTwoTiers(rName, rName, accessTierOne, accessTierDaysOne, accessTierTwo, accessTierDaysTwo),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(resourceName, &itc),
+					resource.TestCheckResourceAttr(resourceName, "tier.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tier.0.access_tier", accessTierOne),
+					resource.TestCheckResourceAttr(resourceName, "tier.0.days", accessTierDaysOne),
+					resource.TestCheckResourceAttr(resourceName, "tier.1.access_tier", accessTierTwo),
+					resource.TestCheckResourceAttr(resourceName, "tier.1.days", accessTierDaysTwo),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAWSS3BucketIntelligentTieringConfiguration(name, bucket string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+  tier {
+	access_tier = "DEEP_ARCHIVE_ACCESS"
+	days        = 180
+	}
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationOneTier(name, bucket, accessTier, accessTierDays string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+  tier {
+    access_tier = "%s"
+    days        = %s
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, accessTier, accessTierDays, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationTwoTiers(name, bucket, accessTierOne, accessTierDaysOne, accessTierTwo, accessTierDaysTwo string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+  tier {
+    access_tier = "%s"
+    days        = %s
+  }
+  tier {
+    access_tier = "%s"
+    days        = %s
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, accessTierOne, accessTierDaysOne, accessTierTwo, accessTierDaysTwo, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfiguration_removed(bucket string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationUpdateBucket(name, originalBucket, updatedBucket string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+	bucket = aws_s3_bucket.test_2.bucket
+	name   = "%s"
+	tier {
+		access_tier = "ARCHIVE_ACCESS"
+		days        = 90
+	}
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+
+resource "aws_s3_bucket" "test_2" {
+  bucket = "%s"
+}
+`, name, originalBucket, updatedBucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationWithEmptyFilter(name, bucket string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+
+  tier {
+	access_tier = "DEEP_ARCHIVE_ACCESS"
+	days        = 180
+	}
+
+  filter {
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefix(name, bucket, prefix string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+  tier {
+	access_tier = "ARCHIVE_ACCESS"
+	days        = 90
+	}
+
+  filter {
+    prefix = "%s"
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, prefix, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationWithFilterSingleTag(name, bucket, tag string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+
+  tier {
+	access_tier = "ARCHIVE_ACCESS"
+	days        = 90
+	}
+
+  filter {
+    tags = {
+      "tag1" = "%s"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, tag, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationWithFilterMultipleTags(name, bucket, tag1, tag2 string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+
+  tier {
+	access_tier = "ARCHIVE_ACCESS"
+	days        = 90
+	}
+
+  filter {
+    tags = {
+      "tag1" = "%s"
+      "tag2" = "%s"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, tag1, tag2, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationWithFilterPrefixAndTags(name, bucket, prefix, tag1, tag2 string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+
+  tier {
+	access_tier = "ARCHIVE_ACCESS"
+	days        = 90
+	}
+
+  filter {
+    prefix = "%s"
+
+    tags = {
+      "tag1" = "%s"
+      "tag2" = "%s"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, prefix, tag1, tag2, bucket)
+}
+
+func testAccAWSS3BucketIntelligentTieringConfigurationWithEmptyTier(name, bucket string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_intelligent_tiering_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  name   = "%s"
+  tier {
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, name, bucket)
+}
+
+func testAccCheckAWSS3BucketIntelligentTieringConfigurationExists(n string, itc *s3.IntelligentTieringConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+		output, err := conn.GetBucketIntelligentTieringConfiguration(&s3.GetBucketIntelligentTieringConfigurationInput{
+			Bucket: aws.String(rs.Primary.Attributes["bucket"]),
+			Id:     aws.String(rs.Primary.Attributes["name"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.IntelligentTieringConfiguration == nil {
+			return fmt.Errorf("error reading S3 Bucket Analytics Configuration %q: empty response", rs.Primary.ID)
+		}
+
+		*itc = *output.IntelligentTieringConfiguration
+
+		return nil
+	}
+}
+
 func testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).s3conn
 
@@ -52,15 +674,21 @@ func testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy(s *terraform.
 		if rs.Type != "aws_s3_bucket_intelligent_tiering_configuration" {
 			continue
 		}
-
-		id = rs.Primary.Id
-		bucket = rs.Priamry.Bucket
+		bucket, name, err := resourceAwsS3BucketIntelligentTieringConfigurationParseID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		return resourceAwsS3IntelligentTieringConfigurationDelete(conn, bucket, name, 1*time.Minute)
-
+		return waitForDeleteS3BucketIntelligentTieringConfiguration(conn, bucket, name, 1*time.Minute)
 	}
+
 	return nil
+
+}
+
+func testAccCheckAWSS3BucketIntelligentTieringConfigurationRemoved(name, bucket string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+		return waitForDeleteS3BucketIntelligentTieringConfiguration(conn, bucket, name, 1*time.Minute)
+	}
 }

--- a/aws/resource_aws_s3_bucket_intelligent_tiering_configuration_test.go
+++ b/aws/resource_aws_s3_bucket_intelligent_tiering_configuration_test.go
@@ -895,27 +895,21 @@ func TestExpandS3IntelligentTieringConfigurations(t *testing.T) {
 			Input:    []interface{}{map[string]interface{}{}},
 			Expected: nil,
 		},
-		"empty tier": {
-			Input: []interface{}{
-				map[string]interface{}{},
-			},
-			Expected: []*s3.Tiering{},
-		},
-		"one tier": {
+		"one input": {
 			Input: []interface{}{
 				map[string]interface{}{
-					"access_tier": "test",
-					"days":        55,
+					"access_tier": "testing",
+					"days":        123,
 				},
 			},
 			Expected: []*s3.Tiering{
 				{
-					AccessTier: aws.String("test"),
-					Days:       aws.Int64(int64(55)),
+					AccessTier: aws.String("testing"),
+					Days:       aws.Int64(int64(123)),
 				},
 			},
 		},
-		"two tiers": {
+		"two inputs": {
 			Input: []interface{}{
 				map[string]interface{}{
 					"access_tier": "test",

--- a/aws/resource_aws_s3_bucket_intelligent_tiering_configuration_test.go
+++ b/aws/resource_aws_s3_bucket_intelligent_tiering_configuration_test.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSS3BucketIntelligentTieringConfiguration_basic(t *testing.T) {
+	var ac s3.AnalyticsConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_intelligent_tiering_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, s3.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketAnalyticsConfiguration(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketAnalyticsConfigurationExists(resourceName, &ac),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "archive_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSS3BucketIntelligentTieringConfigurationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_bucket_intelligent_tiering_configuration" {
+			continue
+		}
+
+		id = rs.Primary.Id
+		bucket = rs.Priamry.Bucket
+		if err != nil {
+			return err
+		}
+
+		return resourceAwsS3IntelligentTieringConfigurationDelete(conn, bucket, name, 1*time.Minute)
+
+	}
+	return nil
+}

--- a/website/docs/r/s3_bucket_intelligent_tiering_configuration.markdown
+++ b/website/docs/r/s3_bucket_intelligent_tiering_configuration.markdown
@@ -1,0 +1,112 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_analytics_configuration"
+description: |-
+  Provides a S3 bucket analytics configuration resource.
+---
+
+# Resource: aws_s3_bucket_analytics_configuration
+
+Provides a S3 bucket [analytics configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html) resource.
+
+## Example Usage
+
+### Add analytics configuration for entire S3 bucket and export results to a second S3 bucket
+
+```terraform
+resource "aws_s3_bucket_analytics_configuration" "example-entire-bucket" {
+  bucket = aws_s3_bucket.example.bucket
+  name   = "EntireBucket"
+
+  storage_class_analysis {
+    data_export {
+      destination {
+        s3_bucket_destination {
+          bucket_arn = aws_s3_bucket.analytics.arn
+        }
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket" "analytics" {
+  bucket = "analytics destination"
+}
+```
+
+### Add analytics configuration with S3 bucket object filter
+
+```terraform
+resource "aws_s3_bucket_analytics_configuration" "example-filtered" {
+  bucket = aws_s3_bucket.example.bucket
+  name   = "ImportantBlueDocuments"
+
+  filter {
+    prefix = "documents/"
+
+    tags = {
+      priority = "high"
+      class    = "blue"
+    }
+  }
+
+  tier {
+
+  }
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket this analytics configuration is associated with.
+* `name` - (Required) Unique identifier of the analytics configuration for the bucket.
+* `filter` - (Optional) Object filtering that accepts a prefix, tags, or a logical AND of prefix and tags (documented below).
+* `storage_class_analysis` - (Optional) Configuration for the analytics data export (documented below).
+
+The `filter` configuration supports the following:
+
+* `prefix` - (Optional) Object prefix for filtering.
+* `tags` - (Optional) Set of object tags for filtering.
+
+The `storage_class_analysis` configuration supports the following:
+
+* `data_export` - (Required) Data export configuration (documented below).
+
+The `data_export` configuration supports the following:
+
+* `output_schema_version` - (Optional) The schema version of exported analytics data. Allowed values: `V_1`. Default value: `V_1`.
+* `destination` - (Required) Specifies the destination for the exported analytics data (documented below).
+
+The `destination` configuration supports the following:
+
+* `s3_bucket_destination` - (Required) Analytics data export currently only supports an S3 bucket destination (documented below).
+
+The `s3_bucket_destination` configuration supports the following:
+
+* `bucket_arn` - (Required) The ARN of the destination bucket.
+* `bucket_account_id` - (Optional) The account ID that owns the destination bucket.
+* `format` - (Optional) The output format of exported analytics data. Allowed values: `CSV`. Default value: `CSV`.
+* `prefix` - (Optional) The prefix to append to exported analytics data.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+S3 bucket analytics configurations can be imported using `bucket:analytics`, e.g.
+
+```
+$ terraform import aws_s3_bucket_analytics_configuration.my-bucket-entire-bucket my-bucket:EntireBucket
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #16123

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3BucketIntelligentTieringConfiguration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketIntelligentTieringConfiguration_ -timeout 180m
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_basic
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_basic
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_removed
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_removed
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_updateBasic
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_updateBasic
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Empty
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Empty
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Prefix
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Prefix
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_SingleTag
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_SingleTag
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_MultipleTags
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_MultipleTags
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_PrefixAndTags
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_PrefixAndTags
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Remove
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Remove
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithTier_Empty
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithTier_Empty
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_Default
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_Default
=== RUN   TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_RemoveOne
=== PAUSE TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_RemoveOne
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_basic
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_PrefixAndTags
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_Default
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_RemoveOne
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_removed
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithTier_Empty
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Remove
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Prefix
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_MultipleTags
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_SingleTag
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Empty
=== CONT  TestAccAWSS3BucketIntelligentTieringConfiguration_updateBasic
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Empty (19.75s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithTier_Empty (20.16s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_Default (89.64s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_basic (89.82s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_removed (124.17s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_MultipleTags (136.85s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithTwoTiers_RemoveOne (138.00s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Remove (140.45s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_Prefix (141.23s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_PrefixAndTags (141.58s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_WithFilter_SingleTag (142.13s)
--- PASS: TestAccAWSS3BucketIntelligentTieringConfiguration_updateBasic (192.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       194.212s
...
```
