### PR TITLE
r/aws_lex_bot, r/aws_lex_intent and r/aws_lex_slot_type: Fix computed behaviour for versions

### DIFF
--- a/.changelog/20336.txt
+++ b/.changelog/20336.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+aws/resource_aws_lex_bot: Fix computed `version` for dependent resources
+```
+
+```release-note:bug
+aws/resource_aws_lex_intent: Fix computed `version` for dependent resources
+```
+
+```release-note:bug
+aws/resource_aws_lex_slot_type: Fix computed `version` for dependent resources
+```

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -177,7 +178,39 @@ func resourceAwsLexBot() *schema.Resource {
 				Computed: true,
 			},
 		},
+		CustomizeDiff: updateComputedAttributesOnBotCreateVersion,
 	}
+}
+
+func updateComputedAttributesOnBotCreateVersion(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	createVersion := d.Get("create_version").(bool)
+	if createVersion && hasBotConfigChanges(d) {
+		d.SetNewComputed("version")
+	}
+	return nil
+}
+
+func hasBotConfigChanges(d resourceDiffer) bool {
+	for _, key := range []string{
+		"description",
+		"child_directed",
+		"detect_sentiment",
+		"enable_model_improvements",
+		"idle_session_ttl_in_seconds",
+		"intent",
+		"locale",
+		"nlu_intent_confidence_threshold",
+		"abort_statement.0.response_card",
+		"abort_statement.0.message",
+		"clarification_prompt",
+		"process_behavior",
+		"voice_id",
+	} {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+	return false
 }
 
 var validateLexBotName = validation.All(

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -879,7 +879,7 @@ func testAccAwsLexBotConfig_basic(rName string) string {
 resource "aws_lex_bot" "test" {
   child_directed = false
   description    = "Bot to order flowers on the behalf of a user"
-  name           = "%s" 
+  name           = "%s"
   abort_statement {
     message {
       content      = "Sorry, I'm not able to assist at this time"
@@ -920,7 +920,7 @@ func testAccAwsLexBotConfig_abortStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_bot" "test" {
   child_directed = false
-  description    = "Bot to order flowers on the behalf of a user" 
+  description    = "Bot to order flowers on the behalf of a user"
   name           = "%s"
   abort_statement {
     message {
@@ -1049,7 +1049,7 @@ func testAccAwsLexBotConfig_descriptionUpdate(rName string) string {
 resource "aws_lex_bot" "test" {
   child_directed = false
   description    = "Bot to order flowers"
-  name           = "%s"  
+  name           = "%s"
   abort_statement {
     message {
       content      = "Sorry, I'm not able to assist at this time"
@@ -1069,7 +1069,7 @@ func testAccAwsLexBotConfig_detectSentimentUpdate(rName string) string {
 resource "aws_lex_bot" "test" {
   child_directed   = false
   description      = "Bot to order flowers on the behalf of a user"
-  detect_sentiment = true 
+  detect_sentiment = true
   name             = "%s"
   abort_statement {
     message {
@@ -1089,8 +1089,8 @@ func testAccAwsLexBotConfig_enableModelImprovementsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_bot" "test" {
   child_directed                  = false
-  description                     = "Bot to order flowers on the behalf of a user" 
-  enable_model_improvements       = true 
+  description                     = "Bot to order flowers on the behalf of a user"
+  enable_model_improvements       = true
   name                            = "%s"
   nlu_intent_confidence_threshold = 0.5
   abort_statement {
@@ -1111,8 +1111,8 @@ func testAccAwsLexBotConfig_idleSessionTtlInSecondsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_bot" "test" {
   child_directed              = false
-  description                 = "Bot to order flowers on the behalf of a user" 
-  idle_session_ttl_in_seconds = 600 
+  description                 = "Bot to order flowers on the behalf of a user"
+  idle_session_ttl_in_seconds = 600
   name                        = "%s"
   abort_statement {
     message {
@@ -1156,7 +1156,7 @@ func testAccAwsLexBotConfig_localeUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_bot" "test" {
   child_directed            = false
-  description               = "Bot to order flowers on the behalf of a user" 
+  description               = "Bot to order flowers on the behalf of a user"
   enable_model_improvements = true
   locale                    = "en-GB"
   name                      = "%s"

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -247,7 +248,36 @@ func resourceAwsLexIntent() *schema.Resource {
 				Computed: true,
 			},
 		},
+		CustomizeDiff: updateComputedAttributesOnIntentCreateVersion,
 	}
+}
+
+func updateComputedAttributesOnIntentCreateVersion(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	createVersion := d.Get("create_version").(bool)
+	if createVersion && hasIntentConfigChanges(d) {
+		d.SetNewComputed("version")
+	}
+	return nil
+}
+
+func hasIntentConfigChanges(d resourceDiffer) bool {
+	for _, key := range []string{
+		"description",
+		"conclusion_statement",
+		"confirmation_prompt",
+		"dialog_code_hook",
+		"follow_up_prompt",
+		"fulfillment_activity",
+		"parent_intent_signature",
+		"rejection_statement",
+		"sample_utterances",
+		"slot",
+	} {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+	return false
 }
 
 func resourceAwsLexIntentCreate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -666,6 +666,7 @@ func TestAccAwsLexIntent_computeVersion(t *testing.T) {
 					resource.TestCheckResourceAttr(intentResourceName, "version", version),
 					testAccCheckAwsLexBotExistsWithVersion(botResourceName, version, &v2),
 					resource.TestCheckResourceAttr(botResourceName, "version", version),
+					resource.TestCheckResourceAttr(botResourceName, "intent.0.intent_version", version),
 				),
 			},
 			{
@@ -680,6 +681,7 @@ func TestAccAwsLexIntent_computeVersion(t *testing.T) {
 					resource.TestCheckResourceAttr(intentResourceName, "sample_utterances.0", "I would like to pick up flowers"),
 					testAccCheckAwsLexBotExistsWithVersion(botResourceName, updatedVersion, &v2),
 					resource.TestCheckResourceAttr(botResourceName, "version", updatedVersion),
+					resource.TestCheckResourceAttr(botResourceName, "intent.0.intent_version", updatedVersion),
 				),
 			},
 		},
@@ -779,8 +781,8 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "test" {
-  name               = "%[1]s"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  name               = "%[1]s"
 }
 
 resource "aws_lambda_permission" "lex" {
@@ -813,8 +815,8 @@ resource "aws_lex_intent" "test" {
 func testAccAwsLexIntentConfig_createVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_intent" "test" {
-  name           = "%s"
   create_version = true
+  name           = "%s"
   fulfillment_activity {
     type = "ReturnIntent"
   }
@@ -1123,7 +1125,7 @@ resource "aws_lex_intent" "test" {
 func testAccAwsLexIntentConfig_slotsCustom(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_intent" "test" {
-  name = "%[1]s"
+  name = "%s"
   fulfillment_activity {
     type = "ReturnIntent"
   }
@@ -1153,8 +1155,8 @@ resource "aws_lex_intent" "test" {
 func testAccAwsLexIntentConfig_sampleUtterancesWithVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_intent" "test" {
-  name           = "%s"
   create_version = true
+  name           = "%s"
   fulfillment_activity {
     type = "ReturnIntent"
   }
@@ -1168,8 +1170,8 @@ resource "aws_lex_intent" "test" {
 func testAccAwsLexIntentConfig_slotsWithVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_intent" "test" {
-  name           = "%[1]s"
   create_version = true
+  name           = "%s"
   fulfillment_activity {
     type = "ReturnIntent"
   }

--- a/aws/resource_aws_lex_slot_type.go
+++ b/aws/resource_aws_lex_slot_type.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"time"
@@ -106,7 +107,29 @@ func resourceAwsLexSlotType() *schema.Resource {
 				Computed: true,
 			},
 		},
+		CustomizeDiff: updateComputedAttributesOnSlotTypeCreateVersion,
 	}
+}
+
+func updateComputedAttributesOnSlotTypeCreateVersion(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	createVersion := d.Get("create_version").(bool)
+	if createVersion && hasSlotTypeConfigChanges(d) {
+		d.SetNewComputed("version")
+	}
+	return nil
+}
+
+func hasSlotTypeConfigChanges(d resourceDiffer) bool {
+	for _, key := range []string{
+		"description",
+		"enumeration_value",
+		"value_selection_strategy",
+	} {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+	return false
 }
 
 func resourceAwsLexSlotTypeCreate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -346,6 +346,57 @@ func TestAccAwsLexSlotType_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAwsLexSlotType_computeVersion(t *testing.T) {
+	var v1 lexmodelbuildingservice.GetSlotTypeOutput
+	var v2 lexmodelbuildingservice.GetIntentOutput
+
+	slotTypeResourceName := "aws_lex_slot_type.test"
+	intentResourceName := "aws_lex_intent.test"
+	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+
+	version := "1"
+	updatedVersion := "2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(lexmodelbuildingservice.EndpointsID, t) },
+		ErrorCheck:   testAccErrorCheck(t, lexmodelbuildingservice.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccAwsLexSlotTypeConfig_withVersion(testSlotTypeID),
+					testAccAwsLexIntentConfig_slotsWithVersion(testSlotTypeID),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsLexSlotTypeExistsWithVersion(slotTypeResourceName, version, &v1),
+					resource.TestCheckResourceAttr(slotTypeResourceName, "version", version),
+					testAccCheckAwsLexIntentExistsWithVersion(intentResourceName, version, &v2),
+					resource.TestCheckResourceAttr(intentResourceName, "version", version),
+				),
+			},
+			{
+				Config: composeConfig(
+					testAccAwsLexSlotTypeUpdateConfig_enumerationValuesWithVersion(testSlotTypeID),
+					testAccAwsLexIntentConfig_slotsWithVersion(testSlotTypeID),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsLexSlotTypeExistsWithVersion(slotTypeResourceName, updatedVersion, &v1),
+					resource.TestCheckResourceAttr(slotTypeResourceName, "version", updatedVersion),
+					resource.TestCheckResourceAttr(slotTypeResourceName, "enumeration_value.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(slotTypeResourceName, "enumeration_value.*", map[string]string{
+						"value": "tulips",
+					}),
+					resource.TestCheckTypeSetElemAttr(slotTypeResourceName, "enumeration_value.*.synonyms.*", "Eduardoregelia"),
+					resource.TestCheckTypeSetElemAttr(slotTypeResourceName, "enumeration_value.*.synonyms.*", "Podonix"),
+					testAccCheckAwsLexIntentExistsWithVersion(intentResourceName, updatedVersion, &v2),
+					resource.TestCheckResourceAttr(intentResourceName, "version", updatedVersion),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsLexSlotTypeExistsWithVersion(rName, slotTypeVersion string, output *lexmodelbuildingservice.GetSlotTypeOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rName]
@@ -511,6 +562,32 @@ resource "aws_lex_slot_type" "test" {
     ]
     value = "lilies"
   }
+}
+`, rName)
+}
+
+func testAccAwsLexSlotTypeUpdateConfig_enumerationValuesWithVersion(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lex_slot_type" "test" {
+  name = "%s"
+  enumeration_value {
+    synonyms = [
+      "Lirium",
+      "Martagon",
+    ]
+    value = "lilies"
+  }
+
+  enumeration_value {
+    synonyms = [
+      "Eduardoregelia",
+      "Podonix",
+    ]
+
+    value = "tulips"
+  }
+
+  create_version = true
 }
 `, rName)
 }

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -373,6 +373,7 @@ func TestAccAwsLexSlotType_computeVersion(t *testing.T) {
 					resource.TestCheckResourceAttr(slotTypeResourceName, "version", version),
 					testAccCheckAwsLexIntentExistsWithVersion(intentResourceName, version, &v2),
 					resource.TestCheckResourceAttr(intentResourceName, "version", version),
+					resource.TestCheckResourceAttr(intentResourceName, "slot.0.slot_type_version", version),
 				),
 			},
 			{
@@ -391,6 +392,7 @@ func TestAccAwsLexSlotType_computeVersion(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(slotTypeResourceName, "enumeration_value.*.synonyms.*", "Podonix"),
 					testAccCheckAwsLexIntentExistsWithVersion(intentResourceName, updatedVersion, &v2),
 					resource.TestCheckResourceAttr(intentResourceName, "version", updatedVersion),
+					resource.TestCheckResourceAttr(intentResourceName, "slot.0.slot_type_version", updatedVersion),
 				),
 			},
 		},
@@ -495,7 +497,8 @@ resource "aws_lex_slot_type" "test" {
 func testAccAwsLexSlotTypeConfig_withVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_slot_type" "test" {
-  name = "%s"
+  create_version = true
+  name           = "%s"
   enumeration_value {
     synonyms = [
       "Lirium",
@@ -503,7 +506,6 @@ resource "aws_lex_slot_type" "test" {
     ]
     value = "lilies"
   }
-  create_version = true
 }
 `, rName)
 }
@@ -527,12 +529,12 @@ resource "aws_lex_slot_type" "test" {
 func testAccAwsLexSlotTypeConfig_enumerationValues(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_slot_type" "test" {
+  name = "%s"
   enumeration_value {
     synonyms = [
       "Lirium",
       "Martagon",
     ]
-
     value = "lilies"
   }
 
@@ -541,11 +543,8 @@ resource "aws_lex_slot_type" "test" {
       "Eduardoregelia",
       "Podonix",
     ]
-
     value = "tulips"
   }
-
-  name = "%s"
 }
 `, rName)
 }
@@ -569,7 +568,8 @@ resource "aws_lex_slot_type" "test" {
 func testAccAwsLexSlotTypeUpdateConfig_enumerationValuesWithVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lex_slot_type" "test" {
-  name = "%s"
+  create_version = true
+  name           = "%s"
   enumeration_value {
     synonyms = [
       "Lirium",
@@ -583,11 +583,8 @@ resource "aws_lex_slot_type" "test" {
       "Eduardoregelia",
       "Podonix",
     ]
-
     value = "tulips"
   }
-
-  create_version = true
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16584

```release-note
bug:

resource/aws_lex_bot: Fix computed `version` for dependent resources
resource/aws_lex_intent: Fix computed `version` for dependent resources
resource/aws_lex_slot_type: Fix computed `version` for dependent resources

```

### Affected Resource(s)
- resource: aws_lex_bot
- resource: aws_lex_intent
- resource: aws_lex_slot_type

Output from acceptance testing for resource/aws_lex_bot:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsLexBot_computeVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsLexBot_computeVersion -timeout 180m
=== RUN   TestAccAwsLexBot_computeVersion
--- PASS: TestAccAwsLexBot_computeVersion (130.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       131.401s
...
```

Output from acceptance testing for resource/aws_lex_intent:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsLexIntent_computeVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsLexIntent_computeVersion -timeout 180m
=== RUN   TestAccAwsLexIntent_computeVersion
=== PAUSE TestAccAwsLexIntent_computeVersion
=== CONT  TestAccAwsLexIntent_computeVersion
--- PASS: TestAccAwsLexIntent_computeVersion (129.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       131.426s
...
```

Output from acceptance testing for resource/aws_lex_slot_type:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsLexSlotType_computeVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsLexSlotType_computeVersion -timeout 180m
=== RUN   TestAccAwsLexSlotType_computeVersion
=== PAUSE TestAccAwsLexSlotType_computeVersion
=== CONT  TestAccAwsLexSlotType_computeVersion
--- PASS: TestAccAwsLexSlotType_computeVersion (135.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       137.159s
...
```
