### PR TITLE
Remove hardcoded domain names from acceptance tests for resources A-B

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -590,12 +590,14 @@ rules:
     paths:
       include:
         - aws/data_source*.go
+        - aws/resource_aws_a*.go
+        - aws/resource_aws_b*.go
         - aws/resource_aws_workspaces_*.go
     patterns:
       - patterns:
         - pattern-regex: '[\"`].*(?<!(example))\.(com|net|org)\b'
         - pattern-regex: '[\"`].*(?<!(amazonaws))\.com\b'
-        - pattern-regex: '[\"`].*(?<!(awsapps))\.com'
+        - pattern-regex: '[\"`].*(?<!(awsapps))\.com\b'
       - pattern-inside: '($X : string)'
     severity: WARNING
 

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -642,6 +642,8 @@ func TestAccAWSAcmCertificate_imported_DomainName(t *testing.T) {
 	newCaCertificate := tlsRsaX509SelfSignedCaCertificatePem(newCaKey)
 	newCertificate := tlsRsaX509LocallySignedCertificatePem(newCaKey, newCaCertificate, key, commonName)
 
+	withoutChainDomain := testAccRandomDomainName()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, acm.EndpointsID),
@@ -664,11 +666,11 @@ func TestAccAWSAcmCertificate_imported_DomainName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAcmCertificateConfigPrivateKeyWithoutChain("example2.com"),
+				Config: testAccAcmCertificateConfigPrivateKeyWithoutChain(withoutChainDomain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", acm.CertificateStatusIssued),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "domain_name", "example2.com"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", withoutChainDomain),
 				),
 			},
 			{

--- a/aws/resource_aws_acmpca_certificate_authority_certificate_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_certificate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/acmpca"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/acmpca/finder"
@@ -14,8 +13,9 @@ import (
 
 func TestAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(t *testing.T) {
 	var v acmpca.GetCertificateAuthorityCertificateOutput
-	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
+
+	commonName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,7 +24,7 @@ func TestAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(t *testing.T) {
 		CheckDestroy: nil, // Certificate authority certificates cannot be deleted
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(rName),
+				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(commonName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_authority_arn", "aws_acmpca_certificate_authority.test", "arn"),
@@ -43,9 +43,10 @@ func TestAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(t *testing.T) {
 
 func TestAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(t *testing.T) {
 	var v acmpca.GetCertificateAuthorityCertificateOutput
-	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
 	updatedResourceName := "aws_acmpca_certificate_authority_certificate.updated"
+
+	commonName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,7 +55,7 @@ func TestAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(t *testing.T) 
 		CheckDestroy: nil, // Certificate authority certificates cannot be deleted
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(rName),
+				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(commonName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_authority_arn", "aws_acmpca_certificate_authority.test", "arn"),
@@ -63,7 +64,7 @@ func TestAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(rName),
+				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(commonName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityCertificateExists(updatedResourceName, &v),
 					resource.TestCheckResourceAttrPair(updatedResourceName, "certificate_authority_arn", "aws_acmpca_certificate_authority.test", "arn"),
@@ -77,8 +78,9 @@ func TestAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(t *testing.T) 
 
 func TestAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA(t *testing.T) {
 	var v acmpca.GetCertificateAuthorityCertificateOutput
-	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_acmpca_certificate_authority_certificate.test"
+
+	commonName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -87,7 +89,7 @@ func TestAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA(t *testing.T)
 		CheckDestroy: nil, // Certificate authority certificates cannot be deleted
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA(rName),
+				Config: testAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA(commonName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_authority_arn", "aws_acmpca_certificate_authority.test", "arn"),
@@ -127,7 +129,7 @@ func testAccCheckAwsAcmpcaCertificateAuthorityCertificateExists(resourceName str
 	}
 }
 
-func testAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(rName string) string {
+func testAccAwsAcmpcaCertificateAuthorityCertificate_RootCA(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority_certificate" "test" {
   certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
@@ -158,16 +160,16 @@ resource "aws_acmpca_certificate_authority" "test" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "%[1]s.com"
+      common_name = %[1]q
     }
   }
 }
 
 data "aws_partition" "current" {}
-`, rName)
+`, commonName)
 }
 
-func testAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(rName string) string {
+func testAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority_certificate" "updated" {
   certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
@@ -198,16 +200,16 @@ resource "aws_acmpca_certificate_authority" "test" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "%[1]s.com"
+      common_name = %[1]q
     }
   }
 }
 
 data "aws_partition" "current" {}
-`, rName)
+`, commonName)
 }
 
-func testAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA(rName string) string {
+func testAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority_certificate" "test" {
   certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
@@ -238,7 +240,7 @@ resource "aws_acmpca_certificate_authority" "test" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "sub.%[1]s.com"
+      common_name = "sub.%[1]s"
     }
   }
 }
@@ -252,7 +254,7 @@ resource "aws_acmpca_certificate_authority" "root" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "%[1]s.com"
+      common_name = %[1]q
     }
   }
 }
@@ -278,5 +280,5 @@ resource "aws_acmpca_certificate" "root" {
 }
 
 data "aws_partition" "current" {}
-`, rName)
+`, commonName)
 }

--- a/aws/resource_aws_acmpca_certificate_authority_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_test.go
@@ -155,8 +155,9 @@ func TestAccAwsAcmpcaCertificateAuthority_disappears(t *testing.T) {
 
 func TestAccAwsAcmpcaCertificateAuthority_Enabled(t *testing.T) {
 	var certificateAuthority acmpca.CertificateAuthority
-	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_acmpca_certificate_authority.test"
+
+	commonName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,7 +166,7 @@ func TestAccAwsAcmpcaCertificateAuthority_Enabled(t *testing.T) {
 		CheckDestroy: testAccCheckAwsAcmpcaCertificateAuthorityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(rName, acmpca.CertificateAuthorityTypeRoot, true),
+				Config: testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(commonName, acmpca.CertificateAuthorityTypeRoot, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityExists(resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "type", acmpca.CertificateAuthorityTypeRoot),
@@ -175,7 +176,7 @@ func TestAccAwsAcmpcaCertificateAuthority_Enabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(rName, acmpca.CertificateAuthorityTypeRoot, true),
+				Config: testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(commonName, acmpca.CertificateAuthorityTypeRoot, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityExists(resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "type", acmpca.CertificateAuthorityTypeRoot),
@@ -184,7 +185,7 @@ func TestAccAwsAcmpcaCertificateAuthority_Enabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(rName, acmpca.CertificateAuthorityTypeRoot, false),
+				Config: testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(commonName, acmpca.CertificateAuthorityTypeRoot, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityExists(resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -205,8 +206,9 @@ func TestAccAwsAcmpcaCertificateAuthority_Enabled(t *testing.T) {
 
 func TestAccAwsAcmpcaCertificateAuthority_DeleteFromActiveState(t *testing.T) {
 	var certificateAuthority acmpca.CertificateAuthority
-	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_acmpca_certificate_authority.test"
+
+	commonName := testAccRandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -215,7 +217,7 @@ func TestAccAwsAcmpcaCertificateAuthority_DeleteFromActiveState(t *testing.T) {
 		CheckDestroy: testAccCheckAwsAcmpcaCertificateAuthorityDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmpcaCertificateAuthorityConfig_WithRootCertificate(rName),
+				Config: testAccAwsAcmpcaCertificateAuthorityConfig_WithRootCertificate(commonName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsAcmpcaCertificateAuthorityExists(resourceName, &certificateAuthority),
 					resource.TestCheckResourceAttr(resourceName, "type", acmpca.CertificateAuthorityTypeRoot),
@@ -709,7 +711,7 @@ func listAcmpcaCertificateAuthorities(conn *acmpca.ACMPCA) ([]*acmpca.Certificat
 	return certificateAuthorities, nil
 }
 
-func testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(rName, certificateAuthorityType string, enabled bool) string {
+func testAccAwsAcmpcaCertificateAuthorityConfig_Enabled(commonName, certificateAuthorityType string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   enabled                         = %[1]t
@@ -721,14 +723,14 @@ resource "aws_acmpca_certificate_authority" "test" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "%[3]s.com"
+      common_name = %[3]q
     }
   }
 }
-`, enabled, certificateAuthorityType, rName)
+`, enabled, certificateAuthorityType, commonName)
 }
 
-func testAccAwsAcmpcaCertificateAuthorityConfig_WithRootCertificate(rName string) string {
+func testAccAwsAcmpcaCertificateAuthorityConfig_WithRootCertificate(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
@@ -739,7 +741,7 @@ resource "aws_acmpca_certificate_authority" "test" {
     signing_algorithm = "SHA512WITHRSA"
 
     subject {
-      common_name = "%[1]s.com"
+      common_name = %[1]q
     }
   }
 }
@@ -765,7 +767,7 @@ resource "aws_acmpca_certificate" "test" {
 }
 
 data "aws_partition" "current" {}
-`, rName)
+`, commonName)
 }
 
 func testAccAwsAcmpcaCertificateAuthorityConfig_Required(commonName string) string {

--- a/aws/resource_aws_apprunner_custom_domain_association_test.go
+++ b/aws/resource_aws_apprunner_custom_domain_association_test.go
@@ -38,7 +38,7 @@ func TestAccAwsAppRunnerCustomDomainAssociation_basic(t *testing.T) {
 					testAccCheckAwsAppRunnerCustomDomainAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "certificate_validation_records.#", "3"),
 					resource.TestCheckResourceAttrSet(resourceName, "dns_target"),
-					resource.TestCheckResourceAttr(resourceName, "domain_name", "hashicorp.com"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "enable_www_subdomain", "true"),
 					resource.TestCheckResourceAttr(resourceName, "status", waiter.CustomDomainAssociationStatusPendingCertificateDnsValidation),
 					resource.TestCheckResourceAttrPair(resourceName, "service_arn", serviceResourceName, "arn"),

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -25,7 +25,7 @@ func resourceAwsAthenaDatabase() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[_a-z0-9]+$"), "see https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[_a-z0-9]+$"), "must be lowercase letters, numbers, or underscore ('_')"),
 			},
 			"bucket": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_athena_database_test.go
+++ b/aws/resource_aws_athena_database_test.go
@@ -83,7 +83,7 @@ func TestAccAWSAthenaDatabase_nameCantHaveUppercase(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAthenaDatabaseConfig(rInt, dbName, false),
-				ExpectError: regexp.MustCompile(`see .*\.com`),
+				ExpectError: regexp.MustCompile(`must be lowercase letters, numbers, or underscore \('_'\)`),
 			},
 		},
 	})


### PR DESCRIPTION
Remove hardcoded domain names from acceptance tests for resources A-B

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19972

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificate\|TestAccAWSAthenaDatabase\|TestAccAwsAcmpcaCertificate\|TestAccAwsAcmpcaCertificateAuthorityCertificate\|TestAccAwsAcmpcaCertificateAuthority\|TestAccAwsAppRunnerCustomDomainAssociation\|TestAccAWSSpotInstanceRequest'

--- SKIP: TestAccAWSAcmCertificateDataSource_singleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (0.00s)
--- SKIP: TestAccAWSAcmCertificate_disableCTLogging (0.00s)
--- SKIP: TestAccAWSAcmCertificate_emailValidation (0.00s)
--- SKIP: TestAccAWSAcmCertificate_rootAndWildcardSan (0.00s)
--- SKIP: TestAccAWSAcmCertificate_dnsValidation (0.00s)
--- SKIP: TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_multipleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificate_san_TrailingPeriod (0.00s)
--- SKIP: TestAccAWSAcmCertificate_san_single (0.00s)
--- SKIP: TestAccAWSAcmCertificate_tags (0.00s)
--- SKIP: TestAccAWSAcmCertificate_root_TrailingPeriod (0.00s)
--- SKIP: TestAccAWSAcmCertificate_root (0.00s)
--- SKIP: TestAccAWSAcmCertificate_wildcardAndRootSan (0.00s)
--- SKIP: TestAccAWSAcmCertificate_wildcard (0.00s)
--- SKIP: TestAccAWSAcmCertificate_san_multiple (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_basic (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_timeout (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdns (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (0.01s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (0.01s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_disappears (65.88s)
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (75.46s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_basic (76.30s)
--- PASS: TestValidateAcmPcaTemplateArn (0.00s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_DeleteFromActiveState (77.26s)
--- PASS: TestExpandAcmpcaValidityValue (0.00s)
--- PASS: TestAccAWSAcmCertificate_privateCert (82.05s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (87.06s)
--- PASS: TestAccAwsAcmpcaCertificateAuthorityCertificate_RootCA (89.68s)
--- PASS: TestAccAwsAcmpcaCertificateAuthorityCertificate_SubordinateCA (90.17s)
--- PASS: TestAccAwsAcmpcaCertificate_SubordinateCertificate (89.98s)
--- PASS: TestAccAwsAcmpcaCertificate_RootCertificate (94.15s)
--- PASS: TestAccAwsAcmpcaCertificate_EndEntityCertificate (95.29s)
--- PASS: TestAccAWSAthenaDatabase_nameCantHaveUppercase (13.32s)
--- PASS: TestAccAwsAcmpcaCertificateAuthorityCertificate_UpdateRootCA (131.89s)
--- PASS: TestAccAWSAcmCertificate_PrivateKey_Tags (132.96s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_S3ObjectAcl (134.52s)
--- PASS: TestAccAWSAthenaDatabase_basic (81.66s)
--- PASS: TestAccAWSAthenaDatabase_encryption (78.88s)
--- PASS: TestAccAWSAthenaDatabase_nameStartsWithUnderscore (77.18s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (172.28s)
--- PASS: TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds (78.74s)
--- PASS: TestAccAwsAcmpcaCertificate_Validity_Absolute (100.29s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Enabled (176.89s)
--- PASS: TestAccAWSAthenaDatabase_destroyFailsIfTablesExist (88.24s)
--- PASS: TestAccAwsAcmpcaCertificate_Validity_EndDate (112.82s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_ExpirationInDays (180.03s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Tags (206.05s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_Enabled (209.59s)
--- PASS: TestAccAWSSpotInstanceRequest_basic (115.60s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_CustomCname (236.43s)
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (112.86s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (99.21s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptStop (84.70s)
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (134.16s)
--- PASS: TestAccAWSSpotInstanceRequest_KeyName (135.67s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptHibernate (89.11s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (105.32s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (105.65s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (116.90s)
--- PASS: TestAccAWSSpotInstanceRequest_tags (184.82s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptDeprecated (83.66s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (139.23s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptFixDeprecated (115.79s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (164.43s)
--- PASS: TestAccAWSSpotInstanceRequest_disappears (337.61s)
--- FAIL: TestAccAwsAppRunnerCustomDomainAssociation_disappears (474.63s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptUpdateFromDeprecated (380.27s)
--- FAIL: TestAccAwsAppRunnerCustomDomainAssociation_basic (532.50s)
--- PASS: TestAccAWSSpotInstanceRequest_InterruptUpdate (444.58s)
```

Pre-existing acceptance test failures reported in #20349