### PR TITLE
r/elasticache_user: wait for modifying/active state to avoid inconsistent result

### DIFF
--- a/.changelog/20339.txt
+++ b/.changelog/20339.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+aws/resource_aws_elasticache_user: Correctly handle user modifications and deletion
+```

--- a/aws/internal/service/elasticache/finder/finder.go
+++ b/aws/internal/service/elasticache/finder/finder.go
@@ -196,11 +196,6 @@ func ElastiCacheUserById(conn *elasticache.ElastiCache, userID string) (*elastic
 			Message: "empty result",
 		}
 	case 1:
-		if aws.StringValue(out.Users[0].Status) != "active" {
-			return nil, &resource.NotFoundError{
-				Message: "empty result",
-			}
-		}
 		return out.Users[0], nil
 	default:
 		return nil, &resource.NotFoundError{

--- a/aws/internal/service/elasticache/waiter/status.go
+++ b/aws/internal/service/elasticache/waiter/status.go
@@ -15,6 +15,10 @@ const (
 	ReplicationGroupStatusDeleting     = "deleting"
 	ReplicationGroupStatusCreateFailed = "create-failed"
 	ReplicationGroupStatusSnapshotting = "snapshotting"
+
+	UserStatusActive    = "active"
+	UserStatusDeleting  = "deleting"
+	UserStatusModifying = "modifying"
 )
 
 // ReplicationGroupStatus fetches the Replication Group and its Status
@@ -123,5 +127,22 @@ func GlobalReplicationGroupMemberStatus(conn *elasticache.ElastiCache, globalRep
 		}
 
 		return member, aws.StringValue(member.Status), nil
+	}
+}
+
+// UserStatus fetches the ElastiCache user and its Status
+func UserStatus(conn *elasticache.ElastiCache, userId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		user, err := finder.ElastiCacheUserById(conn, userId)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return user, aws.StringValue(user.Status), nil
 	}
 }

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -26,7 +26,7 @@ resource "aws_elasticache_user" "test" {
 
 The following arguments are required:
 
-* `access_string` - (Required) Access permissions string used for this user.
+* `access_string` - (Required) Access permissions string used for this user. See [Specifying Permissions Using an Access String](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html#Access-string) for more details.
 * `engine` - (Required) The current supported value is `REDIS`.
 * `user_id` - (Required) The ID of the user.
 * `user_name` - (Required) The username of the user.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20334

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSElasticacheUser_tags (100.89s)
--- PASS: TestAccAWSElasticacheUser_basic (110.82s)
--- PASS: TestAccAWSElasticacheUser_disappears (118.02s)
--- PASS: TestAccAWSElasticacheUser_update (285.83s)
```
