### PR TITLE
Add AWS Go SDK service client for Route53 Recovery Control Config

### DIFF
--- a/.changelog/20348.txt
+++ b/.changelog/20348.txt
@@ -1,0 +1,3 @@
+```release-note:new-service
+Adds aws_route53_recovery_control_config service
+```

--- a/.changelog/20348.txt
+++ b/.changelog/20348.txt
@@ -1,3 +1,0 @@
-```release-note:new-service
-Adds aws_route53_recovery_control_config service
-```

--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -297,7 +297,7 @@ service/route53:
 service/route53domains:
   - '((\*|-) ?`?|(data|resource) "?)aws_route53domains_'
 service/route53recoverycontrolconfig:
-  - '((\*|-) ?`?|(data|resource) "?)aws_route53_recovery_control_config_'  
+  - '((\*|-) ?`?|(data|resource) "?)aws_route53recoverycontrolconfig_'  
 service/route53resolver:
   - '((\*|-) ?`?|(data|resource) "?)aws_route53_resolver_'
 service/s3:

--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -296,6 +296,8 @@ service/route53:
   - '((\*|-) ?`?|(data|resource) "?)aws_route53_(?!resolver_)'
 service/route53domains:
   - '((\*|-) ?`?|(data|resource) "?)aws_route53domains_'
+service/route53recoverycontrolconfig:
+  - '((\*|-) ?`?|(data|resource) "?)aws_route53_recovery_control_config_'  
 service/route53resolver:
   - '((\*|-) ?`?|(data|resource) "?)aws_route53_resolver_'
 service/s3:

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -666,8 +666,8 @@ service/route53domains:
   - '**/route53domains_*'
 service/route53recoverycontrolconfig:
   - 'aws/internal/service/route53recoverycontrolconfig/**/*'
-  - '**/*_route53_recovery_control_config_*'
-  - '**/route53_recovery_control_config_*'
+  - '**/*_route53recoverycontrolconfig_*'
+  - '**/route53recoverycontrolconfig_*'
 service/route53resolver:
   - 'aws/internal/service/route53resolver/**/*'
   - '**/*_route53_resolver_*'

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -664,6 +664,10 @@ service/route53domains:
   - 'aws/internal/service/route53domains/**/*'
   - '**/*_route53domains_*'
   - '**/route53domains_*'
+service/route53recoverycontrolconfig:
+  - 'aws/internal/service/route53recoverycontrolconfig/**/*'
+  - '**/*_route53_recovery_control_config_*'
+  - '**/route53_recovery_control_config_*'
 service/route53resolver:
   - 'aws/internal/service/route53resolver/**/*'
   - '**/*_route53_resolver_*'

--- a/aws/config.go
+++ b/aws/config.go
@@ -136,6 +136,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53domains"
+	"github.com/aws/aws-sdk-go/service/route53recoverycontrolconfig"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3control"
@@ -350,6 +351,7 @@ type AWSClient struct {
 	resourcegroupstaggingapiconn        *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
 	reverseDnsPrefix                    string
 	route53domainsconn                  *route53domains.Route53Domains
+	route53recoverycontrolconfigconn    *route53recoverycontrolconfig.Route53RecoveryControlConfig
 	route53resolverconn                 *route53resolver.Route53Resolver
 	s3conn                              *s3.S3
 	s3connUriCleaningDisabled           *s3.S3
@@ -598,6 +600,7 @@ func (c *Config) Client() (interface{}, error) {
 		resourcegroupstaggingapiconn:        resourcegroupstaggingapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["resourcegroupstaggingapi"])})),
 		reverseDnsPrefix:                    ReverseDns(dnsSuffix),
 		route53domainsconn:                  route53domains.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53domains"])})),
+		route53recoverycontrolconfigconn:    route53recoverycontrolconfig..New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53recoverycontrolconfig"])})),
 		route53resolverconn:                 route53resolver.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53resolver"])})),
 		s3controlconn:                       s3control.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["s3control"])})),
 		s3outpostsconn:                      s3outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["s3outposts"])})),

--- a/aws/config.go
+++ b/aws/config.go
@@ -600,7 +600,7 @@ func (c *Config) Client() (interface{}, error) {
 		resourcegroupstaggingapiconn:        resourcegroupstaggingapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["resourcegroupstaggingapi"])})),
 		reverseDnsPrefix:                    ReverseDns(dnsSuffix),
 		route53domainsconn:                  route53domains.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53domains"])})),
-		route53recoverycontrolconfigconn:    route53recoverycontrolconfig..New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53recoverycontrolconfig"])})),
+		route53recoverycontrolconfigconn:    route53recoverycontrolconfig.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53recoverycontrolconfig"])})),
 		route53resolverconn:                 route53resolver.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["route53resolver"])})),
 		s3controlconn:                       s3control.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["s3control"])})),
 		s3outpostsconn:                      s3outposts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["s3outposts"])})),
@@ -643,6 +643,9 @@ func (c *Config) Client() (interface{}, error) {
 	route53Config := &aws.Config{
 		Endpoint: aws.String(c.Endpoints["route53"]),
 	}
+	route53recoverycontrolconfigConfig := &aws.Config{
+		Endpoint: aws.String(c.Endpoints["route53recoverycontrolconfig"]),
+	}
 	shieldConfig := &aws.Config{
 		Endpoint: aws.String(c.Endpoints["shield"]),
 	}
@@ -663,6 +666,7 @@ func (c *Config) Client() (interface{}, error) {
 	case endpoints.AwsPartitionID:
 		globalAcceleratorConfig.Region = aws.String(endpoints.UsWest2RegionID)
 		route53Config.Region = aws.String(endpoints.UsEast1RegionID)
+		route53recoverycontrolconfigConfig.Region = aws.String(endpoints.UsWest2RegionID)
 		shieldConfig.Region = aws.String(endpoints.UsEast1RegionID)
 	case endpoints.AwsCnPartitionID:
 		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS China partition.
@@ -677,6 +681,7 @@ func (c *Config) Client() (interface{}, error) {
 
 	client.globalacceleratorconn = globalaccelerator.New(sess.Copy(globalAcceleratorConfig))
 	client.r53conn = route53.New(sess.Copy(route53Config))
+	client.route53recoverycontrolconfigconn = route53recoverycontrolconfig.New(sess.Copy(route53recoverycontrolconfigConfig))
 	client.shieldconn = shield.New(sess.Copy(shieldConfig))
 
 	client.apigatewayconn.Handlers.Retry.PushBack(func(r *request.Request) {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1424,6 +1424,7 @@ func init() {
 		"resourcegroupstaggingapi",
 		"route53",
 		"route53domains",
+		"route53recoverycontrolconfig",
 		"route53resolver",
 		"s3",
 		"s3control",

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -167,6 +167,7 @@ variable "service_labels" {
     "robomaker",
     "route53",
     "route53domains",
+    "route53recoverycontrolconfig",
     "route53resolver",
     "s3",
     "s3control",

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -110,6 +110,7 @@ Redshift
 Resource Groups
 Resource Groups Tagging API
 Route53 Domains
+Route53 Recovery Control Config
 Route53 Resolver
 Route53
 S3

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -180,6 +180,7 @@ The Terraform AWS Provider allows the following endpoints to be customized:
   <li><code>resourcegroupstaggingapi</code></li>
   <li><code>route53</code></li>
   <li><code>route53domains</code></li>
+  <li><code>route53recoverycontrolconfig</code></li>
   <li><code>route53resolver</code></li>
   <li><code>s3</code></li>
   <li><code>s3control</code></li>


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Description
AWS introduced Route 53 Application Recovery Controller, a Amazon Route 53 set of capabilities that continuously monitors an application’s ability to recover from failures and controls application recovery across multiple AWS Availability Zones, AWS Regions, and on premises environments to help you to build applications that must deliver very high availability.

### New or Affected Resource(s)

<!--- Please list the new or affected resources and data sources. --->

* aws_route53_recovery_control_config

Closes [#20353](https://github.com/hashicorp/terraform-provider-aws/issues/20353)

### Requires

Requires [AWS SDK v1.40.9](https://github.com/aws/aws-sdk-go/releases/tag/v1.40.9)

### Output from acceptance testing:
N/A

