### PR TITLE
r/aws_instance: launch_template Remove unnecessary api calls

### DIFF
--- a/.changelog/20357.txt
+++ b/.changelog/20357.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+aws/resource_aws_instance: Fix state refresh when launch template was deleted
+```
+
+```release-note:bug
+aws/resource_aws_instance: Fix running `terraform plan` with with `skip_credentials_validation=true`
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

My PR #10807 accidentally introduced two regressions related to instance usage when launch template does not yet exist, or was deleted. This PR addresses those two issues.


Closes #20331
Closes #20287

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ → make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_LaunchTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstance_LaunchTemplate -timeout 180m
=== RUN   TestAccAWSInstance_LaunchTemplate_basic
=== PAUSE TestAccAWSInstance_LaunchTemplate_basic
=== RUN   TestAccAWSInstance_LaunchTemplate_OverrideTemplate
=== PAUSE TestAccAWSInstance_LaunchTemplate_OverrideTemplate
=== RUN   TestAccAWSInstance_LaunchTemplate_SetSpecificVersion
=== PAUSE TestAccAWSInstance_LaunchTemplate_SetSpecificVersion
=== RUN   TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion
=== PAUSE TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion
=== RUN   TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion
=== PAUSE TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion
=== RUN   TestAccAWSInstance_LaunchTemplate_SwapIDAndName
=== PAUSE TestAccAWSInstance_LaunchTemplate_SwapIDAndName
=== CONT  TestAccAWSInstance_LaunchTemplate_basic
=== CONT  TestAccAWSInstance_LaunchTemplate_SetSpecificVersion
=== CONT  TestAccAWSInstance_LaunchTemplate_OverrideTemplate
=== CONT  TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion
=== CONT  TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion
=== CONT  TestAccAWSInstance_LaunchTemplate_SwapIDAndName
--- PASS: TestAccAWSInstance_LaunchTemplate_OverrideTemplate (106.95s)
--- PASS: TestAccAWSInstance_LaunchTemplate_basic (142.57s)
--- PASS: TestAccAWSInstance_LaunchTemplate_SwapIDAndName (177.02s)
--- PASS: TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion (182.85s)
--- PASS: TestAccAWSInstance_LaunchTemplate_SetSpecificVersion (206.90s)
--- PASS: TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion (213.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	216.038s
```
