### PR TITLE
Support 100Gbps Direct Connect

### DIFF
--- a/.changelog/20364.txt
+++ b/.changelog/20364.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_dx_connection: Add support for `100Gbps` `bandwidth`
+```
+
+```release-note:enhancement
+resource/aws_dx_lag: Add support for `100Gbps` `connections_bandwidth`
+```

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1996,6 +1996,7 @@ func validateDxConnectionBandWidth() schema.SchemaValidateFunc {
 		"2Gbps",
 		"5Gbps",
 		"10Gbps",
+		"100Gbps",
 		"50Mbps",
 		"100Mbps",
 		"200Mbps",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2939,6 +2939,7 @@ func TestValidateDxConnectionBandWidth(t *testing.T) {
 		"2Gbps",
 		"5Gbps",
 		"10Gbps",
+		"100Gbps",
 		"50Mbps",
 		"100Mbps",
 		"200Mbps",
@@ -2955,7 +2956,6 @@ func TestValidateDxConnectionBandWidth(t *testing.T) {
 
 	invalidBandwidths := []string{
 		"1Tbps",
-		"100Gbps",
 		"10GBpS",
 		"42Mbps",
 		"0",

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -25,7 +25,7 @@ resource "aws_dx_connection" "hoge" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the connection.
-* `bandwidth` - (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps and 10Gbps. Case sensitive.
+* `bandwidth` - (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps and 100Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location where the connection is located. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -28,7 +28,7 @@ resource "aws_dx_lag" "hoge" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the LAG.
-* `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Valid values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps and 10Gbps. Case sensitive.
+* `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Valid values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps and 100Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
Adding support for 100Gbps Direct Connect to aws_dx_connection and aws_dx_lag.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19257
