### PR TITLE
#17024 Inconsistent ordering of values in codeartifact policies

### DIFF
--- a/aws/resource_aws_codeartifact_domain_permissions_policy.go
+++ b/aws/resource_aws_codeartifact_domain_permissions_policy.go
@@ -36,7 +36,7 @@ func resourceAwsCodeArtifactDomainPermissionsPolicy() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"policy_revision": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_codeartifact_repository_permissions_policy.go
+++ b/aws/resource_aws_codeartifact_repository_permissions_policy.go
@@ -41,7 +41,7 @@ func resourceAwsCodeArtifactRepositoryPermissionsPolicy() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"policy_revision": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17024

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeArtifactDomainPermission'                      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeArtifactDomainPermission -timeout 180m
=== RUN   TestAccAWSCodeArtifactDomainPermissionsPolicy_basic
=== PAUSE TestAccAWSCodeArtifactDomainPermissionsPolicy_basic
=== RUN   TestAccAWSCodeArtifactDomainPermissionsPolicy_owner
=== PAUSE TestAccAWSCodeArtifactDomainPermissionsPolicy_owner
=== RUN   TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears
=== PAUSE TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears
=== RUN   TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears_domain
=== PAUSE TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears_domain
=== CONT  TestAccAWSCodeArtifactDomainPermissionsPolicy_basic
=== CONT  TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears_domain
=== CONT  TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears
=== CONT  TestAccAWSCodeArtifactDomainPermissionsPolicy_owner
--- PASS: TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears_domain (11.92s)
--- PASS: TestAccAWSCodeArtifactDomainPermissionsPolicy_disappears (12.04s)
--- PASS: TestAccAWSCodeArtifactDomainPermissionsPolicy_owner (13.54s)
--- PASS: TestAccAWSCodeArtifactDomainPermissionsPolicy_basic (21.63s)
PASS

make testacc TESTARGS='-run=TestAccAWSCodeArtifactRepositoryPermission'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeArtifactRepositoryPermission -timeout 180m
=== RUN   TestAccAWSCodeArtifactRepositoryPermissionsPolicy_owner
=== PAUSE TestAccAWSCodeArtifactRepositoryPermissionsPolicy_owner
=== RUN   TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears
=== PAUSE TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears
=== RUN   TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears_domain
=== PAUSE TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears_domain
=== CONT  TestAccAWSCodeArtifactRepositoryPermissionsPolicy_owner
=== CONT  TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears_domain
=== CONT  TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears
--- PASS: TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears (12.20s)
--- PASS: TestAccAWSCodeArtifactRepositoryPermissionsPolicy_disappears_domain (12.34s)
--- PASS: TestAccAWSCodeArtifactRepositoryPermissionsPolicy_owner (13.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       13.712s

...
```
