### PR TITLE
Adds aws_organizations_accounts datasource

### DIFF
--- a/.changelog/20370.txt
+++ b/.changelog/20370.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_organizations_accounts
+```

--- a/aws/data_source_aws_organizations_accounts.go
+++ b/aws/data_source_aws_organizations_accounts.go
@@ -1,0 +1,114 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsOrganizationsAccounts() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationsAccountsRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
+			},
+			"accounts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"joined_method": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"joined_timestamp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": tagsSchemaComputed(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationsAccountsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	var account_ids = expandStringList(d.Get("account_ids").([]interface{}))
+
+	var accounts []map[string]interface{}
+
+	for _, account_id := range account_ids {
+		params := &organizations.DescribeAccountInput{
+			AccountId: aws.String(*account_id),
+		}
+
+		acc, err := conn.DescribeAccount(params)
+		if err != nil {
+			return fmt.Errorf("Error describing account: %w", err)
+		}
+
+		params_tags := &organizations.ListTagsForResourceInput{
+			ResourceId: aws.String(*account_id),
+		}
+
+		rt, err := conn.ListTagsForResource(params_tags)
+		valueTags := keyvaluetags.OrganizationsKeyValueTags(rt.Tags)
+		tags := valueTags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()
+		var account = map[string]interface{}{
+			"arn":              aws.StringValue(acc.Account.Arn),
+			"email":            aws.StringValue(acc.Account.Email),
+			"name":             aws.StringValue(acc.Account.Name),
+			"status":           aws.StringValue(acc.Account.Status),
+			"joined_method":    aws.StringValue(acc.Account.JoinedMethod),
+			"joined_timestamp": aws.TimeValue(acc.Account.JoinedTimestamp).Format(time.RFC3339),
+			"tags":             tags,
+		}
+
+		accounts = append(accounts, account)
+	}
+
+	if err := d.Set("accounts", accounts); err != nil {
+		return fmt.Errorf("error setting accounts: %w", err)
+	}
+
+	d.SetId(meta.(*AWSClient).accountid)
+
+	return nil
+}

--- a/aws/data_source_aws_organizations_accounts_test.go
+++ b/aws/data_source_aws_organizations_accounts_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func testAccDataSourceAwsOrganizationsAccounts_basic(t *testing.T) {
+	dataSourceName := "data.aws_organizations_accounts.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ErrorCheck:        testAccErrorCheck(t, organizations.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsOrganizationAccountResourceOnlyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "accounts.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accounts.0.arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accounts.0.joined_method"),
+					testAccCheckResourceAttrRfc3339(dataSourceName, "accounts.0.joined_timestamp"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accounts.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accounts.0.email"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accounts.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accounts.0.tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOrganizationAccountResourceOnlyConfig() string {
+	return fmt.Sprintf(`
+data "aws_organizations_organization" "test" { }
+data "aws_organizations_accounts" "test" { account_ids = [ data.aws_organizations_organization.test.accounts[0].id] }
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -355,6 +355,7 @@ func Provider() *schema.Provider {
 			"aws_organizations_delegated_administrators":     dataSourceAwsOrganizationsDelegatedAdministrators(),
 			"aws_organizations_delegated_services":           dataSourceAwsOrganizationsDelegatedServices(),
 			"aws_organizations_organization":                 dataSourceAwsOrganizationsOrganization(),
+			"aws_organizations_accounts":                     dataSourceAwsOrganizationsAccounts(),
 			"aws_organizations_organizational_units":         dataSourceAwsOrganizationsOrganizationalUnits(),
 			"aws_outposts_outpost":                           dataSourceAwsOutpostsOutpost(),
 			"aws_outposts_outpost_instance_type":             dataSourceAwsOutpostsOutpostInstanceType(),

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -16,9 +16,10 @@ func TestAccAWSOrganizations_serial(t *testing.T) {
 			"DataSource":                 testAccDataSourceAwsOrganizationsOrganization_basic,
 		},
 		"Account": {
-			"basic":    testAccAwsOrganizationsAccount_basic,
-			"ParentId": testAccAwsOrganizationsAccount_ParentId,
-			"Tags":     testAccAwsOrganizationsAccount_Tags,
+			"basic":      testAccAwsOrganizationsAccount_basic,
+			"ParentId":   testAccAwsOrganizationsAccount_ParentId,
+			"Tags":       testAccAwsOrganizationsAccount_Tags,
+			"DataSource": testAccDataSourceAwsOrganizationsAccounts_basic,
 		},
 		"OrganizationalUnit": {
 			"basic":      testAccAwsOrganizationsOrganizationalUnit_basic,

--- a/website/docs/d/organizations_accounts.html.markdown
+++ b/website/docs/d/organizations_accounts.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Organizations"
+layout: "aws"
+page_title: "AWS: aws_organizations_accounts"
+description: |-
+Get all the given accounts info (including tags) owned by the current organization that the user's account belongs to
+---
+
+# Data Source: aws_organizations_accounts
+
+Get all the given accounts info (including tags) owned by the current organization that the user's account belongs to.
+This datasource will be very useful in multi-account setups.
+
+~> **Note:** Account info retrieval must be done from the organization's master account.
+
+!> **WARNING:** For very large multi-account setup this will perform a large number of API requests.
+
+## Example Usage
+
+### List all given account arns for the organization
+
+```terraform
+data "aws_organizations_accounts" "example" {}
+
+output "account_ids" {
+  value = data.aws_organizations_accounts.example.accounts[*].arn
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `account_ids` - (Required) The accounts ID to fetch info from.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `accounts` - List of fetched accounts. All elements have these attributes:
+  * `arn` - ARN of the account
+  * `email` - Email of the account
+  * `id` - Identifier of the account
+  * `name` - Name of the account
+  * `status` - Current status of the account
+  * `joined_method` - Method used to create the account
+  * `joined_timestamp` - Account creation timestamp
+  * `tags` - Key-value map of account tags.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14153

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSOrganizations_serial'
...
=== RUN   testAccDataSourceAwsOrganizationsAccounts_basic
--- PASS: testAccDataSourceAwsOrganizationsAccounts_basic (33.92s)
...
PASS
```

This PR is similar to [this one](https://github.com/hashicorp/terraform-provider-aws/pull/18589) but is a bit more complete and also has tags. We can convert it to single noun `_account` too, WDYT?

Also the acctest depends on the presence of an organization that has at least 1 account in the profile that runs it, but we can do as with other sibling tests and skip it.