### PR TITLE
r/aws_instance: fix spot request with stop behaviour

### DIFF
--- a/.changelog/20372.txt
+++ b/.changelog/20372.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix creating instance with launch template that sets `instance_interruption_behavior` to `stop`
+```

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -2052,11 +2052,7 @@ func fetchLaunchTemplateAmi(specs []interface{}, conn *ec2.EC2) (string, error) 
 		return "", fmt.Errorf("failed fetching Launch Template AMI ID: %w", err)
 	}
 
-	if ltData.ImageId != nil {
-		return *ltData.ImageId, nil
-	}
-
-	return "", nil
+	return aws.StringValue(ltData.ImageId), nil
 }
 
 func fetchLaunchTemplateData(specs []interface{}, conn *ec2.EC2) (*ec2.ResponseLaunchTemplateData, error) {
@@ -2595,9 +2591,7 @@ func buildAwsInstanceOpts(d *schema.ResourceData, meta interface{}) (*awsInstanc
 		}
 
 		if ltData.InstanceMarketOptions != nil && ltData.InstanceMarketOptions.SpotOptions != nil {
-			if v := ltData.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior; v != nil {
-				interruptionBehavior = *v
-			}
+			interruptionBehavior = aws.StringValue(ltData.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior)
 		}
 	}
 

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -2047,8 +2047,21 @@ func blockDeviceIsRoot(bd *ec2.InstanceBlockDeviceMapping, instance *ec2.Instanc
 }
 
 func fetchLaunchTemplateAmi(specs []interface{}, conn *ec2.EC2) (string, error) {
+	ltData, err := fetchLaunchTemplateData(specs, conn)
+	if err != nil {
+		return "", fmt.Errorf("failed fetching Launch Template AMI ID: %w", err)
+	}
+
+	if ltData.ImageId != nil {
+		return *ltData.ImageId, nil
+	}
+
+	return "", nil
+}
+
+func fetchLaunchTemplateData(specs []interface{}, conn *ec2.EC2) (*ec2.ResponseLaunchTemplateData, error) {
 	if len(specs) < 1 {
-		return "", errors.New("Cannot fetch AMI for blank launch template.")
+		return nil, errors.New("Cannot fetch data for blank launch template spec.")
 	}
 
 	spec := specs[0].(map[string]interface{})
@@ -2084,7 +2097,7 @@ func fetchLaunchTemplateAmi(specs []interface{}, conn *ec2.EC2) (string, error) 
 
 	dltv, err := conn.DescribeLaunchTemplateVersions(request)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var ltData *ec2.ResponseLaunchTemplateData
@@ -2095,11 +2108,7 @@ func fetchLaunchTemplateAmi(specs []interface{}, conn *ec2.EC2) (string, error) 
 		ltData = dltv.LaunchTemplateVersions[0].LaunchTemplateData
 	}
 
-	if ltData.ImageId != nil {
-		return *ltData.ImageId, nil
-	}
-
-	return "", nil
+	return ltData, nil
 }
 
 func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
@@ -2576,8 +2585,20 @@ func buildAwsInstanceOpts(d *schema.ResourceData, meta interface{}) (*awsInstanc
 		opts.InstanceType = aws.String(v.(string))
 	}
 
+	var interruptionBehavior string
 	if v, ok := d.GetOk("launch_template"); ok {
 		opts.LaunchTemplate = expandEc2LaunchTemplateSpecification(v.([]interface{}))
+
+		ltData, err := fetchLaunchTemplateData(v.([]interface{}), conn)
+		if err != nil {
+			return nil, err
+		}
+
+		if ltData.InstanceMarketOptions != nil && ltData.InstanceMarketOptions.SpotOptions != nil {
+			if v := ltData.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior; v != nil {
+				interruptionBehavior = *v
+			}
+		}
 	}
 
 	instanceType := d.Get("instance_type").(string)
@@ -2633,12 +2654,15 @@ func buildAwsInstanceOpts(d *schema.ResourceData, meta interface{}) (*awsInstanc
 	// aws_spot_instance_request. They represent the same data. :-|
 	opts.Placement = &ec2.Placement{
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
-		GroupName:        aws.String(d.Get("placement_group").(string)),
 	}
 
 	opts.SpotPlacement = &ec2.SpotPlacement{
 		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
-		GroupName:        aws.String(d.Get("placement_group").(string)),
+	}
+
+	if interruptionBehavior == "" || interruptionBehavior == ec2.InstanceInterruptionBehaviorTerminate {
+		opts.Placement.GroupName = aws.String(d.Get("placement_group").(string))
+		opts.SpotPlacement.GroupName = aws.String(d.Get("placement_group").(string))
 	}
 
 	if v := d.Get("tenancy").(string); v != "" {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2803,6 +2803,30 @@ func TestAccAWSInstance_LaunchTemplate_SwapIDAndName(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_LaunchTemplate_SpotAndStop(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	launchTemplateResourceName := "aws_launch_template.test"
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_WithTemplate_WithSpot_WithStop(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_getPasswordData_falseToTrue(t *testing.T) {
 	var before, after ec2.Instance
 	resourceName := "aws_instance.test"
@@ -6579,6 +6603,34 @@ resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+}
+
+resource "aws_instance" "test" {
+  launch_template {
+    name = aws_launch_template.test.name
+  }
+}
+`, rName))
+}
+
+func testAccInstanceConfig_WithTemplate_WithSpot_WithStop(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
+		fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  instance_market_options {
+    market_type = "spot"
+
+    spot_options {
+      instance_interruption_behavior = "stop"
+      spot_instance_type             = "persistent"
+    }
+  }
 }
 
 resource "aws_instance" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20286

Applied a fix similar to #1986

Before this fix:
```
→ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_LaunchTemplate_SpotAndStop'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstance_LaunchTemplate_SpotAndStop -timeout 180m
=== RUN   TestAccAWSInstance_LaunchTemplate_SpotAndStop
=== PAUSE TestAccAWSInstance_LaunchTemplate_SpotAndStop
=== CONT  TestAccAWSInstance_LaunchTemplate_SpotAndStop
    resource_aws_instance_test.go:2813: Step 1/1 error: Error running apply: exit status 1

        Error: Error launching source instance: InvalidParameterCombination: The parameter GroupName within placement information cannot be specified when instanceInterruptionBehavior is set to 'STOP'.
        	status code: 400, request id: 97fb92a7-92fa-410e-bfe0-d95165ea9f3f

          with aws_instance.test,
          on terraform_plugin_test.tf line 41, in resource "aws_instance" "test":
          41: resource "aws_instance" "test" {

--- FAIL: TestAccAWSInstance_LaunchTemplate_SpotAndStop (28.75s)
```

After:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
→ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_LaunchTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSInstance_LaunchTemplate -timeout 180m
=== RUN   TestAccAWSInstance_LaunchTemplate_basic
=== PAUSE TestAccAWSInstance_LaunchTemplate_basic
=== RUN   TestAccAWSInstance_LaunchTemplate_OverrideTemplate
=== PAUSE TestAccAWSInstance_LaunchTemplate_OverrideTemplate
=== RUN   TestAccAWSInstance_LaunchTemplate_SetSpecificVersion
=== PAUSE TestAccAWSInstance_LaunchTemplate_SetSpecificVersion
=== RUN   TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion
=== PAUSE TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion
=== RUN   TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion
=== PAUSE TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion
=== RUN   TestAccAWSInstance_LaunchTemplate_SwapIDAndName
=== PAUSE TestAccAWSInstance_LaunchTemplate_SwapIDAndName
=== RUN   TestAccAWSInstance_LaunchTemplate_SpotAndStop
=== PAUSE TestAccAWSInstance_LaunchTemplate_SpotAndStop
=== CONT  TestAccAWSInstance_LaunchTemplate_basic
=== CONT  TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion
=== CONT  TestAccAWSInstance_LaunchTemplate_SpotAndStop
=== CONT  TestAccAWSInstance_LaunchTemplate_SwapIDAndName
=== CONT  TestAccAWSInstance_LaunchTemplate_SetSpecificVersion
=== CONT  TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion
=== CONT  TestAccAWSInstance_LaunchTemplate_OverrideTemplate
--- PASS: TestAccAWSInstance_LaunchTemplate_SpotAndStop (123.73s)
--- PASS: TestAccAWSInstance_LaunchTemplate_basic (134.61s)
--- PASS: TestAccAWSInstance_LaunchTemplate_OverrideTemplate (143.45s)
--- PASS: TestAccAWSInstance_LaunchTemplate_SwapIDAndName (182.41s)
--- PASS: TestAccAWSInstance_LaunchTemplate_ModifyTemplate_DefaultVersion (187.26s)
--- PASS: TestAccAWSInstance_LaunchTemplate_SetSpecificVersion (189.33s)
--- PASS: TestAccAWSInstance_LaunchTemplate_UpdateTemplateVersion (245.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	247.700s

```
