### PR TITLE
r/aws_key_pair: Add a note documenting the limitations of the import functionality

### DIFF
--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -54,3 +54,5 @@ Key Pairs can be imported using the `key_name`, e.g.
 ```
 $ terraform import aws_key_pair.deployer deployer-key
 ```
+
+~> **NOTE:** The AWS API does not include the public key in the response, so `terraform apply` will attempt to replace the key pair. There is currently no supported workaround for this limitation.


### PR DESCRIPTION
This attempts to address #1092 and is a re-do of #8891 which seems to have been closed because people weren't happy with the proposed fix (though they seem to have agreed with the sentiment).

This note attempts to make the user aware of the limitations of the import functionality for this resource without going so far as to suggest that the user modify the state manually.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
