### PR TITLE
r/aws_cognito_user_pool: fix empty string_attribute_constraints on user_pool attribute creates no-op update that results in a failure when applied

### DIFF
--- a/.changelog/20386.txt
+++ b/.changelog/20386.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Fixes error when `schema` has empty `string_attribute_constraints` or `number_attribute_constraints`
+```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -424,52 +424,7 @@ func resourceUserPool() *schema.Resource {
 				Optional: true,
 				MinItems: 1,
 				MaxItems: 50,
-				Set: func(v any) int {
-					var buf bytes.Buffer
-					m := v.(map[string]any)
-					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrName].(string)))
-					buf.WriteString(fmt.Sprintf("%s-", m["attribute_data_type"].(string)))
-					buf.WriteString(fmt.Sprintf("%t-", m["developer_only_attribute"].(bool)))
-					buf.WriteString(fmt.Sprintf("%t-", m["mutable"].(bool)))
-					buf.WriteString(fmt.Sprintf("%t-", m["required"].(bool)))
-
-					if v, ok := m["string_attribute_constraints"]; ok {
-						data := v.([]any)
-
-						if len(data) > 0 {
-							buf.WriteString("string_attribute_constraints-")
-							m, _ := data[0].(map[string]any)
-							if ok {
-								if l, ok := m["min_length"]; ok && l.(string) != "" {
-									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
-								}
-
-								if l, ok := m["max_length"]; ok && l.(string) != "" {
-									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
-								}
-							}
-						}
-					}
-
-					if v, ok := m["number_attribute_constraints"]; ok {
-						data := v.([]any)
-
-						if len(data) > 0 {
-							buf.WriteString("number_attribute_constraints-")
-							m, _ := data[0].(map[string]any)
-							if ok {
-								if l, ok := m["min_value"]; ok && l.(string) != "" {
-									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
-								}
-
-								if l, ok := m["max_value"]; ok && l.(string) != "" {
-									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
-								}
-							}
-						}
-					}
-					return create.StringHashcode(buf.String())
-				},
+				Set:      resourceUserPoolSchemaHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attribute_data_type": {
@@ -2330,4 +2285,51 @@ func userPoolSchemaAttributeMatchesStandardAttribute(apiObject *awstypes.SchemaA
 	}
 
 	return false
+}
+
+func resourceUserPoolSchemaHash(v any) int {
+	var buf bytes.Buffer
+	m := v.(map[string]any)
+	buf.WriteString(fmt.Sprintf("%s-", m[names.AttrName].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["attribute_data_type"].(string)))
+	buf.WriteString(fmt.Sprintf("%t-", m["developer_only_attribute"].(bool)))
+	buf.WriteString(fmt.Sprintf("%t-", m["mutable"].(bool)))
+	buf.WriteString(fmt.Sprintf("%t-", m["required"].(bool)))
+
+	if v, ok := m["string_attribute_constraints"]; ok {
+		data := v.([]any)
+
+		if len(data) > 0 {
+			buf.WriteString("string_attribute_constraints-")
+			m, _ := data[0].(map[string]any)
+			if ok {
+				if l, ok := m["min_length"]; ok && l.(string) != "" {
+					buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+				}
+
+				if l, ok := m["max_length"]; ok && l.(string) != "" {
+					buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+				}
+			}
+		}
+	}
+
+	if v, ok := m["number_attribute_constraints"]; ok {
+		data := v.([]any)
+
+		if len(data) > 0 {
+			buf.WriteString("number_attribute_constraints-")
+			m, _ := data[0].(map[string]any)
+			if ok {
+				if l, ok := m["min_value"]; ok && l.(string) != "" {
+					buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+				}
+
+				if l, ok := m["max_value"]; ok && l.(string) != "" {
+					buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+				}
+			}
+		}
+	}
+	return create.StringHashcode(buf.String())
 }

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -4,6 +4,7 @@
 package cognitoidp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -422,6 +424,52 @@ func resourceUserPool() *schema.Resource {
 				Optional: true,
 				MinItems: 1,
 				MaxItems: 50,
+				Set: func(v any) int {
+					var buf bytes.Buffer
+					m := v.(map[string]any)
+					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrName].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", m["attribute_data_type"].(string)))
+					buf.WriteString(fmt.Sprintf("%t-", m["developer_only_attribute"].(bool)))
+					buf.WriteString(fmt.Sprintf("%t-", m["mutable"].(bool)))
+					buf.WriteString(fmt.Sprintf("%t-", m["required"].(bool)))
+
+					if v, ok := m["string_attribute_constraints"]; ok {
+						data := v.([]any)
+
+						if len(data) > 0 {
+							buf.WriteString("string_attribute_constraints-")
+							m, _ := data[0].(map[string]any)
+							if ok {
+								if l, ok := m["min_length"]; ok && l.(string) != "" {
+									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+								}
+
+								if l, ok := m["max_length"]; ok && l.(string) != "" {
+									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+								}
+							}
+						}
+					}
+
+					if v, ok := m["number_attribute_constraints"]; ok {
+						data := v.([]any)
+
+						if len(data) > 0 {
+							buf.WriteString("number_attribute_constraints-")
+							m, _ := data[0].(map[string]any)
+							if ok {
+								if l, ok := m["min_value"]; ok && l.(string) != "" {
+									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+								}
+
+								if l, ok := m["max_value"]; ok && l.(string) != "" {
+									buf.WriteString(fmt.Sprintf("%s-", l.(string)))
+								}
+							}
+						}
+					}
+					return create.StringHashcode(buf.String())
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attribute_data_type": {
@@ -1693,7 +1741,11 @@ func expandSchemaAttributeTypes(tfList []interface{}) []awstypes.SchemaAttribute
 						sact.MinLength = aws.String(v.(string))
 					}
 
-					apiObject.StringAttributeConstraints = sact
+					if sact.MinLength == nil && sact.MaxLength == nil {
+						apiObject.StringAttributeConstraints = nil
+					} else {
+						apiObject.StringAttributeConstraints = sact
+					}
 				}
 			}
 		}

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1389,7 +1389,7 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 				Config: testAccUserPoolConfig_schemaAttributes(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolExists(ctx, resourceName, &pool1),
-					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct3),
+					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct4),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
 						"attribute_data_type":                       "String",
 						"developer_only_attribute":                  acctest.CtFalse,
@@ -1414,19 +1414,27 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 						"attribute_data_type":            "String",
 						"developer_only_attribute":       acctest.CtFalse,
 						"mutable":                        acctest.CtTrue,
-						"name":                           "alias",
+						names.AttrName:                   "strattr",
 						"number_attribute_constraints.#": acctest.Ct0,
 						"required":                       acctest.CtFalse,
 						"string_attribute_constraints.#": acctest.Ct1,
 					}),
-				),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
+						"attribute_data_type":            "Number",
+						"developer_only_attribute":       acctest.CtFalse,
+						"mutable":                        acctest.CtTrue,
+						names.AttrName:                   "numattr",
+						"required":                       acctest.CtFalse,
+						"number_attribute_constraints.#": acctest.Ct1,
+						"string_attribute_constraints.#": acctest.Ct0,
+					})),
 			},
 			{
 				Config: testAccUserPoolConfig_schemaAttributesUpdated(rName, "mybool"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolExists(ctx, resourceName, &pool2),
 					testAccCheckUserPoolNotRecreated(&pool1, &pool2),
-					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct4),
+					resource.TestCheckResourceAttr(resourceName, "schema.#", "5"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
 						"attribute_data_type":                       "String",
 						"developer_only_attribute":                  acctest.CtFalse,
@@ -1462,10 +1470,19 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 						"attribute_data_type":            "String",
 						"developer_only_attribute":       acctest.CtFalse,
 						"mutable":                        acctest.CtTrue,
-						"name":                           "alias",
+						names.AttrName:                   "strattr",
 						"number_attribute_constraints.#": acctest.Ct0,
 						"required":                       acctest.CtFalse,
 						"string_attribute_constraints.#": acctest.Ct1,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
+						"attribute_data_type":            "Number",
+						"developer_only_attribute":       acctest.CtFalse,
+						"mutable":                        acctest.CtTrue,
+						names.AttrName:                   "numattr",
+						"required":                       acctest.CtFalse,
+						"number_attribute_constraints.#": acctest.Ct1,
+						"string_attribute_constraints.#": acctest.Ct0,
 					}),
 				),
 			},
@@ -1473,6 +1490,12 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"schema.2.number_attribute_constraints.0.max_value",
+					"schema.2.number_attribute_constraints.0.min_value",
+					"schema.4.string_attribute_constraints.0.max_length",
+					"schema.4.string_attribute_constraints.0.min_length",
+				},
 			},
 		},
 	})
@@ -2684,9 +2707,18 @@ resource "aws_cognito_user_pool" "test" {
     attribute_data_type      = "String"
     developer_only_attribute = false
     mutable                  = true
-    name                     = "alias"
+    name                     = "strattr"
     required                 = false
     string_attribute_constraints {}
+  }
+
+  schema {
+    attribute_data_type      = "Number"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "numattr"
+    required                 = false
+    number_attribute_constraints {}
   }
 
   schema {
@@ -2722,9 +2754,18 @@ resource "aws_cognito_user_pool" "test" {
     attribute_data_type      = "String"
     developer_only_attribute = false
     mutable                  = true
-    name                     = "alias"
+    name                     = "strattr"
     required                 = false
     string_attribute_constraints {}
+  }
+
+  schema {
+    attribute_data_type      = "Number"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "numattr"
+    required                 = false
+    number_attribute_constraints {}
   }
 
   schema {

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1389,7 +1389,7 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 				Config: testAccUserPoolConfig_schemaAttributes(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolExists(ctx, resourceName, &pool1),
-					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct3),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
 						"attribute_data_type":                       "String",
 						"developer_only_attribute":                  acctest.CtFalse,
@@ -1410,6 +1410,15 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 						"required":                       acctest.CtFalse,
 						"string_attribute_constraints.#": acctest.Ct0,
 					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
+						"attribute_data_type":            "String",
+						"developer_only_attribute":       acctest.CtFalse,
+						"mutable":                        acctest.CtTrue,
+						"name":                           "alias",
+						"number_attribute_constraints.#": acctest.Ct0,
+						"required":                       acctest.CtFalse,
+						"string_attribute_constraints.#": acctest.Ct1,
+					}),
 				),
 			},
 			{
@@ -1417,7 +1426,7 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolExists(ctx, resourceName, &pool2),
 					testAccCheckUserPoolNotRecreated(&pool1, &pool2),
-					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct3),
+					resource.TestCheckResourceAttr(resourceName, "schema.#", acctest.Ct4),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
 						"attribute_data_type":                       "String",
 						"developer_only_attribute":                  acctest.CtFalse,
@@ -1448,6 +1457,15 @@ func TestAccCognitoIDPUserPool_schemaAttributes(t *testing.T) {
 						"number_attribute_constraints.0.max_value": "6",
 						"required":                                 acctest.CtFalse,
 						"string_attribute_constraints.#":           acctest.Ct0,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "schema.*", map[string]string{
+						"attribute_data_type":            "String",
+						"developer_only_attribute":       acctest.CtFalse,
+						"mutable":                        acctest.CtTrue,
+						"name":                           "alias",
+						"number_attribute_constraints.#": acctest.Ct0,
+						"required":                       acctest.CtFalse,
+						"string_attribute_constraints.#": acctest.Ct1,
 					}),
 				),
 			},
@@ -2663,6 +2681,15 @@ resource "aws_cognito_user_pool" "test" {
   }
 
   schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "alias"
+    required                 = false
+    string_attribute_constraints {}
+  }
+
+  schema {
     attribute_data_type      = "Boolean"
     developer_only_attribute = true
     mutable                  = false
@@ -2689,6 +2716,15 @@ resource "aws_cognito_user_pool" "test" {
       min_length = 5
       max_length = 10
     }
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "alias"
+    required                 = false
+    string_attribute_constraints {}
   }
 
   schema {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20276
Closes #37687

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_*'               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPool_* -timeout 180m
=== RUN   TestAccAWSCognitoUserPoolClient_basic
=== PAUSE TestAccAWSCognitoUserPoolClient_basic
=== RUN   TestAccAWSCognitoUserPoolClient_enableRevocation
=== PAUSE TestAccAWSCognitoUserPoolClient_enableRevocation
=== RUN   TestAccAWSCognitoUserPoolClient_refreshTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_refreshTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_accessTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_accessTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_idTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_idTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_tokenValidityUnits
=== PAUSE TestAccAWSCognitoUserPoolClient_tokenValidityUnits
=== RUN   TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_Name
=== PAUSE TestAccAWSCognitoUserPoolClient_Name
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
=== PAUSE TestAccAWSCognitoUserPoolClient_allFields
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== PAUSE TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== RUN   TestAccAWSCognitoUserPoolClient_analyticsConfig
=== PAUSE TestAccAWSCognitoUserPoolClient_analyticsConfig
=== RUN   TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn
=== PAUSE TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn
=== RUN   TestAccAWSCognitoUserPoolClient_disappears
=== PAUSE TestAccAWSCognitoUserPoolClient_disappears
=== RUN   TestAccAWSCognitoUserPoolClient_disappears_userPool
=== PAUSE TestAccAWSCognitoUserPoolClient_disappears_userPool
=== RUN   TestAccAWSCognitoUserPoolDomain_basic
=== PAUSE TestAccAWSCognitoUserPoolDomain_basic
=== RUN   TestAccAWSCognitoUserPoolDomain_custom
    resource_aws_acm_certificate_test.go:88: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAWSCognitoUserPoolDomain_custom (0.00s)
=== RUN   TestAccAWSCognitoUserPoolDomain_disappears
=== PAUSE TestAccAWSCognitoUserPoolDomain_disappears
=== RUN   TestAccAWSCognitoUserPool_basic
=== PAUSE TestAccAWSCognitoUserPool_basic
=== RUN   TestAccAWSCognitoUserPool_recovery
=== PAUSE TestAccAWSCognitoUserPool_recovery
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy
=== PAUSE TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy
=== RUN   TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== PAUSE TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withDeviceConfiguration
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration
=== RUN   TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration
=== PAUSE TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration
=== RUN   TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration
=== PAUSE TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration
=== RUN   TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration
=== PAUSE TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration
=== RUN   TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration
=== RUN   TestAccAWSCognitoUserPool_SmsAuthenticationMessage
=== PAUSE TestAccAWSCognitoUserPool_SmsAuthenticationMessage
=== RUN   TestAccAWSCognitoUserPool_SmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_SmsConfiguration
=== RUN   TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId
=== PAUSE TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId
=== RUN   TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn
=== PAUSE TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn
=== RUN   TestAccAWSCognitoUserPool_SmsVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_SmsVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withEmailConfiguration
=== RUN   TestAccAWSCognitoUserPool_withEmailConfigurationSource
    resource_aws_cognito_user_pool_test.go:799: 'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfigurationSource (0.00s)
=== RUN   TestAccAWSCognitoUserPool_withTags
=== PAUSE TestAccAWSCognitoUserPool_withTags
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
=== PAUSE TestAccAWSCognitoUserPool_withAliasAttributes
=== RUN   TestAccAWSCognitoUserPool_withUsernameAttributes
=== PAUSE TestAccAWSCognitoUserPool_withUsernameAttributes
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
=== PAUSE TestAccAWSCognitoUserPool_withPasswordPolicy
=== RUN   TestAccAWSCognitoUserPool_withUsernameConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withUsernameConfiguration
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig
=== RUN   TestAccAWSCognitoUserPool_schemaAttributes
=== PAUSE TestAccAWSCognitoUserPool_schemaAttributes
=== RUN   TestAccAWSCognitoUserPool_schemaAttributesRemoved
=== PAUSE TestAccAWSCognitoUserPool_schemaAttributesRemoved
=== RUN   TestAccAWSCognitoUserPool_schemaAttributesModified
=== PAUSE TestAccAWSCognitoUserPool_schemaAttributesModified
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== PAUSE TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== RUN   TestAccAWSCognitoUserPool_update
=== PAUSE TestAccAWSCognitoUserPool_update
=== RUN   TestAccAWSCognitoUserPool_disappears
=== PAUSE TestAccAWSCognitoUserPool_disappears
=== RUN   TestAccAWSCognitoUserPoolUICustomization_AllClients_CSS
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_AllClients_CSS
=== RUN   TestAccAWSCognitoUserPoolUICustomization_AllClients_Disappears
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_AllClients_Disappears
=== RUN   TestAccAWSCognitoUserPoolUICustomization_AllClients_ImageFile
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_AllClients_ImageFile
=== RUN   TestAccAWSCognitoUserPoolUICustomization_AllClients_CSSAndImageFile
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_AllClients_CSSAndImageFile
=== RUN   TestAccAWSCognitoUserPoolUICustomization_Client_CSS
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_Client_CSS
=== RUN   TestAccAWSCognitoUserPoolUICustomization_Client_Disappears
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_Client_Disappears
=== RUN   TestAccAWSCognitoUserPoolUICustomization_Client_Image
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_Client_Image
=== RUN   TestAccAWSCognitoUserPoolUICustomization_ClientAndAll_CSS
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_ClientAndAll_CSS
=== RUN   TestAccAWSCognitoUserPoolUICustomization_UpdateClientToAll_CSS
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_UpdateClientToAll_CSS
=== RUN   TestAccAWSCognitoUserPoolUICustomization_UpdateAllToClient_CSS
=== PAUSE TestAccAWSCognitoUserPoolUICustomization_UpdateAllToClient_CSS
=== CONT  TestAccAWSCognitoUserPoolClient_basic
=== CONT  TestAccAWSCognitoUserPool_SmsConfiguration
=== CONT  TestAccAWSCognitoUserPoolDomain_disappears
=== CONT  TestAccAWSCognitoUserPoolUICustomization_Client_Disappears
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig
=== CONT  TestAccAWSCognitoUserPool_withAliasAttributes
=== CONT  TestAccAWSCognitoUserPool_withTags
=== CONT  TestAccAWSCognitoUserPool_withEmailConfiguration
=== CONT  TestAccAWSCognitoUserPool_SmsVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn
=== CONT  TestAccAWSCognitoUserPool_schemaAttributesModified
=== CONT  TestAccAWSCognitoUserPoolUICustomization_UpdateAllToClient_CSS
=== CONT  TestAccAWSCognitoUserPoolUICustomization_UpdateClientToAll_CSS
=== CONT  TestAccAWSCognitoUserPoolUICustomization_ClientAndAll_CSS
=== CONT  TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId
=== CONT  TestAccAWSCognitoUserPoolUICustomization_Client_Image
=== CONT  TestAccAWSCognitoUserPool_withUsernameAttributes
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig
=== CONT  TestAccAWSCognitoUserPool_withPasswordPolicy
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig
--- PASS: TestAccAWSCognitoUserPoolDomain_disappears (104.52s)
=== CONT  TestAccAWSCognitoUserPool_SmsAuthenticationMessage
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesModified (106.17s)
=== CONT  TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (107.97s)
=== CONT  TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration
--- PASS: TestAccAWSCognitoUserPoolClient_basic (122.22s)
=== CONT  TestAccAWSCognitoUserPoolUICustomization_AllClients_Disappears
--- PASS: TestAccAWSCognitoUserPoolUICustomization_Client_Disappears (128.27s)
=== CONT  TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration
--- PASS: TestAccAWSCognitoUserPool_SmsVerificationMessage (139.02s)
=== CONT  TestAccAWSCognitoUserPoolUICustomization_Client_CSS
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (147.02s)
=== CONT  TestAccAWSCognitoUserPoolUICustomization_AllClients_CSSAndImageFile
--- PASS: TestAccAWSCognitoUserPool_withUsernameAttributes (151.36s)
=== CONT  TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration
--- PASS: TestAccAWSCognitoUserPoolUICustomization_Client_Image (163.13s)
=== CONT  TestAccAWSCognitoUserPoolUICustomization_AllClients_ImageFile
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (163.84s)
=== CONT  TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration
--- PASS: TestAccAWSCognitoUserPoolUICustomization_UpdateClientToAll_CSS (180.03s)
=== CONT  TestAccAWSCognitoUserPool_schemaAttributesRemoved
--- PASS: TestAccAWSCognitoUserPoolUICustomization_UpdateAllToClient_CSS (190.18s)
=== CONT  TestAccAWSCognitoUserPool_withUsernameConfiguration
--- PASS: TestAccAWSCognitoUserPoolUICustomization_ClientAndAll_CSS (200.28s)
=== CONT  TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_Disappears (83.20s)
=== CONT  TestAccAWSCognitoUserPoolDomain_basic
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId (206.58s)
=== CONT  TestAccAWSCognitoUserPoolClient_disappears_userPool
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn (206.99s)
=== CONT  TestAccAWSCognitoUserPoolClient_disappears
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (215.59s)
=== CONT  TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn
--- PASS: TestAccAWSCognitoUserPool_withTags (215.86s)
=== CONT  TestAccAWSCognitoUserPool_withEmailVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration (227.18s)
=== CONT  TestAccAWSCognitoUserPoolClient_analyticsConfig
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig (229.36s)
=== CONT  TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
--- PASS: TestAccAWSCognitoUserPool_SmsAuthenticationMessage (134.80s)
=== CONT  TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig (244.82s)
=== CONT  TestAccAWSCognitoUserPool_recovery
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration (147.50s)
=== CONT  TestAccAWSCognitoUserPool_schemaAttributes
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration (139.35s)
=== CONT  TestAccAWSCognitoUserPool_basic
=== CONT  TestAccAWSCognitoUserPoolClient_idTokenValidity
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration (160.31s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesRemoved (89.22s)
=== CONT  TestAccAWSCognitoUserPoolClient_Name
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (72.41s)
=== CONT  TestAccAWSCognitoUserPool_disappears
--- PASS: TestAccAWSCognitoUserPoolUICustomization_Client_CSS (144.22s)
=== CONT  TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (76.72s)
=== CONT  TestAccAWSCognitoUserPoolUICustomization_AllClients_CSS
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (82.42s)
=== CONT  TestAccAWSCognitoUserPoolClient_tokenValidityUnits
--- PASS: TestAccAWSCognitoUserPoolClient_disappears_userPool (88.34s)
=== CONT  TestAccAWSCognitoUserPool_withAdvancedSecurityMode
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_ImageFile (140.89s)
=== CONT  TestAccAWSCognitoUserPool_withDeviceConfiguration
--- PASS: TestAccAWSCognitoUserPool_withUsernameConfiguration (120.73s)
=== CONT  TestAccAWSCognitoUserPool_withVerificationMessageTemplate
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfigWithArn (98.00s)
=== CONT  TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy
--- PASS: TestAccAWSCognitoUserPool_disappears (55.97s)
=== CONT  TestAccAWSCognitoUserPool_update
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (123.66s)
=== CONT  TestAccAWSCognitoUserPoolClient_accessTokenValidity
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_CSSAndImageFile (192.65s)
=== CONT  TestAccAWSCognitoUserPoolClient_enableRevocation
--- PASS: TestAccAWSCognitoUserPool_basic (75.40s)
=== CONT  TestAccAWSCognitoUserPoolClient_refreshTokenValidity
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration (195.73s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (122.60s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (114.99s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributes (105.89s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration (209.69s)
--- PASS: TestAccAWSCognitoUserPoolClient_idTokenValidity (105.78s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (65.79s)
--- PASS: TestAccAWSCognitoUserPool_recovery (143.01s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (120.47s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnitsWTokenValidity (113.15s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (95.83s)
--- PASS: TestAccAWSCognitoUserPoolClient_tokenValidityUnits (116.12s)
--- PASS: TestAccAWSCognitoUserPoolUICustomization_AllClients_CSS (126.02s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (185.87s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (106.19s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (132.46s)
--- PASS: TestAccAWSCognitoUserPoolClient_enableRevocation (120.59s)
--- PASS: TestAccAWSCognitoUserPoolClient_accessTokenValidity (130.70s)
--- PASS: TestAccAWSCognitoUserPoolClient_refreshTokenValidity (132.98s)
--- PASS: TestAccAWSCognitoUserPool_update (164.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       495.469s
```
