### PR TITLE
Add tag filter to aws_efs_file_system data source

### DIFF
--- a/aws/data_source_aws_efs_file_system_test.go
+++ b/aws/data_source_aws_efs_file_system_test.go
@@ -40,6 +40,36 @@ func TestAccDataSourceAwsEfsFileSystem_id(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsEfsFileSystem_tags(t *testing.T) {
+	dataSourceName := "data.aws_efs_file_system.test"
+	resourceName := "aws_efs_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, efs.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEfsFileSystemTagsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsEfsFileSystemCheck(dataSourceName, resourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "performance_mode", resourceName, "performance_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "creation_token", resourceName, "creation_token"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encrypted", resourceName, "encrypted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provisioned_throughput_in_mibps", resourceName, "provisioned_throughput_in_mibps"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "throughput_mode", resourceName, "throughput_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "lifecycle_policy", resourceName, "lifecycle_policy"),
+					resource.TestMatchResourceAttr(dataSourceName, "size_in_bytes", regexp.MustCompile(`^\d+$`)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAwsEfsFileSystem_name(t *testing.T) {
 	dataSourceName := "data.aws_efs_file_system.test"
 	resourceName := "aws_efs_file_system.test"
@@ -159,6 +189,28 @@ resource "aws_efs_file_system" "test" {}
 
 data "aws_efs_file_system" "test" {
   file_system_id = aws_efs_file_system.test.id
+}
+`
+
+const testAccDataSourceAwsEfsFileSystemTagsConfig = `
+
+resource "aws_efs_file_system" "test" {
+	tags = {
+    Name        = "default-efs"
+    Environment = "dev"
+  }
+}
+
+resource "aws_efs_file_system" "wrong-env" {
+	tags = {
+    Environment = "test"
+  }
+}
+
+resource "aws_efs_file_system" "no-tags" {}
+
+data "aws_efs_file_system" "test" {
+  tags = aws_efs_file_system.test.tags
 }
 `
 

--- a/website/docs/d/efs_file_system.html.markdown
+++ b/website/docs/d/efs_file_system.html.markdown
@@ -21,6 +21,12 @@ variable "file_system_id" {
 data "aws_efs_file_system" "by_id" {
   file_system_id = var.file_system_id
 }
+
+data "aws_efs_file_system" "by_tag" {
+  tags {
+    environment = "dev"
+  }
+}
 ```
 
 ## Argument Reference
@@ -29,6 +35,7 @@ The following arguments are supported:
 
 * `file_system_id` - (Optional) The ID that identifies the file system (e.g. fs-ccfc0d65).
 * `creation_token` - (Optional) Restricts the list to the file system with this creation token.
+* `tags` - (Optional) Restricts the list to the file system with these tags.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18097

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsEfs'

=== RUN   TestAccDataSourceAwsEfsFileSystem_id
=== PAUSE TestAccDataSourceAwsEfsFileSystem_id
=== RUN   TestAccDataSourceAwsEfsFileSystem_tags
=== PAUSE TestAccDataSourceAwsEfsFileSystem_tags
=== RUN   TestAccDataSourceAwsEfsFileSystem_name
=== PAUSE TestAccDataSourceAwsEfsFileSystem_name
=== RUN   TestAccDataSourceAwsEfsFileSystem_availabilityZone
=== PAUSE TestAccDataSourceAwsEfsFileSystem_availabilityZone
=== RUN   TestAccDataSourceAwsEfsFileSystem_NonExistent
=== PAUSE TestAccDataSourceAwsEfsFileSystem_NonExistent
=== RUN   TestAccDataSourceAwsEfsMountTarget_basic
=== PAUSE TestAccDataSourceAwsEfsMountTarget_basic
=== RUN   TestAccDataSourceAwsEfsMountTarget_byAccessPointID
=== PAUSE TestAccDataSourceAwsEfsMountTarget_byAccessPointID
=== RUN   TestAccDataSourceAwsEfsMountTarget_byFileSystemID
=== PAUSE TestAccDataSourceAwsEfsMountTarget_byFileSystemID
=== CONT  TestAccDataSourceAwsEfsFileSystem_id
=== CONT  TestAccDataSourceAwsEfsMountTarget_basic
=== CONT  TestAccDataSourceAwsEfsMountTarget_byFileSystemID
=== CONT  TestAccDataSourceAwsEfsMountTarget_byAccessPointID
=== CONT  TestAccDataSourceAwsEfsFileSystem_availabilityZone
=== CONT  TestAccDataSourceAwsEfsFileSystem_NonExistent
=== CONT  TestAccDataSourceAwsEfsFileSystem_name
=== CONT  TestAccDataSourceAwsEfsFileSystem_tags
--- PASS: TestAccDataSourceAwsEfsFileSystem_NonExistent (13.13s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_name (47.60s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_id (57.83s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_tags (58.17s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_availabilityZone (67.11s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_byFileSystemID (145.16s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_basic (152.66s)
--- PASS: TestAccDataSourceAwsEfsMountTarget_byAccessPointID (160.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       160.242s
```
