### PR TITLE
r/aws_launch_tamplate: Allow more resource values for tag specification

### DIFF
--- a/.changelog/20409.txt
+++ b/.changelog/20409.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_launch_template: Allow adding network-interfaces in tag specification
+```

--- a/.changelog/20409.txt
+++ b/.changelog/20409.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_launch_template: Allow adding network-interfaces in tag specification
+resource/aws_launch_template: Allow all supported resource types `tag_specifications.resource_type`
 ```

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -595,14 +595,9 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"resource_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ec2.ResourceTypeInstance,
-								ec2.ResourceTypeVolume,
-								ec2.ResourceTypeSpotInstancesRequest,
-								ec2.ResourceTypeElasticGpu,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(ec2.ResourceType_Values(), false),
 						},
 						"tags": tagsSchema(),
 					},

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -471,7 +471,7 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "ram_disk_id"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tag_specifications.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tag_specifications.#", "5"),
 				),
 			},
 			{
@@ -1704,6 +1704,14 @@ resource "aws_launch_template" "test" {
 
   tag_specifications {
     resource_type = "elastic-gpu"
+
+    tags = {
+      Name = "test"
+    }
+  }
+
+  tag_specifications {
+    resource_type = "network-interface"
 
     tags = {
       Name = "test"

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -341,7 +341,7 @@ The tags to apply to the resources during launch. You can tag instances, volumes
 
 Each `tag_specifications` block supports the following:
 
-* `resource_type` - The type of resource to tag. Valid values are `instance`, `volume`, `elastic-gpu` and `spot-instances-request`.
+* `resource_type` - The type of resource to tag.
 * `tags` - A map of tags to assign to the resource.
 
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19140
Relates #14601

Replaced hardcoded list of allowed resource type strings according to #14601 and this [comment](https://github.com/hashicorp/terraform-provider-aws/pull/14662#discussion_r472231120)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
→ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_data'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_data -timeout 180m
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (44.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.109s
```
