### PR TITLE
sweeper/appconfig_*: add sweepers

### DIFF
--- a/aws/resource_aws_appconfig_environment_test.go
+++ b/aws/resource_aws_appconfig_environment_test.go
@@ -2,16 +2,101 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appconfig"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_appconfig_environment", &resource.Sweeper{
+		Name: "aws_appconfig_environment",
+		F:    testSweepAppConfigEnvironments,
+	})
+}
+
+func testSweepAppConfigEnvironments(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*AWSClient).appconfigconn
+	sweepResources := make([]*testSweepResource, 0)
+	var errs *multierror.Error
+
+	input := &appconfig.ListApplicationsInput{}
+
+	err = conn.ListApplicationsPages(input, func(page *appconfig.ListApplicationsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, item := range page.Items {
+			if item == nil {
+				continue
+			}
+
+			appId := aws.StringValue(item.Id)
+
+			envInput := &appconfig.ListEnvironmentsInput{
+				ApplicationId: item.Id,
+			}
+
+			err := conn.ListEnvironmentsPages(envInput, func(page *appconfig.ListEnvironmentsOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, item := range page.Items {
+					if item == nil {
+						continue
+					}
+
+					id := fmt.Sprintf("%s:%s", aws.StringValue(item.Id), appId)
+
+					log.Printf("[INFO] Deleting AppConfig Environment (%s)", id)
+					r := resourceAwsAppconfigEnvironment()
+					d := r.Data(nil)
+					d.SetId(id)
+
+					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("error listing AppConfig Environments for Application (%s): %w", appId, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing AppConfig Applications: %w", err))
+	}
+
+	if err = testSweepResourceOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping AppConfig Environments for %s: %w", region, err))
+	}
+
+	if testSweepSkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping AppConfig Environments sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func TestAccAWSAppConfigEnvironment_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/20238

Output from sweeper testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make sweep SWEEP='us-west-2' SWEEPARGS='-sweep-run=aws_appconfig_application'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_appconfig_application -timeout 60m
2021/08/03 00:12:56 [DEBUG] Running Sweepers for region (us-west-2):
2021/08/03 00:12:56 [DEBUG] Running Sweeper (aws_appconfig_hosted_configuration_version) in region (us-west-2)
2021/08/03 00:12:56 [INFO] AWS Auth provider used: "EnvProvider"
2021/08/03 00:12:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/03 00:12:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/03 00:12:59 [INFO] Deleting AppConfig Hosted Configuration Version (sn8ni42/1xwuvom/1)
2021/08/03 00:12:59 [DEBUG] Waiting for state to become: [success]
2021/08/03 00:12:59 [DEBUG] Completed Sweeper (aws_appconfig_hosted_configuration_version) in region (us-west-2) in 3.397686553s
2021/08/03 00:12:59 [DEBUG] Running Sweeper (aws_appconfig_environment) in region (us-west-2)
2021/08/03 00:13:00 [DEBUG] Completed Sweeper (aws_appconfig_environment) in region (us-west-2) in 686.098687ms
2021/08/03 00:13:00 [DEBUG] Sweeper (aws_appconfig_application) has dependency (aws_appconfig_configuration_profile), running..
2021/08/03 00:13:00 [DEBUG] Sweeper (aws_appconfig_configuration_profile) has dependency (aws_appconfig_hosted_configuration_version), running..
2021/08/03 00:13:00 [DEBUG] Sweeper (aws_appconfig_hosted_configuration_version) already ran in region (us-west-2)
2021/08/03 00:13:00 [DEBUG] Running Sweeper (aws_appconfig_configuration_profile) in region (us-west-2)
2021/08/03 00:13:01 [INFO] Deleting AppConfig Configuration Profile (1xwuvom:sn8ni42)
2021/08/03 00:13:01 [DEBUG] Waiting for state to become: [success]
2021/08/03 00:13:01 [DEBUG] Completed Sweeper (aws_appconfig_configuration_profile) in region (us-west-2) in 1.069567277s
2021/08/03 00:13:01 [DEBUG] Sweeper (aws_appconfig_application) has dependency (aws_appconfig_environment), running..
2021/08/03 00:13:01 [DEBUG] Sweeper (aws_appconfig_environment) already ran in region (us-west-2)
2021/08/03 00:13:01 [DEBUG] Running Sweeper (aws_appconfig_application) in region (us-west-2)
2021/08/03 00:13:01 [INFO] Deleting AppConfig Application (sn8ni42)
2021/08/03 00:13:01 [DEBUG] Waiting for state to become: [success]
2021/08/03 00:13:02 [DEBUG] Completed Sweeper (aws_appconfig_application) in region (us-west-2) in 726.324739ms
2021/08/03 00:13:02 [DEBUG] Sweeper (aws_appconfig_configuration_profile) has dependency (aws_appconfig_hosted_configuration_version), running..
2021/08/03 00:13:02 [DEBUG] Sweeper (aws_appconfig_hosted_configuration_version) already ran in region (us-west-2)
2021/08/03 00:13:02 [DEBUG] Sweeper (aws_appconfig_configuration_profile) already ran in region (us-west-2)
2021/08/03 00:13:02 Completed Sweepers for region (us-west-2) in 5.880031327s
2021/08/03 00:13:02 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_appconfig_configuration_profile
	- aws_appconfig_application
	- aws_appconfig_hosted_configuration_version
	- aws_appconfig_environment
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.420s
```

```
make sweep SWEEP='us-west-2' SWEEPARGS='-sweep-run=aws_appconfig_deployment_strategy'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_appconfig_deployment_strategy -timeout 60m
2021/08/03 00:38:29 [DEBUG] Running Sweepers for region (us-west-2):
2021/08/03 00:38:29 [DEBUG] Running Sweeper (aws_appconfig_deployment_strategy) in region (us-west-2)
2021/08/03 00:38:29 [INFO] AWS Auth provider used: "EnvProvider"
2021/08/03 00:38:29 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/03 00:38:30 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/03 00:38:31 [DEBUG] Skipping AppConfig Deployment Strategy (AppConfig.AllAtOnce): predefined strategy cannot be deleted
2021/08/03 00:38:31 [DEBUG] Skipping AppConfig Deployment Strategy (AppConfig.Linear50PercentEvery30Seconds): predefined strategy cannot be deleted
2021/08/03 00:38:31 [DEBUG] Skipping AppConfig Deployment Strategy (AppConfig.Canary10Percent20Minutes): predefined strategy cannot be deleted
2021/08/03 00:38:31 [DEBUG] Completed Sweeper (aws_appconfig_deployment_strategy) in region (us-west-2) in 1.518329749s
2021/08/03 00:38:31 Completed Sweepers for region (us-west-2) in 1.518494839s
2021/08/03 00:38:31 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_appconfig_deployment_strategy
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.437s
```