### PR TITLE
r/appconfig_deployment: add to `deployment_strategy_id` validation

### DIFF
--- a/.changelog/20420.txt
+++ b/.changelog/20420.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appconfig_deployment: Include predefined strategies in plan time validation of `deployment_strategy_id`
+```

--- a/aws/resource_aws_appconfig_deployment.go
+++ b/aws/resource_aws_appconfig_deployment.go
@@ -58,7 +58,7 @@ func resourceAwsAppconfigDeployment() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-z0-9]{4,7}`), ""),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`(^[a-z0-9]{4,7}$|^AppConfig\.[A-Za-z0-9]{9,40}$)`), ""),
 			},
 			"description": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_appconfig_deployment_test.go
+++ b/aws/resource_aws_appconfig_deployment_test.go
@@ -53,6 +53,35 @@ func TestAccAWSAppConfigDeployment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAppConfigDeployment_PredefinedStrategy(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appconfig_deployment.test"
+	strategy := "AppConfig.Linear50PercentEvery30Seconds"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, appconfig.EndpointsID),
+		Providers:  testAccProviders,
+		// AppConfig Deployments cannot be destroyed, but we want to ensure
+		// the Application and its dependents are removed.
+		CheckDestroy: testAccCheckAppConfigApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAppConfigDeploymentConfig_PredefinedStrategy(rName, strategy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAppConfigDeploymentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_strategy_id", strategy),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSAppConfigDeployment_Tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_appconfig_deployment.test"
@@ -187,6 +216,21 @@ resource "aws_appconfig_deployment" "test"{
   environment_id           = aws_appconfig_environment.test.environment_id
 }
 `, rName))
+}
+
+func testAccAWSAppConfigDeploymentConfig_PredefinedStrategy(rName, strategy string) string {
+	return composeConfig(
+		testAccAWSAppConfigDeploymentConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_deployment" "test"{
+  application_id           = aws_appconfig_application.test.id
+  configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
+  configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number
+  description              = %[1]q
+  deployment_strategy_id   = %[2]q
+  environment_id           = aws_appconfig_environment.test.environment_id
+}
+`, rName, strategy))
 }
 
 func testAccAWSAppConfigDeploymentTags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/appconfig_deployment.html.markdown
+++ b/website/docs/r/appconfig_deployment.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `application_id` - (Required, Forces new resource) The application ID. Must be between 4 and 7 characters in length.
 * `configuration_profile_id` - (Required, Forces new resource) The configuration profile ID. Must be between 4 and 7 characters in length.
 * `configuration_version` - (Required, Forces new resource) The configuration version to deploy. Can be at most 1024 characters.
-* `deployment_strategy_id` - (Required, Forces new resource) The deployment strategy ID. Must be between 4 and 7 characters in length.
+* `deployment_strategy_id` - (Required, Forces new resource) The deployment strategy ID or name of a predefined deployment strategy. See [Predefined Deployment Strategies](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-creating-deployment-strategy.html#appconfig-creating-deployment-strategy-predefined) for more details.
 * `description` - (Optional, Forces new resource) The description of the deployment. Can be at most 1024 characters.
 * `environment_id` - (Required, Forces new resource) The environment ID. Must be between 4 and 7 characters in length.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/20418

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAppConfigDeployment_PredefinedStrategy (151.45s)
--- PASS: TestAccAWSAppConfigDeployment_basic (212.57s)
--- PASS: TestAccAWSAppConfigDeployment_Tags (241.59s)
```
