### PR TITLE
Fix branch name symmetry issue for Amplify

### DIFF
--- a/.changelog/20426.txt
+++ b/.changelog/20426.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+aws/resource_aws_amplify_branch: Correctly handle branch names that contain '/'
+```

--- a/aws/internal/service/amplify/id.go
+++ b/aws/internal/service/amplify/id.go
@@ -34,7 +34,7 @@ func BranchCreateResourceID(appID, branchName string) string {
 }
 
 func BranchParseResourceID(id string) (string, string, error) {
-	parts := strings.Split(id, branchResourceIDSeparator)
+	parts := strings.SplitN(id, branchResourceIDSeparator, 2)
 
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil

--- a/aws/internal/service/amplify/id_test.go
+++ b/aws/internal/service/amplify/id_test.go
@@ -1,0 +1,68 @@
+package amplify_test
+
+import (
+	"testing"
+
+	tfamplify "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/amplify"
+)
+
+func TestBranchParseResourceID(t *testing.T) {
+	testCases := []struct {
+		TestName           string
+		InputID            string
+		ExpectError        bool
+		ExpectedAppID      string
+		ExpectedBranchName string
+	}{
+		{
+			TestName:    "empty ID",
+			InputID:     "",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect format",
+			InputID:     "test",
+			ExpectError: true,
+		},
+		{
+			TestName:           "valid ID",
+			InputID:            tfamplify.BranchCreateResourceID("appID", "branchName"),
+			ExpectedAppID:      "appID",
+			ExpectedBranchName: "branchName",
+		},
+		{
+			TestName:           "valid ID one slash",
+			InputID:            tfamplify.BranchCreateResourceID("appID", "part1/part_2"),
+			ExpectedAppID:      "appID",
+			ExpectedBranchName: "part1/part_2",
+		},
+		{
+			TestName:           "valid ID three slashes",
+			InputID:            tfamplify.BranchCreateResourceID("appID", "part1/part_2/part-3/part4"),
+			ExpectedAppID:      "appID",
+			ExpectedBranchName: "part1/part_2/part-3/part4",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotAppID, gotBranchName, err := tfamplify.BranchParseResourceID(testCase.InputID)
+
+			if err == nil && testCase.ExpectError {
+				t.Fatalf("expected error")
+			}
+
+			if err != nil && !testCase.ExpectError {
+				t.Fatalf("unexpected error")
+			}
+
+			if gotAppID != testCase.ExpectedAppID {
+				t.Errorf("got AppID %s, expected %s", gotAppID, testCase.ExpectedAppID)
+			}
+
+			if gotBranchName != testCase.ExpectedBranchName {
+				t.Errorf("got BranchName %s, expected %s", gotBranchName, testCase.ExpectedBranchName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes a symmetry issue in `BranchParseResourceID(...)`  for aws_amplify_branch when the branch name contains '/'

Closes #20410 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAmplify'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAmplify -timeout 180m
=== RUN   TestAccAWSAmplify_serial
=== RUN   TestAccAWSAmplify_serial/App
=== RUN   TestAccAWSAmplify_serial/App/Name
=== PAUSE TestAccAWSAmplify_serial/App/Name
=== RUN   TestAccAWSAmplify_serial/App/basic
=== PAUSE TestAccAWSAmplify_serial/App/basic
=== RUN   TestAccAWSAmplify_serial/App/disappears
=== PAUSE TestAccAWSAmplify_serial/App/disappears
=== RUN   TestAccAWSAmplify_serial/App/Tags
=== PAUSE TestAccAWSAmplify_serial/App/Tags
=== RUN   TestAccAWSAmplify_serial/App/AutoBranchCreationConfig
=== PAUSE TestAccAWSAmplify_serial/App/AutoBranchCreationConfig
=== RUN   TestAccAWSAmplify_serial/App/BasicAuthCredentials
=== PAUSE TestAccAWSAmplify_serial/App/BasicAuthCredentials
=== RUN   TestAccAWSAmplify_serial/App/BuildSpec
=== PAUSE TestAccAWSAmplify_serial/App/BuildSpec
=== RUN   TestAccAWSAmplify_serial/App/EnvironmentVariables
=== PAUSE TestAccAWSAmplify_serial/App/EnvironmentVariables
=== RUN   TestAccAWSAmplify_serial/App/Repository
    resource_aws_amplify_app_test.go:591: Environment variable AMPLIFY_GITHUB_ACCESS_TOKEN is not set
=== RUN   TestAccAWSAmplify_serial/App/CustomRules
=== PAUSE TestAccAWSAmplify_serial/App/CustomRules
=== RUN   TestAccAWSAmplify_serial/App/Description
=== PAUSE TestAccAWSAmplify_serial/App/Description
=== RUN   TestAccAWSAmplify_serial/App/IamServiceRole
=== PAUSE TestAccAWSAmplify_serial/App/IamServiceRole
=== CONT  TestAccAWSAmplify_serial/App/Name
=== CONT  TestAccAWSAmplify_serial/App/BuildSpec
=== CONT  TestAccAWSAmplify_serial/App/Description
=== CONT  TestAccAWSAmplify_serial/App/Tags
=== CONT  TestAccAWSAmplify_serial/App/BasicAuthCredentials
=== CONT  TestAccAWSAmplify_serial/App/AutoBranchCreationConfig
=== CONT  TestAccAWSAmplify_serial/App/CustomRules
=== CONT  TestAccAWSAmplify_serial/App/IamServiceRole
=== CONT  TestAccAWSAmplify_serial/App/disappears
=== CONT  TestAccAWSAmplify_serial/App/basic
=== CONT  TestAccAWSAmplify_serial/App/EnvironmentVariables
=== RUN   TestAccAWSAmplify_serial/BackendEnvironment
=== RUN   TestAccAWSAmplify_serial/BackendEnvironment/basic
=== PAUSE TestAccAWSAmplify_serial/BackendEnvironment/basic
=== RUN   TestAccAWSAmplify_serial/BackendEnvironment/disappears
=== PAUSE TestAccAWSAmplify_serial/BackendEnvironment/disappears
=== RUN   TestAccAWSAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName
=== PAUSE TestAccAWSAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName
=== CONT  TestAccAWSAmplify_serial/BackendEnvironment/basic
=== CONT  TestAccAWSAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName
=== CONT  TestAccAWSAmplify_serial/BackendEnvironment/disappears
=== RUN   TestAccAWSAmplify_serial/Branch
=== RUN   TestAccAWSAmplify_serial/Branch/basic
=== PAUSE TestAccAWSAmplify_serial/Branch/basic
=== RUN   TestAccAWSAmplify_serial/Branch/disappears
=== PAUSE TestAccAWSAmplify_serial/Branch/disappears
=== RUN   TestAccAWSAmplify_serial/Branch/Tags
=== PAUSE TestAccAWSAmplify_serial/Branch/Tags
=== RUN   TestAccAWSAmplify_serial/Branch/BasicAuthCredentials
=== PAUSE TestAccAWSAmplify_serial/Branch/BasicAuthCredentials
=== RUN   TestAccAWSAmplify_serial/Branch/EnvironmentVariables
=== PAUSE TestAccAWSAmplify_serial/Branch/EnvironmentVariables
=== RUN   TestAccAWSAmplify_serial/Branch/OptionalArguments
=== PAUSE TestAccAWSAmplify_serial/Branch/OptionalArguments
=== CONT  TestAccAWSAmplify_serial/Branch/basic
=== CONT  TestAccAWSAmplify_serial/Branch/BasicAuthCredentials
=== CONT  TestAccAWSAmplify_serial/Branch/Tags
=== CONT  TestAccAWSAmplify_serial/Branch/disappears
=== CONT  TestAccAWSAmplify_serial/Branch/OptionalArguments
=== CONT  TestAccAWSAmplify_serial/Branch/EnvironmentVariables
=== RUN   TestAccAWSAmplify_serial/DomainAssociation
=== RUN   TestAccAWSAmplify_serial/DomainAssociation/update
    resource_aws_amplify_domain_association_test.go:92: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAWSAmplify_serial/DomainAssociation/basic
    resource_aws_amplify_domain_association_test.go:22: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAWSAmplify_serial/DomainAssociation/disappears
    resource_aws_amplify_domain_association_test.go:63: Environment variable AMPLIFY_DOMAIN_NAME is not set
=== RUN   TestAccAWSAmplify_serial/Webhook
=== RUN   TestAccAWSAmplify_serial/Webhook/basic
=== PAUSE TestAccAWSAmplify_serial/Webhook/basic
=== RUN   TestAccAWSAmplify_serial/Webhook/disappears
=== PAUSE TestAccAWSAmplify_serial/Webhook/disappears
=== RUN   TestAccAWSAmplify_serial/Webhook/update
=== PAUSE TestAccAWSAmplify_serial/Webhook/update
=== CONT  TestAccAWSAmplify_serial/Webhook/basic
=== CONT  TestAccAWSAmplify_serial/Webhook/update
=== CONT  TestAccAWSAmplify_serial/Webhook/disappears
--- PASS: TestAccAWSAmplify_serial (269.60s)
    --- PASS: TestAccAWSAmplify_serial/App (0.00s)
        --- SKIP: TestAccAWSAmplify_serial/App/Repository (0.00s)
        --- PASS: TestAccAWSAmplify_serial/App/disappears (32.28s)
        --- PASS: TestAccAWSAmplify_serial/App/basic (43.71s)
        --- PASS: TestAccAWSAmplify_serial/App/Name (60.91s)
        --- PASS: TestAccAWSAmplify_serial/App/BuildSpec (76.14s)
        --- PASS: TestAccAWSAmplify_serial/App/EnvironmentVariables (77.57s)
        --- PASS: TestAccAWSAmplify_serial/App/BasicAuthCredentials (79.13s)
        --- PASS: TestAccAWSAmplify_serial/App/Tags (80.07s)
        --- PASS: TestAccAWSAmplify_serial/App/CustomRules (82.83s)
        --- PASS: TestAccAWSAmplify_serial/App/IamServiceRole (85.87s)
        --- PASS: TestAccAWSAmplify_serial/App/Description (92.10s)
        --- PASS: TestAccAWSAmplify_serial/App/AutoBranchCreationConfig (95.11s)
    --- PASS: TestAccAWSAmplify_serial/BackendEnvironment (0.00s)
        --- PASS: TestAccAWSAmplify_serial/BackendEnvironment/disappears (29.65s)
        --- PASS: TestAccAWSAmplify_serial/BackendEnvironment/DeploymentArtifacts_StackName (34.05s)
        --- PASS: TestAccAWSAmplify_serial/BackendEnvironment/basic (38.81s)
    --- PASS: TestAccAWSAmplify_serial/Branch (0.01s)
        --- PASS: TestAccAWSAmplify_serial/Branch/disappears (32.95s)
        --- PASS: TestAccAWSAmplify_serial/Branch/basic (37.61s)
        --- PASS: TestAccAWSAmplify_serial/Branch/OptionalArguments (59.65s)
        --- PASS: TestAccAWSAmplify_serial/Branch/Tags (76.29s)
        --- PASS: TestAccAWSAmplify_serial/Branch/EnvironmentVariables (76.49s)
        --- PASS: TestAccAWSAmplify_serial/Branch/BasicAuthCredentials (76.62s)
    --- PASS: TestAccAWSAmplify_serial/DomainAssociation (0.00s)
        --- SKIP: TestAccAWSAmplify_serial/DomainAssociation/update (0.00s)
        --- SKIP: TestAccAWSAmplify_serial/DomainAssociation/basic (0.00s)
        --- SKIP: TestAccAWSAmplify_serial/DomainAssociation/disappears (0.00s)
    --- PASS: TestAccAWSAmplify_serial/Webhook (0.00s)
        --- PASS: TestAccAWSAmplify_serial/Webhook/disappears (33.25s)
        --- PASS: TestAccAWSAmplify_serial/Webhook/basic (36.50s)
        --- PASS: TestAccAWSAmplify_serial/Webhook/update (59.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	271.580s
```
