### PR TITLE
docs: align docs for fields with SchemaConfigModeAttr

### DIFF
--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -22,15 +22,16 @@ For more information, see the Amazon VPC User Guide on [Route Tables](https://do
 resource "aws_default_route_table" "example" {
   default_route_table_id = aws_vpc.example.default_route_table_id
 
-  route {
-    cidr_block = "10.0.1.0/24"
-    gateway_id = aws_internet_gateway.example.id
-  }
-
-  route {
-    ipv6_cidr_block        = "::/0"
-    egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
-  }
+  route = [
+    {
+      cidr_block = "10.0.1.0/24"
+      gateway_id = aws_internet_gateway.example.id
+    },
+    {
+      ipv6_cidr_block        = "::/0"
+      egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
+    }
+  ]
 
   tags = {
     Name = "example"
@@ -61,7 +62,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `propagating_vgws` - (Optional) List of virtual gateways for propagation.
-* `route` - (Optional) Configuration block of routes. Detailed below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). This means that omitting this argument is interpreted as ignoring any existing routes. To remove all managed routes an empty list should be specified. See the example above.
+* `route` - (Optional) Set of objects. Detailed below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). This means that omitting this argument is interpreted as ignoring any existing routes. To remove all managed routes an empty list should be specified. See the example above.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### route

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -32,19 +32,23 @@ resource "aws_vpc" "mainvpc" {
 resource "aws_default_security_group" "default" {
   vpc_id = aws_vpc.mainvpc.id
 
-  ingress {
-    protocol  = -1
-    self      = true
-    from_port = 0
-    to_port   = 0
-  }
+  ingress = [
+    {
+      protocol  = -1
+      self      = true
+      from_port = 0
+      to_port   = 0
+    }
+  ]
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  egress = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 }
 ```
 
@@ -60,12 +64,14 @@ resource "aws_vpc" "mainvpc" {
 resource "aws_default_security_group" "default" {
   vpc_id = aws_vpc.mainvpc.id
 
-  ingress {
-    protocol  = -1
-    self      = true
-    from_port = 0
-    to_port   = 0
-  }
+  ingress = [
+    {
+      protocol  = -1
+      self      = true
+      from_port = 0
+      to_port   = 0
+    }
+  ]
 }
 ```
 
@@ -84,7 +90,9 @@ The following arguments are optional:
 
 ### egress and ingress
 
-Both the `egress` and `ingress` configuration blocks have the same arguments.
+Both arguments are processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+
+Both `egress` and `ingress` objects have the same arguments.
 
 * `cidr_blocks` - (Optional) List of CIDR blocks.
 * `description` - (Optional) Description of this rule.

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -249,15 +249,19 @@ steps are being managed outside of Terraform.
 resource "aws_emr_cluster" "example" {
   # ... other configuration ...
 
-  step {
-    action_on_failure = "TERMINATE_CLUSTER"
-    name              = "Setup Hadoop Debugging"
+  step = [
+    {
+      action_on_failure = "TERMINATE_CLUSTER"
+      name              = "Setup Hadoop Debugging"
 
-    hadoop_jar_step {
-      jar  = "command-runner.jar"
-      args = ["state-pusher-script"]
+      hadoop_jar_step = [
+        {
+          jar  = "command-runner.jar"
+          args = ["state-pusher-script"]
+        }
+      ]
     }
-  }
+  ]
 
   # Optional: ignore outside changes to running cluster steps
   lifecycle {
@@ -446,6 +450,8 @@ Attributes for the EBS volumes attached to each EC2 instance in the `master_inst
 
 ## step
 
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+
 Attributes for step configuration
 
 * `action_on_failure` - (Required) The action to take if the step fails. Valid values: `TERMINATE_JOB_FLOW`, `TERMINATE_CLUSTER`, `CANCEL_AND_WAIT`, and `CONTINUE`
@@ -453,6 +459,8 @@ Attributes for step configuration
 * `name` - (Required) The name of the step.
 
 ### hadoop_jar_step
+
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 
 Attributes for Hadoop job step configuration
 

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -23,23 +23,27 @@ a conflict of rule settings and will overwrite rules.
 resource "aws_network_acl" "main" {
   vpc_id = aws_vpc.main.id
 
-  egress {
-    protocol   = "tcp"
-    rule_no    = 200
-    action     = "allow"
-    cidr_block = "10.3.0.0/18"
-    from_port  = 443
-    to_port    = 443
-  }
+  egress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 200
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port  = 443
+      to_port    = 443
+    }
+  ]
 
-  ingress {
-    protocol   = "tcp"
-    rule_no    = 100
-    action     = "allow"
-    cidr_block = "10.3.0.0/18"
-    from_port  = 80
-    to_port    = 80
-  }
+  ingress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 100
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port  = 80
+      to_port    = 80
+    }
+  ]
 
   tags = {
     Name = "main"
@@ -58,6 +62,10 @@ The following arguments are supported:
 * `egress` - (Optional) Specifies an egress rule. Parameters defined below.
   This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### egress and ingress
+
+Both arguments are processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 
 Both `egress` and `ingress` support the following keys:
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -35,15 +35,16 @@ the separate resource.
 resource "aws_route_table" "example" {
   vpc_id = aws_vpc.example.id
 
-  route {
-    cidr_block = "10.0.1.0/24"
-    gateway_id = aws_internet_gateway.example.id
-  }
-
-  route {
-    ipv6_cidr_block        = "::/0"
-    egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
-  }
+  route = [
+    {
+      cidr_block = "10.0.1.0/24"
+      gateway_id = aws_internet_gateway.example.id
+    },
+    {
+      ipv6_cidr_block        = "::/0"
+      egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
+    }
+  ]
 
   tags = {
     Name = "example"
@@ -76,6 +77,8 @@ This means that omitting this argument is interpreted as ignoring any existing r
 * `propagating_vgws` - (Optional) A list of virtual gateways for propagation.
 
 ### route Argument Reference
+
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 
 One of the following destination arguments must be supplied:
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -31,22 +31,26 @@ resource "aws_security_group" "allow_tls" {
   description = "Allow TLS inbound traffic"
   vpc_id      = aws_vpc.main.id
 
-  ingress {
-    description      = "TLS from VPC"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = [aws_vpc.main.cidr_block]
-    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
-  }
+  ingress = [
+    {
+      description      = "TLS from VPC"
+      from_port        = 443
+      to_port          = 443
+      protocol         = "tcp"
+      cidr_blocks      = [aws_vpc.main.cidr_block]
+      ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+    }
+  ]
 
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
+  egress = [
+    {
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+  ]
 
   tags = {
     Name = "allow_tls"
@@ -60,13 +64,15 @@ resource "aws_security_group" "allow_tls" {
 resource "aws_security_group" "example" {
   # ... other configuration ...
 
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
+  egress = [
+    {
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+  ]
 }
 ```
 
@@ -81,12 +87,14 @@ Prefix list IDs are exported on VPC Endpoints, so you can use this format:
 resource "aws_security_group" "example" {
   # ... other configuration ...
 
-  egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    prefix_list_ids = [aws_vpc_endpoint.my_endpoint.prefix_list_id]
-  }
+  egress = [
+    {
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      prefix_list_ids = [aws_vpc_endpoint.my_endpoint.prefix_list_id]
+    }
+  ]
 }
 
 resource "aws_vpc_endpoint" "my_endpoint" {
@@ -111,6 +119,8 @@ The following arguments are supported:
 
 ### ingress
 
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+
 The following arguments are required:
 
 * `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp` or `icmpv6`).
@@ -127,6 +137,8 @@ The following arguments are optional:
 * `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
 
 ### egress
+
+This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
 
 The following arguments are required:
 


### PR DESCRIPTION
Fields which use `ConfigMode: schema.SchemaConfigModeAttr` are generally treated as attributes by core. See https://github.com/hashicorp/terraform/blob/v1.0.3/internal/lang/blocktoattr/schema.go for more.

Additionally it is proposed to deprecate blocks generally in providers in the long run as per https://github.com/hashicorp/terraform-plugin-framework/issues/85

This documentation update reflects this plan and current reality by encouraging users to use the attribute notation.

I assume that some fields should probably be renamed to plural in the long run, but that seems like a job for another PR and more careful planning.