### PR TITLE
ASG - correct min value on max_instance_lifetime in the docs

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -325,7 +325,7 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
    Auto Scaling Group will not select instances with this setting for termination
    during scale in events.
 * `service_linked_role_arn` (Optional) The ARN of the service-linked role that the ASG will use to call other AWS services
-* `max_instance_lifetime` (Optional) The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds.
+* `max_instance_lifetime` (Optional) The maximum amount of time, in seconds, that an instance can be in service. Values must be either equal to 0 or between 86400 and 31536000 seconds (inclusive). A value of 0 is used to remove a previously set value.
 * `instance_refresh` - (Optional) If this block is configured, start an
    [Instance Refresh](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
    when this Auto Scaling Group is updated. Defined [below](#instance_refresh).


### PR DESCRIPTION
As per the docs and the error given on the API the min value for max_instance_lifetime is 86400

https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

