### PR TITLE
Oracle only national character set

### DIFF
--- a/.changelog/20437.txt
+++ b/.changelog/20437.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_instance: Add `nchar_character_set_name` argument
+```

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -292,7 +292,7 @@ func resourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-			"national_character_set": {
+			"nchar_character_set_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -1157,7 +1157,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.CharacterSetName = aws.String(attr.(string))
 		}
 
-		if attr, ok := d.GetOk("national_character_set"); ok {
+		if attr, ok := d.GetOk("nchar_character_set_name"); ok {
 			opts.NcharCharacterSetName = aws.String(attr.(string))
 		}
 
@@ -1386,15 +1386,8 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if v.DBSubnetGroup != nil {
 		d.Set("db_subnet_group_name", v.DBSubnetGroup.DBSubnetGroupName)
 	}
-
-	if v.CharacterSetName != nil {
-		d.Set("character_set_name", v.CharacterSetName)
-	}
-
-	if v.NcharCharacterSetName != nil {
-		d.Set("national_character_set", v.NcharCharacterSetName)
-	}
-
+	d.Set("character_set_name", v.CharacterSetName)
+	d.Set("nchar_character_set_name", v.NcharCharacterSetName)
 	d.Set("timezone", v.Timezone)
 
 	if len(v.DBParameterGroups) > 0 {

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -292,6 +292,12 @@ func resourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"national_character_set": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"option_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -1151,6 +1157,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.CharacterSetName = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("national_character_set"); ok {
+			opts.NcharCharacterSetName = aws.String(attr.(string))
+		}
+
 		if attr, ok := d.GetOk("timezone"); ok {
 			opts.Timezone = aws.String(attr.(string))
 		}
@@ -1379,6 +1389,10 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	if v.CharacterSetName != nil {
 		d.Set("character_set_name", v.CharacterSetName)
+	}
+
+	if v.NcharCharacterSetName != nil {
+		d.Set("national_character_set", v.NcharCharacterSetName)
 	}
 
 	d.Set("timezone", v.Timezone)

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -5225,8 +5225,8 @@ resource "aws_db_instance" "test" {
   engine                          = data.aws_rds_orderable_db_instance.test.engine
   identifier                      = %q
   instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
-  license_model  				  = "bring-your-own-license"
-  national_character_set 		  = "UTF8"
+  license_model                   = "bring-your-own-license"
+  national_character_set          = "UTF8"
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true
@@ -5249,7 +5249,7 @@ resource "aws_db_instance" "test" {
   engine                          = data.aws_rds_orderable_db_instance.test.engine
   identifier                      = %q
   instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
-  license_model  				  = "bring-your-own-license"
+  license_model                   = "bring-your-own-license"
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -5189,9 +5189,9 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_EnabledCloudwatchLogsExports_Oracle(rName string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
-  engine         = "oracle-se2"
-  license_model  = "bring-your-own-license"
-  storage_type   = "standard"
+  engine        = "oracle-se2"
+  license_model = "bring-your-own-license"
+  storage_type  = "standard"
 
   preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
 }
@@ -5200,7 +5200,7 @@ resource "aws_db_instance" "test" {
   allocated_storage               = 10
   enabled_cloudwatch_logs_exports = ["alert", "listener", "trace"]
   engine                          = data.aws_rds_orderable_db_instance.test.engine
-  identifier                      = %q
+  identifier                      = %[1]q
   instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   license_model                   = "bring-your-own-license"
   password                        = "avoid-plaintext-passwords"
@@ -5213,23 +5213,23 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_NationalCharacterSet_Oracle(rName string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
-  engine         = "oracle-se2"
-  license_model  = "bring-your-own-license"
-  storage_type   = "standard"
+  engine        = "oracle-se2"
+  license_model = "bring-your-own-license"
+  storage_type  = "standard"
 
   preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
 }
 
 resource "aws_db_instance" "test" {
-  allocated_storage               = 10
-  engine                          = data.aws_rds_orderable_db_instance.test.engine
-  identifier                      = %q
-  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
-  license_model                   = "bring-your-own-license"
-  nchar_character_set_name        = "UTF8"
-  password                        = "avoid-plaintext-passwords"
-  username                        = "tfacctest"
-  skip_final_snapshot             = true
+  allocated_storage        = 10
+  engine                   = data.aws_rds_orderable_db_instance.test.engine
+  identifier               = %[1]q
+  instance_class           = data.aws_rds_orderable_db_instance.test.instance_class
+  license_model            = "bring-your-own-license"
+  nchar_character_set_name = "UTF8"
+  password                 = "avoid-plaintext-passwords"
+  username                 = "tfacctest"
+  skip_final_snapshot      = true
 }
 `, rName)
 }
@@ -5237,22 +5237,22 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_NoNationalCharacterSet_Oracle(rName string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
-  engine         = "oracle-se2"
-  license_model  = "bring-your-own-license"
-  storage_type   = "standard"
+  engine        = "oracle-se2"
+  license_model = "bring-your-own-license"
+  storage_type  = "standard"
 
   preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
 }
 
 resource "aws_db_instance" "test" {
-  allocated_storage               = 10
-  engine                          = data.aws_rds_orderable_db_instance.test.engine
-  identifier                      = %q
-  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
-  license_model                   = "bring-your-own-license"
-  password                        = "avoid-plaintext-passwords"
-  username                        = "tfacctest"
-  skip_final_snapshot             = true
+  allocated_storage   = 10
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = %[1]q
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  license_model       = "bring-your-own-license"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
 }
 `, rName)
 }

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -3306,7 +3306,7 @@ func TestAccAWSDBInstance_NationalCharacterSet_Oracle(t *testing.T) {
 				Config: testAccAWSDBInstanceConfig_NationalCharacterSet_Oracle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "national_character_set", "UTF8"),
+					resource.TestCheckResourceAttr(resourceName, "nchar_character_set_name", "UTF8"),
 				),
 			},
 			{
@@ -3341,7 +3341,7 @@ func TestAccAWSDBInstance_NoNationalCharacterSet_Oracle(t *testing.T) {
 				Config: testAccAWSDBInstanceConfig_NoNationalCharacterSet_Oracle(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "national_character_set", "AL16UTF16"),
+					resource.TestCheckResourceAttr(resourceName, "nchar_character_set_name", "AL16UTF16"),
 				),
 			},
 			{
@@ -5202,7 +5202,7 @@ resource "aws_db_instance" "test" {
   engine                          = data.aws_rds_orderable_db_instance.test.engine
   identifier                      = %q
   instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
-  license_model  				  = "bring-your-own-license"
+  license_model                   = "bring-your-own-license"
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true
@@ -5226,7 +5226,7 @@ resource "aws_db_instance" "test" {
   identifier                      = %q
   instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   license_model                   = "bring-your-own-license"
-  national_character_set          = "UTF8"
+  nchar_character_set_name        = "UTF8"
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -154,6 +154,8 @@ Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monit
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
 * `name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case.
+* `national_character_set` - (Optional, Forces new resource) The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
+Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
 * `option_group_name` - (Optional) Name of the DB option group to associate.
 * `parameter_group_name` - (Optional) Name of the DB parameter group to
 associate.

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -154,7 +154,7 @@ Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monit
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
 * `name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case.
-* `national_character_set` - (Optional, Forces new resource) The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
+* `nchar_character_set_name` - (Optional, Forces new resource) The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
 * `option_group_name` - (Optional) Name of the DB option group to associate.
 * `parameter_group_name` - (Optional) Name of the DB parameter group to


### PR DESCRIPTION
This adds the option to set the national_character_set variable for Oracle & two new acceptance tests for the Oracle National Character Set parameter.  I also fixed up the other Oracle acceptance test as it was referring to an SE version that is no longer supported in RDS; TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle

https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20413 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDBInstance_NationalCharacterSet_Oracle'                                          <aws:default>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_NationalCharacterSet_Oracle -timeout 180m
=== RUN   TestAccAWSDBInstance_NationalCharacterSet_Oracle
=== PAUSE TestAccAWSDBInstance_NationalCharacterSet_Oracle
=== CONT  TestAccAWSDBInstance_NationalCharacterSet_Oracle
--- PASS: TestAccAWSDBInstance_NationalCharacterSet_Oracle (1200.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1207.816s

$ make testacc TESTARGS='-run=TestAccAWSDBInstance_NoNationalCharacterSet_Oracle'                                        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_NoNationalCharacterSet_Oracle -timeout 180m
=== RUN   TestAccAWSDBInstance_NoNationalCharacterSet_Oracle
=== PAUSE TestAccAWSDBInstance_NoNationalCharacterSet_Oracle
=== CONT  TestAccAWSDBInstance_NoNationalCharacterSet_Oracle
--- PASS: TestAccAWSDBInstance_NoNationalCharacterSet_Oracle (1112.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1120.786s

$ make testacc TESTARGS='-run=TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle'                                  <aws:default>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle -timeout 180m
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (1234.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1243.273s
...
```
