### PR TITLE
r/apigateway_vpc_link: move stateConf to internal/service/apigateway and update delete target status

### DIFF
--- a/.changelog/20441.txt
+++ b/.changelog/20441.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+aws/resource_aws_apigateway_vpc_link: Ensure deletion does not return an error when resource is not found
+```

--- a/aws/internal/service/apigateway/waiter/waiter.go
+++ b/aws/internal/service/apigateway/waiter/waiter.go
@@ -8,16 +8,35 @@ import (
 )
 
 const (
+	// Maximum amount of time for VpcLink to become available
+	ApiGatewayVpcLinkAvailableTimeout = 20 * time.Minute
+
 	// Maximum amount of time for VpcLink to delete
 	ApiGatewayVpcLinkDeleteTimeout = 20 * time.Minute
 )
 
+func ApiGatewayVpcLinkAvailable(conn *apigateway.APIGateway, vpcLinkId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{apigateway.VpcLinkStatusPending},
+		Target:     []string{apigateway.VpcLinkStatusAvailable},
+		Refresh:    apiGatewayVpcLinkStatus(conn, vpcLinkId),
+		Timeout:    ApiGatewayVpcLinkAvailableTimeout,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
 func ApiGatewayVpcLinkDeleted(conn *apigateway.APIGateway, vpcLinkId string) error {
 	stateConf := resource.StateChangeConf{
-		Pending: []string{apigateway.VpcLinkStatusPending,
+		Pending: []string{
+			apigateway.VpcLinkStatusPending,
 			apigateway.VpcLinkStatusAvailable,
-			apigateway.VpcLinkStatusDeleting},
-		Target:     []string{""},
+			apigateway.VpcLinkStatusDeleting,
+		},
+		Target:     []string{},
 		Timeout:    ApiGatewayVpcLinkDeleteTimeout,
 		MinTimeout: 1 * time.Second,
 		Refresh:    apiGatewayVpcLinkStatus(conn, vpcLinkId),


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/20316

Output from acceptance testing before change:
```
Error: error waiting for API Gateway VPC Link (63k00x) deletion: couldn't find resource (21 retries)

    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: error waiting for API Gateway VPC Link (63k00x) deletion: couldn't find resource (21 retries)
--- FAIL: TestAccAWSAPIGatewayVpcLink_basic (849.54s)
```
Output from acceptance testing after change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAPIGatewayVpcLink_disappears (704.22s)
--- PASS: TestAccAWSAPIGatewayVpcLink_basic (725.88s)
--- PASS: TestAccAWSAPIGatewayVpcLink_tags (726.58s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_tags (63.22s)
```
