### PR TITLE
f athena request pays enabled

### DIFF
--- a/.changelog/20457.txt
+++ b/.changelog/20457.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_athena_workgroup: Add `requester_pays_enabled` argument
+```

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -66,13 +66,9 @@ func resourceAwsAthenaWorkgroup() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"encryption_option": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														athena.EncryptionOptionCseKms,
-														athena.EncryptionOptionSseKms,
-														athena.EncryptionOptionSseS3,
-													}, false),
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(athena.EncryptionOption_Values(), false),
 												},
 												"kms_key_arn": {
 													Type:         schema.TypeString,
@@ -112,13 +108,10 @@ func resourceAwsAthenaWorkgroup() *schema.Resource {
 				),
 			},
 			"state": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  athena.WorkGroupStateEnabled,
-				ValidateFunc: validation.StringInSlice([]string{
-					athena.WorkGroupStateDisabled,
-					athena.WorkGroupStateEnabled,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      athena.WorkGroupStateEnabled,
+				ValidateFunc: validation.StringInSlice(athena.WorkGroupState_Values(), false),
 			},
 			"force_destroy": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -89,6 +89,11 @@ func resourceAwsAthenaWorkgroup() *schema.Resource {
 								},
 							},
 						},
+						"requester_pays_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -323,6 +328,10 @@ func expandAthenaWorkGroupConfiguration(l []interface{}) *athena.WorkGroupConfig
 		configuration.ResultConfiguration = expandAthenaWorkGroupResultConfiguration(v.([]interface{}))
 	}
 
+	if v, ok := m["requester_pays_enabled"]; ok {
+		configuration.RequesterPaysEnabled = aws.Bool(v.(bool))
+	}
+
 	return configuration
 }
 
@@ -351,6 +360,10 @@ func expandAthenaWorkGroupConfigurationUpdates(l []interface{}) *athena.WorkGrou
 
 	if v, ok := m["result_configuration"]; ok {
 		configurationUpdates.ResultConfigurationUpdates = expandAthenaWorkGroupResultConfigurationUpdates(v.([]interface{}))
+	}
+
+	if v, ok := m["requester_pays_enabled"]; ok {
+		configurationUpdates.RequesterPaysEnabled = aws.Bool(v.(bool))
 	}
 
 	return configurationUpdates
@@ -430,6 +443,7 @@ func flattenAthenaWorkGroupConfiguration(configuration *athena.WorkGroupConfigur
 		"enforce_workgroup_configuration":    aws.BoolValue(configuration.EnforceWorkGroupConfiguration),
 		"publish_cloudwatch_metrics_enabled": aws.BoolValue(configuration.PublishCloudWatchMetricsEnabled),
 		"result_configuration":               flattenAthenaWorkGroupResultConfiguration(configuration.ResultConfiguration),
+		"requester_pays_enabled":             aws.BoolValue(configuration.RequesterPaysEnabled),
 	}
 
 	return []interface{}{m}

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -51,6 +51,7 @@ The `configuration` configuration block supports the following arguments:
 * `enforce_workgroup_configuration` - (Optional) Boolean whether the settings for the workgroup override client-side settings. For more information, see [Workgroup Settings Override Client-Side Settings](https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html). Defaults to `true`.
 * `publish_cloudwatch_metrics_enabled` - (Optional) Boolean whether Amazon CloudWatch metrics are enabled for the workgroup. Defaults to `true`.
 * `result_configuration` - (Optional) Configuration block with result settings. Documented below.
+* `requester_pays_enabled` - (Optional) If set to true , allows members assigned to a workgroup to reference Amazon S3 Requester Pays buckets in queries. If set to false , workgroup members cannot query data from Requester Pays buckets, and queries that retrieve data from Requester Pays buckets cause an error. The default is false . For more information about Requester Pays buckets, see [Requester Pays Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) in the Amazon Simple Storage Service Developer Guide.
 
 #### result_configuration Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14776

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAthenaWorkGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAthenaWorkGroup -timeout 180m
=== RUN   TestAccAWSAthenaWorkGroup_basic
=== PAUSE TestAccAWSAthenaWorkGroup_basic
=== RUN   TestAccAWSAthenaWorkGroup_disappears
=== PAUSE TestAccAWSAthenaWorkGroup_disappears
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_RequesterPaysEnabled
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_RequesterPaysEnabled
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation_ForceDestroy
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation_ForceDestroy
=== RUN   TestAccAWSAthenaWorkGroup_Description
=== PAUSE TestAccAWSAthenaWorkGroup_Description
=== RUN   TestAccAWSAthenaWorkGroup_State
=== PAUSE TestAccAWSAthenaWorkGroup_State
=== RUN   TestAccAWSAthenaWorkGroup_ForceDestroy
=== PAUSE TestAccAWSAthenaWorkGroup_ForceDestroy
=== RUN   TestAccAWSAthenaWorkGroup_Tags
=== PAUSE TestAccAWSAthenaWorkGroup_Tags
=== CONT  TestAccAWSAthenaWorkGroup_basic
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_RequesterPaysEnabled
=== CONT  TestAccAWSAthenaWorkGroup_Description
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation_ForceDestroy
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms
=== CONT  TestAccAWSAthenaWorkGroup_State
=== CONT  TestAccAWSAthenaWorkGroup_ForceDestroy
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery
=== CONT  TestAccAWSAthenaWorkGroup_Tags
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration
=== CONT  TestAccAWSAthenaWorkGroup_disappears
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3
--- PASS: TestAccAWSAthenaWorkGroup_disappears (31.45s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3 (44.16s)
--- PASS: TestAccAWSAthenaWorkGroup_basic (44.22s)
--- PASS: TestAccAWSAthenaWorkGroup_ForceDestroy (67.01s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration (67.99s)
--- PASS: TestAccAWSAthenaWorkGroup_Description (68.07s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery (68.12s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled (68.18s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_RequesterPaysEnabled (68.19s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms (68.71s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation (78.41s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation_ForceDestroy (79.72s)
--- PASS: TestAccAWSAthenaWorkGroup_State (81.56s)
--- PASS: TestAccAWSAthenaWorkGroup_Tags (81.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.110s
...
```
