### PR TITLE
r/aws_synthetics_canary: Correctly report creation errors

### DIFF
--- a/.changelog/20463.txt
+++ b/.changelog/20463.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_synthetics_canary: Correctly report any resource creation errors
+```

--- a/aws/internal/service/synthetics/finder/finder.go
+++ b/aws/internal/service/synthetics/finder/finder.go
@@ -3,18 +3,34 @@ package finder
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/synthetics"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// CanaryByName returns the Canary corresponding to the specified Name.
-func CanaryByName(conn *synthetics.Synthetics, name string) (*synthetics.GetCanaryOutput, error) {
+func CanaryByName(conn *synthetics.Synthetics, name string) (*synthetics.Canary, error) {
 	input := &synthetics.GetCanaryInput{
 		Name: aws.String(name),
 	}
 
 	output, err := conn.GetCanary(input)
+
+	if tfawserr.ErrCodeEquals(err, synthetics.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	return output, nil
+	if output == nil || output.Canary == nil || output.Canary.Status == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.Canary, nil
 }

--- a/aws/internal/service/synthetics/waiter/status.go
+++ b/aws/internal/service/synthetics/waiter/status.go
@@ -1,26 +1,25 @@
 package waiter
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/synthetics/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-func CanaryStatus(conn *synthetics.Synthetics, name string) resource.StateRefreshFunc {
+func CanaryState(conn *synthetics.Synthetics, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.CanaryByName(conn, name)
 
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
 		if err != nil {
-			return nil, synthetics.CanaryStateError, err
+			return nil, "", err
 		}
 
-		if aws.StringValue(output.Canary.Status.State) == synthetics.CanaryStateError {
-			return output, synthetics.CanaryStateError, fmt.Errorf("%s: %s", aws.StringValue(output.Canary.Status.StateReasonCode), aws.StringValue(output.Canary.Status.StateReason))
-		}
-
-		return output, aws.StringValue(output.Canary.Status.State), nil
+		return output, aws.StringValue(output.Status.State), nil
 	}
 }

--- a/aws/internal/service/synthetics/waiter/waiter.go
+++ b/aws/internal/service/synthetics/waiter/waiter.go
@@ -1,89 +1,112 @@
 package waiter
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
-	// Maximum amount of time to wait for a Canary to return Ready
 	CanaryCreatedTimeout = 5 * time.Minute
 	CanaryRunningTimeout = 5 * time.Minute
 	CanaryStoppedTimeout = 5 * time.Minute
 	CanaryDeletedTimeout = 5 * time.Minute
 )
 
-// CanaryReady waits for a Canary to return Ready
-func CanaryReady(conn *synthetics.Synthetics, name string) (*synthetics.GetCanaryOutput, error) {
+func CanaryReady(conn *synthetics.Synthetics, name string) (*synthetics.Canary, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{synthetics.CanaryStateCreating, synthetics.CanaryStateUpdating},
 		Target:  []string{synthetics.CanaryStateReady},
-		Refresh: CanaryStatus(conn, name),
+		Refresh: CanaryState(conn, name),
 		Timeout: CanaryCreatedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*synthetics.GetCanaryOutput); ok {
-		return v, err
+	if output, ok := outputRaw.(*synthetics.Canary); ok {
+		if status := output.Status; aws.StringValue(status.State) == synthetics.CanaryStateError {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(status.StateReasonCode), aws.StringValue(status.StateReason)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
 }
 
-// CanaryReady waits for a Canary to return Stopped
-func CanaryStopped(conn *synthetics.Synthetics, name string) (*synthetics.GetCanaryOutput, error) {
+func CanaryStopped(conn *synthetics.Synthetics, name string) (*synthetics.Canary, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{synthetics.CanaryStateStopping, synthetics.CanaryStateUpdating,
-			synthetics.CanaryStateRunning, synthetics.CanaryStateReady, synthetics.CanaryStateStarting},
+		Pending: []string{
+			synthetics.CanaryStateStopping,
+			synthetics.CanaryStateUpdating,
+			synthetics.CanaryStateRunning,
+			synthetics.CanaryStateReady,
+			synthetics.CanaryStateStarting,
+		},
 		Target:  []string{synthetics.CanaryStateStopped},
-		Refresh: CanaryStatus(conn, name),
+		Refresh: CanaryState(conn, name),
 		Timeout: CanaryStoppedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*synthetics.GetCanaryOutput); ok {
-		return v, err
+	if output, ok := outputRaw.(*synthetics.Canary); ok {
+		if status := output.Status; aws.StringValue(status.State) == synthetics.CanaryStateError {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(status.StateReasonCode), aws.StringValue(status.StateReason)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
 }
 
-// CanaryReady waits for a Canary to return Running
-func CanaryRunning(conn *synthetics.Synthetics, name string) (*synthetics.GetCanaryOutput, error) {
+func CanaryRunning(conn *synthetics.Synthetics, name string) (*synthetics.Canary, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{synthetics.CanaryStateStarting, synthetics.CanaryStateUpdating,
-			synthetics.CanaryStateStarting, synthetics.CanaryStateReady},
+		Pending: []string{
+			synthetics.CanaryStateStarting,
+			synthetics.CanaryStateUpdating,
+			synthetics.CanaryStateStarting,
+			synthetics.CanaryStateReady,
+		},
 		Target:  []string{synthetics.CanaryStateRunning},
-		Refresh: CanaryStatus(conn, name),
+		Refresh: CanaryState(conn, name),
 		Timeout: CanaryRunningTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*synthetics.GetCanaryOutput); ok {
-		return v, err
+	if output, ok := outputRaw.(*synthetics.Canary); ok {
+		if status := output.Status; aws.StringValue(status.State) == synthetics.CanaryStateError {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(status.StateReasonCode), aws.StringValue(status.StateReason)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
 }
 
-// CanaryReady waits for a Canary to return Ready
-func CanaryDeleted(conn *synthetics.Synthetics, name string) (*synthetics.GetCanaryOutput, error) {
+func CanaryDeleted(conn *synthetics.Synthetics, name string) (*synthetics.Canary, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{synthetics.CanaryStateDeleting, synthetics.CanaryStateStopped},
 		Target:  []string{},
-		Refresh: CanaryStatus(conn, name),
+		Refresh: CanaryState(conn, name),
 		Timeout: CanaryDeletedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*synthetics.GetCanaryOutput); ok {
-		return v, err
+	if output, ok := outputRaw.(*synthetics.Canary); ok {
+		if status := output.Status; aws.StringValue(status.State) == synthetics.CanaryStateError {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(status.StateReasonCode), aws.StringValue(status.StateReason)))
+		}
+
+		return output, err
 	}
 
 	return nil, err

--- a/aws/resource_aws_synthetics_canary_test.go
+++ b/aws/resource_aws_synthetics_canary_test.go
@@ -92,7 +92,7 @@ func TestAccAWSSyntheticsCanary_basic(t *testing.T) {
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf1),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexp.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-1.0"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "840"),
@@ -123,7 +123,7 @@ func TestAccAWSSyntheticsCanary_basic(t *testing.T) {
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf2),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexp.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-1.0"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "840"),
@@ -160,10 +160,10 @@ func TestAccAWSSyntheticsCanary_runtimeVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAwsSyntheticsCanaryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSyntheticsCanaryRuntimeVersionConfig(rName, "syn-nodejs-2.1"),
+				Config: testAccAWSSyntheticsCanaryRuntimeVersionConfig(rName, "syn-nodejs-puppeteer-3.1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf1),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-2.1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.1"),
 				),
 			},
 			{
@@ -173,10 +173,10 @@ func TestAccAWSSyntheticsCanary_runtimeVersion(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"zip_file", "start_canary"},
 			},
 			{
-				Config: testAccAWSSyntheticsCanaryRuntimeVersionConfig(rName, "syn-nodejs-2.2"),
+				Config: testAccAWSSyntheticsCanaryRuntimeVersionConfig(rName, "syn-nodejs-puppeteer-3.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf1),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-2.2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
 				),
 			},
 		},
@@ -289,7 +289,7 @@ func TestAccAWSSyntheticsCanary_s3(t *testing.T) {
 					testAccCheckAwsSyntheticsCanaryExists(resourceName, &conf),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexp.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-1.0"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "840"),
@@ -746,7 +746,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -767,7 +767,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -789,7 +789,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-2.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -811,7 +811,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -845,7 +845,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest_modified.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -863,7 +863,7 @@ resource "aws_synthetics_canary" "test" {
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
   start_canary         = %[2]t
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -881,7 +881,7 @@ resource "aws_synthetics_canary" "test" {
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest_modified.zip"
   start_canary         = %[2]t
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -900,7 +900,7 @@ resource "aws_synthetics_canary" "test" {
   s3_bucket            = aws_s3_bucket_object.test.bucket
   s3_key               = aws_s3_bucket_object.test.key
   s3_version           = aws_s3_bucket_object.test.version_id
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -981,7 +981,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -1008,7 +1008,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -1035,7 +1035,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -1059,7 +1059,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"
@@ -1080,7 +1080,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-1.0"
+  runtime_version      = "syn-nodejs-puppeteer-3.2"
 
   schedule {
     expression = "rate(0 minute)"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18636.
Closes #18616.

The underlying problem was the retry logic around create - The error code wasn't being checked which meant that `resourceAwsSyntheticsCanaryRead()` (and hence `finder.CanaryByName()`) was being called when `d.SetId()` hadn't.
After correcting that, the underlying acceptance tests errors were all related to an out-of-date [runtime](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library.html).

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Commercial

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSyntheticsCanary_'     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSyntheticsCanary_ -timeout 180m
=== RUN   TestAccAWSSyntheticsCanary_basic
=== PAUSE TestAccAWSSyntheticsCanary_basic
=== RUN   TestAccAWSSyntheticsCanary_runtimeVersion
=== PAUSE TestAccAWSSyntheticsCanary_runtimeVersion
=== RUN   TestAccAWSSyntheticsCanary_startCanary
=== PAUSE TestAccAWSSyntheticsCanary_startCanary
=== RUN   TestAccAWSSyntheticsCanary_startCanary_codeChanges
=== PAUSE TestAccAWSSyntheticsCanary_startCanary_codeChanges
=== RUN   TestAccAWSSyntheticsCanary_s3
=== PAUSE TestAccAWSSyntheticsCanary_s3
=== RUN   TestAccAWSSyntheticsCanary_runConfig
=== PAUSE TestAccAWSSyntheticsCanary_runConfig
=== RUN   TestAccAWSSyntheticsCanary_runConfigTracing
=== PAUSE TestAccAWSSyntheticsCanary_runConfigTracing
=== RUN   TestAccAWSSyntheticsCanary_vpc
=== PAUSE TestAccAWSSyntheticsCanary_vpc
=== RUN   TestAccAWSSyntheticsCanary_tags
=== PAUSE TestAccAWSSyntheticsCanary_tags
=== RUN   TestAccAWSSyntheticsCanary_disappears
=== PAUSE TestAccAWSSyntheticsCanary_disappears
=== CONT  TestAccAWSSyntheticsCanary_basic
=== CONT  TestAccAWSSyntheticsCanary_runConfigTracing
=== CONT  TestAccAWSSyntheticsCanary_disappears
=== CONT  TestAccAWSSyntheticsCanary_vpc
=== CONT  TestAccAWSSyntheticsCanary_tags
=== CONT  TestAccAWSSyntheticsCanary_startCanary_codeChanges
=== CONT  TestAccAWSSyntheticsCanary_runConfig
=== CONT  TestAccAWSSyntheticsCanary_runtimeVersion
=== CONT  TestAccAWSSyntheticsCanary_startCanary
=== CONT  TestAccAWSSyntheticsCanary_s3
--- PASS: TestAccAWSSyntheticsCanary_disappears (48.46s)
--- PASS: TestAccAWSSyntheticsCanary_s3 (67.11s)
--- PASS: TestAccAWSSyntheticsCanary_basic (93.51s)
--- PASS: TestAccAWSSyntheticsCanary_runConfigTracing (96.91s)
--- PASS: TestAccAWSSyntheticsCanary_startCanary_codeChanges (97.36s)
--- PASS: TestAccAWSSyntheticsCanary_tags (99.72s)
--- PASS: TestAccAWSSyntheticsCanary_runtimeVersion (101.69s)
--- PASS: TestAccAWSSyntheticsCanary_startCanary (102.51s)
--- PASS: TestAccAWSSyntheticsCanary_runConfig (114.58s)
--- PASS: TestAccAWSSyntheticsCanary_vpc (673.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	676.924s
```

#### GovCloud

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSyntheticsCanary_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSyntheticsCanary_ -timeout 180m
=== RUN   TestAccAWSSyntheticsCanary_basic
=== PAUSE TestAccAWSSyntheticsCanary_basic
=== RUN   TestAccAWSSyntheticsCanary_runtimeVersion
=== PAUSE TestAccAWSSyntheticsCanary_runtimeVersion
=== RUN   TestAccAWSSyntheticsCanary_startCanary
=== PAUSE TestAccAWSSyntheticsCanary_startCanary
=== RUN   TestAccAWSSyntheticsCanary_startCanary_codeChanges
=== PAUSE TestAccAWSSyntheticsCanary_startCanary_codeChanges
=== RUN   TestAccAWSSyntheticsCanary_s3
=== PAUSE TestAccAWSSyntheticsCanary_s3
=== RUN   TestAccAWSSyntheticsCanary_runConfig
=== PAUSE TestAccAWSSyntheticsCanary_runConfig
=== RUN   TestAccAWSSyntheticsCanary_runConfigTracing
=== PAUSE TestAccAWSSyntheticsCanary_runConfigTracing
=== RUN   TestAccAWSSyntheticsCanary_vpc
=== PAUSE TestAccAWSSyntheticsCanary_vpc
=== RUN   TestAccAWSSyntheticsCanary_tags
=== PAUSE TestAccAWSSyntheticsCanary_tags
=== RUN   TestAccAWSSyntheticsCanary_disappears
=== PAUSE TestAccAWSSyntheticsCanary_disappears
=== CONT  TestAccAWSSyntheticsCanary_basic
=== CONT  TestAccAWSSyntheticsCanary_runConfigTracing
=== CONT  TestAccAWSSyntheticsCanary_startCanary_codeChanges
=== CONT  TestAccAWSSyntheticsCanary_s3
=== CONT  TestAccAWSSyntheticsCanary_disappears
=== CONT  TestAccAWSSyntheticsCanary_tags
=== CONT  TestAccAWSSyntheticsCanary_vpc
=== CONT  TestAccAWSSyntheticsCanary_runtimeVersion
=== CONT  TestAccAWSSyntheticsCanary_runConfig
=== CONT  TestAccAWSSyntheticsCanary_startCanary
--- PASS: TestAccAWSSyntheticsCanary_disappears (63.68s)
--- PASS: TestAccAWSSyntheticsCanary_s3 (70.33s)
--- PASS: TestAccAWSSyntheticsCanary_tags (107.20s)
--- PASS: TestAccAWSSyntheticsCanary_basic (108.20s)
--- PASS: TestAccAWSSyntheticsCanary_runConfigTracing (108.31s)
--- PASS: TestAccAWSSyntheticsCanary_runtimeVersion (108.56s)
--- PASS: TestAccAWSSyntheticsCanary_startCanary_codeChanges (116.20s)
--- PASS: TestAccAWSSyntheticsCanary_runConfig (117.67s)
--- PASS: TestAccAWSSyntheticsCanary_startCanary (121.42s)
--- PASS: TestAccAWSSyntheticsCanary_vpc (1788.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1791.753s
```