### PR TITLE
r/imagebuilder_image_configuration: set `terminate_instance_on_failure` directly in API requests

### DIFF
--- a/.changelog/20464.txt
+++ b/.changelog/20464.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+aws/resource_aws_imagebuilder_infrastructure_configuration: Always set `terminate_instance_on_failure` on create and update
+```

--- a/aws/resource_aws_imagebuilder_infrastructure_configuration.go
+++ b/aws/resource_aws_imagebuilder_infrastructure_configuration.go
@@ -129,7 +129,8 @@ func resourceAwsImageBuilderInfrastructureConfigurationCreate(d *schema.Resource
 	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &imagebuilder.CreateInfrastructureConfigurationInput{
-		ClientToken: aws.String(resource.UniqueId()),
+		ClientToken:                aws.String(resource.UniqueId()),
+		TerminateInstanceOnFailure: aws.Bool(d.Get("terminate_instance_on_failure").(bool)),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -174,10 +175,6 @@ func resourceAwsImageBuilderInfrastructureConfigurationCreate(d *schema.Resource
 
 	if len(tags) > 0 {
 		input.Tags = tags.IgnoreAws().ImagebuilderTags()
-	}
-
-	if v, ok := d.GetOk("terminate_instance_on_failure"); ok {
-		input.TerminateInstanceOnFailure = aws.Bool(v.(bool))
 	}
 
 	var output *imagebuilder.CreateInfrastructureConfigurationOutput
@@ -290,6 +287,7 @@ func resourceAwsImageBuilderInfrastructureConfigurationUpdate(d *schema.Resource
 	) {
 		input := &imagebuilder.UpdateInfrastructureConfigurationInput{
 			InfrastructureConfigurationArn: aws.String(d.Id()),
+			TerminateInstanceOnFailure:     aws.Bool(d.Get("terminate_instance_on_failure").(bool)),
 		}
 
 		if v, ok := d.GetOk("description"); ok {
@@ -326,10 +324,6 @@ func resourceAwsImageBuilderInfrastructureConfigurationUpdate(d *schema.Resource
 
 		if v, ok := d.GetOk("subnet_id"); ok {
 			input.SubnetId = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("terminate_instance_on_failure"); ok {
-			input.TerminateInstanceOnFailure = aws.Bool(v.(bool))
 		}
 
 		err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Notes 

* boolean field with a `Default` failed the `d.GetOk()` checks that controlled whether or not the value was set in the input structs

Output from  acceptance testing before change:
```
Attribute 'terminate_instance_on_failure' expected "false", got "true"
```
Output from acceptance testing after change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsImageBuilderComponentDataSource_Arn (84.36s)
--- PASS: TestAccAwsImageBuilderComponent_ChangeDescription (90.75s)
--- PASS: TestAccAwsImageBuilderComponent_Description (89.33s)
--- PASS: TestAccAwsImageBuilderComponent_KmsKeyId (86.22s)
--- PASS: TestAccAwsImageBuilderComponent_Platform_Windows (92.57s)
--- PASS: TestAccAwsImageBuilderComponent_SupportedOsVersions (92.02s)
--- PASS: TestAccAwsImageBuilderComponent_Tags (202.35s)
--- PASS: TestAccAwsImageBuilderComponent_Uri (92.44s)
--- PASS: TestAccAwsImageBuilderComponent_basic (90.64s)
--- PASS: TestAccAwsImageBuilderComponent_disappears (69.02s)
--- PASS: TestAccAwsImageBuilderDistributionConfigurationDataSource_Arn (85.94s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Description (153.10s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution (118.57s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_AmiTags (151.14s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_Description (149.23s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_KmsKeyId (150.05s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_LaunchPermission_UserGroups (82.05s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_LaunchPermission_UserIds (151.22s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_Name (146.87s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_AmiDistributionConfiguration_TargetAccountIds (144.81s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Distribution_LicenseConfigurationArns (146.22s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_Tags (206.98s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_basic (90.93s)
--- PASS: TestAccAwsImageBuilderDistributionConfiguration_disappears (76.90s)
--- PASS: TestAccAwsImageBuilderImageDataSource_Arn_Aws (67.69s)
--- PASS: TestAccAwsImageBuilderImageDataSource_Arn_Self (1447.45s)
--- PASS: TestAccAwsImageBuilderImagePipelineDataSource_Arn (102.41s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Description (169.59s)
--- PASS: TestAccAwsImageBuilderImagePipeline_DistributionConfigurationArn (170.21s)
--- PASS: TestAccAwsImageBuilderImagePipeline_EnhancedImageMetadataEnabled (169.64s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageRecipeArn (166.83s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageTestsConfiguration_ImageTestsEnabled (167.80s)
--- PASS: TestAccAwsImageBuilderImagePipeline_ImageTestsConfiguration_TimeoutMinutes (161.94s)
--- PASS: TestAccAwsImageBuilderImagePipeline_InfrastructureConfigurationArn (167.50s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_PipelineExecutionStartCondition (165.91s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Schedule_ScheduleExpression (167.27s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Status (169.12s)
--- PASS: TestAccAwsImageBuilderImagePipeline_Tags (193.85s)
--- PASS: TestAccAwsImageBuilderImagePipeline_basic (106.84s)
--- PASS: TestAccAwsImageBuilderImagePipeline_disappears (97.22s)
--- PASS: TestAccAwsImageBuilderImageRecipeDataSource_Arn (90.77s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_DeviceName (83.78s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_DeleteOnTermination (88.55s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_Encrypted (86.67s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_Iops (89.56s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_KmsKeyId (86.56s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_SnapshotId (110.10s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeSize (84.66s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp2 (85.55s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_Ebs_VolumeTypeGp3 (90.22s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_NoDevice (87.73s)
--- PASS: TestAccAwsImageBuilderImageRecipe_BlockDeviceMapping_VirtualName (81.50s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Component (80.28s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Description (79.38s)
--- PASS: TestAccAwsImageBuilderImageRecipe_Tags (129.47s)
--- PASS: TestAccAwsImageBuilderImageRecipe_WorkingDirectory (70.14s)
--- PASS: TestAccAwsImageBuilderImageRecipe_basic (88.95s)
--- PASS: TestAccAwsImageBuilderImageRecipe_disappears (77.53s)
--- PASS: TestAccAwsImageBuilderImage_DistributionConfigurationArn (1450.02s)
--- PASS: TestAccAwsImageBuilderImage_EnhancedImageMetadataEnabled (1187.26s)
--- PASS: TestAccAwsImageBuilderImage_ImageTestsConfiguration_ImageTestsEnabled (952.78s)
--- PASS: TestAccAwsImageBuilderImage_ImageTestsConfiguration_TimeoutMinutes (1319.56s)
--- PASS: TestAccAwsImageBuilderImage_Tags (1463.45s)
--- PASS: TestAccAwsImageBuilderImage_basic (1447.66s)
--- PASS: TestAccAwsImageBuilderImage_disappears (1198.82s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfigurationDataSource_Arn (98.69s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_Description (100.89s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_InstanceProfileName (113.16s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_InstanceTypes (101.74s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_KeyPair (106.33s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_Logging_S3Logs_S3BucketName (97.24s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_Logging_S3Logs_S3KeyPrefix (95.94s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_ResourceTags (96.24s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_SecurityGroupIds (93.10s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_SnsTopicArn (89.20s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_SubnetId (81.97s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_Tags (97.29s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_TerminateInstanceOnFailure (66.09s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_basic (59.21s)
--- PASS: TestAccAwsImageBuilderInfrastructureConfiguration_disappears (55.72s)
```
