### PR TITLE
Serialize Cloud HSM v2 acceptance tests

### DIFF
--- a/aws/data_source_aws_cloudhsm_v2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm_v2_cluster_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
+func testAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.cluster"
 	dataSourceName := "data.aws_cloudhsm_v2_cluster.default"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
 		ErrorCheck: testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:  testAccProviders,

--- a/aws/data_source_aws_cloudhsm_v2_test.go
+++ b/aws/data_source_aws_cloudhsm_v2_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestAccDataSourceCloudHsmV2_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Cluster": {
+			"basic": testAccDataSourceCloudHsmV2Cluster_basic,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/aws/resource_aws_cloudhsm_v2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm_v2_cluster_test.go
@@ -70,10 +70,10 @@ func testSweepCloudhsmv2Clusters(region string) error {
 	return errors.ErrorOrNil()
 }
 
-func TestAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
+func testAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,
@@ -105,10 +105,10 @@ func TestAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Cluster_disappears(t *testing.T) {
+func testAccAWSCloudHsmV2Cluster_disappears(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,
@@ -128,10 +128,10 @@ func TestAccAWSCloudHsmV2Cluster_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
+func testAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_cloudhsm_v2_hsm_test.go
+++ b/aws/resource_aws_cloudhsm_v2_hsm_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudhsmv2/finder"
 )
 
-func TestAccAWSCloudHsmV2Hsm_basic(t *testing.T) {
+func testAccAWSCloudHsmV2Hsm_basic(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_hsm.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,
@@ -43,10 +43,10 @@ func TestAccAWSCloudHsmV2Hsm_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Hsm_disappears(t *testing.T) {
+func testAccAWSCloudHsmV2Hsm_disappears(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_hsm.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,
@@ -66,11 +66,11 @@ func TestAccAWSCloudHsmV2Hsm_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Hsm_disappears_Cluster(t *testing.T) {
+func testAccAWSCloudHsmV2Hsm_disappears_Cluster(t *testing.T) {
 	clusterResourceName := "aws_cloudhsm_v2_cluster.test"
 	resourceName := "aws_cloudhsm_v2_hsm.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,
@@ -89,10 +89,10 @@ func TestAccAWSCloudHsmV2Hsm_disappears_Cluster(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Hsm_AvailabilityZone(t *testing.T) {
+func testAccAWSCloudHsmV2Hsm_AvailabilityZone(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_hsm.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,
@@ -114,10 +114,10 @@ func TestAccAWSCloudHsmV2Hsm_AvailabilityZone(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Hsm_IpAddress(t *testing.T) {
+func testAccAWSCloudHsmV2Hsm_IpAddress(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_hsm.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, cloudhsmv2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_cloudhsm_v2_test.go
+++ b/aws/resource_aws_cloudhsm_v2_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestAccAWSCloudHsmV2_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Cluster": {},
+		"Hsm": {
+			"availabilityZone":   testAccAWSCloudHsmV2Hsm_AvailabilityZone,
+			"basic":              testAccAWSCloudHsmV2Hsm_basic,
+			"disappears":         testAccAWSCloudHsmV2Hsm_disappears,
+			"disappears_Cluster": testAccAWSCloudHsmV2Hsm_disappears_Cluster,
+			"ipAddress":          testAccAWSCloudHsmV2Hsm_IpAddress,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/aws/resource_aws_cloudhsm_v2_test.go
+++ b/aws/resource_aws_cloudhsm_v2_test.go
@@ -6,7 +6,11 @@ import (
 
 func TestAccAWSCloudHsmV2_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
-		"Cluster": {},
+		"Cluster": {
+			"basic":      testAccAWSCloudHsmV2Cluster_basic,
+			"disappears": testAccAWSCloudHsmV2Cluster_disappears,
+			"tags":       testAccAWSCloudHsmV2Cluster_Tags,
+		},
 		"Hsm": {
 			"availabilityZone":   testAccAWSCloudHsmV2Hsm_AvailabilityZone,
 			"basic":              testAccAWSCloudHsmV2Hsm_basic,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes errors such as 

```
=== RUN   TestAccAWSCloudHsmV2Hsm_disappears
=== PAUSE TestAccAWSCloudHsmV2Hsm_disappears
=== CONT  TestAccAWSCloudHsmV2Hsm_disappears
resource_aws_cloudhsm_v2_hsm_test.go:49: Step 1/1 error: Error running apply: exit status 1
Error: error creating CloudHSMv2 Cluster: CloudHsmServiceException: Cluster limit reached for the account.
on terraform_plugin_test.tf line 23, in resource "aws_cloudhsm_v2_cluster" "test":
23: resource "aws_cloudhsm_v2_cluster" "test" {
--- FAIL: TestAccAWSCloudHsmV2Hsm_disappears (43.79s)
```

Also adds a test sweeper for HSMs to prevent errors such as

```
    resource_aws_cloudhsm_v2_hsm_test.go:73: Step 1/1 error: Check failed: Check 2/2 error: error deleting CloudHSMv2 Cluster (cluster-xs7ct4mgks5): CloudHsmInvalidRequestException: The cluster 'cluster-xs7ct4mgks5' still contains HSMs. Please delete the HSMs and try again.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TEST=./aws SWEEP=us-east-1,us-east-2,us-west-1,us-west-2 SWEEPARGS=-sweep-run=aws_cloudhsm_v2_cluster make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-east-1,us-east-2,us-west-1,us-west-2 -sweep-run=aws_cloudhsm_v2_cluster -timeout 60m
2021/08/06 13:58:53 [DEBUG] Running Sweepers for region (us-east-1):
2021/08/06 13:58:53 [DEBUG] Sweeper (aws_cloudhsm_v2_cluster) has dependency (aws_cloudhsm_v2_hsm), running..
2021/08/06 13:58:53 [DEBUG] Running Sweeper (aws_cloudhsm_v2_hsm) in region (us-east-1)
2021/08/06 13:58:53 [INFO] AWS Auth provider used: "EnvProvider"
2021/08/06 13:58:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:55 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_hsm) in region (us-east-1) in 1.774269712s
2021/08/06 13:58:55 [DEBUG] Running Sweeper (aws_cloudhsm_v2_cluster) in region (us-east-1)
2021/08/06 13:58:55 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_cluster) in region (us-east-1) in 116.576835ms
2021/08/06 13:58:55 [DEBUG] Sweeper (aws_cloudhsm_v2_hsm) already ran in region (us-east-1)
2021/08/06 13:58:55 Completed Sweepers for region (us-east-1) in 1.891222061s
2021/08/06 13:58:55 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_cloudhsm_v2_hsm
	- aws_cloudhsm_v2_cluster
2021/08/06 13:58:55 [DEBUG] Running Sweepers for region (us-east-2):
2021/08/06 13:58:55 [DEBUG] Sweeper (aws_cloudhsm_v2_cluster) has dependency (aws_cloudhsm_v2_hsm), running..
2021/08/06 13:58:55 [DEBUG] Running Sweeper (aws_cloudhsm_v2_hsm) in region (us-east-2)
2021/08/06 13:58:55 [INFO] AWS Auth provider used: "EnvProvider"
2021/08/06 13:58:55 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:55 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:56 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_hsm) in region (us-east-2) in 646.035148ms
2021/08/06 13:58:56 [DEBUG] Running Sweeper (aws_cloudhsm_v2_cluster) in region (us-east-2)
2021/08/06 13:58:56 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_cluster) in region (us-east-2) in 162.535935ms
2021/08/06 13:58:56 [DEBUG] Sweeper (aws_cloudhsm_v2_hsm) already ran in region (us-east-2)
2021/08/06 13:58:56 Completed Sweepers for region (us-east-2) in 808.69369ms
2021/08/06 13:58:56 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_cloudhsm_v2_hsm
	- aws_cloudhsm_v2_cluster
2021/08/06 13:58:56 [DEBUG] Running Sweepers for region (us-west-1):
2021/08/06 13:58:56 [DEBUG] Sweeper (aws_cloudhsm_v2_cluster) has dependency (aws_cloudhsm_v2_hsm), running..
2021/08/06 13:58:56 [DEBUG] Running Sweeper (aws_cloudhsm_v2_hsm) in region (us-west-1)
2021/08/06 13:58:56 [INFO] AWS Auth provider used: "EnvProvider"
2021/08/06 13:58:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:57 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_hsm) in region (us-west-1) in 1.022483724s
2021/08/06 13:58:57 [DEBUG] Running Sweeper (aws_cloudhsm_v2_cluster) in region (us-west-1)
2021/08/06 13:58:57 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_cluster) in region (us-west-1) in 313.634564ms
2021/08/06 13:58:57 [DEBUG] Sweeper (aws_cloudhsm_v2_hsm) already ran in region (us-west-1)
2021/08/06 13:58:57 Completed Sweepers for region (us-west-1) in 1.336291755s
2021/08/06 13:58:57 Sweeper Tests for region (us-west-1) ran successfully:
	- aws_cloudhsm_v2_hsm
	- aws_cloudhsm_v2_cluster
2021/08/06 13:58:57 [DEBUG] Running Sweepers for region (us-west-2):
2021/08/06 13:58:57 [DEBUG] Sweeper (aws_cloudhsm_v2_cluster) has dependency (aws_cloudhsm_v2_hsm), running..
2021/08/06 13:58:57 [DEBUG] Running Sweeper (aws_cloudhsm_v2_hsm) in region (us-west-2)
2021/08/06 13:58:57 [INFO] AWS Auth provider used: "EnvProvider"
2021/08/06 13:58:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/08/06 13:58:58 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_hsm) in region (us-west-2) in 1.176082151s
2021/08/06 13:58:58 [DEBUG] Running Sweeper (aws_cloudhsm_v2_cluster) in region (us-west-2)
2021/08/06 13:58:59 [DEBUG] Completed Sweeper (aws_cloudhsm_v2_cluster) in region (us-west-2) in 364.011568ms
2021/08/06 13:58:59 [DEBUG] Sweeper (aws_cloudhsm_v2_hsm) already ran in region (us-west-2)
2021/08/06 13:58:59 Completed Sweepers for region (us-west-2) in 1.540353992s
2021/08/06 13:58:59 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_cloudhsm_v2_hsm
	- aws_cloudhsm_v2_cluster
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.883s
```
