### PR TITLE
tests/data_aws_ec2_instance_type: update expected ebsInfo.nvmeSupport value for m5.large instance type

### DIFF
--- a/aws/data_source_aws_ec2_instance_type_test.go
+++ b/aws/data_source_aws_ec2_instance_type_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceAwsEc2InstanceType_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceBasic, "default_threads_per_core", "2"),
 					resource.TestCheckResourceAttr(resourceBasic, "default_vcpus", "2"),
 					resource.TestCheckResourceAttr(resourceBasic, "ebs_encryption_support", "supported"),
-					resource.TestCheckResourceAttr(resourceBasic, "ebs_nvme_support", "unsupported"),
+					resource.TestCheckResourceAttr(resourceBasic, "ebs_nvme_support", "required"),
 					resource.TestCheckResourceAttr(resourceBasic, "ebs_optimized_support", "default"),
 					resource.TestCheckResourceAttr(resourceBasic, "efa_supported", "false"),
 					resource.TestCheckResourceAttr(resourceBasic, "ena_support", "required"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
### Notes
* seems the `m5.large` instance type by default requires `nvmeSupport`
* output from aws cli
```
$ aws ec2 describe-instance-types

        {
            "InstanceType": "m5.large",
            "CurrentGeneration": true,
            "FreeTierEligible": false,
            "SupportedUsageClasses": [
                "on-demand",
                "spot"
            ],
            "SupportedRootDeviceTypes": [
                "ebs"
            ],
            "SupportedVirtualizationTypes": [
                "hvm"
            ],
            "BareMetal": false,
            "Hypervisor": "nitro",
            "ProcessorInfo": {
                "SupportedArchitectures": [
                    "x86_64"
                ],
                "SustainedClockSpeedInGhz": 3.1
            },
            "VCpuInfo": {
                "DefaultVCpus": 2,
                "DefaultCores": 1,
                "DefaultThreadsPerCore": 2,
                "ValidCores": [
                    1
                ],
                "ValidThreadsPerCore": [
                    1,
                    2
                ]
            },
            "MemoryInfo": {
                "SizeInMiB": 8192
            },
            "InstanceStorageSupported": false,
            "EbsInfo": {
                "EbsOptimizedSupport": "default",
                "EncryptionSupport": "supported",
                "EbsOptimizedInfo": {
                    "BaselineBandwidthInMbps": 650,
                    "BaselineThroughputInMBps": 81.25,
                    "BaselineIops": 3600,
                    "MaximumBandwidthInMbps": 4750,
                    "MaximumThroughputInMBps": 593.75,
                    "MaximumIops": 18750
                },
                "NvmeSupport": "required"
            },
            "NetworkInfo": {
                "NetworkPerformance": "Up to 10 Gigabit",
                "MaximumNetworkInterfaces": 3,
                "MaximumNetworkCards": 1,
                "DefaultNetworkCardIndex": 0,
                "NetworkCards": [
                    {
                        "NetworkCardIndex": 0,
                        "NetworkPerformance": "Up to 10 Gigabit",
                        "MaximumNetworkInterfaces": 3
                    }
                ],
                "Ipv4AddressesPerInterface": 10,
                "Ipv6AddressesPerInterface": 10,
                "Ipv6Supported": true,
                "EnaSupport": "required",
                "EfaSupported": false
            },
            "PlacementGroupInfo": {
                "SupportedStrategies": [
                    "cluster",
                    "partition",
                    "spread"
                ]
            },
            "HibernationSupported": true,
            "BurstablePerformanceSupported": false,
            "DedicatedHostsSupported": true,
            "AutoRecoverySupported": true
        },
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccDataSourceAwsEc2InstanceType_basic (9.87s)
```
