### PR TITLE
SageMaker acceptance tests: Correct `instance_type` for JupyterServer App

### DIFF
--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -399,7 +399,7 @@ func testAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "system"),
 				),
 			},
 			{
@@ -783,7 +783,7 @@ resource "aws_sagemaker_domain" "test" {
 
     jupyter_server_app_settings {
       default_resource_spec {
-        instance_type = "ml.t3.micro"
+        instance_type = "system"
       }
     }
   }

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -252,7 +252,7 @@ func testAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "system"),
 				),
 			},
 			{
@@ -488,7 +488,7 @@ resource "aws_sagemaker_user_profile" "test" {
 
     jupyter_server_app_settings {
       default_resource_spec {
-        instance_type = "ml.t3.micro"
+        instance_type = "system"
       }
     }
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes

```
=== RUN   TestAccAWSSagemaker_serial/Domain/jupyterServerAppSettings
resource_aws_sagemaker_domain_test.go:389: Step 1/2 error: Error running apply: exit status 1
Error: error creating SageMaker domain: ValidationException: Invalid instance type 'ml.t3.micro' for JupyterServer App. Only 'system' instance type is supported
  status code: 400, request id: 45877bbe-0821-44b6-a56b-d46a638dc3cf
on terraform_plugin_test.tf line 43, in resource "aws_sagemaker_domain" "test":
43: resource "aws_sagemaker_domain" "test" {
```

and

```
=== RUN   TestAccAWSSagemaker_serial/UserProfile/jupyterServerAppSettings
resource_aws_sagemaker_user_profile_test.go:242: Step 1/2 error: Error running apply: exit status 1
Error: error creating SageMaker User Profile: ValidationException: Invalid instance type 'ml.t3.micro' for JupyterServer App. Only 'system' instance type is supported
  status code: 400, request id: 3934935e-125c-4d82-a109-8d59f416b9cb
on terraform_plugin_test.tf line 51, in resource "aws_sagemaker_user_profile" "test":
51: resource "aws_sagemaker_user_profile" "test" {
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAWSSagemaker_serial/Domain/jupyterServerAppSettings\|TestAccAWSSagemaker_serial/UserProfile/jupyterServerAppSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSagemaker_serial/Domain/jupyterServerAppSettings\|TestAccAWSSagemaker_serial/UserProfile/jupyterServerAppSettings -timeout 180m
=== RUN   TestAccAWSSagemaker_serial
=== RUN   TestAccAWSSagemaker_serial/Domain
=== RUN   TestAccAWSSagemaker_serial/Domain/jupyterServerAppSettings
--- PASS: TestAccAWSSagemaker_serial (250.87s)
    --- PASS: TestAccAWSSagemaker_serial/Domain (250.87s)
        --- PASS: TestAccAWSSagemaker_serial/Domain/jupyterServerAppSettings (250.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	254.152s
```
