### PR TITLE
tests/data.aws_neptune_engine_version: update version number to non-deprecated version

### DIFF
--- a/aws/data_source_aws_neptune_engine_version_test.go
+++ b/aws/data_source_aws_neptune_engine_version_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccAWSNeptuneEngineVersionDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_neptune_engine_version.test"
-	version := "1.0.1.0"
+	version := "1.0.2.1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccAWSNeptuneEngineVersionPreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_basic (9.94s)
```

## Reference:
* Versions up to 1.0.2.0 have been deprecated: https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases-1.0.1.2.html