### PR TITLE
Serialize SageMaker acceptance tests: r/aws_sagemaker_workforce

### DIFF
--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -102,20 +102,29 @@ func DomainByName(conn *sagemaker.SageMaker, domainID string) (*sagemaker.Descri
 	return output, nil
 }
 
-// FeatureGroupByName returns the feature group corresponding to the specified name.
-// Returns nil if no feature group is found.
 func FeatureGroupByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeFeatureGroupOutput, error) {
 	input := &sagemaker.DescribeFeatureGroupInput{
 		FeatureGroupName: aws.String(name),
 	}
 
 	output, err := conn.DescribeFeatureGroup(input)
+
+	if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
 	if output == nil {
-		return nil, nil
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
 	}
 
 	return output, nil

--- a/aws/internal/service/sagemaker/waiter/status.go
+++ b/aws/internal/service/sagemaker/waiter/status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -17,8 +18,6 @@ const (
 	SagemakerImageVersionStatusNotFound      = "NotFound"
 	SagemakerImageVersionStatusFailed        = "Failed"
 	SagemakerDomainStatusNotFound            = "NotFound"
-	SagemakerFeatureGroupStatusNotFound      = "NotFound"
-	SagemakerFeatureGroupStatusUnknown       = "Unknown"
 	SagemakerUserProfileStatusNotFound       = "NotFound"
 	SagemakerModelPackageGroupStatusNotFound = "NotFound"
 	SagemakerAppStatusNotFound               = "NotFound"
@@ -157,20 +156,16 @@ func DomainStatus(conn *sagemaker.SageMaker, domainID string) resource.StateRefr
 	}
 }
 
-// FeatureGroupStatus fetches the Feature Group and its Status
 func FeatureGroupStatus(conn *sagemaker.SageMaker, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := finder.FeatureGroupByName(conn, name)
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
-			return nil, SagemakerFeatureGroupStatusNotFound, nil
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
 		if err != nil {
-			return nil, SagemakerFeatureGroupStatusUnknown, err
-		}
-
-		if output == nil {
-			return nil, SagemakerFeatureGroupStatusNotFound, nil
+			return nil, "", err
 		}
 
 		return output, aws.StringValue(output.FeatureGroupStatus), nil

--- a/aws/resource_aws_sagemaker_domain_test.go
+++ b/aws/resource_aws_sagemaker_domain_test.go
@@ -399,7 +399,7 @@ func testAccAWSSagemakerDomain_jupyterServerAppSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "system"),
 				),
 			},
 			{
@@ -783,7 +783,7 @@ resource "aws_sagemaker_domain" "test" {
 
     jupyter_server_app_settings {
       default_resource_spec {
-        instance_type = "ml.t3.micro"
+        instance_type = "system"
       }
     }
   }

--- a/aws/resource_aws_sagemaker_feature_group_test.go
+++ b/aws/resource_aws_sagemaker_feature_group_test.go
@@ -485,7 +485,7 @@ resource "aws_iam_policy" "test" {
 }
 
 func testAccAWSSagemakerFeatureGroupBasicConfig(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSSagemakerFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -501,11 +501,11 @@ resource "aws_sagemaker_feature_group" "test" {
     enable_online_store = true
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupDescriptionConfig(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSSagemakerFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -522,11 +522,11 @@ resource "aws_sagemaker_feature_group" "test" {
     enable_online_store = true
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupConfigMultiFeature(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSSagemakerFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -547,11 +547,11 @@ resource "aws_sagemaker_feature_group" "test" {
     enable_online_store = true
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupOnlineSecurityConfig(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSSagemakerFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
@@ -576,12 +576,14 @@ resource "aws_sagemaker_feature_group" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupOfflineBasicConfig(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) +
-		testAccAWSSagemakerFeatureGroupOfflineBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSSagemakerFeatureGroupBaseConfig(rName),
+		testAccAWSSagemakerFeatureGroupOfflineBaseConfig(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -603,12 +605,14 @@ resource "aws_sagemaker_feature_group" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupOfflineCreateGlueCatalogConfig(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) +
-		testAccAWSSagemakerFeatureGroupOfflineBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSSagemakerFeatureGroupBaseConfig(rName),
+		testAccAWSSagemakerFeatureGroupOfflineBaseConfig(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -630,12 +634,14 @@ resource "aws_sagemaker_feature_group" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupOfflineCreateGlueCatalogConfigProvidedCatalog(rName string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) +
-		testAccAWSSagemakerFeatureGroupOfflineBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSSagemakerFeatureGroupBaseConfig(rName),
+		testAccAWSSagemakerFeatureGroupOfflineBaseConfig(rName),
+		fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -672,11 +678,11 @@ resource "aws_sagemaker_feature_group" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSSagemakerFeatureGroupTags1(rName, tag1Key, tag1Value string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSSagemakerFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -696,11 +702,11 @@ resource "aws_sagemaker_feature_group" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tag1Key, tag1Value)
+`, rName, tag1Key, tag1Value))
 }
 
 func testAccAWSSagemakerFeatureGroupTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
-	return testAccAWSSagemakerFeatureGroupBaseConfig(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSSagemakerFeatureGroupBaseConfig(rName), fmt.Sprintf(`
 resource "aws_sagemaker_feature_group" "test" {
   feature_group_name             = %[1]q
   record_identifier_feature_name = %[1]q
@@ -721,5 +727,5 @@ resource "aws_sagemaker_feature_group" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tag1Key, tag1Value, tag2Key, tag2Value)
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value))
 }

--- a/aws/resource_aws_sagemaker_feature_group_test.go
+++ b/aws/resource_aws_sagemaker_feature_group_test.go
@@ -59,12 +59,33 @@ func testSweepSagemakerFeatureGroups(region string) error {
 	return nil
 }
 
-func TestAccAWSSagemakerFeatureGroup_basic(t *testing.T) {
+func TestAccAWSSagemakerFeatureGroup_serial(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":                         testAccAWSSagemakerFeatureGroup_basic,
+		"description":                   testAccAWSSagemakerFeatureGroup_description,
+		"disappears":                    TestAccAWSSagemakerFeatureGroup_disappears,
+		"multipleFeatures":              testAccAWSSagemakerFeatureGroup_multipleFeatures,
+		"offlineConfig_basic":           testAccAWSSagemakerFeatureGroup_offlineConfig_basic,
+		"offlineConfig_createCatalog":   testAccAWSSagemakerFeatureGroup_offlineConfig_createCatalog,
+		"offlineConfig_providedCatalog": TestAccAWSSagemakerFeatureGroup_offlineConfig_providedCatalog,
+		"onlineConfigSecurityConfig":    testAccAWSSagemakerFeatureGroup_onlineConfigSecurityConfig,
+		"tags":                          testAccAWSSagemakerFeatureGroup_tags,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAWSSagemakerFeatureGroup_basic(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -95,12 +116,12 @@ func TestAccAWSSagemakerFeatureGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFeatureGroup_description(t *testing.T) {
+func testAccAWSSagemakerFeatureGroup_description(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -123,12 +144,12 @@ func TestAccAWSSagemakerFeatureGroup_description(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFeatureGroup_tags(t *testing.T) {
+func testAccAWSSagemakerFeatureGroup_tags(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -171,12 +192,12 @@ func TestAccAWSSagemakerFeatureGroup_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFeatureGroup_multipleFeatures(t *testing.T) {
+func testAccAWSSagemakerFeatureGroup_multipleFeatures(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -203,12 +224,12 @@ func TestAccAWSSagemakerFeatureGroup_multipleFeatures(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFeatureGroup_onlineConfigSecurityConfig(t *testing.T) {
+func testAccAWSSagemakerFeatureGroup_onlineConfigSecurityConfig(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -234,12 +255,12 @@ func TestAccAWSSagemakerFeatureGroup_onlineConfigSecurityConfig(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFeatureGroup_offlineConfig_basic(t *testing.T) {
+func testAccAWSSagemakerFeatureGroup_offlineConfig_basic(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -266,12 +287,12 @@ func TestAccAWSSagemakerFeatureGroup_offlineConfig_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFeatureGroup_offlineConfig_createCatalog(t *testing.T) {
+func testAccAWSSagemakerFeatureGroup_offlineConfig_createCatalog(t *testing.T) {
 	var featureGroup sagemaker.DescribeFeatureGroupOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -307,7 +328,7 @@ func TestAccAWSSagemakerFeatureGroup_offlineConfig_providedCatalog(t *testing.T)
 	resourceName := "aws_sagemaker_feature_group.test"
 	glueTableResourceName := "aws_glue_catalog_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,
@@ -342,7 +363,7 @@ func TestAccAWSSagemakerFeatureGroup_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_feature_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_sagemaker_test.go
+++ b/aws/resource_aws_sagemaker_test.go
@@ -37,6 +37,12 @@ func TestAccAWSSagemaker_serial(t *testing.T) {
 			"kernelGatewayAppSettings":        testAccAWSSagemakerUserProfile_kernelGatewayAppSettings,
 			"jupyterServerAppSettings":        testAccAWSSagemakerUserProfile_jupyterServerAppSettings,
 		},
+		"Workforce": {
+			"disappears":     testAccAWSSagemakerWorkforce_disappears,
+			"CognitoConfig":  testAccAWSSagemakerWorkforce_cognitoConfig,
+			"OidcConfig":     testAccAWSSagemakerWorkforce_oidcConfig,
+			"SourceIpConfig": testAccAWSSagemakerWorkforce_sourceIpConfig,
+		},
 		"Workteam": {
 			"disappears":         testAccAWSSagemakerWorkteam_disappears,
 			"CognitoConfig":      testAccAWSSagemakerWorkteam_cognitoConfig,

--- a/aws/resource_aws_sagemaker_user_profile_test.go
+++ b/aws/resource_aws_sagemaker_user_profile_test.go
@@ -252,7 +252,7 @@ func testAccAWSSagemakerUserProfile_jupyterServerAppSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "system"),
 				),
 			},
 			{
@@ -488,7 +488,7 @@ resource "aws_sagemaker_user_profile" "test" {
 
     jupyter_server_app_settings {
       default_resource_spec {
-        instance_type = "ml.t3.micro"
+        instance_type = "system"
       }
     }
   }

--- a/aws/resource_aws_sagemaker_workforce_test.go
+++ b/aws/resource_aws_sagemaker_workforce_test.go
@@ -63,7 +63,7 @@ func testSweepSagemakerWorkforces(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSSagemakerWorkforce_cognitoConfig(t *testing.T) {
+func testAccAWSSagemakerWorkforce_cognitoConfig(t *testing.T) {
 	var workforce sagemaker.Workforce
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_workforce.test"
@@ -98,7 +98,7 @@ func TestAccAWSSagemakerWorkforce_cognitoConfig(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerWorkforce_oidcConfig(t *testing.T) {
+func testAccAWSSagemakerWorkforce_oidcConfig(t *testing.T) {
 	var workforce sagemaker.Workforce
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_workforce.test"
@@ -162,7 +162,7 @@ func TestAccAWSSagemakerWorkforce_oidcConfig(t *testing.T) {
 		},
 	})
 }
-func TestAccAWSSagemakerWorkforce_sourceIpConfig(t *testing.T) {
+func testAccAWSSagemakerWorkforce_sourceIpConfig(t *testing.T) {
 	var workforce sagemaker.Workforce
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_workforce.test"
@@ -209,7 +209,7 @@ func TestAccAWSSagemakerWorkforce_sourceIpConfig(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerWorkforce_disappears(t *testing.T) {
+func testAccAWSSagemakerWorkforce_disappears(t *testing.T) {
 	var workforce sagemaker.Workforce
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_workforce.test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes

```
=== RUN   TestAccAWSSagemakerWorkforce_sourceIpConfig
resource_aws_sagemaker_workforce_test.go:170: Step 1/4 error: Error running apply: exit status 1
Error: error creating SageMaker Workforce (tf-acc-test-1288726154760400114): ValidationException: Cannot create more than one workforce for account *******. If you are trying to update existing workforce, please use UpdateWorkforce API
  status code: 400, request id: ae21c06e-eb0e-483c-9284-1ff3b925e761
on terraform_plugin_test.tf line 17, in resource "aws_sagemaker_workforce" "test":
17: resource "aws_sagemaker_workforce" "test" {
--- FAIL: TestAccAWSSagemakerWorkforce_sourceIpConfig (46.85s)
=== RUN   TestAccAWSSagemakerWorkforce_cognitoConfig
resource_aws_sagemaker_workforce_test.go:71: Step 1/2 error: Error running apply: exit status 1
Error: error creating SageMaker Workforce (tf-acc-test-6724704016552939252): ValidationException: Cannot create more than one workforce for account *******. If you are trying to update existing workforce, please use UpdateWorkforce API
  status code: 400, request id: 34540e69-dedd-43b6-a87c-7cad4325377c
on terraform_plugin_test.tf line 17, in resource "aws_sagemaker_workforce" "test":
17: resource "aws_sagemaker_workforce" "test" {
--- FAIL: TestAccAWSSagemakerWorkforce_cognitoConfig (52.53s)
=== RUN   TestAccAWSSagemakerWorkforce_disappears
resource_aws_sagemaker_workforce_test.go:217: Step 1/1 error: Error running apply: exit status 1
Error: error creating SageMaker Workforce (tf-acc-test-2820408731236482529): ValidationException: Cannot create more than one workforce for account *******. If you are trying to update existing workforce, please use UpdateWorkforce API
  status code: 400, request id: ea90a02c-9864-4f19-94aa-141820c4cf44
on terraform_plugin_test.tf line 17, in resource "aws_sagemaker_workforce" "test":
17: resource "aws_sagemaker_workforce" "test" {
--- FAIL: TestAccAWSSagemakerWorkforce_disappears (44.41s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAWSSagemaker_serial/Workforce'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSagemaker_serial/Workforce -timeout 180m
=== RUN   TestAccAWSSagemaker_serial
=== RUN   TestAccAWSSagemaker_serial/Workforce
=== RUN   TestAccAWSSagemaker_serial/Workforce/disappears
=== RUN   TestAccAWSSagemaker_serial/Workforce/CognitoConfig
=== RUN   TestAccAWSSagemaker_serial/Workforce/OidcConfig
=== RUN   TestAccAWSSagemaker_serial/Workforce/SourceIpConfig
--- PASS: TestAccAWSSagemaker_serial (125.30s)
    --- PASS: TestAccAWSSagemaker_serial/Workforce (125.30s)
        --- PASS: TestAccAWSSagemaker_serial/Workforce/disappears (21.86s)
        --- PASS: TestAccAWSSagemaker_serial/Workforce/CognitoConfig (22.32s)
        --- PASS: TestAccAWSSagemaker_serial/Workforce/OidcConfig (33.02s)
        --- PASS: TestAccAWSSagemaker_serial/Workforce/SourceIpConfig (48.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	128.417s
```
