### PR TITLE
tests/db_instance_role_association: use db instance data source in place of deprecated engine

### DIFF
--- a/aws/resource_aws_db_instance_role_association_test.go
+++ b/aws/resource_aws_db_instance_role_association_test.go
@@ -160,13 +160,23 @@ func testAccCheckAWSDbInstanceRoleAssociationDisappears(dbInstance *rds.DBInstan
 
 func testAccAWSDbInstanceRoleAssociationConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine        = "oracle-se2"
+  license_model = "bring-your-own-license"
+  storage_type  = "standard"
+
+  preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
+}
+
 data "aws_iam_policy_document" "rds_assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
     effect  = "Allow"
 
     principals {
-      identifiers = ["rds.amazonaws.com"]
+      identifiers = ["rds.${data.aws_partition.current.dns_suffix}"]
       type        = "Service"
     }
   }
@@ -179,9 +189,10 @@ resource "aws_iam_role" "test" {
 
 resource "aws_db_instance" "test" {
   allocated_storage   = 10
-  engine              = "oracle-se"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = %[1]q
-  instance_class      = "db.t3.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  license_model       = data.aws_rds_orderable_db_instance.test.license_model
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDbInstanceRoleAssociation_disappears (1301.96s)
--- PASS: TestAccAWSDbInstanceRoleAssociation_basic (1381.95s)
```
