### PR TITLE
Add parameter build_type to codebuild_webhook

### DIFF
--- a/.changelog/20480.txt
+++ b/.changelog/20480.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codebuild_webhook: Add support for `build_type`
+```

--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -29,6 +29,14 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"build_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					codebuild.WebhookBuildTypeBuild,
+					codebuild.WebhookBuildTypeBuildBatch,
+				}, false),
+			},
 			"branch_filter": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -96,6 +104,10 @@ func resourceAwsCodeBuildWebhookCreate(d *schema.ResourceData, meta interface{})
 	input := &codebuild.CreateWebhookInput{
 		ProjectName:  aws.String(d.Get("project_name").(string)),
 		FilterGroups: expandWebhookFilterGroups(d),
+	}
+
+	if v, ok := d.GetOk("build_type"); ok {
+		input.BuildType = aws.String(v.(string))
 	}
 
 	// The CodeBuild API requires this to be non-empty if defined
@@ -180,6 +192,7 @@ func resourceAwsCodeBuildWebhookRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
+	d.Set("build_type", project.Webhook.BuildType)
 	d.Set("branch_filter", project.Webhook.BranchFilter)
 	d.Set("filter_group", flattenAwsCodeBuildWebhookFilterGroups(project.Webhook.FilterGroups))
 	d.Set("payload_url", project.Webhook.PayloadUrl)
@@ -199,12 +212,14 @@ func resourceAwsCodeBuildWebhookUpdate(d *schema.ResourceData, meta interface{})
 	if len(filterGroups) >= 1 {
 		_, err = conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
 			ProjectName:  aws.String(d.Id()),
+			BuildType:    aws.String(d.Get("build_type").(string)),
 			FilterGroups: filterGroups,
 			RotateSecret: aws.Bool(false),
 		})
 	} else {
 		_, err = conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
 			ProjectName:  aws.String(d.Id()),
+			BuildType:    aws.String(d.Get("build_type").(string)),
 			BranchFilter: aws.String(d.Get("branch_filter").(string)),
 			RotateSecret: aws.Bool(false),
 		})

--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -30,12 +30,9 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 				ForceNew: true,
 			},
 			"build_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					codebuild.WebhookBuildTypeBuild,
-					codebuild.WebhookBuildTypeBuildBatch,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(codebuild.WebhookBuildType_Values(), false),
 			},
 			"branch_filter": {
 				Type:          schema.TypeString,
@@ -53,16 +50,9 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codebuild.WebhookFilterTypeEvent,
-											codebuild.WebhookFilterTypeActorAccountId,
-											codebuild.WebhookFilterTypeBaseRef,
-											codebuild.WebhookFilterTypeFilePath,
-											codebuild.WebhookFilterTypeHeadRef,
-											codebuild.WebhookFilterTypeCommitMessage,
-										}, false),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(codebuild.WebhookFilterType_Values(), false),
 									},
 									"exclude_matched_pattern": {
 										Type:     schema.TypeBool,

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -326,7 +326,8 @@ func testAccCheckAWSCodeBuildWebhookExists(name string, webhook *codebuild.Webho
 
 func testAccAWSCodeBuildWebhookConfig_Bitbucket(rName, sourceLocation string) string {
 	return composeConfig(
-		testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName, sourceLocation), `
+		testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName, sourceLocation),
+		`
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
 }
@@ -334,7 +335,9 @@ resource "aws_codebuild_webhook" "test" {
 }
 
 func testAccAWSCodeBuildWebhookConfig_GitHub(rName string) string {
-	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName) + `
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_basic(rName),
+		`
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
 }
@@ -342,9 +345,9 @@ resource "aws_codebuild_webhook" "test" {
 }
 
 func testAccAWSCodeBuildWebhookConfig_GitHubEnterprise(rName string, branchFilter string) string {
-	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName), fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
-  name         = "%s"
+  name         = %[1]q
   service_role = aws_iam_role.test.arn
 
   artifacts {
@@ -365,31 +368,33 @@ resource "aws_codebuild_project" "test" {
 
 resource "aws_codebuild_webhook" "test" {
   project_name  = aws_codebuild_project.test.name
-  branch_filter = "%s"
+  branch_filter = %[2]q
 }
-`, rName, branchFilter)
+`, rName, branchFilter))
 }
 
 func testAccAWSCodeBuildWebhookConfig_BuildType(rName, branchFilter string) string {
-	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName)+`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_basic(rName), fmt.Sprintf(`
 resource "aws_codebuild_webhook" "test" {
-  build_type = "%s"
-  project_name  = aws_codebuild_project.test.name
+  build_type   = %[1]q
+  project_name = aws_codebuild_project.test.name
 }
-`, branchFilter)
+`, branchFilter))
 }
 
 func testAccAWSCodeBuildWebhookConfig_BranchFilter(rName, branchFilter string) string {
-	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName)+`
+	return composeConfig(testAccAWSCodeBuildProjectConfig_basic(rName), fmt.Sprintf(`
 resource "aws_codebuild_webhook" "test" {
-  branch_filter = "%s"
+  branch_filter = %[1]q
   project_name  = aws_codebuild_project.test.name
 }
-`, branchFilter)
+`, branchFilter))
 }
 
 func testAccAWSCodeBuildWebhookConfig_FilterGroup(rName string) string {
-	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName) + `
+	return composeConfig(
+		testAccAWSCodeBuildProjectConfig_basic(rName),
+		`
 resource "aws_codebuild_webhook" "test" {
   project_name = aws_codebuild_project.test.name
 

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -128,6 +128,41 @@ func TestAccAWSCodeBuildWebhook_GitHubEnterprise(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeBuildWebhook_BuildType(t *testing.T) {
+	var webhook codebuild.Webhook
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_webhook.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		ErrorCheck:   testAccErrorCheck(t, codebuild.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildWebhookConfig_BuildType(rName, "BUILD"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildWebhookExists(resourceName, &webhook),
+					resource.TestCheckResourceAttr(resourceName, "build_type", "BUILD"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildWebhookConfig_BuildType(rName, "BUILD_BATCH"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildWebhookExists(resourceName, &webhook),
+					resource.TestCheckResourceAttr(resourceName, "build_type", "BUILD_BATCH"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret"},
+			},
+		},
+	})
+}
+
 func TestAccAWSCodeBuildWebhook_BranchFilter(t *testing.T) {
 	var webhook codebuild.Webhook
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -333,6 +368,15 @@ resource "aws_codebuild_webhook" "test" {
   branch_filter = "%s"
 }
 `, rName, branchFilter)
+}
+
+func testAccAWSCodeBuildWebhookConfig_BuildType(rName, branchFilter string) string {
+	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName)+`
+resource "aws_codebuild_webhook" "test" {
+  build_type = "%s"
+  project_name  = aws_codebuild_project.test.name
+}
+`, branchFilter)
 }
 
 func testAccAWSCodeBuildWebhookConfig_BranchFilter(rName, branchFilter string) string {

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -23,7 +23,7 @@ When working with [Bitbucket](https://bitbucket.org) and [GitHub](https://github
 ```terraform
 resource "aws_codebuild_webhook" "example" {
   project_name = aws_codebuild_project.example.name
-  build_type = "BUILD"
+  build_type   = "BUILD"
   filter_group {
     filter {
       type    = "EVENT"

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -23,7 +23,7 @@ When working with [Bitbucket](https://bitbucket.org) and [GitHub](https://github
 ```terraform
 resource "aws_codebuild_webhook" "example" {
   project_name = aws_codebuild_project.example.name
-
+  build_type = "BUILD"
   filter_group {
     filter {
       type    = "EVENT"
@@ -69,6 +69,7 @@ resource "github_repository_webhook" "example" {
 The following arguments are supported:
 
 * `project_name` - (Required) The name of the build project.
+* `build_type` - (Optional) The type of build this webhook will trigger(BUILD | BUILD_BATCH).
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built. It is recommended to use `filter_group` over `branch_filter`.
 * `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -69,7 +69,7 @@ resource "github_repository_webhook" "example" {
 The following arguments are supported:
 
 * `project_name` - (Required) The name of the build project.
-* `build_type` - (Optional) The type of build this webhook will trigger(BUILD | BUILD_BATCH).
+* `build_type` - (Optional) The type of build this webhook will trigger. Valid values for this parameter are: `BUILD`, `BUILD_BATCH`.
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built. It is recommended to use `filter_group` over `branch_filter`.
 * `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TESTARGS='-run=TestAccAWSCodeBuildWebhook_BuildType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildWebhook_BuildType -timeout 180m
=== RUN   TestAccAWSCodeBuildWebhook_BuildType
=== PAUSE TestAccAWSCodeBuildWebhook_BuildType
=== CONT  TestAccAWSCodeBuildWebhook_BuildType
--- PASS: TestAccAWSCodeBuildWebhook_BuildType (92.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	93.776s
```

Closes #16824