### PR TITLE
r/aws_lambda_event_source_mapping: Ignore change to `last_modified` in acceptance test import steps

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -51,9 +51,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_basic(t *testing.T) {
 				Config:   testAccAWSLambdaEventSourceMappingConfigKinesisBatchSize(rName, "null"),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisUpdateFunctionName(rName),
@@ -104,9 +105,10 @@ func TestAccAWSLambdaEventSourceMapping_SQS_basic(t *testing.T) {
 				Config:   testAccAWSLambdaEventSourceMappingConfigSqsBatchSize(rName, "null"),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigSqsUpdateFunctionName(rName),
@@ -159,9 +161,10 @@ func TestAccAWSLambdaEventSourceMapping_DynamoDB_basic(t *testing.T) {
 				Config:   testAccAWSLambdaEventSourceMappingConfigDynamoDbBatchSize(rName, "null"),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 		},
 	})
@@ -187,9 +190,10 @@ func TestAccAWSLambdaEventSourceMapping_DynamoDB_FunctionResponseTypes(t *testin
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigDynamoDbNoFunctionResponseTypes(rName),
@@ -223,9 +227,10 @@ func TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigSqsBatchWindow(rName, batchWindowUpdate),
@@ -305,9 +310,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_StartingPositionTimestamp(t *tes
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 		},
 	})
@@ -334,9 +340,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_BatchWindow(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisBatchWindow(rName, batchWindowUpdate),
@@ -370,9 +377,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor(t *testing
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisParallelizationFactor(rName, parallelizationFactorUpdate),
@@ -406,9 +414,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_TumblingWindowInSeconds(t *testi
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisTumblingWindowInSeconds(rName, tumblingWindowInSecondsUpdate),
@@ -442,9 +451,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttempts(t *testing.
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisMaximumRetryAttempts(rName, maximumRetryAttemptsUpdate),
@@ -478,9 +488,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsZero(t *test
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisMaximumRetryAttempts(rName, maximumRetryAttemptsUpdate),
@@ -521,9 +532,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsNegativeOne(
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisMaximumRetryAttempts(rName, maximumRetryAttemptsUpdate),
@@ -564,9 +576,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSeconds(t *tes
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisMaximumRecordAgeInSeconds(rName, maximumRecordAgeInSecondsUpdate),
@@ -600,9 +613,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSecondsNegativ
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisMaximumRecordAgeInSeconds(rName, maximumRecordAgeInSecondsUpdate),
@@ -636,9 +650,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_BisectBatch(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisBisectBatch(rName, bisectBatchUpdate),
@@ -673,9 +688,10 @@ func TestAccAWSLambdaEventSourceMapping_Kinesis_DestinationConfig(t *testing.T) 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigKinesisDestinationConfig(rName, rName+"-update"),
@@ -721,9 +737,10 @@ func TestAccAWSLambdaEventSourceMapping_MSK(t *testing.T) {
 				Config:   testAccAWSLambdaEventSourceMappingConfigMsk(rName, "null"),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigMsk(rName, "9999"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes acceptance test failures such as

```
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor
resource_aws_lambda_event_source_mapping_test.go:359: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) (len=1) {
(string) (len=13) "last_modified": (string) (len=20) "2021-08-07T14:16:00Z"
}
(map[string]string) (len=1) {
(string) (len=13) "last_modified": (string) (len=20) "2021-08-07T14:15:00Z"
}
--- FAIL: TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor (157.53s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaEventSourceMapping_ -timeout 180m
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_DynamoDB_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_DynamoDB_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_DynamoDB_FunctionResponseTypes
=== PAUSE TestAccAWSLambdaEventSourceMapping_DynamoDB_FunctionResponseTypes
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== RUN   TestAccAWSLambdaEventSourceMapping_disappears
=== PAUSE TestAccAWSLambdaEventSourceMapping_disappears
=== RUN   TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_StartingPositionTimestamp
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_StartingPositionTimestamp
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_BatchWindow
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_BatchWindow
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_TumblingWindowInSeconds
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_TumblingWindowInSeconds
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttempts
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttempts
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsZero
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsZero
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsNegativeOne
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsNegativeOne
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSeconds
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSeconds
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSecondsNegativeOne
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSecondsNegativeOne
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_BisectBatch
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_BisectBatch
=== RUN   TestAccAWSLambdaEventSourceMapping_Kinesis_DestinationConfig
=== PAUSE TestAccAWSLambdaEventSourceMapping_Kinesis_DestinationConfig
=== RUN   TestAccAWSLambdaEventSourceMapping_MSK
=== PAUSE TestAccAWSLambdaEventSourceMapping_MSK
=== RUN   TestAccAWSLambdaEventSourceMapping_SelfManagedKafka
=== PAUSE TestAccAWSLambdaEventSourceMapping_SelfManagedKafka
=== RUN   TestAccAWSLambdaEventSourceMapping_ActiveMQ
=== PAUSE TestAccAWSLambdaEventSourceMapping_ActiveMQ
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSecondsNegativeOne
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsNegativeOne
=== CONT  TestAccAWSLambdaEventSourceMapping_disappears
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttempts
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_TumblingWindowInSeconds
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsZero
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSeconds
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_StartingPositionTimestamp
=== CONT  TestAccAWSLambdaEventSourceMapping_SelfManagedKafka
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_BatchWindow
=== CONT  TestAccAWSLambdaEventSourceMapping_MSK
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_DestinationConfig
=== CONT  TestAccAWSLambdaEventSourceMapping_ActiveMQ
=== CONT  TestAccAWSLambdaEventSourceMapping_Kinesis_BisectBatch
=== CONT  TestAccAWSLambdaEventSourceMapping_SQS_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_DynamoDB_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_BisectBatch (90.86s)
=== CONT  TestAccAWSLambdaEventSourceMapping_DynamoDB_FunctionResponseTypes
--- PASS: TestAccAWSLambdaEventSourceMapping_disappears (95.97s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttempts (103.78s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_TumblingWindowInSeconds (111.98s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsZero (117.49s)
--- PASS: TestAccAWSLambdaEventSourceMapping_DynamoDB_basic (121.95s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRetryAttemptsNegativeOne (133.78s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_StartingPositionTimestamp (136.27s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_ParallelizationFactor (136.48s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_DestinationConfig (153.74s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SelfManagedKafka (163.06s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSecondsNegativeOne (177.08s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_BatchWindow (183.15s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_MaximumRecordAgeInSeconds (183.67s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_basic (197.09s)
--- PASS: TestAccAWSLambdaEventSourceMapping_Kinesis_BatchWindow (204.43s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (211.15s)
--- PASS: TestAccAWSLambdaEventSourceMapping_DynamoDB_FunctionResponseTypes (127.71s)
--- PASS: TestAccAWSLambdaEventSourceMapping_SQS_basic (239.74s)
--- PASS: TestAccAWSLambdaEventSourceMapping_ActiveMQ (1393.36s)
--- PASS: TestAccAWSLambdaEventSourceMapping_MSK (2350.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2353.357s
```
