### PR TITLE
r/iam_user_login_profile: Fix wrong import

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/encryption"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccAWSUserLoginProfile_notAKey (11.62s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (11.76s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (23.50s)
--- PASS: TestAccAWSUserLoginProfile_keybase (23.66s)
--- PASS: TestAccAWSUserLoginProfile_basic (32.44s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSUserLoginProfile_notAKey (13.47s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (13.52s)
--- PASS: TestAccAWSUserLoginProfile_keybase (22.77s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (22.86s)
--- PASS: TestAccAWSUserLoginProfile_basic (30.81s)
```
