### PR TITLE
r/aws_serverlessapplicationrepository_cloudformation_stack: make apply fail if the parameters set to be default value

### DIFF
--- a/.changelog/20518.txt
+++ b/.changelog/20518.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_serverlessapplicationrepository_cloudformation_stack: Make apply failed when any parameters are set to default values
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16485

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsServerlessApplicationRepositoryCloudFormationStack_default_params'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsServerlessApplicationRepositoryCloudFormationStack_default_params -timeout 180m
=== RUN   TestAccAwsServerlessApplicationRepositoryCloudFormationStack_default_params
=== PAUSE TestAccAwsServerlessApplicationRepositoryCloudFormationStack_default_params
=== CONT  TestAccAwsServerlessApplicationRepositoryCloudFormationStack_default_params
--- PASS: TestAccAwsServerlessApplicationRepositoryCloudFormationStack_default_params (157.37s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       157.463s
```

Make apply failed when any parameters are set to default value in `aws_serverlessapplicationrepository_cloudformation_stack`, because the resource only handles non-default parameters.
If parameters set to be default value in a resource,  the first apply success, but second apply will fail.

There are two reasons for the error.

1. this resource omit default value by the below, but the default value stored in tf-state. This makes difference in plan and terraform update parameters in place
  https://github.com/hashicorp/terraform-provider-aws/blob/ac06ced75cba0daf09fef2938752ad13cc6fff6e/aws/resource_aws_serverlessapplicationrepository_cloudformation_stack.go#L204-L206
2. `aws_serverlessapplicationrepository_cloudformation_stack` cannot be updated in place related to #16485

It bothers us to find the reasons of the error, so this PR makes apply fail when the above condition meets
