### PR TITLE
aws route53recoveryreadiness add new resources

### DIFF
--- a/.changelog/20526.txt
+++ b/.changelog/20526.txt
@@ -1,0 +1,15 @@
+```release-note:new-resource
+aws_route53recoveryreadiness_cell
+```
+
+```release-note:new-resource
+aws_route53recoveryreadiness_recovery_group
+```
+
+```release-note:new-resource
+aws_route53recoveryreadiness_resource_set
+```
+
+```release-note:new-resource
+aws_route53recoveryreadiness_readiness_check
+```

--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -105,6 +105,7 @@ var serviceNames = []string{
 	"rds",
 	"resourcegroups",
 	"route53",
+	"route53recoveryreadiness",
 	"route53resolver",
 	"sagemaker",
 	"securityhub",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -144,6 +144,7 @@ var mapServiceNames = []string{
 	"qldb",
 	"pinpoint",
 	"resourcegroups",
+	"route53recoveryreadiness",
 	"securityhub",
 	"schemas",
 	"signer",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -111,6 +111,7 @@ var serviceNames = []string{
 	"redshift",
 	"resourcegroups",
 	"route53",
+	"route53recoveryreadiness",
 	"route53resolver",
 	"sagemaker",
 	"secretsmanager",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -92,6 +92,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/resourcegroups"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/aws/aws-sdk-go/service/schemas"
@@ -2239,6 +2240,23 @@ func Route53ListTags(conn *route53.Route53, identifier string, resourceType stri
 	}
 
 	return Route53KeyValueTags(output.ResourceTagSet.Tags), nil
+}
+
+// Route53recoveryreadinessListTags lists route53recoveryreadiness service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func Route53recoveryreadinessListTags(conn *route53recoveryreadiness.Route53RecoveryReadiness, identifier string) (KeyValueTags, error) {
+	input := &route53recoveryreadiness.ListTagsForResourcesInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResources(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return Route53recoveryreadinessKeyValueTags(output.Tags), nil
 }
 
 // Route53resolverListTags lists route53resolver service tags.

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -2252,6 +2252,13 @@ func Route53recoveryreadinessListTags(conn *route53recoveryreadiness.Route53Reco
 
 	output, err := conn.ListTagsForResources(input)
 
+	if tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
+		err = &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return New(nil), err
 	}

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -102,6 +102,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/resourcegroups"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/aws/aws-sdk-go/service/schemas"
@@ -327,6 +328,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(resourcegroupstaggingapi.New)
 	case "route53":
 		funcType = reflect.TypeOf(route53.New)
+	case "route53recoveryreadiness":
+		funcType = reflect.TypeOf(route53recoveryreadiness.New)
 	case "route53resolver":
 		funcType = reflect.TypeOf(route53resolver.New)
 	case "sagemaker":
@@ -441,6 +444,8 @@ func ServiceListTagsFunction(serviceName string) string {
 		return "DescribeTags"
 	case "resourcegroups":
 		return "GetTags"
+	case "route53recoveryreadiness":
+		return "ListTagsForResources"
 	case "sagemaker":
 		return "ListTags"
 	case "sqs":

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -457,6 +457,16 @@ func ResourcegroupsKeyValueTags(tags map[string]*string) KeyValueTags {
 	return New(tags)
 }
 
+// Route53recoveryreadinessTags returns route53recoveryreadiness service tags.
+func (tags KeyValueTags) Route53recoveryreadinessTags() map[string]*string {
+	return aws.StringMap(tags.Map())
+}
+
+// Route53recoveryreadinessKeyValueTags creates KeyValueTags from route53recoveryreadiness service tags.
+func Route53recoveryreadinessKeyValueTags(tags map[string]*string) KeyValueTags {
+	return New(tags)
+}
+
 // SchemasTags returns schemas service tags.
 func (tags KeyValueTags) SchemasTags() map[string]*string {
 	return aws.StringMap(tags.Map())

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -100,6 +100,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/resourcegroups"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/aws/aws-sdk-go/service/schemas"
@@ -3506,6 +3507,42 @@ func Route53UpdateTags(conn *route53.Route53, identifier string, resourceType st
 
 	if err != nil {
 		return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+	}
+
+	return nil
+}
+
+// Route53recoveryreadinessUpdateTags updates route53recoveryreadiness service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func Route53recoveryreadinessUpdateTags(conn *route53recoveryreadiness.Route53RecoveryReadiness, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &route53recoveryreadiness.UntagResourceInput{
+			ResourceArn: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &route53recoveryreadiness.TagResourceInput{
+			ResourceArn: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().Route53recoveryreadinessTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
 	}
 
 	return nil

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1004,6 +1004,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_rule":                               resourceAwsRoute53ResolverRule(),
 			"aws_route53recoveryreadiness_cell":                       resourceAwsRoute53RecoveryReadinessCell(),
 			"aws_route53recoveryreadiness_recovery_group":             resourceAwsRoute53RecoveryReadinessRecoveryGroup(),
+			"aws_route53recoveryreadiness_resource_set":               resourceAwsRoute53RecoveryReadinessResourceSet(),
 			"aws_route":                                               resourceAwsRoute(),
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1003,6 +1003,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_rule_association":                   resourceAwsRoute53ResolverRuleAssociation(),
 			"aws_route53_resolver_rule":                               resourceAwsRoute53ResolverRule(),
 			"aws_route53recoveryreadiness_cell":                       resourceAwsRoute53RecoveryReadinessCell(),
+			"aws_route53recoveryreadiness_readiness_check":            resourceAwsRoute53RecoveryReadinessReadinessCheck(),
 			"aws_route53recoveryreadiness_recovery_group":             resourceAwsRoute53RecoveryReadinessRecoveryGroup(),
 			"aws_route53recoveryreadiness_resource_set":               resourceAwsRoute53RecoveryReadinessResourceSet(),
 			"aws_route":                                               resourceAwsRoute(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1003,6 +1003,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_rule_association":                   resourceAwsRoute53ResolverRuleAssociation(),
 			"aws_route53_resolver_rule":                               resourceAwsRoute53ResolverRule(),
 			"aws_route53recoveryreadiness_cell":                       resourceAwsRoute53RecoveryReadinessCell(),
+			"aws_route53recoveryreadiness_recovery_group":             resourceAwsRoute53RecoveryReadinessRecoveryGroup(),
 			"aws_route":                                               resourceAwsRoute(),
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1002,6 +1002,7 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_query_log_config_association":       resourceAwsRoute53ResolverQueryLogConfigAssociation(),
 			"aws_route53_resolver_rule_association":                   resourceAwsRoute53ResolverRuleAssociation(),
 			"aws_route53_resolver_rule":                               resourceAwsRoute53ResolverRule(),
+			"aws_route53recoveryreadiness_cell":                       resourceAwsRoute53RecoveryReadinessCell(),
 			"aws_route":                                               resourceAwsRoute(),
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),

--- a/aws/resource_aws_route53recoveryreadiness_cell.go
+++ b/aws/resource_aws_route53recoveryreadiness_cell.go
@@ -21,6 +21,10 @@ func resourceAwsRoute53RecoveryReadinessCell() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -158,7 +162,7 @@ func resourceAwsRoute53RecoveryReadinessCellDelete(d *schema.ResourceData, meta 
 	gcinput := &route53recoveryreadiness.GetCellInput{
 		CellName: aws.String(d.Id()),
 	}
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.GetCell(gcinput)
 		if err != nil {
 			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {

--- a/aws/resource_aws_route53recoveryreadiness_cell.go
+++ b/aws/resource_aws_route53recoveryreadiness_cell.go
@@ -1,0 +1,179 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsRoute53RecoveryReadinessCell() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53RecoveryReadinessCellCreate,
+		Read:   resourceAwsRoute53RecoveryReadinessCellRead,
+		Update: resourceAwsRoute53RecoveryReadinessCellUpdate,
+		Delete: resourceAwsRoute53RecoveryReadinessCellDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cell_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cells": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"parent_readiness_scopes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+		},
+
+		CustomizeDiff: SetTagsDiff,
+	}
+}
+
+func resourceAwsRoute53RecoveryReadinessCellCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &route53recoveryreadiness.CreateCellInput{
+		CellName: aws.String(d.Get("cell_name").(string)),
+		Cells:    expandStringList(d.Get("cells").([]interface{})),
+	}
+
+	resp, err := conn.CreateCell(input)
+	if err != nil {
+		return fmt.Errorf("error creating Route53 Recovery Readiness Cell: %w", err)
+	}
+
+	d.SetId(aws.StringValue(resp.CellName))
+
+	if len(tags) > 0 {
+		arn := aws.StringValue(resp.CellArn)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error adding Route53 Recovery Readiness Cell (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessCellRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessCellRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	input := &route53recoveryreadiness.GetCellInput{
+		CellName: aws.String(d.Id()),
+	}
+	resp, err := conn.GetCell(input)
+	if err != nil {
+		return fmt.Errorf("error describing Route53 Recovery Readiness Cell: %s", err)
+	}
+	d.Set("arn", resp.CellArn)
+	d.Set("cell_name", resp.CellName)
+	d.Set("cells", resp.Cells)
+	d.Set("parent_readiness_scopes", resp.ParentReadinessScopes)
+
+	tags, err := keyvaluetags.Route53recoveryreadinessListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Recovery Readiness Cell (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53RecoveryReadinessCellUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.UpdateCellInput{
+		CellName: aws.String(d.Id()),
+		Cells:    expandStringList(d.Get("cells").([]interface{})),
+	}
+
+	_, err := conn.UpdateCell(input)
+	if err != nil {
+		return fmt.Errorf("error updating Route53 Recovery Readiness Cell: %s", err)
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		arn := d.Get("arn").(string)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Recovery Readiness Cell (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessCellRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessCellDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.DeleteCellInput{
+		CellName: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteCell(input)
+	if err != nil {
+		if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Route53 Recovery Readiness Cell: %s", err)
+	}
+
+	gcinput := &route53recoveryreadiness.GetCellInput{
+		CellName: aws.String(d.Id()),
+	}
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.GetCell(gcinput)
+		if err != nil {
+			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("Route 53 Recovery Readiness Cell (%s) still exists", d.Id()))
+	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.GetCell(gcinput)
+	}
+	if err != nil {
+		return fmt.Errorf("error waiting for Route 53 Recovery Readiness Cell (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_route53recoveryreadiness_cell_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_cell_test.go
@@ -1,0 +1,238 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsRoute53RecoveryReadinessCell_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_cell.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessCellDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`cell/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cells.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parent_readiness_scopes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessCell_nestedCell(t *testing.T) {
+	rNameParent := acctest.RandomWithPrefix("tf-acc-test-parent")
+	rNameChild := acctest.RandomWithPrefix("tf-acc-test-child")
+	resourceNameParent := "aws_route53recoveryreadiness_cell.test_parent"
+	resourceNameChild := "aws_route53recoveryreadiness_cell.test_child"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessCellDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellChildConfig(rNameChild),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceNameChild),
+					testAccMatchResourceAttrGlobalARN(resourceNameChild, "arn", "route53-recovery-readiness", regexp.MustCompile(`cell/.+`)),
+				),
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellParentConfig(rNameChild, rNameParent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceNameParent),
+					testAccMatchResourceAttrGlobalARN(resourceNameParent, "arn", "route53-recovery-readiness", regexp.MustCompile(`cell/.+`)),
+					resource.TestCheckResourceAttr(resourceNameParent, "cells.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameParent, "parent_readiness_scopes.#", "0"),
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceNameChild),
+					testAccMatchResourceAttrGlobalARN(resourceNameChild, "arn", "route53-recovery-readiness", regexp.MustCompile(`cell/.+`)),
+					resource.TestCheckResourceAttr(resourceNameChild, "cells.#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellParentConfig(rNameChild, rNameParent),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameChild, "parent_readiness_scopes.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceNameParent,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceNameChild,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessCell_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_cell.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessCellDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellConfig_Tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellConfig_Tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellConfig_Tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessCellDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53recoveryreadiness_cell" {
+			continue
+		}
+
+		input := &route53recoveryreadiness.GetCellInput{
+			CellName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetCell(input)
+		if err == nil {
+			return fmt.Errorf("Route53RecoveryReadiness Channel (%s) not deleted", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessCellExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+		input := &route53recoveryreadiness.GetCellInput{
+			CellName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetCell(input)
+
+		return err
+	}
+}
+
+func testAccPreCheckAwsRoute53RecoveryReadiness(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.ListCellsInput{}
+
+	_, err := conn.ListCells(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAwsRoute53RecoveryReadinessCellConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test" {
+  cell_name = %q
+}
+`, rName)
+}
+
+func testAccAwsRoute53RecoveryReadinessCellChildConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test_child" {
+  cell_name = %q
+}
+`, rName)
+}
+
+func testAccAwsRoute53RecoveryReadinessCellParentConfig(rName, rName2 string) string {
+	return composeConfig(testAccAwsRoute53RecoveryReadinessCellChildConfig(rName), fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test_parent" {
+  cell_name = %q
+  cells     = [aws_route53recoveryreadiness_cell.test_child.arn]
+}
+`, rName2))
+}
+
+func testAccAwsRoute53RecoveryReadinessCellConfig_Tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test" {
+  cell_name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAwsRoute53RecoveryReadinessCellConfig_Tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test" {
+  cell_name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_route53recoveryreadiness_cell_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_cell_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccAwsRoute53RecoveryReadinessCell_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_cell.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -40,11 +41,34 @@ func TestAccAwsRoute53RecoveryReadinessCell_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsRoute53RecoveryReadinessCell_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_cell.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessCellDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessCellConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessCellExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53RecoveryReadinessCell(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsRoute53RecoveryReadinessCell_nestedCell(t *testing.T) {
 	rNameParent := acctest.RandomWithPrefix("tf-acc-test-parent")
 	rNameChild := acctest.RandomWithPrefix("tf-acc-test-child")
 	resourceNameParent := "aws_route53recoveryreadiness_cell.test_parent"
 	resourceNameChild := "aws_route53recoveryreadiness_cell.test_child"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -93,6 +117,7 @@ func TestAccAwsRoute53RecoveryReadinessCell_nestedCell(t *testing.T) {
 func TestAccAwsRoute53RecoveryReadinessCell_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_cell.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -136,6 +161,7 @@ func TestAccAwsRoute53RecoveryReadinessCell_tags(t *testing.T) {
 func TestAccAwsRoute53RecoveryReadinessCell_timeout(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_cell.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -185,6 +211,7 @@ func testAccCheckAwsRoute53RecoveryReadinessCellDestroy(s *terraform.State) erro
 func testAccCheckAwsRoute53RecoveryReadinessCellExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
+
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
 		}
@@ -246,6 +273,7 @@ func testAccAwsRoute53RecoveryReadinessCellConfig_Tags1(rName, tagKey1, tagValue
 	return fmt.Sprintf(`
 resource "aws_route53recoveryreadiness_cell" "test" {
   cell_name = %[1]q
+
   tags = {
     %[2]q = %[3]q
   }
@@ -257,6 +285,7 @@ func testAccAwsRoute53RecoveryReadinessCellConfig_Tags2(rName, tagKey1, tagValue
 	return fmt.Sprintf(`
 resource "aws_route53recoveryreadiness_cell" "test" {
   cell_name = %[1]q
+
   tags = {
     %[2]q = %[3]q
     %[4]q = %[5]q

--- a/aws/resource_aws_route53recoveryreadiness_readiness_check.go
+++ b/aws/resource_aws_route53recoveryreadiness_readiness_check.go
@@ -21,6 +21,10 @@ func resourceAwsRoute53RecoveryReadinessReadinessCheck() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -147,7 +151,7 @@ func resourceAwsRoute53RecoveryReadinessReadinessCheckDelete(d *schema.ResourceD
 	gcinput := &route53recoveryreadiness.GetReadinessCheckInput{
 		ReadinessCheckName: aws.String(d.Id()),
 	}
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.GetReadinessCheck(gcinput)
 		if err != nil {
 			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {

--- a/aws/resource_aws_route53recoveryreadiness_readiness_check.go
+++ b/aws/resource_aws_route53recoveryreadiness_readiness_check.go
@@ -1,0 +1,168 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsRoute53RecoveryReadinessReadinessCheck() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53RecoveryReadinessReadinessCheckCreate,
+		Read:   resourceAwsRoute53RecoveryReadinessReadinessCheckRead,
+		Update: resourceAwsRoute53RecoveryReadinessReadinessCheckUpdate,
+		Delete: resourceAwsRoute53RecoveryReadinessReadinessCheckDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"readiness_check_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_set_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+		},
+
+		CustomizeDiff: SetTagsDiff,
+	}
+}
+
+func resourceAwsRoute53RecoveryReadinessReadinessCheckCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &route53recoveryreadiness.CreateReadinessCheckInput{
+		ReadinessCheckName: aws.String(d.Get("readiness_check_name").(string)),
+		ResourceSetName:    aws.String(d.Get("resource_set_name").(string)),
+	}
+
+	resp, err := conn.CreateReadinessCheck(input)
+	if err != nil {
+		return fmt.Errorf("error creating Route53 Recovery Readiness ReadinessCheck: %w", err)
+	}
+
+	d.SetId(aws.StringValue(resp.ReadinessCheckName))
+
+	if len(tags) > 0 {
+		arn := aws.StringValue(resp.ReadinessCheckArn)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error adding Route53 Recovery Readiness ReadinessCheck (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessReadinessCheckRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessReadinessCheckRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	input := &route53recoveryreadiness.GetReadinessCheckInput{
+		ReadinessCheckName: aws.String(d.Id()),
+	}
+	resp, err := conn.GetReadinessCheck(input)
+	if err != nil {
+		return fmt.Errorf("error describing Route53 Recovery Readiness ReadinessCheck: %s", err)
+	}
+	d.Set("arn", resp.ReadinessCheckArn)
+	d.Set("readiness_check_name", resp.ReadinessCheckName)
+	d.Set("resource_set_name", resp.ResourceSet)
+
+	tags, err := keyvaluetags.Route53recoveryreadinessListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Recovery Readiness ReadinessCheck (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53RecoveryReadinessReadinessCheckUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.UpdateReadinessCheckInput{
+		ReadinessCheckName: aws.String(d.Get("readiness_check_name").(string)),
+		ResourceSetName:    aws.String(d.Get("resource_set_name").(string)),
+	}
+
+	_, err := conn.UpdateReadinessCheck(input)
+	if err != nil {
+		return fmt.Errorf("error updating Route53 Recovery Readiness ReadinessCheck: %s", err)
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		arn := d.Get("arn").(string)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Recovery Readiness ReadinessCheck (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessReadinessCheckRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessReadinessCheckDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.DeleteReadinessCheckInput{
+		ReadinessCheckName: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteReadinessCheck(input)
+	if err != nil {
+		if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Route53 Recovery Readiness ReadinessCheck: %s", err)
+	}
+
+	gcinput := &route53recoveryreadiness.GetReadinessCheckInput{
+		ReadinessCheckName: aws.String(d.Id()),
+	}
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.GetReadinessCheck(gcinput)
+		if err != nil {
+			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("Route 53 Recovery Readiness ReadinessCheck (%s) still exists", d.Id()))
+	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.GetReadinessCheck(gcinput)
+	}
+	if err != nil {
+		return fmt.Errorf("error waiting for Route 53 Recovery Readiness ReadinessCheck (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_route53recoveryreadiness_readiness_check_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_readiness_check_test.go
@@ -1,0 +1,186 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rSetName := acctest.RandomWithPrefix("tf-acc-test-set")
+	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessReadinessCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessReadinessCheckConfig(rName, rSetName, cwArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessReadinessCheckExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`readiness-check/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "resource_set_name", rSetName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessReadinessCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags1(rName, cwArn, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessReadinessCheckExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags2(rName, cwArn, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessReadinessCheckExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags1(rName, cwArn, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessReadinessCheckExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessReadinessCheckDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53recoveryreadiness_readiness_check" {
+			continue
+		}
+
+		input := &route53recoveryreadiness.GetReadinessCheckInput{
+			ReadinessCheckName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetReadinessCheck(input)
+		if err == nil {
+			return fmt.Errorf("Route53RecoveryReadiness Readiness Check (%s) not deleted", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessReadinessCheckExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+		input := &route53recoveryreadiness.GetReadinessCheckInput{
+			ReadinessCheckName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetReadinessCheck(input)
+
+		return err
+	}
+}
+
+func testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_ResourceSet(rSetName, cwArn string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::CloudWatch::Alarm"
+
+  resources {
+    resource_arn = %[2]q
+  }
+}
+`, rSetName, cwArn)
+}
+
+func testAccAwsRoute53RecoveryReadinessReadinessCheckConfig(rName, rSetName, cwArn string) string {
+	return composeConfig(testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_ResourceSet(rSetName, cwArn), fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_readiness_check" "test" {
+  readiness_check_name = %q
+  resource_set_name    = aws_route53recoveryreadiness_resource_set.test.resource_set_name
+}
+`, rName))
+}
+
+func testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags1(rName, cwArn, tagKey1, tagValue1 string) string {
+	return composeConfig(testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_ResourceSet("resource-set-for-testing", cwArn), fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_readiness_check" "test" {
+  readiness_check_name = %[1]q
+  resource_set_name    = aws_route53recoveryreadiness_resource_set.test.resource_set_name
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags2(rName, cwArn, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return composeConfig(testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_ResourceSet("resource-set-for-testing", cwArn), fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_readiness_check" "test" {
+  readiness_check_name = %[1]q
+  resource_set_name    = aws_route53recoveryreadiness_resource_set.test.resource_set_name
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/aws/resource_aws_route53recoveryreadiness_readiness_check_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_readiness_check_test.go
@@ -25,6 +25,7 @@ func TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic(t *testing.T) {
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -48,6 +49,36 @@ func TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsRoute53RecoveryReadinessReadinessCheck_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rSetName := acctest.RandomWithPrefix("tf-acc-test-set")
+	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessReadinessCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessReadinessCheckConfig(rName, rSetName, cwArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessReadinessCheckExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53RecoveryReadinessReadinessCheck(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_readiness_check.test"
@@ -58,6 +89,7 @@ func TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags(t *testing.T) {
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -109,6 +141,7 @@ func TestAccAwsRoute53RecoveryReadinessReadinessCheck_timeout(t *testing.T) {
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -199,6 +232,7 @@ func testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags1(rName, cwArn, 
 resource "aws_route53recoveryreadiness_readiness_check" "test" {
   readiness_check_name = %[1]q
   resource_set_name    = aws_route53recoveryreadiness_resource_set.test.resource_set_name
+
   tags = {
     %[2]q = %[3]q
   }
@@ -211,6 +245,7 @@ func testAccAwsRoute53RecoveryReadinessReadinessCheckConfig_Tags2(rName, cwArn, 
 resource "aws_route53recoveryreadiness_readiness_check" "test" {
   readiness_check_name = %[1]q
   resource_set_name    = aws_route53recoveryreadiness_resource_set.test.resource_set_name
+
   tags = {
     %[2]q = %[3]q
     %[4]q = %[5]q

--- a/aws/resource_aws_route53recoveryreadiness_recovery_group.go
+++ b/aws/resource_aws_route53recoveryreadiness_recovery_group.go
@@ -21,6 +21,10 @@ func resourceAwsRoute53RecoveryReadinessRecoveryGroup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -150,7 +154,7 @@ func resourceAwsRoute53RecoveryReadinessRecoveryGroupDelete(d *schema.ResourceDa
 	gcinput := &route53recoveryreadiness.GetRecoveryGroupInput{
 		RecoveryGroupName: aws.String(d.Id()),
 	}
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.GetRecoveryGroup(gcinput)
 		if err != nil {
 			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {

--- a/aws/resource_aws_route53recoveryreadiness_recovery_group.go
+++ b/aws/resource_aws_route53recoveryreadiness_recovery_group.go
@@ -1,0 +1,171 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsRoute53RecoveryReadinessRecoveryGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53RecoveryReadinessRecoveryGroupCreate,
+		Read:   resourceAwsRoute53RecoveryReadinessRecoveryGroupRead,
+		Update: resourceAwsRoute53RecoveryReadinessRecoveryGroupUpdate,
+		Delete: resourceAwsRoute53RecoveryReadinessRecoveryGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"recovery_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cells": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+		},
+
+		CustomizeDiff: SetTagsDiff,
+	}
+}
+
+func resourceAwsRoute53RecoveryReadinessRecoveryGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &route53recoveryreadiness.CreateRecoveryGroupInput{
+		RecoveryGroupName: aws.String(d.Get("recovery_group_name").(string)),
+		Cells:             expandStringList(d.Get("cells").([]interface{})),
+	}
+
+	resp, err := conn.CreateRecoveryGroup(input)
+	if err != nil {
+		return fmt.Errorf("error creating Route53 Recovery Readiness RecoveryGroup: %w", err)
+	}
+
+	d.SetId(aws.StringValue(resp.RecoveryGroupName))
+
+	if len(tags) > 0 {
+		arn := aws.StringValue(resp.RecoveryGroupArn)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error adding Route53 Recovery Readiness RecoveryGroup (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessRecoveryGroupRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessRecoveryGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	input := &route53recoveryreadiness.GetRecoveryGroupInput{
+		RecoveryGroupName: aws.String(d.Id()),
+	}
+	resp, err := conn.GetRecoveryGroup(input)
+	if err != nil {
+		return fmt.Errorf("error describing Route53 Recovery Readiness RecoveryGroup: %s", err)
+	}
+	d.Set("arn", resp.RecoveryGroupArn)
+	d.Set("recovery_group_name", resp.RecoveryGroupName)
+	d.Set("cells", resp.Cells)
+
+	tags, err := keyvaluetags.Route53recoveryreadinessListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Recovery Readiness RecoveryGroup (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53RecoveryReadinessRecoveryGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.UpdateRecoveryGroupInput{
+		RecoveryGroupName: aws.String(d.Id()),
+		Cells:             expandStringList(d.Get("cells").([]interface{})),
+	}
+
+	_, err := conn.UpdateRecoveryGroup(input)
+	if err != nil {
+		return fmt.Errorf("error updating Route53 Recovery Readiness RecoveryGroup: %s", err)
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		arn := d.Get("arn").(string)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Recovery Readiness RecoveryGroup (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessRecoveryGroupRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessRecoveryGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.DeleteRecoveryGroupInput{
+		RecoveryGroupName: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteRecoveryGroup(input)
+	if err != nil {
+		if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Route53 Recovery Readiness RecoveryGroup: %s", err)
+	}
+
+	gcinput := &route53recoveryreadiness.GetRecoveryGroupInput{
+		RecoveryGroupName: aws.String(d.Id()),
+	}
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.GetRecoveryGroup(gcinput)
+		if err != nil {
+			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("Route 53 Recovery Readiness RecoveryGroup (%s) still exists", d.Id()))
+	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.GetRecoveryGroup(gcinput)
+	}
+	if err != nil {
+		return fmt.Errorf("error waiting for Route 53 Recovery Readiness RecoveryGroup (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_route53recoveryreadiness_recovery_group.go
+++ b/aws/resource_aws_route53recoveryreadiness_recovery_group.go
@@ -32,17 +32,17 @@ func resourceAwsRoute53RecoveryReadinessRecoveryGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"recovery_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"cells": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"recovery_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"tags":     tagsSchema(),
 			"tags_all": tagsSchemaComputed(),

--- a/aws/resource_aws_route53recoveryreadiness_recovery_group_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_recovery_group_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_recovery_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -34,6 +35,28 @@ func TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessRecoveryGroup_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_recovery_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53RecoveryReadinessRecoveryGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/resource_aws_route53recoveryreadiness_recovery_group_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_recovery_group_test.go
@@ -1,0 +1,194 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_recovery_group.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`recovery-group/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cells.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessRecoveryGroup_nestedCell(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameCell := acctest.RandomWithPrefix("tf-acc-test-cell")
+	resourceName := "aws_route53recoveryreadiness_recovery_group.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessRecoveryGroupAndCellConfig(rName, rNameCell),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`recovery-group/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cells.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessRecoveryGroup_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_recovery_group.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig_Tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig_Tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig_Tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53recoveryreadiness_recovery_group" {
+			continue
+		}
+
+		input := &route53recoveryreadiness.GetRecoveryGroupInput{
+			RecoveryGroupName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetRecoveryGroup(input)
+		if err == nil {
+			return fmt.Errorf("Route53RecoveryReadiness Recovery Group (%s) not deleted", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessRecoveryGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+		input := &route53recoveryreadiness.GetRecoveryGroupInput{
+			RecoveryGroupName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetRecoveryGroup(input)
+
+		return err
+	}
+}
+
+func testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_recovery_group" "test" {
+  recovery_group_name = %q
+}
+`, rName)
+}
+
+func testAccAwsRoute53RecoveryReadinessRecoveryGroupAndCellConfig(rName, rNameCell string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test" {
+  cell_name = %[2]q
+}
+
+resource "aws_route53recoveryreadiness_recovery_group" "test" {
+  recovery_group_name = %[1]q
+  cells               = [aws_route53recoveryreadiness_cell.test.arn]
+}
+`, rName, rNameCell)
+}
+
+func testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig_Tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_recovery_group" "test" {
+  recovery_group_name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAwsRoute53RecoveryReadinessRecoveryGroupConfig_Tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_recovery_group" "test" {
+  recovery_group_name = %[1]q
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_route53recoveryreadiness_resource_set.go
+++ b/aws/resource_aws_route53recoveryreadiness_resource_set.go
@@ -47,17 +47,6 @@ func resourceAwsRoute53RecoveryReadinessResourceSet() *schema.Resource {
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"resource_arn": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"readiness_scopes": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
 						"component_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -125,6 +114,17 @@ func resourceAwsRoute53RecoveryReadinessResourceSet() *schema.Resource {
 									},
 								},
 							},
+						},
+						"readiness_scopes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"resource_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},

--- a/aws/resource_aws_route53recoveryreadiness_resource_set.go
+++ b/aws/resource_aws_route53recoveryreadiness_resource_set.go
@@ -21,6 +21,10 @@ func resourceAwsRoute53RecoveryReadinessResourceSet() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -241,7 +245,7 @@ func resourceAwsRoute53RecoveryReadinessResourceSetDelete(d *schema.ResourceData
 	gcinput := &route53recoveryreadiness.GetResourceSetInput{
 		ResourceSetName: aws.String(d.Id()),
 	}
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.GetResourceSet(gcinput)
 		if err != nil {
 			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {

--- a/aws/resource_aws_route53recoveryreadiness_resource_set.go
+++ b/aws/resource_aws_route53recoveryreadiness_resource_set.go
@@ -1,0 +1,424 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsRoute53RecoveryReadinessResourceSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53RecoveryReadinessResourceSetCreate,
+		Read:   resourceAwsRoute53RecoveryReadinessResourceSetRead,
+		Update: resourceAwsRoute53RecoveryReadinessResourceSetUpdate,
+		Delete: resourceAwsRoute53RecoveryReadinessResourceSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_set_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_set_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"readiness_scopes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"component_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dns_target_resource": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"domain_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"hosted_zone_arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"record_set_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"record_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"target_resource": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"nlb_resource": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"arn": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"r53_resource": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"domain_name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"record_set_id": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+		},
+
+		CustomizeDiff: SetTagsDiff,
+	}
+}
+
+func resourceAwsRoute53RecoveryReadinessResourceSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &route53recoveryreadiness.CreateResourceSetInput{
+		ResourceSetName: aws.String(d.Get("resource_set_name").(string)),
+		ResourceSetType: aws.String(d.Get("resource_set_type").(string)),
+		Resources:       expandAwsRoute53RecoveryReadinessResourceSetResources(d.Get("resources").([]interface{})),
+	}
+
+	resp, err := conn.CreateResourceSet(input)
+	if err != nil {
+		return fmt.Errorf("error creating Route53 Recovery Readiness Resource Set: %w", err)
+	}
+
+	d.SetId(aws.StringValue(resp.ResourceSetName))
+
+	if len(tags) > 0 {
+		arn := aws.StringValue(resp.ResourceSetArn)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error adding Route53 Recovery Readiness Resource Set (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessResourceSetRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessResourceSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	input := &route53recoveryreadiness.GetResourceSetInput{
+		ResourceSetName: aws.String(d.Id()),
+	}
+	resp, err := conn.GetResourceSet(input)
+	if err != nil {
+		return fmt.Errorf("error describing Route53 Recovery Readiness ResourceSet: %s", err)
+	}
+	d.Set("arn", resp.ResourceSetArn)
+	d.Set("resource_set_name", resp.ResourceSetName)
+	d.Set("resource_set_type", resp.ResourceSetType)
+
+	if err := d.Set("resources", flattenAwsRoute53RecoveryReadinessResourceSetResources(resp.Resources)); err != nil {
+		return fmt.Errorf("Error setting AWS Route53 Recovery Readiness Resource Set resources: %s", err)
+	}
+
+	tags, err := keyvaluetags.Route53recoveryreadinessListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Recovery Readiness Resource Set (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53RecoveryReadinessResourceSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.UpdateResourceSetInput{
+		ResourceSetName: aws.String(d.Id()),
+		ResourceSetType: aws.String(d.Get("resource_set_type").(string)),
+		Resources:       expandAwsRoute53RecoveryReadinessResourceSetResources(d.Get("resources").([]interface{})),
+	}
+
+	_, err := conn.UpdateResourceSet(input)
+	if err != nil {
+		return fmt.Errorf("error updating Route53 Recovery Readiness Resource Set: %s", err)
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		arn := d.Get("arn").(string)
+		if err := keyvaluetags.Route53recoveryreadinessUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Recovery Readiness Resource Set (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsRoute53RecoveryReadinessResourceSetRead(d, meta)
+}
+
+func resourceAwsRoute53RecoveryReadinessResourceSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.DeleteResourceSetInput{
+		ResourceSetName: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteResourceSet(input)
+	if err != nil {
+		if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Route53 Recovery Readiness Resource Set: %s", err)
+	}
+
+	gcinput := &route53recoveryreadiness.GetResourceSetInput{
+		ResourceSetName: aws.String(d.Id()),
+	}
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.GetResourceSet(gcinput)
+		if err != nil {
+			if isAWSErr(err, route53recoveryreadiness.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("Route 53 Recovery Readiness Resource Set (%s) still exists", d.Id()))
+	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.GetResourceSet(gcinput)
+	}
+	if err != nil {
+		return fmt.Errorf("error waiting for Route 53 Recovery Readiness Resource Set (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandAwsRoute53RecoveryReadinessResourceSetResources(rs []interface{}) []*route53recoveryreadiness.Resource {
+	var resources []*route53recoveryreadiness.Resource
+
+	for _, r := range rs {
+		r := r.(map[string]interface{})
+		resource := &route53recoveryreadiness.Resource{}
+		if v, ok := r["resource_arn"]; ok && v.(string) != "" {
+			resource.ResourceArn = aws.String(v.(string))
+		}
+		if v, ok := r["readiness_scopes"]; ok {
+			resource.ReadinessScopes = expandStringList(v.([]interface{}))
+		}
+		if v, ok := r["component_id"]; ok {
+			resource.ComponentId = aws.String(v.(string))
+		}
+		if v, ok := r["dns_target_resource"]; ok {
+			resource.DnsTargetResource = expandAwsRoute53RecoveryReadinessResourceSetDnsTargetResource(v.([]interface{}))
+		}
+		resources = append(resources, resource)
+	}
+	return resources
+}
+
+func flattenAwsRoute53RecoveryReadinessResourceSetResources(resources []*route53recoveryreadiness.Resource) []map[string]interface{} {
+	rs := make([]map[string]interface{}, 0)
+	for _, resource := range resources {
+		r := map[string]interface{}{}
+		if v := resource.ResourceArn; v != nil {
+			r["resource_arn"] = v
+		}
+		if v := resource.ReadinessScopes; v != nil {
+			r["readiness_scopes"] = v
+		}
+		if v := resource.ComponentId; v != nil {
+			r["component_id"] = v
+		}
+		if v := resource.DnsTargetResource; v != nil {
+			r["dns_target_resource"] = flattenAwsRoute53RecoveryReadinessResourceSetDnsTargetResource(v)
+		}
+		rs = append(rs, r)
+	}
+	return rs
+}
+
+func expandAwsRoute53RecoveryReadinessResourceSetDnsTargetResource(dtrs []interface{}) *route53recoveryreadiness.DNSTargetResource {
+	dtresource := &route53recoveryreadiness.DNSTargetResource{}
+	for _, dtr := range dtrs {
+		dtr := dtr.(map[string]interface{})
+		if v, ok := dtr["domain_name"]; ok && v.(string) != "" {
+			dtresource.DomainName = aws.String(v.(string))
+		}
+		if v, ok := dtr["hosted_zone_arn"]; ok {
+			dtresource.HostedZoneArn = aws.String(v.(string))
+		}
+		if v, ok := dtr["record_set_id"]; ok {
+			dtresource.RecordSetId = aws.String(v.(string))
+		}
+		if v, ok := dtr["record_type"]; ok {
+			dtresource.RecordType = aws.String(v.(string))
+		}
+		if v, ok := dtr["target_resource"]; ok {
+			dtresource.TargetResource = expandAwsRoute53RecoveryReadinessResourceSetTargetResource(v.([]interface{}))
+		}
+	}
+	return dtresource
+}
+
+func flattenAwsRoute53RecoveryReadinessResourceSetDnsTargetResource(dtresource *route53recoveryreadiness.DNSTargetResource) []map[string]interface{} {
+	if dtresource == nil {
+		return nil
+	}
+
+	dtr := make(map[string]interface{})
+	dtr["domain_name"] = dtresource.DomainName
+	dtr["hosted_zone_arn"] = dtresource.HostedZoneArn
+	dtr["record_set_id"] = dtresource.RecordSetId
+	dtr["record_type"] = dtresource.RecordType
+	dtr["target_resource"] = flattenAwsRoute53RecoveryReadinessResourceSetTargetResource(dtresource.TargetResource)
+	result := []map[string]interface{}{dtr}
+	return result
+}
+
+func expandAwsRoute53RecoveryReadinessResourceSetTargetResource(trs []interface{}) *route53recoveryreadiness.TargetResource {
+	if len(trs) == 0 {
+		return nil
+	}
+	tresource := &route53recoveryreadiness.TargetResource{}
+	for _, tr := range trs {
+		if tr == nil {
+			return nil
+		}
+		tr := tr.(map[string]interface{})
+		if v, ok := tr["nlb_resource"]; ok && len(v.([]interface{})) > 0 {
+			tresource.NLBResource = expandAwsRoute53RecoveryReadinessResourceSetNLBResource(v.([]interface{}))
+		}
+		if v, ok := tr["r53_resource"]; ok && len(v.([]interface{})) > 0 {
+			tresource.R53Resource = expandAwsRoute53RecoveryReadinessResourceSetR53ResourceRecord(v.([]interface{}))
+		}
+	}
+	return tresource
+}
+
+func flattenAwsRoute53RecoveryReadinessResourceSetTargetResource(tresource *route53recoveryreadiness.TargetResource) []map[string]interface{} {
+	if tresource == nil {
+		return nil
+	}
+
+	tr := make(map[string]interface{})
+	tr["nlb_resource"] = flattenAwsRoute53RecoveryReadinessResourceSetNLBResource(tresource.NLBResource)
+	tr["r53_resource"] = flattenAwsRoute53RecoveryReadinessResourceSetR53ResourceRecord(tresource.R53Resource)
+	result := []map[string]interface{}{tr}
+	return result
+}
+
+func expandAwsRoute53RecoveryReadinessResourceSetNLBResource(nlbrs []interface{}) *route53recoveryreadiness.NLBResource {
+	nlbresource := &route53recoveryreadiness.NLBResource{}
+	for _, nlbr := range nlbrs {
+		nlbr := nlbr.(map[string]interface{})
+		if v, ok := nlbr["arn"]; ok && v.(string) != "" {
+			nlbresource.Arn = aws.String(v.(string))
+		}
+	}
+	return nlbresource
+}
+
+func flattenAwsRoute53RecoveryReadinessResourceSetNLBResource(nlbresource *route53recoveryreadiness.NLBResource) []map[string]interface{} {
+	if nlbresource == nil {
+		return nil
+	}
+
+	nlbr := make(map[string]interface{})
+	nlbr["arn"] = nlbresource.Arn
+	result := []map[string]interface{}{nlbr}
+	return result
+}
+
+func expandAwsRoute53RecoveryReadinessResourceSetR53ResourceRecord(r53rs []interface{}) *route53recoveryreadiness.R53ResourceRecord {
+	r53resource := &route53recoveryreadiness.R53ResourceRecord{}
+	for _, r53r := range r53rs {
+		r53r := r53r.(map[string]interface{})
+		if v, ok := r53r["domain_name"]; ok && v.(string) != "" {
+			r53resource.DomainName = aws.String(v.(string))
+		}
+		if v, ok := r53r["record_set_id"]; ok {
+			r53resource.RecordSetId = aws.String(v.(string))
+		}
+	}
+	return r53resource
+}
+
+func flattenAwsRoute53RecoveryReadinessResourceSetR53ResourceRecord(r53resource *route53recoveryreadiness.R53ResourceRecord) []map[string]interface{} {
+	if r53resource == nil {
+		return nil
+	}
+
+	r53r := make(map[string]interface{})
+	r53r["domain_name"] = r53resource.DomainName
+	r53r["record_set_id"] = r53resource.RecordSetId
+	result := []map[string]interface{}{r53r}
+	return result
+}

--- a/aws/resource_aws_route53recoveryreadiness_resource_set_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_resource_set_test.go
@@ -163,7 +163,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope(t *testing.T) 
 	})
 }
 
-func TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource(t *testing.T) {
+func TestAccAwsRoute53RecoveryReadinessResourceSet_basicDNSTargetResource(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	domainName := "myTestDomain.test"
@@ -206,7 +206,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource(t *tes
 	})
 }
 
-func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget(t *testing.T) {
+func TestAccAwsRoute53RecoveryReadinessResourceSet_dnsTargetResourceNLBTarget(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	hzArn := arn.ARN{
@@ -243,7 +243,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget(t 
 	})
 }
 
-func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target(t *testing.T) {
+func TestAccAwsRoute53RecoveryReadinessResourceSet_dnsTargetResourceR53Target(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
 	hzArn := arn.ARN{

--- a/aws/resource_aws_route53recoveryreadiness_resource_set_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_resource_set_test.go
@@ -24,6 +24,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_basic(t *testing.T) {
 		Service:   "cloudwatch",
 	}.String()
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -48,6 +49,35 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsRoute53RecoveryReadinessResourceSet_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetConfig(rName, cwArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53RecoveryReadinessResourceSet(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsRoute53RecoveryReadinessResourceSet_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
@@ -58,6 +88,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_tags(t *testing.T) {
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -108,6 +139,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope(t *testing.T) 
 		Resource:  "alarm:zzzzzzzzz",
 		Service:   "cloudwatch",
 	}.String()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -144,6 +176,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource(t *tes
 	}.String()
 	recordType := "A"
 	recordSetId := "12345"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -183,6 +216,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget(t 
 		Resource:  "hostedzone/zzzzzzzzz",
 		Service:   "route53",
 	}.String()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -221,6 +255,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target(t 
 	}.String()
 	domainName := "my.target.domain"
 	recordSetId := "987654321"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -258,6 +293,7 @@ func TestAccAwsRoute53RecoveryReadinessResourceSet_timeout(t *testing.T) {
 		Service:   "cloudwatch",
 	}.String()
 	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
 		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
@@ -418,9 +454,11 @@ func testAccAwsRoute53RecoveryReadinessResourceSetConfig_Tags2(rName, cwArn, tag
 resource "aws_route53recoveryreadiness_resource_set" "test" {
   resource_set_name = %[1]q
   resource_set_type = "AWS::CloudWatch::Alarm"
+
   resources {
     resource_arn = %[2]q
   }
+
   tags = {
     %[3]q = %[4]q
     %[5]q = %[6]q

--- a/aws/resource_aws_route53recoveryreadiness_resource_set_test.go
+++ b/aws/resource_aws_route53recoveryreadiness_resource_set_test.go
@@ -1,0 +1,481 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/route53recoveryreadiness"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAwsRoute53RecoveryReadinessResourceSet_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetConfig(rName, cwArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`resource-set.+`)),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessResourceSet_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetConfig_Tags1(rName, cwArn, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetConfig_Tags2(rName, cwArn, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetConfig_Tags1(rName, cwArn, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+	cwArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "alarm:zzzzzzzzz",
+		Service:   "cloudwatch",
+	}.String()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAwsRoute53RecoveryReadiness(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetConfig_ReadinessScopes(rName, cwArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`resource-set.+`)),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.readiness_scopes.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+	domainName := "myTestDomain.test"
+	hzArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "hostedzone/zzzzzzzzz",
+		Service:   "route53",
+	}.String()
+	recordType := "A"
+	recordSetId := "12345"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAwsRoute53RecoveryReadinessResourceSet(t)
+		},
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetBasicDnsTargetResourceConfig(rName, domainName, hzArn, recordType, recordSetId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`resource-set.+`)),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.dns_target_resource.0.domain_name", domainName),
+					resource.TestCheckResourceAttrSet(resourceName, "resources.0.dns_target_resource.0.hosted_zone_arn"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.dns_target_resource.0.record_type", recordType),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.dns_target_resource.0.record_set_id", recordSetId),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+	hzArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "hostedzone/zzzzzzzzz",
+		Service:   "route53",
+	}.String()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAwsRoute53RecoveryReadiness(t)
+		},
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetDnsTargetResourceNlbTargetConfig(rName, hzArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`resource-set.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "resources.0.dns_target_resource.0.target_resource.0.nlb_resource.0.arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53recoveryreadiness_resource_set.test"
+	hzArn := arn.ARN{
+		AccountID: "123456789012",
+		Partition: endpoints.AwsPartitionID,
+		Region:    endpoints.EuWest1RegionID,
+		Resource:  "hostedzone/zzzzzzzzz",
+		Service:   "route53",
+	}.String()
+	domainName := "my.target.domain"
+	recordSetId := "987654321"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAwsRoute53RecoveryReadiness(t)
+		},
+		ErrorCheck:        testAccErrorCheck(t, route53recoveryreadiness.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRoute53RecoveryReadinessResourceSetDnsTargetResourceR53TargetConfig(rName, hzArn, domainName, recordSetId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(resourceName),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "route53-recovery-readiness", regexp.MustCompile(`resource-set.+`)),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.dns_target_resource.0.target_resource.0.r53_resource.0.domain_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.dns_target_resource.0.target_resource.0.r53_resource.0.record_set_id", recordSetId),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessResourceSetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53recoveryreadiness_resource_set" {
+			continue
+		}
+
+		input := &route53recoveryreadiness.GetResourceSetInput{
+			ResourceSetName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetResourceSet(input)
+		if err == nil {
+			return fmt.Errorf("Route53RecoveryReadiness Resource Set (%s) not deleted", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsRoute53RecoveryReadinessResourceSetExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+		input := &route53recoveryreadiness.GetResourceSetInput{
+			ResourceSetName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetResourceSet(input)
+
+		return err
+	}
+}
+
+func testAccPreCheckAwsRoute53RecoveryReadinessResourceSet(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).route53recoveryreadinessconn
+
+	input := &route53recoveryreadiness.ListResourceSetsInput{}
+
+	_, err := conn.ListResourceSets(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetConfig_NLB(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_lb" "test" {
+  name = %[1]q
+
+  subnets = [
+    aws_subnet.test1.id,
+    aws_subnet.test2.id,
+  ]
+
+  load_balancer_type         = "network"
+  internal                   = true
+  idle_timeout               = 60
+  enable_deletion_protection = false
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+}
+
+data "aws_caller_identity" "current" {}
+`, rName)
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetConfig(rName, cwArn string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::CloudWatch::Alarm"
+
+  resources {
+    resource_arn = %[2]q
+  }
+}
+`, rName, cwArn)
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetConfig_Tags1(rName, cwArn, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::CloudWatch::Alarm"
+
+  resources {
+    resource_arn = %[2]q
+  }
+
+  tags = {
+    %[3]q = %[4]q
+  }
+}
+`, rName, cwArn, tagKey1, tagValue1)
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetConfig_Tags2(rName, cwArn, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::CloudWatch::Alarm"
+  resources {
+    resource_arn = %[2]q
+  }
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, rName, cwArn, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetConfig_ReadinessScopes(rName, cwArn string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_cell" "test" {
+  cell_name = "resource_set_test_cell"
+}
+
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::CloudWatch::Alarm"
+
+  resources {
+    resource_arn     = %[2]q
+    readiness_scopes = [aws_route53recoveryreadiness_cell.test.arn]
+  }
+}
+`, rName, cwArn)
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetBasicDnsTargetResourceConfig(rName, domainName, hzArn, recordType, recordSetId string) string {
+	return composeConfig(fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::Route53RecoveryReadiness::DNSTargetResource"
+
+  resources {
+    dns_target_resource {
+      domain_name     = %[2]q
+      hosted_zone_arn = %[3]q
+      record_type     = %[4]q
+      record_set_id   = %[5]q
+    }
+  }
+}
+`, rName, domainName, hzArn, recordType, recordSetId))
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetDnsTargetResourceNlbTargetConfig(rName, hzArn string) string {
+	return composeConfig(testAccAwsRoute53RecoveryReadinessResourceSetConfig_NLB(rName), fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::Route53RecoveryReadiness::DNSTargetResource"
+
+  resources {
+    dns_target_resource {
+      domain_name     = "myTestDomain.test"
+      hosted_zone_arn = %[2]q
+      record_type     = "A"
+      record_set_id   = "12345"
+
+      target_resource {
+        nlb_resource {
+          arn = aws_lb.test.arn
+        }
+      }
+    }
+  }
+}
+`, rName, hzArn))
+}
+
+func testAccAwsRoute53RecoveryReadinessResourceSetDnsTargetResourceR53TargetConfig(rName, hzArn, domainName, recordSetId string) string {
+	return fmt.Sprintf(`
+resource "aws_route53recoveryreadiness_resource_set" "test" {
+  resource_set_name = %[1]q
+  resource_set_type = "AWS::Route53RecoveryReadiness::DNSTargetResource"
+
+  resources {
+    dns_target_resource {
+      domain_name     = "myTestDomain.test"
+      hosted_zone_arn = %[2]q
+      record_type     = "A"
+      record_set_id   = "12345"
+
+      target_resource {
+        r53_resource {
+          domain_name   = %[3]q
+          record_set_id = %[4]q
+        }
+      }
+    }
+  }
+}
+`, rName, hzArn, domainName, recordSetId)
+}

--- a/website/docs/r/route53recoveryreadiness_cell.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_cell.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Route53 Recovery Readiness"
+layout: "aws"
+page_title: "AWS: aws_route53recoveryreadiness_cell"
+description: |-
+  Provides an AWS Route 53 Recovery Readiness Cell
+---
+
+# Resource: aws_route53recoveryreadiness_cell
+
+Provides an AWS Route 53 Recovery Readiness Cell
+
+## Example Usage
+
+```terraform
+resource "aws_route53recoveryreadiness_cell" "us-west-2-failover-cell" {
+  cell_name  = "us-west-2-failover-cell"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cell_name` - (Required) A unique name describing the cell
+* `cells` - (Optional) A list of cell arns to add as nested fault domains within this cell
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the cell
+* `parent_readiness_scopes` - A list of readiness scopes (recovery groups or cells) that contain this cell
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Route53 Recovery Readiness cells can be imported via the cell name, e.g.
+
+```
+$ terraform import aws_route53recoveryreadiness_cell.us-west-2-failover-cell us-west-2-failover-cell
+```

--- a/website/docs/r/route53recoveryreadiness_cell.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_cell.html.markdown
@@ -8,31 +8,34 @@ description: |-
 
 # Resource: aws_route53recoveryreadiness_cell
 
-Provides an AWS Route 53 Recovery Readiness Cell
+Provides an AWS Route 53 Recovery Readiness Cell.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53recoveryreadiness_cell" "us-west-2-failover-cell" {
+resource "aws_route53recoveryreadiness_cell" "example" {
   cell_name = "us-west-2-failover-cell"
 }
 ```
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `cell_name` - (Required) A unique name describing the cell
-* `cells` - (Optional) A list of cell arns to add as nested fault domains within this cell
+* `cell_name` - (Required) Unique name describing the cell.
+
+The following arguments are optional:
+
+* `cells` - (Optional) List of cell arns to add as nested fault domains within this cell.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the cell
-* `parent_readiness_scopes` - A list of readiness scopes (recovery groups or cells) that contain this cell
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of the cell
+* `parent_readiness_scopes` - List of readiness scopes (recovery groups or cells) that contain this cell.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/route53recoveryreadiness_cell.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_cell.html.markdown
@@ -41,3 +41,10 @@ Route53 Recovery Readiness cells can be imported via the cell name, e.g.
 ```
 $ terraform import aws_route53recoveryreadiness_cell.us-west-2-failover-cell us-west-2-failover-cell
 ```
+
+## Timeouts
+
+`aws_route53recoveryreadiness_cell` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
+configuration options:
+
+- `delete` - (Default `5m`) Used when deleting the Cell

--- a/website/docs/r/route53recoveryreadiness_cell.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_cell.html.markdown
@@ -14,7 +14,7 @@ Provides an AWS Route 53 Recovery Readiness Cell
 
 ```terraform
 resource "aws_route53recoveryreadiness_cell" "us-west-2-failover-cell" {
-  cell_name  = "us-west-2-failover-cell"
+  cell_name = "us-west-2-failover-cell"
 }
 ```
 

--- a/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
@@ -15,7 +15,7 @@ Provides an AWS Route 53 Recovery Readiness Readiness Check
 ```terraform
 resource "aws_route53recoveryreadiness_readiness_check" "my-cw-alarm-check" {
   readiness_check_name = my-cw-alarm-check
-  resource_set_name = my-cw-alarm-set
+  resource_set_name    = my-cw-alarm-set
 }
 ```
 

--- a/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Route53 Recovery Readiness"
+layout: "aws"
+page_title: "AWS: aws_route53recoveryreadiness_readiness_check"
+description: |-
+  Provides an AWS Route 53 Recovery Readiness Readiness Check
+---
+
+# Resource: aws_route53recoveryreadiness_readiness_check
+
+Provides an AWS Route 53 Recovery Readiness Readiness Check
+
+## Example Usage
+
+```terraform
+resource "aws_route53recoveryreadiness_readiness_check" "my-cw-alarm-check" {
+  readiness_check_name = my-cw-alarm-check
+  resource_set_name = my-cw-alarm-set
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `readiness_check_name` - (Required) A unique name describing the readiness check
+* `resource_set_name` - (Required) A name describing the resource set that will be monitored for readiness
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the readiness_check
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Route53 Recovery Readiness readiness checks can be imported via the readiness check name, e.g.
+
+```
+$ terraform import aws_route53recoveryreadiness_readiness_check.my-cw-alarm-check
+```

--- a/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
@@ -41,3 +41,10 @@ Route53 Recovery Readiness readiness checks can be imported via the readiness ch
 ```
 $ terraform import aws_route53recoveryreadiness_readiness_check.my-cw-alarm-check
 ```
+
+## Timeouts
+
+`aws_route53recoveryreadiness_readiness_check` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
+configuration options:
+
+- `delete` - (Default `5m`) Used when deleting the Readiness Check

--- a/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_readiness_check.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # Resource: aws_route53recoveryreadiness_readiness_check
 
-Provides an AWS Route 53 Recovery Readiness Readiness Check
+Provides an AWS Route 53 Recovery Readiness Readiness Check.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53recoveryreadiness_readiness_check" "my-cw-alarm-check" {
+resource "aws_route53recoveryreadiness_readiness_check" "example" {
   readiness_check_name = my-cw-alarm-check
   resource_set_name    = my-cw-alarm-set
 }
@@ -21,18 +21,21 @@ resource "aws_route53recoveryreadiness_readiness_check" "my-cw-alarm-check" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `readiness_check_name` - (Required) A unique name describing the readiness check
-* `resource_set_name` - (Required) A name describing the resource set that will be monitored for readiness
+* `readiness_check_name` - (Required) Unique name describing the readiness check.
+* `resource_set_name` - (Required) Name describing the resource set that will be monitored for readiness.
+
+The following arguments are optional:
+
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the readiness_check
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of the readiness_check
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
@@ -40,3 +40,9 @@ Route53 Recovery Readiness recovery groups can be imported via the recovery grou
 ```
 $ terraform import aws_route53recoveryreadiness_recovery_group.my-high-availability-app my-high-availability-app
 ```
+## Timeouts
+
+`aws_route53recoveryreadiness_recovery_group` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
+configuration options:
+
+- `delete` - (Default `5m`) Used when deleting the Recovery Group

--- a/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Route53 Recovery Readiness"
+layout: "aws"
+page_title: "AWS: aws_route53recoveryreadiness_recovery_group"
+description: |-
+  Provides an AWS Route 53 Recovery Readiness Recovery Group
+---
+
+# Resource: aws_route53recoveryreadiness_recovery_group
+
+Provides an AWS Route 53 Recovery Readiness Recovery Group
+
+## Example Usage
+
+```terraform
+resource "aws_route53recoveryreadiness_recovery_group" "my-high-availability-app" {
+  recovery_group_name  = "my-high-availability-app"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `recovery_group_name` - (Required) A unique name describing the recovery group
+* `cells` - (Optional) A list of cell arns to add as nested fault domains within this recovery group
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the recovery group
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Route53 Recovery Readiness recovery groups can be imported via the recovery group name, e.g.
+
+```
+$ terraform import aws_route53recoveryreadiness_recovery_group.my-high-availability-app my-high-availability-app
+```

--- a/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
@@ -40,6 +40,7 @@ Route53 Recovery Readiness recovery groups can be imported via the recovery grou
 ```
 $ terraform import aws_route53recoveryreadiness_recovery_group.my-high-availability-app my-high-availability-app
 ```
+
 ## Timeouts
 
 `aws_route53recoveryreadiness_recovery_group` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)

--- a/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
@@ -14,7 +14,7 @@ Provides an AWS Route 53 Recovery Readiness Recovery Group
 
 ```terraform
 resource "aws_route53recoveryreadiness_recovery_group" "my-high-availability-app" {
-  recovery_group_name  = "my-high-availability-app"
+  recovery_group_name = "my-high-availability-app"
 }
 ```
 

--- a/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_recovery_group.html.markdown
@@ -8,30 +8,33 @@ description: |-
 
 # Resource: aws_route53recoveryreadiness_recovery_group
 
-Provides an AWS Route 53 Recovery Readiness Recovery Group
+Provides an AWS Route 53 Recovery Readiness Recovery Group.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53recoveryreadiness_recovery_group" "my-high-availability-app" {
+resource "aws_route53recoveryreadiness_recovery_group" "example" {
   recovery_group_name = "my-high-availability-app"
 }
 ```
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `recovery_group_name` - (Required) A unique name describing the recovery group
-* `cells` - (Optional) A list of cell arns to add as nested fault domains within this recovery group
+* `recovery_group_name` - (Required) A unique name describing the recovery group.
+
+The following argument are optional:
+
+* `cells` - (Optional) List of cell arns to add as nested fault domains within this recovery group
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the recovery group
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of the recovery group
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
@@ -75,3 +75,10 @@ Route53 Recovery Readiness resource set name can be imported via the resource se
 ```
 $ terraform import aws_route53recoveryreadiness_resource_set.my-cw-alarm-set
 ```
+
+## Timeouts
+
+`aws_route53recoveryreadiness_resource_set` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
+configuration options:
+
+- `delete` - (Default `5m`) Used when deleting the Resource Set

--- a/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
@@ -8,17 +8,17 @@ description: |-
 
 # Resource: aws_route53recoveryreadiness_resource_set
 
-Provides an AWS Route 53 Recovery Readiness Resource Set
+Provides an AWS Route 53 Recovery Readiness Resource Set.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53recoveryreadiness_resource_set" "my-cw-alarm-set" {
+resource "aws_route53recoveryreadiness_resource_set" "example" {
   resource_set_name = my-cw-alarm-set
   resource_set_type = "AWS::CloudWatch::Alarm"
 
   resources {
-    resource_arn = aws_cloudwatch_metric_alarm.test.arn
+    resource_arn = aws_cloudwatch_metric_alarm.example.arn
   }
 }
 ```
@@ -27,46 +27,49 @@ resource "aws_route53recoveryreadiness_resource_set" "my-cw-alarm-set" {
 
 The following arguments are supported:
 
-* `resource_set_name` - (Required) A unique name describing the resource set
-* `resource_set_type` - (Required) AWS Resource type of the resources in the ResourceSet
-* `resources` - (Required) A list of resources to add to this resource set. Documented below.
+* `resource_set_name` - (Required) Unique name describing the resource set.
+* `resource_set_type` - (Required) Type of the resources in the resource set.
+* `resources` - (Required) List of resources to add to this resource set. See below.
+
+The following arguments are optional:
+
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-## resources
+### resources
 
-* `readiness_scopes` - (Optional) A RecoveryGroup ARN or Cell ARN that this resourceis contained within.
-* `resource_arn` - (Optional) The ARN of the AWS resource, required unless dns_target_resource is specified.
-* `dns_target_resource` - (Optional) A component for DNS/Routing Control Readiness Checks. Required unless resource_arn is specified.
+* `dns_target_resource` - (Required if `resource_arn` is not set) Component for DNS/Routing Control Readiness Checks.
+* `readiness_scopes` - (Optional) Recovery group ARN or cell ARN that contains this resource set.
+* `resource_arn` - (Required if `dns_target_resource` is not set) ARN of the resource.
 
-## dns_target_resource
+### dns_target_resource
 
-* `domain_name` - (Optional) The DNS Name that acts as the ingress point to a portion of application.
-* `hosted_zone_arn` - (Optional) The Hosted Zone ARN that contains the DNS record with the provided name of target resource.
-* `record_set_id` - (Optional) The R53 Set Id to uniquely identify a record given a domain_name and a record type.
-* `record_type` - (Optional) The Type of DNS Record of target resource.
-* `target_resource` - (Optional) The target resource the R53 record specified with the above params points to.
+* `domain_name` - (Optional) DNS Name that acts as the ingress point to a portion of application.
+* `hosted_zone_arn` - (Optional) Hosted Zone ARN that contains the DNS record with the provided name of target resource.
+* `record_set_id` - (Optional) Route53 record set id to uniquely identify a record given a `domain_name` and a `record_type`.
+* `record_type` - (Optional) Type of DNS Record of target resource.
+* `target_resource` - (Optional) Target resource the R53 record specified with the above params points to.
 
-## target_resource
+### target_resource
 
-* `nlb_resource` - (Optional) The NLB resource a DNS Target Resource points to. Required if r53_resource is not set.
-* `r53_resource` - (Optional) The Route 53 resource a DNS Target Resource record points to.
+* `nlb_resource` - (Optional) NLB resource a DNS Target Resource points to. Required if `r53_resource` is not set.
+* `r53_resource` - (Optional) Route53 resource a DNS Target Resource record points to.
 
-## nlb_resource
+### nlb_resource
 
-* `arn` - (Required) An NLB resource arn
+* `arn` - (Required) NLB resource ARN.
 
-## r53_resource
+### r53_resource
 
-* `domain_name` - (Optional) The domain name that is targeted.
-* `record_set_id` - (Optional) The Resource Record set id that is targeted.
+* `domain_name` - (Optional) Domain name that is targeted.
+* `record_set_id` - (Optional) Resource record set ID that is targeted.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the resource set
-* `resources.#.component_id` - A unique identified for DNS Target Resources, use for readiness checks.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of the resource set
+* `resources.#.component_id` - Unique identified for DNS Target Resources, use for readiness checks.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Route53 Recovery Readiness"
+layout: "aws"
+page_title: "AWS: aws_route53recoveryreadiness_resource_set"
+description: |-
+  Provides an AWS Route 53 Recovery Readiness Resource Set
+---
+
+# Resource: aws_route_53recoveryreadiness_resource_set
+
+Provides an AWS Route 53 Recovery Readiness Resource Set
+
+## Example Usage
+
+```terraform
+resource "aws_route53recoveryreadiness_resource_set" "my-cw-alarm-set" {
+  resource_set_name = my-cw-alarm-set
+  resource_set_type = "AWS::CloudWatch::Alarm"
+  
+  resources {
+	  resource_arn = aws_cloudwatch_metric_alarm.test.arn
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_set_name` - (Required) A unique name describing the resource set
+* `resource_set_type` - (Required) AWS Resource type of the resources in the ResourceSet
+* `resources` - (Required) A list of resources to add to this resource set. Documented below.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## resources
+
+* `readiness_scopes` - (Optional) A RecoveryGroup ARN or Cell ARN that this resourceis contained within.
+* `resource_arn` - (Optional) The ARN of the AWS resource, required unless dns_target_resource is specified.
+* `dns_target_resource` - (Optional) A component for DNS/Routing Control Readiness Checks. Required unless resource_arn is specified.
+
+## dns_target_resource
+
+* `domain_name` - (Optional) The DNS Name that acts as the ingress point to a portion of application.
+* `hosted_zone_arn` - (Optional) The Hosted Zone ARN that contains the DNS record with the provided name of target resource.
+* `record_set_id` - (Optional) The R53 Set Id to uniquely identify a record given a domain_name and a record type.
+* `record_type` - (Optional) The Type of DNS Record of target resource.
+* `target_resource` - (Optional) The target resource the R53 record specified with the above params points to.
+
+## target_resource
+
+* `nlb_resource` - (Optional) The NLB resource a DNS Target Resource points to. Required if r53_resource is not set.
+* `r53_resource` - (Optional) The Route 53 resource a DNS Target Resource record points to.
+
+## nlb_resource
+
+* `arn` - (Required) An NLB resource arn
+
+## r53_resource
+
+* `domain_name` - (Optional) The domain name that is targeted.
+* `record_set_id` - (Optional) The Resource Record set id that is targeted.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the resource set
+* `resources.#.component_id` - A unique identified for DNS Target Resources, use for readiness checks.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Route53 Recovery Readiness resource set name can be imported via the resource set name, e.g.
+
+```
+$ terraform import aws_route53recoveryreadiness_resource_set.my-cw-alarm-set
+```

--- a/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
@@ -16,9 +16,9 @@ Provides an AWS Route 53 Recovery Readiness Resource Set
 resource "aws_route53recoveryreadiness_resource_set" "my-cw-alarm-set" {
   resource_set_name = my-cw-alarm-set
   resource_set_type = "AWS::CloudWatch::Alarm"
-  
+
   resources {
-	  resource_arn = aws_cloudwatch_metric_alarm.test.arn
+    resource_arn = aws_cloudwatch_metric_alarm.test.arn
   }
 }
 ```

--- a/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
+++ b/website/docs/r/route53recoveryreadiness_resource_set.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides an AWS Route 53 Recovery Readiness Resource Set
 ---
 
-# Resource: aws_route_53recoveryreadiness_resource_set
+# Resource: aws_route53recoveryreadiness_resource_set
 
 Provides an AWS Route 53 Recovery Readiness Resource Set
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20525
Closes #20384

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsRoute53RecoveryReadiness'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRoute53RecoveryReadiness -timeout 180m
=== RUN   TestAccAwsRoute53RecoveryReadinessCell_basic
=== PAUSE TestAccAwsRoute53RecoveryReadinessCell_basic
=== RUN   TestAccAwsRoute53RecoveryReadinessCell_nestedCell
=== PAUSE TestAccAwsRoute53RecoveryReadinessCell_nestedCell
=== RUN   TestAccAwsRoute53RecoveryReadinessCell_tags
=== PAUSE TestAccAwsRoute53RecoveryReadinessCell_tags
=== RUN   TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic
=== PAUSE TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic
=== RUN   TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags
=== PAUSE TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags
=== RUN   TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic
=== PAUSE TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic
=== RUN   TestAccAwsRoute53RecoveryReadinessRecoveryGroup_nestedCell
=== PAUSE TestAccAwsRoute53RecoveryReadinessRecoveryGroup_nestedCell
=== RUN   TestAccAwsRoute53RecoveryReadinessRecoveryGroup_tags
=== PAUSE TestAccAwsRoute53RecoveryReadinessRecoveryGroup_tags
=== RUN   TestAccAwsRoute53RecoveryReadinessResourceSet_basic
=== PAUSE TestAccAwsRoute53RecoveryReadinessResourceSet_basic
=== RUN   TestAccAwsRoute53RecoveryReadinessResourceSet_tags
=== PAUSE TestAccAwsRoute53RecoveryReadinessResourceSet_tags
=== RUN   TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope
=== PAUSE TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope
=== RUN   TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource
=== PAUSE TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource
=== RUN   TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget
=== PAUSE TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget
=== RUN   TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target
=== PAUSE TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target
=== CONT  TestAccAwsRoute53RecoveryReadinessCell_basic
=== CONT  TestAccAwsRoute53RecoveryReadinessResourceSet_basic
=== CONT  TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget
=== CONT  TestAccAwsRoute53RecoveryReadinessResourceSet_tags
=== CONT  TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags
=== CONT  TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic
=== CONT  TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope
=== CONT  TestAccAwsRoute53RecoveryReadinessRecoveryGroup_nestedCell
=== CONT  TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource
=== CONT  TestAccAwsRoute53RecoveryReadinessRecoveryGroup_tags
=== CONT  TestAccAwsRoute53RecoveryReadinessCell_tags
=== CONT  TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic
=== CONT  TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target
=== CONT  TestAccAwsRoute53RecoveryReadinessCell_nestedCell
--- PASS: TestAccAwsRoute53RecoveryReadinessReadinessCheck_basic (46.48s)
--- PASS: TestAccAwsRoute53RecoveryReadinessResourceSet_basic (48.71s)
--- PASS: TestAccAwsRoute53RecoveryReadinessCell_basic (48.71s)
--- PASS: TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceR53Target (49.04s)
--- PASS: TestAccAwsRoute53RecoveryReadinessRecoveryGroup_basic (49.09s)
--- PASS: TestAccAwsRoute53RecoveryReadinessRecoveryGroup_nestedCell (49.85s)
--- PASS: TestAccAwsRoute53RecoveryReadinessResourceSet_basicDnsTargetResource (50.32s)
--- PASS: TestAccAwsRoute53RecoveryReadinessResourceSet_readinessScope (51.05s)
--- PASS: TestAccAwsRoute53RecoveryReadinessCell_nestedCell (83.83s)
--- PASS: TestAccAwsRoute53RecoveryReadinessCell_tags (83.91s)
--- PASS: TestAccAwsRoute53RecoveryReadinessRecoveryGroup_tags (83.97s)
--- PASS: TestAccAwsRoute53RecoveryReadinessResourceSet_tags (83.99s)
--- PASS: TestAccAwsRoute53RecoveryReadinessReadinessCheck_tags (85.00s)
--- PASS: TestAccAwsRoute53RecoveryReadinessResourceSet_DnsTargetResourceNlbTarget (246.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	249.321s
...
```
