### PR TITLE
D add rabbitmq lambda event source doc

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -1244,6 +1244,7 @@ func testAccAWSLambdaEventSourceMappingConfigActiveMQBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1260,6 +1261,7 @@ EOF
 
 resource "aws_iam_role_policy" "test" {
   role = aws_iam_role.test.name
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1345,6 +1347,7 @@ func testAccAWSLambdaEventSourceMappingConfigRabbitMQBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1361,6 +1364,7 @@ EOF
 
 resource "aws_iam_role_policy" "test" {
   role = aws_iam_role.test.name
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1765,7 +1769,7 @@ resource "aws_lambda_event_source_mapping" "test" {
 
   source_access_configuration {
     type = "VIRTUAL_HOST" 
-    uri = "/vhost"
+    uri  = "/vhost"
   }
 
   source_access_configuration {

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -832,6 +832,44 @@ func TestAccAWSLambdaEventSourceMapping_ActiveMQ(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaEventSourceMapping_RabbitMQ(t *testing.T) {
+	var v lambda.EventSourceMappingConfiguration
+	resourceName := "aws_lambda_event_source_mapping.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSecretsManager(t)
+			testAccPartitionHasServicePreCheck("mq", t)
+			testAccPreCheckAWSMq(t)
+		},
+		ErrorCheck:   testAccErrorCheck(t, lambda.EndpointsID, "mq", "secretsmanager"),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfigRabbitMQ(rName, "100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "queues.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "queues.*", "test"),
+					resource.TestCheckResourceAttr(resourceName, "source_access_configuration.#", "2"),
+				),
+			},
+			// batch_size became optional.  Ensure that if the user supplies the default
+			// value, but then moves to not providing the value, that we don't consider this
+			// a diff.
+			{
+				PlanOnly: true,
+				Config:   testAccAWSLambdaEventSourceMappingConfigRabbitMQ(rName, "null"),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLambdaEventSourceMappingIsBeingDisabled(conf *lambda.EventSourceMappingConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
@@ -1202,11 +1240,10 @@ resource "aws_lambda_function" "test" {
 `, rName))
 }
 
-func testAccAWSLambdaEventSourceMappingConfigMQBase(rName string) string {
+func testAccAWSLambdaEventSourceMappingConfigActiveMQBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
-
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1223,7 +1260,6 @@ EOF
 
 resource "aws_iam_role_policy" "test" {
   role = aws_iam_role.test.name
-
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1281,6 +1317,90 @@ resource "aws_mq_broker" "test" {
   security_groups         = [aws_security_group.test.id]
   authentication_strategy = "simple"
   storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+
+  publicly_accessible = true
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = jsonencode({ username = "Test", password = "TestTest1234" })
+}
+`, rName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfigRabbitMQBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "lambda.amazonaws.com"
+    },
+    "Effect": "Allow"
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.name
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "mq:DescribeBroker",
+        "secretsmanager:GetSecretValue",
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeVpcs",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  role          = aws_iam_role.test.arn
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_mq_broker" "test" {
+  broker_name             = %[1]q
+  engine_type             = "RabbitMQ"
+  engine_version          = "3.8.11"
+  host_instance_type      = "mq.t3.micro"
+  authentication_strategy = "simple"
 
   logs {
     general = true
@@ -1614,7 +1734,7 @@ func testAccAWSLambdaEventSourceMappingConfigActiveMQ(rName, batchSize string) s
 		batchSize = "null"
 	}
 
-	return composeConfig(testAccAWSLambdaEventSourceMappingConfigMQBase(rName), fmt.Sprintf(`
+	return composeConfig(testAccAWSLambdaEventSourceMappingConfigActiveMQBase(rName), fmt.Sprintf(`
 resource "aws_lambda_event_source_mapping" "test" {
   batch_size       = %[1]s
   event_source_arn = aws_mq_broker.test.arn
@@ -1627,5 +1747,31 @@ resource "aws_lambda_event_source_mapping" "test" {
     uri  = aws_secretsmanager_secret_version.test.arn
   }
 }
+`, batchSize))
+}
+
+func testAccAWSLambdaEventSourceMappingConfigRabbitMQ(rName, batchSize string) string {
+	if batchSize == "" {
+		batchSize = "null"
+	}
+
+	return composeConfig(testAccAWSLambdaEventSourceMappingConfigRabbitMQBase(rName), fmt.Sprintf(`
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size       = %[1]s
+  event_source_arn = aws_mq_broker.test.arn
+  enabled          = true
+  function_name    = aws_lambda_function.test.arn
+  queues           = ["test"]
+
+  source_access_configuration {
+    type = "VIRTUAL_HOST" 
+    uri = "/vhost"
+  }
+
+  source_access_configuration {
+    type = "BASIC_AUTH"
+    uri  = aws_secretsmanager_secret_version.test.arn
+  }
+}   
 `, batchSize))
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -1768,7 +1768,7 @@ resource "aws_lambda_event_source_mapping" "test" {
   queues           = ["test"]
 
   source_access_configuration {
-    type = "VIRTUAL_HOST" 
+    type = "VIRTUAL_HOST"
     uri  = "/vhost"
   }
 

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -1776,6 +1776,6 @@ resource "aws_lambda_event_source_mapping" "test" {
     type = "BASIC_AUTH"
     uri  = aws_secretsmanager_secret_version.test.arn
   }
-} 
+}
 `, batchSize))
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -1776,6 +1776,6 @@ resource "aws_lambda_event_source_mapping" "test" {
     type = "BASIC_AUTH"
     uri  = aws_secretsmanager_secret_version.test.arn
   }
-}   
+} 
 `, batchSize))
 }

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -114,7 +114,7 @@ resource "aws_lambda_event_source_mapping" "example" {
   queues           = ["example"]
 
   source_access_configuration {
-    type = "VIRTUAL_HOST" 
+    type = "VIRTUAL_HOST"
     uri  = "/example"
   }
 

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -87,6 +87,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 ```
 
 ### Amazon MQ (ActiveMQ)
+
 ```terraform
 resource "aws_lambda_event_source_mapping" "example" {
   batch_size       = 10
@@ -103,6 +104,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 ```
 
 ### Amazon MQ (RabbitMQ)
+
 ```terraform
 resource "aws_lambda_event_source_mapping" "example" {
   batch_size       = 1
@@ -113,7 +115,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 
   source_access_configuration {
     type = "VIRTUAL_HOST" 
-    uri = "/example"
+    uri  = "/example"
   }
 
   source_access_configuration {

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Lambda"
 layout: "aws"
 page_title: "AWS: aws_lambda_event_source_mapping"
 description: |-
-  Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB, SQS and Managed Streaming for Apache Kafka (MSK).
+  Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB, SQS, Amazon MQ and Managed Streaming for Apache Kafka (MSK).
 ---
 
 # Resource: aws_lambda_event_source_mapping
 
-Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB, SQS and Managed Streaming for Apache Kafka (MSK).
+Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB, SQS, Amazon MQ and Managed Streaming for Apache Kafka (MSK).
 
 For information about Lambda and how to use it, see [What is AWS Lambda?][1].
 For information about event source mappings, see [CreateEventSourceMapping][2] in the API docs.

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -86,6 +86,43 @@ resource "aws_lambda_event_source_mapping" "example" {
 }
 ```
 
+### Amazon MQ (ActiveMQ)
+```terraform
+resource "aws_lambda_event_source_mapping" "example" {
+  batch_size       = 10
+  event_source_arn = aws_mq_broker.example.arn
+  enabled          = true
+  function_name    = aws_lambda_function.example.arn
+  queues           = ["example"]
+
+  source_access_configuration {
+    type = "BASIC_AUTH"
+    uri  = aws_secretsmanager_secret_version.example.arn
+  }
+}
+```
+
+### Amazon MQ (RabbitMQ)
+```terraform
+resource "aws_lambda_event_source_mapping" "example" {
+  batch_size       = 1
+  event_source_arn = aws_mq_broker.example.arn
+  enabled          = true
+  function_name    = aws_lambda_function.example.arn
+  queues           = ["example"]
+
+  source_access_configuration {
+    type = "VIRTUAL_HOST" 
+    uri = "/example"
+  }
+
+  source_access_configuration {
+    type = "BASIC_AUTH"
+    uri  = aws_secretsmanager_secret_version.example.arn
+  }
+}
+```
+
 ## Argument Reference
 
 * `batch_size` - (Optional) The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to `100` for DynamoDB, Kinesis, MQ and MSK, `10` for SQS.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #20511 

I've already closed 20511 as I found the solution to the issue I was facing. This PR is simply to update the associated documentation to show how to solve what I was looking for along with an additional test to prove that the solution works. The context is adding an Amazon MQ (RabbitMQ) queue as an event source for a lambda function.  A relatively new capability:

* [Announcement](https://aws.amazon.com/about-aws/whats-new/2021/07/aws-lambda-now-supports-amazon-mq-for-rabbitmq-as-an-event-source/)
* [Developer Guide](https://docs.aws.amazon.com/lambda/latest/dg/with-mq.html)

Output from acceptance testing:
```
$ make testacc TESTARGS="-run='^TestAccAWSLambdaEventSourceMapping_(Active|Rabbit)MQ'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run='^TestAccAWSLambdaEventSourceMapping_(Active|Rabbit)MQ' -timeout 180m
=== RUN   TestAccAWSLambdaEventSourceMapping_ActiveMQ
=== PAUSE TestAccAWSLambdaEventSourceMapping_ActiveMQ
=== RUN   TestAccAWSLambdaEventSourceMapping_RabbitMQ
=== PAUSE TestAccAWSLambdaEventSourceMapping_RabbitMQ
=== CONT  TestAccAWSLambdaEventSourceMapping_ActiveMQ
=== CONT  TestAccAWSLambdaEventSourceMapping_RabbitMQ
--- PASS: TestAccAWSLambdaEventSourceMapping_RabbitMQ (762.20s)
--- PASS: TestAccAWSLambdaEventSourceMapping_ActiveMQ (1439.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1442.028s
```
