### PR TITLE
r/cloudwatch_log_stream: catch not found errors in CheckDestroy test method and do the same in resource

### DIFF
--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -113,9 +114,15 @@ func resourceAwsCloudWatchLogStreamDelete(d *schema.ResourceData, meta interface
 		LogGroupName:  aws.String(d.Get("log_group_name").(string)),
 		LogStreamName: aws.String(d.Id()),
 	}
+
 	_, err := conn.DeleteLogStream(params)
+
+	if tfawserr.ErrCodeEquals(err, cloudwatchlogs.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
 	if err != nil {
-		return fmt.Errorf("Error deleting CloudWatch Log Stream: %s", err)
+		return fmt.Errorf("error deleting CloudWatch Log Stream (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_cloudwatch_log_stream_test.go
+++ b/aws/resource_aws_cloudwatch_log_stream_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -119,6 +120,10 @@ func testAccCheckAWSCloudWatchLogStreamDestroy(s *terraform.State) error {
 
 		logGroupName := rs.Primary.Attributes["log_group_name"]
 		_, exists, err := lookupCloudWatchLogStream(conn, rs.Primary.ID, logGroupName, nil)
+
+		if tfawserr.ErrCodeEquals(err, cloudwatchlogs.ErrCodeResourceNotFoundException) {
+			continue
+		}
 
 		if err != nil {
 			return fmt.Errorf("error reading CloudWatch Log Stream (%s): %w", rs.Primary.ID, err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing before change:

```
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: error reading CloudWatch Log Stream (tf-acc-test-7621889320263752005): ResourceNotFoundException: The specified log group does not exist.
--- FAIL: TestAccAWSCloudWatchLogStream_basic (15.64s)
```
Output from acceptance testing after change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSCloudWatchLogStream_basic (16.10s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears_LogGroup (12.51s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears (13.97s)
```
