### PR TITLE
r/eks_node_group: change `instance_types` back to a TypeSet since it supports multiple values

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -75,7 +75,7 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				Optional: true,
 			},
 			"instance_types": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -285,8 +285,8 @@ func resourceAwsEksNodeGroupCreate(ctx context.Context, d *schema.ResourceData, 
 		input.DiskSize = aws.Int64(int64(v.(int)))
 	}
 
-	if v := d.Get("instance_types").([]interface{}); len(v) > 0 {
-		input.InstanceTypes = expandStringList(v)
+	if v := d.Get("instance_types").(*schema.Set); v.Len() > 0 {
+		input.InstanceTypes = expandStringSet(v)
 	}
 
 	if v := d.Get("labels").(map[string]interface{}); len(v) > 0 {

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -126,7 +126,7 @@ The following arguments are optional:
 * `capacity_type` - (Optional) Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. Terraform will only perform drift detection if a configuration value is provided.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
-* `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
+* `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 * `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
 * `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name. Conflicts with `node_group_name_prefix`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Notes
* originally the `instance_types` argument was limited to only 1 value so it was defined as a `TypeList+MaxItems: 1` from a `TypeSet` to adhere to our linter rules but later support for multiple values was added , leaving the argument as only a `TypeList` which can on occasion lead to non-empty plans depending on the order returned from the API. To account for this, we can change the argument back to a `TypeSet` since order does not matter.

Relates https://github.com/hashicorp/terraform-provider-aws/pull/13340 , https://github.com/hashicorp/terraform-provider-aws/pull/16510 

Output from acceptance testing before change:
```
=== CONT  TestAccAWSEksNodeGroup_InstanceTypes_Multiple
    resource_aws_eks_node_group_test.go:351: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_eks_node_group.test must be replaced
        -/+ resource "aws_eks_node_group" "test" {
              ~ ami_type               = "AL2_x86_64" -> (known after apply)
              ~ arn                    = "arn:aws:eks:us-west-2:*******:nodegroup/tf-acc-test-6142434190859222803/tf-acc-test-6142434190859222803/26bd9b34-6b1b-541c-8c07-ffda3b4c27b5" -> (known after apply)
              ~ capacity_type          = "ON_DEMAND" -> (known after apply)
              ~ disk_size              = 20 -> (known after apply)
              ~ id                     = "tf-acc-test-6142434190859222803:tf-acc-test-6142434190859222803" -> (known after apply)
              ~ instance_types         = [
                  - "t3.large",
                  + "t2.medium",
                    "t2.large",
                  + "t3.large",
                    "t3.medium",
                  - "t2.medium",
                ]
              + node_group_name_prefix = (known after apply)
              ~ release_version        = "1.20.4-20210722" -> (known after apply)
              ~ resources              = [
                  - {
                      - autoscaling_groups              = [
                          - {
                              - name = "eks-26bd9b34-6b1b-541c-8c07-ffda3b4c27b5"
                            },
                        ]
                      - remote_access_security_group_id = ""
                    },
                ] -> (known after apply)
              ~ status                 = "ACTIVE" -> (known after apply)
              ~ tags_all               = {} -> (known after apply)
              ~ version                = "1.20" -> (known after apply)
                # (4 unchanged attributes hidden)
        
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccAWSEksNodeGroup_InstanceTypes_Multiple (1436.72s)
```
Output from acceptance testing after change:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Single (1109.58s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes_Multiple (1232.87s)
```
