### PR TITLE
bugfix for lambda in ap-northeast-3

### DIFF
--- a/.changelog/20555.txt
+++ b/.changelog/20555.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: fix Osaka ap-northeast-3 lambda function creation, failing due to code signer service not available in the region.
+``` 

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -837,6 +837,15 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 
+	// Currently, this functionality is not enabled in ap-northeast-3 (Osaka) region
+	// and returns ambiguous error codes (e.g. AccessDeniedException)
+	// so we cannot just ignore the error as would typically.
+
+	//lintignore:AWSAT003
+	if meta.(*AWSClient).region == "ap-northeast-3" {
+		return nil
+	}
+
 	// Code Signing is only supported on zip packaged lambda functions.
 	var codeSigningConfigArn string
 

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -842,8 +842,7 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 	// so we cannot just ignore the error as would typically.
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	//lintignore:AWSAT003
-	if meta.(*AWSClient).region == "ap-northeast-3" {
+	if meta.(*AWSClient).region == endpoints.ApNortheast3RegionID {
 		return nil
 	}
 

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -840,7 +840,8 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 	// Currently, this functionality is not enabled in ap-northeast-3 (Osaka) region
 	// and returns ambiguous error codes (e.g. AccessDeniedException)
 	// so we cannot just ignore the error as would typically.
-
+	// We are hardcoding the region here, because go aws sdk endpoints
+	// package does not support Signer service
 	//lintignore:AWSAT003
 	if meta.(*AWSClient).region == "ap-northeast-3" {
 		return nil

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -196,6 +196,8 @@ func TestAccAWSLambdaFunction_codeSigningConfig(t *testing.T) {
 		t.Skip("Lambda code signing config is not supported in GovCloud partition")
 	}
 
+	// We are hardcoding the region here, because go aws sdk endpoints
+	// package does not support Signer service
 	//lintignore:AWSAT003
 	if testAccGetRegion() != "ap-northeast-3" {
 		t.Skip("Lambda code signing config is not supported in Osaka ap-northeast-3 region", testAccGetRegion())

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -196,6 +196,11 @@ func TestAccAWSLambdaFunction_codeSigningConfig(t *testing.T) {
 		t.Skip("Lambda code signing config is not supported in GovCloud partition")
 	}
 
+	//lintignore:AWSAT003
+	if testAccGetRegion() != "ap-northeast-3" {
+		t.Skip("Lambda code signing config is not supported in Osaka ap-northeast-3 region", testAccGetRegion())
+	}
+
 	var conf lambda.GetFunctionOutput
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_csc_%s", rString)

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -192,15 +193,14 @@ func TestAccAWSLambdaFunction_disappears(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_codeSigningConfig(t *testing.T) {
-	if testAccGetPartition() == "aws-us-gov" {
-		t.Skip("Lambda code signing config is not supported in GovCloud partition")
+	if got, want := testAccGetPartition(), endpoints.AwsUsGovPartitionID; got == want {
+		t.Skipf("Lambda code signing config is not supported in %s partition", got)
 	}
 
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	//lintignore:AWSAT003
-	if testAccGetRegion() != "ap-northeast-3" {
-		t.Skip("Lambda code signing config is not supported in Osaka ap-northeast-3 region", testAccGetRegion())
+	if got, want := testAccGetRegion(), endpoints.ApNortheast3RegionID; got == want {
+		t.Skipf("Lambda code signing config is not supported in %s region", got)
 	}
 
 	var conf lambda.GetFunctionOutput
@@ -1000,8 +1000,8 @@ func TestAccAWSLambdaFunction_imageConfig(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
-	if testAccGetPartition() == "aws-us-gov" {
-		t.Skip("Lambda tracing config is not supported in GovCloud partition")
+	if got, want := testAccGetPartition(), endpoints.AwsUsGovPartitionID; got == want {
+		t.Skipf("Lambda tracing config is not supported in %s partition", got)
 	}
 
 	var conf lambda.GetFunctionOutput


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16755

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_codeSigningConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_codeSigningConfig -timeout 180m
=== RUN   TestAccAWSLambdaFunction_codeSigningConfig
    resource_aws_lambda_function_test.go:201: Lambda code signing config is not supported in Osaka ap-northeast-3 region us-west-2
--- SKIP: TestAccAWSLambdaFunction_codeSigningConfig (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1.399s
```

### Before
```
resource "aws_iam_role" "iam_for_lambda" {
  name = "role-for-ap-northeast-3"
  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Service": "lambda.amazonaws.com"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}
EOF
}

resource "aws_lambda_function" "test_lambda" {
  filename      = "lambda_function_payload.zip"
  function_name = "test_function"
  role          = aws_iam_role.iam_for_lambda.arn
  handler       = "handler.lambda_handler"

  runtime = "python3.8"
}

provider "aws" {
  region ="ap-northeast-3"
}
```
would fail with 
```
Error: error getting Lambda Function (test_function) code signing config AccessDeniedException: 
│       status code: 403, request id: 508a2015-f870-4292-b0f8-eb2b0fb4cb42
```