### PR TITLE
Adds configurable timeouts for `aws_config_organization_conformance_pack`

### DIFF
--- a/.changelog/20560.txt
+++ b/.changelog/20560.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_config_organization_conformance_pack: Add configurable timeouts
+```

--- a/aws/configservice.go
+++ b/aws/configservice.go
@@ -15,10 +15,6 @@ const (
 	ConfigConformancePackCreateTimeout = 5 * time.Minute
 	ConfigConformancePackDeleteTimeout = 5 * time.Minute
 
-	ConfigOrganizationConformancePackCreateTimeout = 10 * time.Minute
-	ConfigOrganizationConformancePackUpdateTimeout = 10 * time.Minute
-	ConfigOrganizationConformancePackDeleteTimeout = 20 * time.Minute
-
 	ConfigConformancePackStatusNotFound = "NotFound"
 	ConfigConformancePackStatusUnknown  = "Unknown"
 )
@@ -417,11 +413,11 @@ func configWaitForConformancePackStateDeleteComplete(conn *configservice.ConfigS
 	return err
 }
 
-func configWaitForOrganizationConformancePackStatusCreateSuccessful(conn *configservice.ConfigService, name string) error {
+func configWaitForOrganizationConformancePackStatusCreateSuccessful(conn *configservice.ConfigService, name string, timeout time.Duration) error {
 	stateChangeConf := resource.StateChangeConf{
 		Pending: []string{configservice.OrganizationResourceStatusCreateInProgress},
 		Target:  []string{configservice.OrganizationResourceStatusCreateSuccessful},
-		Timeout: ConfigOrganizationConformancePackCreateTimeout,
+		Timeout: timeout,
 		Refresh: configRefreshOrganizationConformancePackCreationStatus(conn, name),
 		// Include a delay to help avoid ResourceDoesNotExist errors
 		Delay: 30 * time.Second,
@@ -433,11 +429,11 @@ func configWaitForOrganizationConformancePackStatusCreateSuccessful(conn *config
 
 }
 
-func configWaitForOrganizationConformancePackStatusUpdateSuccessful(conn *configservice.ConfigService, name string) error {
+func configWaitForOrganizationConformancePackStatusUpdateSuccessful(conn *configservice.ConfigService, name string, timeout time.Duration) error {
 	stateChangeConf := resource.StateChangeConf{
 		Pending: []string{configservice.OrganizationResourceStatusUpdateInProgress},
 		Target:  []string{configservice.OrganizationResourceStatusUpdateSuccessful},
-		Timeout: ConfigOrganizationConformancePackUpdateTimeout,
+		Timeout: timeout,
 		Refresh: configRefreshOrganizationConformancePackStatus(conn, name),
 	}
 
@@ -446,11 +442,11 @@ func configWaitForOrganizationConformancePackStatusUpdateSuccessful(conn *config
 	return err
 }
 
-func configWaitForOrganizationConformancePackStatusDeleteSuccessful(conn *configservice.ConfigService, name string) error {
+func configWaitForOrganizationConformancePackStatusDeleteSuccessful(conn *configservice.ConfigService, name string, timeout time.Duration) error {
 	stateChangeConf := resource.StateChangeConf{
 		Pending: []string{configservice.OrganizationResourceStatusDeleteInProgress},
 		Target:  []string{configservice.OrganizationResourceStatusDeleteSuccessful},
-		Timeout: ConfigOrganizationConformancePackDeleteTimeout,
+		Timeout: timeout,
 		Refresh: configRefreshOrganizationConformancePackStatus(conn, name),
 	}
 

--- a/aws/resource_aws_config_organization_conformance_pack.go
+++ b/aws/resource_aws_config_organization_conformance_pack.go
@@ -3,7 +3,8 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
+	"regexp",
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/configservice"
@@ -21,6 +22,12 @@ func resourceAwsConfigOrganizationConformancePack() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -141,7 +148,7 @@ func resourceAwsConfigOrganizationConformancePackCreate(d *schema.ResourceData, 
 
 	d.SetId(name)
 
-	if err := configWaitForOrganizationConformancePackStatusCreateSuccessful(conn, d.Id()); err != nil {
+	if err := configWaitForOrganizationConformancePackStatusCreateSuccessful(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error waiting for Config Organization Conformance Pack (%s) to be created: %w", d.Id(), err)
 	}
 
@@ -226,7 +233,7 @@ func resourceAwsConfigOrganizationConformancePackUpdate(d *schema.ResourceData, 
 		return fmt.Errorf("error updating Config Organization Conformance Pack (%s): %w", d.Id(), err)
 	}
 
-	if err := configWaitForOrganizationConformancePackStatusUpdateSuccessful(conn, d.Id()); err != nil {
+	if err := configWaitForOrganizationConformancePackStatusUpdateSuccessful(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return fmt.Errorf("error waiting for Config Organization Conformance Pack (%s) to be updated: %w", d.Id(), err)
 	}
 
@@ -250,7 +257,7 @@ func resourceAwsConfigOrganizationConformancePackDelete(d *schema.ResourceData, 
 		return fmt.Errorf("erorr deleting Config Organization Conformance Pack (%s): %w", d.Id(), err)
 	}
 
-	if err := configWaitForOrganizationConformancePackStatusDeleteSuccessful(conn, d.Id()); err != nil {
+	if err := configWaitForOrganizationConformancePackStatusDeleteSuccessful(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		if tfawserr.ErrCodeEquals(err, configservice.ErrCodeNoSuchOrganizationConformancePackException) {
 			return nil
 		}

--- a/aws/resource_aws_config_organization_conformance_pack.go
+++ b/aws/resource_aws_config_organization_conformance_pack.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp",
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/website/docs/r/config_organization_conformance_pack.html.markdown
+++ b/website/docs/r/config_organization_conformance_pack.html.markdown
@@ -117,6 +117,7 @@ In addition to all arguments above, the following attributes are exported:
 - `create` - (Default `10 minutes`) Used for creating conformance pack
 - `update` - (Default `10 minutes`) Used for conformance pack modifications
 - `delete` - (Default `20 minutes`) Used for destroying conformance pack
+
 ## Import
 
 Config Organization Conformance Packs can be imported using the `name`, e.g.

--- a/website/docs/r/config_organization_conformance_pack.html.markdown
+++ b/website/docs/r/config_organization_conformance_pack.html.markdown
@@ -109,6 +109,14 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Amazon Resource Name (ARN) of the organization conformance pack.
 * `id` - The name of the organization conformance pack.
 
+## Timeouts
+
+`aws_config_organization_conformance_pack` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating conformance pack
+- `update` - (Default `10 minutes`) Used for conformance pack modifications
+- `delete` - (Default `20 minutes`) Used for destroying conformance pack
 ## Import
 
 Config Organization Conformance Packs can be imported using the `name`, e.g.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20345

Output from acceptance testing:

I don't have a test AWS organization to run these acceptance tests in.
