### PR TITLE
r/aws_eks_identity_provider_config: Use `CreateWithoutTimeout`et al.

### DIFF
--- a/.changelog/20561.txt
+++ b/.changelog/20561.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_identity_provider_config: Increase Create and Delete timeouts to 40 minutes
+```

--- a/aws/resource_aws_eks_identity_provider_config.go
+++ b/aws/resource_aws_eks_identity_provider_config.go
@@ -22,10 +22,10 @@ import (
 
 func resourceAwsEksIdentityProviderConfig() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAwsEksIdentityProviderConfigCreate,
-		ReadContext:   resourceAwsEksIdentityProviderConfigRead,
-		UpdateContext: resourceAwsEksIdentityProviderConfigUpdate,
-		DeleteContext: resourceAwsEksIdentityProviderConfigDelete,
+		CreateWithoutTimeout: resourceAwsEksIdentityProviderConfigCreate,
+		ReadWithoutTimeout:   resourceAwsEksIdentityProviderConfigRead,
+		UpdateWithoutTimeout: resourceAwsEksIdentityProviderConfigUpdate,
+		DeleteWithoutTimeout: resourceAwsEksIdentityProviderConfigDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -34,8 +34,8 @@ func resourceAwsEksIdentityProviderConfig() *schema.Resource {
 		CustomizeDiff: SetTagsDiff,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(25 * time.Minute),
-			Delete: schema.DefaultTimeout(25 * time.Minute),
+			Create: schema.DefaultTimeout(40 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/eks_identity_provider_config.html.markdown
+++ b/website/docs/r/eks_identity_provider_config.html.markdown
@@ -56,8 +56,8 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_eks_identity_provider_config` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
 
-* `create` - (Default `25 minutes`) How long to wait for the EKS Identity Provider Configuration to be associated.
-* `delete` - (Default `25 minutes`) How long to wait for the EKS Identity Provider Configuration to be disassociated.
+* `create` - (Default `40 minutes`) How long to wait for the EKS Identity Provider Configuration to be associated.
+* `delete` - (Default `40 minutes`) How long to wait for the EKS Identity Provider Configuration to be disassociated.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20558.
Closes #20155.
Relates #15090.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAWSEksIdentityProviderConfig_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksIdentityProviderConfig_ -timeout 180m
=== RUN   TestAccAWSEksIdentityProviderConfig_basic
=== PAUSE TestAccAWSEksIdentityProviderConfig_basic
=== RUN   TestAccAWSEksIdentityProviderConfig_disappears
=== PAUSE TestAccAWSEksIdentityProviderConfig_disappears
=== RUN   TestAccAWSEksIdentityProviderConfig_AllOidcOptions
=== PAUSE TestAccAWSEksIdentityProviderConfig_AllOidcOptions
=== RUN   TestAccAWSEksIdentityProviderConfig_Tags
=== PAUSE TestAccAWSEksIdentityProviderConfig_Tags
=== CONT  TestAccAWSEksIdentityProviderConfig_basic
=== CONT  TestAccAWSEksIdentityProviderConfig_Tags
=== CONT  TestAccAWSEksIdentityProviderConfig_AllOidcOptions
=== CONT  TestAccAWSEksIdentityProviderConfig_disappears
--- PASS: TestAccAWSEksIdentityProviderConfig_AllOidcOptions (3932.72s)
--- PASS: TestAccAWSEksIdentityProviderConfig_disappears (4613.14s)
--- PASS: TestAccAWSEksIdentityProviderConfig_Tags (4632.16s)
--- PASS: TestAccAWSEksIdentityProviderConfig_basic (4664.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4667.967s
```
