### PR TITLE
r/aws_eks_addon: Update addon versions for `TestAccAWSEksAddon_AddonVersion`

### DIFF
--- a/.changelog/20562.txt
+++ b/.changelog/20562.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_addon: Treat `DEGRADED` as a pending state during creation
+```

--- a/aws/internal/service/eks/waiter/waiter.go
+++ b/aws/internal/service/eks/waiter/waiter.go
@@ -19,7 +19,7 @@ const (
 
 func AddonCreated(ctx context.Context, conn *eks.EKS, clusterName, addonName string) (*eks.Addon, error) {
 	stateConf := resource.StateChangeConf{
-		Pending: []string{eks.AddonStatusCreating},
+		Pending: []string{eks.AddonStatusCreating, eks.AddonStatusDegraded},
 		Target:  []string{eks.AddonStatusActive},
 		Refresh: AddonStatus(ctx, conn, clusterName, addonName),
 		Timeout: AddonCreatedTimeout,

--- a/aws/resource_aws_eks_addon_test.go
+++ b/aws/resource_aws_eks_addon_test.go
@@ -180,8 +180,8 @@ func TestAccAWSEksAddon_AddonVersion(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_addon.test"
 	addonName := "vpc-cni"
-	addonVersion1 := "v1.6.3-eksbuild.1"
-	addonVersion2 := "v1.7.5-eksbuild.1"
+	addonVersion1 := "v1.8.0-eksbuild.1"
+	addonVersion2 := "v1.9.0-eksbuild.1"
 	ctx := context.TODO()
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20559.
Closes #20404.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAWSEksAddon_'                                             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksAddon_ -timeout 180m
=== RUN   TestAccAWSEksAddon_basic
=== PAUSE TestAccAWSEksAddon_basic
=== RUN   TestAccAWSEksAddon_disappears
=== PAUSE TestAccAWSEksAddon_disappears
=== RUN   TestAccAWSEksAddon_disappears_Cluster
=== PAUSE TestAccAWSEksAddon_disappears_Cluster
=== RUN   TestAccAWSEksAddon_AddonVersion
=== PAUSE TestAccAWSEksAddon_AddonVersion
=== RUN   TestAccAWSEksAddon_ResolveConflicts
=== PAUSE TestAccAWSEksAddon_ResolveConflicts
=== RUN   TestAccAWSEksAddon_ServiceAccountRoleArn
=== PAUSE TestAccAWSEksAddon_ServiceAccountRoleArn
=== RUN   TestAccAWSEksAddon_Tags
=== PAUSE TestAccAWSEksAddon_Tags
=== RUN   TestAccAWSEksAddon_defaultTags_providerOnly
=== PAUSE TestAccAWSEksAddon_defaultTags_providerOnly
=== RUN   TestAccAWSEksAddon_defaultTags_updateToProviderOnly
=== PAUSE TestAccAWSEksAddon_defaultTags_updateToProviderOnly
=== RUN   TestAccAWSEksAddon_defaultTags_updateToResourceOnly
=== PAUSE TestAccAWSEksAddon_defaultTags_updateToResourceOnly
=== RUN   TestAccAWSEksAddon_defaultTags_providerAndResource_nonOverlappingTag
=== PAUSE TestAccAWSEksAddon_defaultTags_providerAndResource_nonOverlappingTag
=== RUN   TestAccAWSEksAddon_defaultTags_providerAndResource_overlappingTag
=== PAUSE TestAccAWSEksAddon_defaultTags_providerAndResource_overlappingTag
=== RUN   TestAccAWSEksAddon_defaultTags_providerAndResource_duplicateTag
=== PAUSE TestAccAWSEksAddon_defaultTags_providerAndResource_duplicateTag
=== RUN   TestAccAWSEksAddon_defaultAndIgnoreTags
=== PAUSE TestAccAWSEksAddon_defaultAndIgnoreTags
=== RUN   TestAccAWSEksAddon_ignoreTags
=== PAUSE TestAccAWSEksAddon_ignoreTags
=== CONT  TestAccAWSEksAddon_basic
=== CONT  TestAccAWSEksAddon_defaultAndIgnoreTags
=== CONT  TestAccAWSEksAddon_defaultTags_providerAndResource_duplicateTag
=== CONT  TestAccAWSEksAddon_defaultTags_updateToResourceOnly
=== CONT  TestAccAWSEksAddon_defaultTags_providerAndResource_overlappingTag
=== CONT  TestAccAWSEksAddon_ServiceAccountRoleArn
=== CONT  TestAccAWSEksAddon_defaultTags_updateToProviderOnly
=== CONT  TestAccAWSEksAddon_ignoreTags
=== CONT  TestAccAWSEksAddon_Tags
=== CONT  TestAccAWSEksAddon_defaultTags_providerOnly
=== CONT  TestAccAWSEksAddon_disappears_Cluster
=== CONT  TestAccAWSEksAddon_disappears
=== CONT  TestAccAWSEksAddon_defaultTags_providerAndResource_nonOverlappingTag
=== CONT  TestAccAWSEksAddon_ResolveConflicts
=== CONT  TestAccAWSEksAddon_AddonVersion
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_duplicateTag (8.19s)
--- PASS: TestAccAWSEksAddon_defaultAndIgnoreTags (706.18s)
--- PASS: TestAccAWSEksAddon_Tags (737.67s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_overlappingTag (742.59s)
--- PASS: TestAccAWSEksAddon_disappears_Cluster (769.20s)
--- PASS: TestAccAWSEksAddon_defaultTags_updateToResourceOnly (807.04s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerOnly (827.16s)
--- PASS: TestAccAWSEksAddon_ServiceAccountRoleArn (827.61s)
--- PASS: TestAccAWSEksAddon_defaultTags_providerAndResource_nonOverlappingTag (833.54s)
--- PASS: TestAccAWSEksAddon_defaultTags_updateToProviderOnly (838.97s)
--- PASS: TestAccAWSEksAddon_basic (848.20s)
--- PASS: TestAccAWSEksAddon_ignoreTags (857.08s)
--- PASS: TestAccAWSEksAddon_AddonVersion (860.12s)
--- PASS: TestAccAWSEksAddon_ResolveConflicts (880.88s)
--- PASS: TestAccAWSEksAddon_disappears (938.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       941.907s
```
