### PR TITLE
r/aws_glue_dev_endpoint: Correctly report failure reason

### DIFF
--- a/aws/internal/service/glue/enum.go
+++ b/aws/internal/service/glue/enum.go
@@ -1,0 +1,8 @@
+package glue
+
+const (
+	DevEndpointStatusFailed       = "FAILED"
+	DevEndpointStatusProvisioning = "PROVISIONING"
+	DevEndpointStatusReady        = "READY"
+	DevEndpointStatusTerminating  = "TERMINATING"
+)

--- a/aws/internal/service/glue/waiter/waiter.go
+++ b/aws/internal/service/glue/waiter/waiter.go
@@ -1,10 +1,14 @@
 package waiter
 
 import (
+	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfglue "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -151,38 +155,42 @@ func TriggerDeleted(conn *glue.Glue, triggerName string) (*glue.GetTriggerOutput
 	return nil, err
 }
 
-// GlueDevEndpointCreated waits for a Glue Dev Endpoint to become available.
-func GlueDevEndpointCreated(conn *glue.Glue, devEndpointId string) (*glue.GetDevEndpointOutput, error) {
+func GlueDevEndpointCreated(conn *glue.Glue, name string) (*glue.DevEndpoint, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			"PROVISIONING",
-		},
-		Target:  []string{"READY"},
-		Refresh: GlueDevEndpointStatus(conn, devEndpointId),
+		Pending: []string{tfglue.DevEndpointStatusProvisioning},
+		Target:  []string{tfglue.DevEndpointStatusReady},
+		Refresh: GlueDevEndpointStatus(conn, name),
 		Timeout: 15 * time.Minute,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*glue.GetDevEndpointOutput); ok {
+	if output, ok := outputRaw.(*glue.DevEndpoint); ok {
+		if status := aws.StringValue(output.Status); status == tfglue.DevEndpointStatusFailed {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.FailureReason)))
+		}
+
 		return output, err
 	}
 
 	return nil, err
 }
 
-// GlueDevEndpointDeleted waits for a Glue Dev Endpoint to become terminated.
-func GlueDevEndpointDeleted(conn *glue.Glue, devEndpointId string) (*glue.GetDevEndpointOutput, error) {
+func GlueDevEndpointDeleted(conn *glue.Glue, name string) (*glue.DevEndpoint, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"TERMINATING"},
+		Pending: []string{tfglue.DevEndpointStatusTerminating},
 		Target:  []string{},
-		Refresh: GlueDevEndpointStatus(conn, devEndpointId),
+		Refresh: GlueDevEndpointStatus(conn, name),
 		Timeout: 15 * time.Minute,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*glue.GetDevEndpointOutput); ok {
+	if output, ok := outputRaw.(*glue.DevEndpoint); ok {
+		if status := aws.StringValue(output.Status); status == tfglue.DevEndpointStatusFailed {
+			tfresource.SetLastError(err, errors.New(aws.StringValue(output.FailureReason)))
+		}
+
 		return output, err
 	}
 

--- a/aws/resource_aws_glue_dev_endpoint.go
+++ b/aws/resource_aws_glue_dev_endpoint.go
@@ -14,8 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue/waiter"
 	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsGlueDevEndpoint() *schema.Resource {
@@ -24,6 +26,7 @@ func resourceAwsGlueDevEndpoint() *schema.Resource {
 		Read:   resourceAwsGlueDevEndpointRead,
 		Update: resourceAwsDevEndpointUpdate,
 		Delete: resourceAwsDevEndpointDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -247,14 +250,14 @@ func resourceAwsGlueDevEndpointCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating Glue Dev Endpoint: %s", err)
+		return fmt.Errorf("error creating Glue Dev Endpoint: %w", err)
 	}
 
 	d.SetId(name)
 
 	log.Printf("[DEBUG] Waiting for Glue Dev Endpoint (%s) to become available", d.Id())
 	if _, err := waiter.GlueDevEndpointCreated(conn, d.Id()); err != nil {
-		return fmt.Errorf("error while waiting for Glue Dev Endpoint (%s) to become available: %s", d.Id(), err)
+		return fmt.Errorf("error while waiting for Glue Dev Endpoint (%s) to become available: %w", d.Id(), err)
 	}
 
 	return resourceAwsGlueDevEndpointRead(d, meta)
@@ -265,25 +268,16 @@ func resourceAwsGlueDevEndpointRead(d *schema.ResourceData, meta interface{}) er
 	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	request := &glue.GetDevEndpointInput{
-		EndpointName: aws.String(d.Id()),
-	}
+	endpoint, err := finder.DevEndpointByName(conn, d.Id())
 
-	output, err := conn.GetDevEndpoint(request)
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
-			log.Printf("[WARN] Glue Dev Endpoint (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error reading Glue Dev Endpoint (%s): %s", d.Id(), err)
-	}
-
-	endpoint := output.DevEndpoint
-	if endpoint == nil {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Glue Dev Endpoint (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	endpointARN := arn.ARN{
@@ -295,93 +289,93 @@ func resourceAwsGlueDevEndpointRead(d *schema.ResourceData, meta interface{}) er
 	}.String()
 
 	if err := d.Set("arn", endpointARN); err != nil {
-		return fmt.Errorf("error setting arn for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting arn for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("arguments", aws.StringValueMap(endpoint.Arguments)); err != nil {
-		return fmt.Errorf("error setting arguments for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting arguments for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("availability_zone", endpoint.AvailabilityZone); err != nil {
-		return fmt.Errorf("error setting availability_zone for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting availability_zone for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("extra_jars_s3_path", endpoint.ExtraJarsS3Path); err != nil {
-		return fmt.Errorf("error setting extra_jars_s3_path for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting extra_jars_s3_path for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("extra_python_libs_s3_path", endpoint.ExtraPythonLibsS3Path); err != nil {
-		return fmt.Errorf("error setting extra_python_libs_s3_path for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting extra_python_libs_s3_path for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("failure_reason", endpoint.FailureReason); err != nil {
-		return fmt.Errorf("error setting failure_reason for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting failure_reason for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("glue_version", endpoint.GlueVersion); err != nil {
-		return fmt.Errorf("error setting glue_version for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting glue_version for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("name", endpoint.EndpointName); err != nil {
-		return fmt.Errorf("error setting name for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting name for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("number_of_nodes", endpoint.NumberOfNodes); err != nil {
-		return fmt.Errorf("error setting number_of_nodes for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting number_of_nodes for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("number_of_workers", endpoint.NumberOfWorkers); err != nil {
-		return fmt.Errorf("error setting number_of_workers for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting number_of_workers for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("private_address", endpoint.PrivateAddress); err != nil {
-		return fmt.Errorf("error setting private_address for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting private_address for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("public_address", endpoint.PublicAddress); err != nil {
-		return fmt.Errorf("error setting public_address for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting public_address for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("public_key", endpoint.PublicKey); err != nil {
-		return fmt.Errorf("error setting public_key for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting public_key for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("public_keys", flattenStringSet(endpoint.PublicKeys)); err != nil {
-		return fmt.Errorf("error setting public_keys for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting public_keys for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("role_arn", endpoint.RoleArn); err != nil {
-		return fmt.Errorf("error setting role_arn for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting role_arn for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("security_configuration", endpoint.SecurityConfiguration); err != nil {
-		return fmt.Errorf("error setting security_configuration for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting security_configuration for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("security_group_ids", flattenStringSet(endpoint.SecurityGroupIds)); err != nil {
-		return fmt.Errorf("error setting security_group_ids for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting security_group_ids for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("status", endpoint.Status); err != nil {
-		return fmt.Errorf("error setting status for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting status for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("subnet_id", endpoint.SubnetId); err != nil {
-		return fmt.Errorf("error setting subnet_id for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting subnet_id for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("vpc_id", endpoint.VpcId); err != nil {
-		return fmt.Errorf("error setting vpc_id for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting vpc_id for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("worker_type", endpoint.WorkerType); err != nil {
-		return fmt.Errorf("error setting worker_type for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting worker_type for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	tags, err := keyvaluetags.GlueListTags(conn, endpointARN)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for Glue Dev Endpoint (%s): %s", endpointARN, err)
+		return fmt.Errorf("error listing tags for Glue Dev Endpoint (%s): %w", endpointARN, err)
 	}
 
 	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
@@ -396,11 +390,11 @@ func resourceAwsGlueDevEndpointRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := d.Set("yarn_endpoint_address", endpoint.YarnEndpointAddress); err != nil {
-		return fmt.Errorf("error setting yarn_endpoint_address for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting yarn_endpoint_address for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("zeppelin_remote_spark_interpreter_port", endpoint.ZeppelinRemoteSparkInterpreterPort); err != nil {
-		return fmt.Errorf("error setting zeppelin_remote_spark_interpreter_port for Glue Dev Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting zeppelin_remote_spark_interpreter_port for Glue Dev Endpoint (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -497,14 +491,14 @@ func resourceAwsDevEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating Glue Dev Endpoint: %s", err)
+			return fmt.Errorf("error updating Glue Dev Endpoint: %w", err)
 		}
 	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := keyvaluetags.GlueUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -514,28 +508,22 @@ func resourceAwsDevEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsDevEndpointDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).glueconn
 
-	deleteOpts := &glue.DeleteDevEndpointInput{
+	log.Printf("[INFO] Deleting Glue Dev Endpoint: %s", d.Id())
+	_, err := conn.DeleteDevEndpoint(&glue.DeleteDevEndpointInput{
 		EndpointName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
+		return nil
 	}
 
-	log.Printf("[INFO] Deleting Glue Dev Endpoint: %s", d.Id())
-
-	_, err := conn.DeleteDevEndpoint(deleteOpts)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
-			return nil
-		}
-
 		return fmt.Errorf("error deleting Glue Dev Endpoint (%s): %s", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Waiting for Glue Dev Endpoint (%s) to become terminated", d.Id())
 	if _, err := waiter.GlueDevEndpointDeleted(conn, d.Id()); err != nil {
-		if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
-			return nil
-		}
-
-		return fmt.Errorf("error while waiting for Glue Dev Endpoint (%s) to become terminated: %s", d.Id(), err)
+		return fmt.Errorf("error while waiting for Glue Dev Endpoint (%s) to become terminated: %w", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20563.

This PR ensures that any `FailureReason` is correctly reported via the `LastError` mechanism.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I can't reproduce the failure in any tests I run manually

```
% make testacc TESTARGS='-run=TestAccGlueDevEndpoint_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccGlueDevEndpoint_Basic -timeout 180m
=== RUN   TestAccGlueDevEndpoint_Basic
=== PAUSE TestAccGlueDevEndpoint_Basic
=== CONT  TestAccGlueDevEndpoint_Basic
--- PASS: TestAccGlueDevEndpoint_Basic (503.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	508.419s
% make testacc TESTARGS='-run=TestAccGlueDevEndpoint_Basic'    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccGlueDevEndpoint_Basic -timeout 180m
=== RUN   TestAccGlueDevEndpoint_Basic
=== PAUSE TestAccGlueDevEndpoint_Basic
=== CONT  TestAccGlueDevEndpoint_Basic
    resource_aws_glue_dev_endpoint_test.go:77: Step 1/2 error: Error running apply: exit status 1
        
        Error: error while waiting for Glue Dev Endpoint (tf-acc-test-2507860979464468914) to become available: timeout while waiting for state to become 'READY' (last state: 'PROVISIONING', timeout: 15m0s)
        
          with aws_glue_dev_endpoint.test,
          on terraform_plugin_test.tf line 25, in resource "aws_glue_dev_endpoint" "test":
          25: resource "aws_glue_dev_endpoint" "test" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting Glue Dev Endpoint (tf-acc-test-2507860979464468914): InvalidInputException: DevEndpoint tf-acc-test-2507860979464468914 is Provisioning. Please retry later.
        
--- FAIL: TestAccGlueDevEndpoint_Basic (918.32s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	921.355s
FAIL
make: *** [testacc] Error 1
```
