### PR TITLE
Mods for Flink ENI configuration and timeout

### DIFF
--- a/aws/internal/service/kinesisanalyticsv2/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalyticsv2/waiter/waiter.go
@@ -10,14 +10,14 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-const (
-	ApplicationDeletedTimeout = 5 * time.Minute
-	ApplicationStartedTimeout = 5 * time.Minute
-	ApplicationStoppedTimeout = 5 * time.Minute
-	ApplicationUpdatedTimeout = 5 * time.Minute
+const ( // TODO: make timers varaible form within KAv2 schema
+	ApplicationDeletedTimeout = 15 * time.Minute
+	ApplicationStartedTimeout = 15 * time.Minute
+	ApplicationStoppedTimeout = 15 * time.Minute
+	ApplicationUpdatedTimeout = 15 * time.Minute
 
-	SnapshotCreatedTimeout = 5 * time.Minute
-	SnapshotDeletedTimeout = 5 * time.Minute
+	SnapshotCreatedTimeout = 15 * time.Minute
+	SnapshotDeletedTimeout = 15 * time.Minute
 )
 
 // ApplicationDeleted waits for an Application to return Deleted


### PR DESCRIPTION
## What we did and why
### Added configuration to KinesisAnalyticsv2 resource to allow for specifying ENIs
Our specific use case required connecting Flink from within a VPC to Kinesis through EIPs. Flink creates ENIs that are nearly invisible. Only by querying the aws cli can you determine their ids. Our modification uses the new schema field **eni_configuration** to gather the generated ENIs. ENIs matching the ec2CustomFilters listed under **eni_configuration.filter** and KinesisAnalyticsv2 tags are put into a list under **eni_configuration.eni_ids**. We can then use this list elsewhere to create aws_eip_associations.

### Increased default timeouts for KinesisAnalyticsv2 resource.
AWS Flink was taking longer than 5 minutes to spool up so terraform was always timing out. Increasing the default allowed Terraform to continue. Probably should be configurable with an addition of a timeouts field in the schema in the future.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
