### PR TITLE
Handle paginated response when fetch parameters from rds cluster parameter group

### DIFF
--- a/.changelog/16010.txt
+++ b/.changelog/16010.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 resource/aws_rds_cluster_parameter_group: Handle paginated response when reading parameters from RDS cluster parameter group.
 ```

--- a/.changelog/16010.txt
+++ b/.changelog/16010.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_cluster_parameter_group: Handle paginated response when reading parameters from RDS cluster parameter group.
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Closes #16010

Synchronise the behaviour for `aws_rds_cluster_parameter_group` with the behaviour for `resource_aws_db_parameter_group` (Handle paginated response for AWS)