### PR TITLE
Update AWS ElasticSearch module examples

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -160,6 +160,7 @@ resource "aws_elasticsearch_domain" "es" {
 
   cluster_config {
     instance_type = "m4.large.elasticsearch"
+    zone_awareness_enabled = true
   }
 
   vpc_options {

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -17,14 +17,10 @@ Manages an AWS Elasticsearch Domain.
 ```terraform
 resource "aws_elasticsearch_domain" "example" {
   domain_name           = "example"
-  elasticsearch_version = "1.5"
+  elasticsearch_version = "7.10"
 
   cluster_config {
     instance_type = "r4.large.elasticsearch"
-  }
-
-  snapshot_options {
-    automated_snapshot_start_hour = 23
   }
 
   tags = {
@@ -193,10 +189,6 @@ resource "aws_elasticsearch_domain" "es" {
 }
 CONFIG
 
-  snapshot_options {
-    automated_snapshot_start_hour = 23
-  }
-
   tags = {
     Domain = "TestDomain"
   }
@@ -224,7 +216,7 @@ The following arguments are optional:
 * `encrypt_at_rest` - (Optional) Configuration block for encrypt at rest options. Only available for [certain instance types](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html). Detailed below.
 * `log_publishing_options` - (Optional) Configuration block for publishing slow and application logs to CloudWatch Logs. This block can be declared multiple times, for each log_type, within the same resource. Detailed below.
 * `node_to_node_encryption` - (Optional) Configuration block for node-to-node encryption options. Detailed below.
-* `snapshot_options` - (Optional) Configuration block for snapshot related options. Detailed below.
+* `snapshot_options` - (Optional) Configuration block for snapshot related options. Detailed below. DEPRECATED. For domains running Elasticsearch 5.3 and later, Amazon ES takes hourly automated snapshots, making this setting irrelevant. For domains running earlier versions of Elasticsearch, Amazon ES takes daily automated snapshots.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_options` - (Optional) Configuration block for VPC related options. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)). Detailed below.
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -159,7 +159,7 @@ resource "aws_elasticsearch_domain" "es" {
   elasticsearch_version = "6.3"
 
   cluster_config {
-    instance_type = "m4.large.elasticsearch"
+    instance_type          = "m4.large.elasticsearch"
     zone_awareness_enabled = true
   }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### About these documentation updates
The `VPC based ES` example uses two subnets. This throws an error `Error: ValidationException: You must specify exactly one subnet` which can be solved by adding `zone_awareness_enabled = true` to the `cluster_config`. [Several people have had this problem](https://stackoverflow.com/questions/56594965/unable-to-add-2-subnets-for-an-elasticsearch-with-terraform) from following this example in the docs.

While we're at it, let's remove the deprecated `snapshot_options`, since those have been deprecated since 5.3.
