### PR TITLE
Add msk_kafka_version data source

### DIFF
--- a/.changelog/20638.txt
+++ b/.changelog/20638.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_msk_kafka_version
+```

--- a/aws/data_source_aws_msk_kafka_version.go
+++ b/aws/data_source_aws_msk_kafka_version.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsMskKafkaVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsMskKafkaVersionRead,
+
+		Schema: map[string]*schema.Schema{
+			"preferred_versions": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"version"},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional:      true,
+				ConflictsWith: []string{"preferred_versions"},
+			},
+		},
+	}
+}
+
+func dataSourceAwsMskKafkaVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kafkaconn
+
+	listKafkaVersionsInput  := &kafka.ListKafkaVersionsInput{}
+
+	var kafkaVersions []*kafka.KafkaVersion
+	for {
+		listKafkaVersionsOutput, err := conn.ListKafkaVersions(listKafkaVersionsInput)
+
+		if err != nil {
+			return fmt.Errorf("error listing MSK Clusters: %w", err)
+		}
+
+		if listKafkaVersionsOutput == nil {
+			break
+		}
+
+		kafkaVersions = append(kafkaVersions, listKafkaVersionsOutput.KafkaVersions...)
+
+		if aws.StringValue(listKafkaVersionsOutput.NextToken) == "" {
+			break
+		}
+
+		listKafkaVersionsInput.NextToken = listKafkaVersionsOutput.NextToken
+	}
+
+	if len(kafkaVersions) == 0 {
+		return fmt.Errorf("error reading MSK Kafka versions: no results found")
+	}
+
+	var found *kafka.KafkaVersion
+	if l := d.Get("preferred_versions").([]interface{}); len(l) > 0 {
+		for _, elem := range l {
+			preferredVersion, ok := elem.(string)
+
+			if !ok {
+				continue
+			}
+
+			for _, kafkaVersion := range kafkaVersions {
+				if preferredVersion == aws.StringValue(kafkaVersion.Version) {
+					found = kafkaVersion
+					break
+				}
+			}
+
+			if found != nil {
+				break
+			}
+		}
+	}
+
+	if found == nil && len(kafkaVersions) > 1 {
+		return fmt.Errorf("multiple MSK Kafka versions (%v) match the criteria", kafkaVersions)
+	}
+
+	if found == nil && len(kafkaVersions) == 1 {
+		found = kafkaVersions[0]
+	}
+
+	if found == nil {
+		return fmt.Errorf("no MSK  Kafka versions match the criteria")
+	}
+
+	d.SetId(aws.StringValue(found.Version))
+	d.Set("status", found.Status)
+	d.Set("version", found.Version)
+
+	return nil
+}

--- a/aws/data_source_aws_msk_kafka_version.go
+++ b/aws/data_source_aws_msk_kafka_version.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kafka"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -24,87 +25,77 @@ func dataSourceAwsMskKafkaVersion() *schema.Resource {
 			},
 			"version": {
 				Type:         schema.TypeString,
-				Computed:     true,
 				Optional:     true,
+				Computed:     true,
 				ExactlyOneOf: []string{"version", "preferred_versions"},
 			},
 		},
 	}
 }
 
-func findMskKafkaVersion(prefferedVersions []interface{}, versions []*kafka.KafkaVersion) *kafka.KafkaVersion {
+func findMskKafkaVersion(preferredVersions []interface{}, versions []*kafka.KafkaVersion) *kafka.KafkaVersion {
 	var found *kafka.KafkaVersion
-	if l := prefferedVersions; len(l) > 0 {
-		for _, elem := range l {
-			preferredVersion, ok := elem.(string)
 
-			if !ok {
-				continue
-			}
+	for _, v := range preferredVersions {
+		preferredVersion, ok := v.(string)
 
-			for _, kafkaVersion := range versions {
-				if preferredVersion == aws.StringValue(kafkaVersion.Version) {
-					found = kafkaVersion
-					break
-				}
-			}
+		if !ok {
+			continue
+		}
 
-			if found != nil {
+		for _, kafkaVersion := range versions {
+			if preferredVersion == aws.StringValue(kafkaVersion.Version) {
+				found = kafkaVersion
+
 				break
 			}
 		}
+
+		if found != nil {
+			break
+		}
 	}
+
 	return found
 }
 
 func dataSourceAwsMskKafkaVersionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kafkaconn
 
-	listKafkaVersionsInput := &kafka.ListKafkaVersionsInput{}
-
 	var kafkaVersions []*kafka.KafkaVersion
-	for {
-		listKafkaVersionsOutput, err := conn.ListKafkaVersions(listKafkaVersionsInput)
 
-		if err != nil {
-			return fmt.Errorf("error listing MSK Kafka versions: %w", err)
+	err := conn.ListKafkaVersionsPages(&kafka.ListKafkaVersionsInput{}, func(page *kafka.ListKafkaVersionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
 
-		if listKafkaVersionsOutput == nil {
-			break
-		}
+		kafkaVersions = append(kafkaVersions, page.KafkaVersions...)
 
-		kafkaVersions = append(kafkaVersions, listKafkaVersionsOutput.KafkaVersions...)
+		return !lastPage
+	})
 
-		if aws.StringValue(listKafkaVersionsOutput.NextToken) == "" {
-			break
-		}
-
-		listKafkaVersionsInput.NextToken = listKafkaVersionsOutput.NextToken
+	if err != nil {
+		return fmt.Errorf("error listing Kafka versions: %w", err)
 	}
 
 	if len(kafkaVersions) == 0 {
-		return fmt.Errorf("error reading MSK Kafka versions: no results found")
+		return fmt.Errorf("no Kafka versions found")
 	}
 
 	var found *kafka.KafkaVersion
-	if v, ok := d.GetOk("version"); ok {
+
+	if v, ok := d.GetOk("preferred_versions"); ok {
+		found = findMskKafkaVersion(v.([]interface{}), kafkaVersions)
+	} else if v, ok := d.GetOk("version"); ok {
 		found = findMskKafkaVersion([]interface{}{v}, kafkaVersions)
 	}
 
-	if pv, ok := d.GetOk("preferred_versions"); ok {
-		found = findMskKafkaVersion(pv.([]interface{}), kafkaVersions)
-	}
-
-	if found == nil && len(kafkaVersions) > 1 {
-		return fmt.Errorf("multiple MSK Kafka versions (%v) match the criteria", kafkaVersions)
-	}
-
 	if found == nil {
-		return fmt.Errorf("no MSK  Kafka versions match the criteria")
+		return fmt.Errorf("no Kafka versions match the criteria")
 	}
 
 	d.SetId(aws.StringValue(found.Version))
+
 	d.Set("status", found.Status)
 	d.Set("version", found.Version)
 

--- a/aws/data_source_aws_msk_kafka_version_test.go
+++ b/aws/data_source_aws_msk_kafka_version_test.go
@@ -1,0 +1,82 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSMskKafkaVersion_basic(t *testing.T) {
+	dataSourceName := "data.aws_msk_kafka_version.test"
+	version := "2.4.1.1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSMskKafkaVersionPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, kafka.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMskKafkaVersionDataSourceBasicConfig(version),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "version", version),
+					resource.TestCheckResourceAttrSet(dataSourceName, "status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSMskKafkaVersion_preferred(t *testing.T) {
+	dataSourceName := "data.aws_msk_kafka_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSMskKafkaVersionPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, kafka.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMskKafkaVersionDataSourcePreferredConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "version", "2.4.1.1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSMskKafkaVersionPreCheck(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).kafkaconn
+
+	input := &kafka.ListKafkaVersionsInput{}
+
+	_, err := conn.ListKafkaVersions(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAWSMskKafkaVersionDataSourceBasicConfig(version string) string {
+	return fmt.Sprintf(`
+data "aws_msk_kafka_version" "test" {
+  version = %[1]q
+}
+`, version)
+}
+
+func testAccAWSMskKafkaVersionDataSourcePreferredConfig() string {
+	return `
+data "aws_msk_kafka_version" "test" {
+  preferred_versions = ["2.4.1.1", "2.4.1", "2.2.1"]
+}
+`
+}

--- a/aws/data_source_aws_msk_kafka_version_test.go
+++ b/aws/data_source_aws_msk_kafka_version_test.go
@@ -2,13 +2,13 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/kafka"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/kafka"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSMskKafkaVersion_basic(t *testing.T) {
+func TestAccAWSMskKafkaVersionDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_msk_kafka_version.test"
 	version := "2.4.1.1"
 
@@ -29,7 +29,7 @@ func TestAccAWSMskKafkaVersion_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSMskKafkaVersion_preferred(t *testing.T) {
+func TestAccAWSMskKafkaVersionDataSource_preferred(t *testing.T) {
 	dataSourceName := "data.aws_msk_kafka_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -347,6 +347,7 @@ func Provider() *schema.Provider {
 			"aws_mq_broker":                                  dataSourceAwsMqBroker(),
 			"aws_msk_cluster":                                dataSourceAwsMskCluster(),
 			"aws_msk_configuration":                          dataSourceAwsMskConfiguration(),
+			"aws_msk_kafka_version":                          dataSourceAwsMskKafkaVersion(),
 			"aws_nat_gateway":                                dataSourceAwsNatGateway(),
 			"aws_neptune_orderable_db_instance":              dataSourceAwsNeptuneOrderableDbInstance(),
 			"aws_neptune_engine_version":                     dataSourceAwsNeptuneEngineVersion(),

--- a/website/docs/d/msk_kafka_version.html.markdown
+++ b/website/docs/d/msk_kafka_version.html.markdown
@@ -1,0 +1,36 @@
+---
+subcategory: "Managed Streaming for Kafka (MSK)"
+layout: "aws"
+page_title: "AWS: aws_msk_kafka_version"
+description: |-
+  Get information on a Amazon MSK Kafka Version
+---
+
+# Data Source: aws_msk_cluster
+
+Get information on a Amazon MSK Kafka Version
+
+## Example Usage
+
+```terraform
+data "aws_msk_kafka_version" "test" {
+  preferred_versions = ["2.4.1.1", "2.4.1", "2.2.1"]
+}
+
+data "aws_msk_kafka_version" "test" {
+  version = "2.8.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `preffered_versions` - (Optional) Ordered list of preferred Kafka versions. The first match in this list will be returned. Either `required_versions` or `version` must be set.
+* `version`            - (Optional) Version of MSK Kafka. For example 2.4.1.1 or "2.2.1" etc. Either `required_versions` or `version` must be set.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `status` - Status of the MSK Kafka version eg. ACTIVE, DEPRECATED.

--- a/website/docs/d/msk_kafka_version.html.markdown
+++ b/website/docs/d/msk_kafka_version.html.markdown
@@ -13,11 +13,11 @@ Get information on a Amazon MSK Kafka Version
 ## Example Usage
 
 ```terraform
-data "aws_msk_kafka_version" "test" {
+data "aws_msk_kafka_version" "example" {
   preferred_versions = ["2.4.1.1", "2.4.1", "2.2.1"]
 }
 
-data "aws_msk_kafka_version" "test" {
+data "aws_msk_kafka_version" "example" {
   version = "2.8.0"
 }
 ```

--- a/website/docs/d/msk_kafka_version.html.markdown
+++ b/website/docs/d/msk_kafka_version.html.markdown
@@ -26,11 +26,11 @@ data "aws_msk_kafka_version" "example" {
 
 The following arguments are supported:
 
-* `preffered_versions` - (Optional) Ordered list of preferred Kafka versions. The first match in this list will be returned. Either `required_versions` or `version` must be set.
-* `version`            - (Optional) Version of MSK Kafka. For example 2.4.1.1 or "2.2.1" etc. Either `required_versions` or `version` must be set.
+* `preferred_versions` - (Optional) Ordered list of preferred Kafka versions. The first match in this list will be returned. Either `preferred_versions` or `version` must be set.
+* `version` - (Optional) Version of MSK Kafka. For example 2.4.1.1 or "2.2.1" etc. Either `preferred_versions` or `version` must be set.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `status` - Status of the MSK Kafka version eg. ACTIVE, DEPRECATED.
+* `status` - Status of the MSK Kafka version eg. `ACTIVE` or `DEPRECATED`.

--- a/website/docs/d/msk_kafka_version.html.markdown
+++ b/website/docs/d/msk_kafka_version.html.markdown
@@ -13,7 +13,7 @@ Get information on a Amazon MSK Kafka Version
 ## Example Usage
 
 ```terraform
-data "aws_msk_kafka_version" "example" {
+data "aws_msk_kafka_version" "preferred" {
   preferred_versions = ["2.4.1.1", "2.4.1", "2.2.1"]
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16268

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMskKafkaVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMskKafkaVersion -timeout 180m
=== RUN   TestAccAWSMskKafkaVersion_basic
=== PAUSE TestAccAWSMskKafkaVersion_basic
=== RUN   TestAccAWSMskKafkaVersion_preferred
=== PAUSE TestAccAWSMskKafkaVersion_preferred
=== CONT  TestAccAWSMskKafkaVersion_basic
=== CONT  TestAccAWSMskKafkaVersion_preferred
--- PASS: TestAccAWSMskKafkaVersion_basic (17.61s)
--- PASS: TestAccAWSMskKafkaVersion_preferred (17.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       17.766s
```
