### PR TITLE
rd/route53_zone - add `arn` attribute

### DIFF
--- a/.changelog/20652.txt
+++ b/.changelog/20652.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_route53_zone: Add `arn` attribute
+```
+
+```release-note:enhancement
+resource/aws_route53_zone: Add plan time validation for `comment`
+```
+
+```release-note:enhancement
+data-source/aws_route53_zone: Add `arn` attribute
+```

--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -15,6 +16,10 @@ func dataSourceAwsRoute53Zone() *schema.Resource {
 		Read: dataSourceAwsRoute53ZoneRead,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"zone_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -189,6 +194,13 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "route53",
+		Resource:  fmt.Sprintf("hostedzone/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -24,6 +24,7 @@ func TestAccAWSRoute53ZoneDataSource_id(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsRoute53ZoneConfigId(fqdn),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "name_servers.#", dataSourceName, "name_servers.#"),

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -179,6 +180,7 @@ func TestAccAWSRoute53Zone_basic(t *testing.T) {
 				Config: testAccRoute53ZoneConfig(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					testAccMatchResourceAttrGlobalARNNoAccount(resourceName, "arn", "route53", regexp.MustCompile("hostedzone/.+")),
 					resource.TestCheckResourceAttr(resourceName, "name", zoneName),
 					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -54,6 +54,7 @@ the selected Hosted Zone.
 
 The following attribute is additionally exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the Hosted Zone.
 * `caller_reference` - Caller Reference of the Hosted Zone.
 * `comment` - The comment field of the Hosted Zone.
 * `name_servers` - The list of DNS name servers for the Hosted Zone.

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -84,6 +84,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the zone.
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
 * `name_servers` - A list of name servers in associated (or default) delegation set.
   Find more about delegation sets in [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The Amazon Resource Name (ARN) of the zone.
+* `arn` - The Amazon Resource Name (ARN) of the Hosted Zone.
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
 * `name_servers` - A list of name servers in associated (or default) delegation set.
   Find more about delegation sets in [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20647

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53Zone_'
--- PASS: TestAccAWSRoute53Zone_disappears (78.37s)
--- PASS: TestAccAWSRoute53Zone_multiple (112.07s)
--- PASS: TestAccAWSRoute53Zone_basic (118.98s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (119.63s)
--- PASS: TestAccAWSRoute53Zone_Comment (202.60s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (216.23s)
--- PASS: TestAccAWSRoute53Zone_Tags (243.91s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (272.20s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (314.59s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (354.00s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (489.74s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSRoute53Zone_'
--- PASS: TestAccAWSRoute53ZoneDataSource_id (95.37s)
--- PASS: TestAccAWSRoute53ZoneDataSource_vpc (158.02s)
--- PASS: TestAccAWSRoute53ZoneDataSource_tags (159.61s)
--- PASS: TestAccAWSRoute53ZoneDataSource_serviceDiscovery (176.49s)
Error: no matching Route53Zone found

  on terraform_plugin_test.tf line 6, in data "aws_route53_zone" "test":
   6: data "aws_route53_zone" "test" {


    data_source_aws_route53_zone_test.go:44: Step 1/1 error: Error running pre-apply plan: exit status 1
        
        Error: no matching Route53Zone found
        
          on terraform_plugin_test.tf line 6, in data "aws_route53_zone" "test":
           6: data "aws_route53_zone" "test" {
        
        
--- FAIL: TestAccAWSRoute53ZoneDataSource_name (15.25s)

```

error seems unrelated
