### PR TITLE
rd/route53_delegation_set - add `arn` attribute + remove resource from state when doesn't exist

### DIFF
--- a/.changelog/20664.txt
+++ b/.changelog/20664.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_route53_delegation_set: Add `arn` attribute
+```
+
+```release-note:enhancement
+resource/aws_route53_delegation_set: Add plan time validation for `reference_name`
+```
+
+```release-note:enhancement
+data-source/aws_route53_delegation_set: Add `arn` attribute
+```

--- a/.changelog/20664.txt
+++ b/.changelog/20664.txt
@@ -9,3 +9,7 @@ resource/aws_route53_delegation_set: Add plan time validation for `reference_nam
 ```release-note:enhancement
 data-source/aws_route53_delegation_set: Add `arn` attribute
 ```
+
+```release-note:bug
+resource/aws_route53_delegation_set: Properly remove from state when resource does not exist
+```

--- a/aws/data_source_aws_route53_delegation_set_test.go
+++ b/aws/data_source_aws_route53_delegation_set_test.go
@@ -23,6 +23,7 @@ func TestAccAWSRoute53DelegationSetDataSource_basic(t *testing.T) {
 			{
 				Config: testAccAWSDataSourceAWSRoute53DelegationSetConfig_basic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_servers.#", resourceName, "name_servers.#"),
 					resource.TestMatchResourceAttr("data.aws_route53_delegation_set.dset", "caller_reference", regexp.MustCompile("DynDNS(.*)")),
 				),

--- a/aws/resource_aws_route53_delegation_set_test.go
+++ b/aws/resource_aws_route53_delegation_set_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -26,6 +27,7 @@ func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
 				Config: testAccRoute53DelegationSetConfig(refName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53DelegationSetExists(resourceName),
+					testAccMatchResourceAttrGlobalARNNoAccount(resourceName, "arn", "route53", regexp.MustCompile("delegationset/.+")),
 				),
 			},
 			{
@@ -71,6 +73,28 @@ func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"reference_name"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53DelegationSet_disappears(t *testing.T) {
+	refName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_delegation_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53DelegationSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53DelegationSetConfig(refName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53DelegationSetExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53DelegationSet(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/d/route53_delegation_set.html.markdown
+++ b/website/docs/d/route53_delegation_set.html.markdown
@@ -24,9 +24,11 @@ data "aws_route53_delegation_set" "dset" {
 
 ## Argument Reference
 
+
 * `id` - (Required) The Hosted Zone id of the desired delegation set.
 
 The following attribute is additionally exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the Delegation Set.
 * `caller_reference` - Caller Reference of the delegation set.
 * `name_servers` - The list of DNS name servers for the delegation set.

--- a/website/docs/r/route53_delegation_set.html.markdown
+++ b/website/docs/r/route53_delegation_set.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the Delegation Set.
 * `id` - The delegation set ID
 * `name_servers` - A list of authoritative name servers for the hosted zone
   (effectively a list of NS records).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53DelegationSet_'
--- PASS: TestAccAWSRoute53DelegationSet_disappears (46.16s)
--- PASS: TestAccAWSRoute53DelegationSet_basic (63.57s)
--- PASS: TestAccAWSRoute53DelegationSet_withZones (126.55s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSRoute53DelegationSetDataSource_basic'
--- PASS: TestAccAWSRoute53DelegationSetDataSource_basic (99.35s)
```