### PR TITLE
r/route53_query_log - add `arn` attribute + remove resource from state when doesn't exist

### DIFF
--- a/.changelog/20666.txt
+++ b/.changelog/20666.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_route53_query_log: Add `arn` attribute.
+```
+
+```release-note:bug
+resource/aws_route53_query_log: Properly remove from state when resource does not exist
+```

--- a/aws/resource_aws_route53_query_log.go
+++ b/aws/resource_aws_route53_query_log.go
@@ -99,8 +99,12 @@ func resourceAwsRoute53QueryLogDelete(d *schema.ResourceData, meta interface{}) 
 	}
 	log.Printf("[DEBUG] Deleting Route53 query logging configuration: %#v", input)
 	_, err := r53.DeleteQueryLoggingConfig(input)
+	if isAWSErr(err, route53.ErrCodeNoSuchQueryLoggingConfig, "") {
+		return nil
+	}
+
 	if err != nil {
-		return fmt.Errorf("Error deleting Route53 query logging configuration: %s", err)
+		return fmt.Errorf("error deleting Route53 query logging configuration (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_route53_query_log.go
+++ b/aws/resource_aws_route53_query_log.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -19,6 +20,10 @@ func resourceAwsRoute53QueryLog() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"cloudwatch_log_group_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -64,12 +69,24 @@ func resourceAwsRoute53QueryLogRead(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Reading Route53 query logging configuration: %#v", input)
 	out, err := r53.GetQueryLoggingConfig(input)
 	if err != nil {
+		if isAWSErr(err, route53.ErrCodeNoSuchQueryLoggingConfig, "") || isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+			log.Printf("[WARN] Route53 Query Logging Config (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading Route53 query logging configuration: %s", err)
 	}
 	log.Printf("[DEBUG] Route53 query logging configuration received: %#v", out)
 
 	d.Set("cloudwatch_log_group_arn", out.QueryLoggingConfig.CloudWatchLogsLogGroupArn)
 	d.Set("zone_id", out.QueryLoggingConfig.HostedZoneId)
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "route53",
+		Resource:  fmt.Sprintf("queryloggingconfig/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,13 +38,10 @@ func testSweepRoute53QueryLogs(region string) error {
 		for _, queryLoggingConfig := range page.QueryLoggingConfigs {
 			id := aws.StringValue(queryLoggingConfig.Id)
 
-			log.Printf("[INFO] Deleting Route53 query logging configuration: %s", id)
-			_, err := conn.DeleteQueryLoggingConfig(&route53.DeleteQueryLoggingConfigInput{
-				Id: aws.String(id),
-			})
-			if isAWSErr(err, route53.ErrCodeNoSuchQueryLoggingConfig, "") {
-				continue
-			}
+			r := resourceAwsRoute53QueryLog()
+			d := r.Data(nil)
+			d.SetId(id)
+			err := r.Delete(d, client)
 			if err != nil {
 				sweeperErr := fmt.Errorf("error deleting Route53 query logging configuration (%s): %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
@@ -86,6 +84,7 @@ func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 				Config: testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53QueryLogExists(resourceName, &queryLoggingConfig),
+					testAccMatchResourceAttrGlobalARNNoAccount(resourceName, "arn", "route53", regexp.MustCompile("queryloggingconfig/.+")),
 					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_log_group_arn", cloudwatchLogGroupResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "zone_id", route53ZoneResourceName, "zone_id"),
 				),
@@ -94,6 +93,57 @@ func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53QueryLog_disappears(t *testing.T) {
+	resourceName := "aws_route53_query_log.test"
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domainName := testAccRandomDomainName()
+
+	var queryLoggingConfig route53.QueryLoggingConfig
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckRoute53QueryLog(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRoute53QueryLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53QueryLogExists(resourceName, &queryLoggingConfig),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53QueryLog(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53QueryLog_disappears_hostedZone(t *testing.T) {
+	resourceName := "aws_route53_query_log.test"
+	route53ZoneResourceName := "aws_route53_zone.test"
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	domainName := testAccRandomDomainName()
+
+	var queryLoggingConfig route53.QueryLoggingConfig
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckRoute53QueryLog(t) },
+		ErrorCheck:        testAccErrorCheck(t, route53.EndpointsID),
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckRoute53QueryLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53QueryLogExists(resourceName, &queryLoggingConfig),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute53Zone(), route53ZoneResourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/route53_query_log.html.markdown
+++ b/website/docs/r/route53_query_log.html.markdown
@@ -84,6 +84,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the Query Logging Config.
 * `id` - The query logging configuration ID
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17954.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53QueryLog_'
--- PASS: TestAccAWSRoute53QueryLog_disappears_hostedZone (131.76s)
--- PASS: TestAccAWSRoute53QueryLog_disappears (142.06s)
--- PASS: TestAccAWSRoute53QueryLog_basic (162.43s)
```
