### PR TITLE
Fix AWS S3 bucket import of `acl` and `grant` attributes

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -3048,6 +3048,9 @@ func flattenCannedACL(d *schema.ResourceData, ap *s3.GetBucketAclOutput) bool {
 		d.Set("acl", "aws-exec-read")
 	case owner_full_control && !all_users_read && !all_users_write && !authenticated_users_read && !ec2_read && logdelivery_read_acp && logdelivery_write:
 		d.Set("acl", "log-delivery-write")
+	default:
+		// No combination matched a canned ACL
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6193 and #17791

Relates #3728

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_REGION=eu-west-3 make testacc TESTARGS='-run=TestAccAWSS3Bucket_Security'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_Security -timeout 180m
=== RUN   TestAccAWSS3Bucket_Security_policy
=== PAUSE TestAccAWSS3Bucket_Security_policy
=== RUN   TestAccAWSS3Bucket_Security_updateACL
=== PAUSE TestAccAWSS3Bucket_Security_updateACL
=== RUN   TestAccAWSS3Bucket_Security_updateGrant
=== PAUSE TestAccAWSS3Bucket_Security_updateGrant
=== RUN   TestAccAWSS3Bucket_Security_ACLToGrant
=== PAUSE TestAccAWSS3Bucket_Security_ACLToGrant
=== RUN   TestAccAWSS3Bucket_Security_GrantToACL
=== PAUSE TestAccAWSS3Bucket_Security_GrantToACL
=== RUN   TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== PAUSE TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== RUN   TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== PAUSE TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== RUN   TestAccAWSS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== RUN   TestAccAWSS3Bucket_Security_corsUpdate
=== PAUSE TestAccAWSS3Bucket_Security_corsUpdate
=== RUN   TestAccAWSS3Bucket_Security_corsDelete
=== PAUSE TestAccAWSS3Bucket_Security_corsDelete
=== RUN   TestAccAWSS3Bucket_Security_corsEmptyOrigin
=== PAUSE TestAccAWSS3Bucket_Security_corsEmptyOrigin
=== RUN   TestAccAWSS3Bucket_Security_logging
=== PAUSE TestAccAWSS3Bucket_Security_logging
=== CONT  TestAccAWSS3Bucket_Security_policy
=== CONT  TestAccAWSS3Bucket_Security_ACLToGrant
=== CONT  TestAccAWSS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== CONT  TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== CONT  TestAccAWSS3Bucket_Security_logging
=== CONT  TestAccAWSS3Bucket_Security_corsDelete
=== CONT  TestAccAWSS3Bucket_Security_corsEmptyOrigin
=== CONT  TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== CONT  TestAccAWSS3Bucket_Security_updateGrant
=== CONT  TestAccAWSS3Bucket_Security_GrantToACL
=== CONT  TestAccAWSS3Bucket_Security_updateACL
=== CONT  TestAccAWSS3Bucket_Security_corsUpdate
--- PASS: TestAccAWSS3Bucket_Security_corsDelete (28.51s)
--- PASS: TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenTypical (31.10s)
--- PASS: TestAccAWSS3Bucket_Security_corsEmptyOrigin (31.45s)
--- PASS: TestAccAWSS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (32.20s)
--- PASS: TestAccAWSS3Bucket_Security_logging (33.30s)
--- PASS: TestAccAWSS3Bucket_Security_ACLToGrant (45.32s)
--- PASS: TestAccAWSS3Bucket_Security_corsUpdate (45.82s)
--- PASS: TestAccAWSS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (46.39s)
--- PASS: TestAccAWSS3Bucket_Security_GrantToACL (47.10s)
--- PASS: TestAccAWSS3Bucket_Security_policy (57.15s)
--- PASS: TestAccAWSS3Bucket_Security_updateGrant (60.18s)
--- PASS: TestAccAWSS3Bucket_Security_updateACL (99.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       99.222s
```
