### PR TITLE
fix build_type default value

### DIFF
--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -199,17 +199,22 @@ func resourceAwsCodeBuildWebhookUpdate(d *schema.ResourceData, meta interface{})
 	var err error
 	filterGroups := expandWebhookFilterGroups(d)
 
+	var buildType *string = nil
+	if v, ok := d.GetOk("build_type"); ok {
+		buildType = aws.String(v.(string))
+	}
+
 	if len(filterGroups) >= 1 {
 		_, err = conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
 			ProjectName:  aws.String(d.Id()),
-			BuildType:    aws.String(d.Get("build_type").(string)),
+			BuildType:    buildType,
 			FilterGroups: filterGroups,
 			RotateSecret: aws.Bool(false),
 		})
 	} else {
 		_, err = conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
 			ProjectName:  aws.String(d.Id()),
-			BuildType:    aws.String(d.Get("build_type").(string)),
+			BuildType:    buildType,
 			BranchFilter: aws.String(d.Get("branch_filter").(string)),
 			RotateSecret: aws.Bool(false),
 		})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSCodeBuildWebhook_BuildType'                                      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildWebhook_BuildType -timeout 180m
=== RUN   TestAccAWSCodeBuildWebhook_BuildType
=== PAUSE TestAccAWSCodeBuildWebhook_BuildType
=== CONT  TestAccAWSCodeBuildWebhook_BuildType
--- PASS: TestAccAWSCodeBuildWebhook_BuildType (96.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       97.836s
```
