### PR TITLE
[WIP] add support for method throttling in usage plans

### DIFF
--- a/website/docs/r/api_gateway_usage_plan.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan.html.markdown
@@ -74,6 +74,13 @@ resource "aws_api_gateway_usage_plan" "example" {
   api_stages {
     api_id = aws_api_gateway_rest_api.example.id
     stage  = aws_api_gateway_stage.production.stage_name
+    throttle {
+      method = "/pets/GET"
+      throttle_settings {
+        burst_limit = 3
+        rate_limit  = 6
+      }
+    }
   }
 
   quota_settings {
@@ -107,6 +114,7 @@ The API Gateway Usage Plan argument layout is a structure composed of several su
 
 * `api_id` (Required) - API Id of the associated API stage in a usage plan.
 * `stage` (Required) - API stage name of the associated API stage in a usage plan.
+* `throttle` (Optional) - Method-level throttling information for an API stage in a usage plan.
 
 #### Quota Settings Arguments
 
@@ -118,6 +126,11 @@ The API Gateway Usage Plan argument layout is a structure composed of several su
 
 * `burst_limit` (Optional) - The API request burst limit, the maximum rate limit over a time ranging from one to a few seconds, depending upon whether the underlying token bucket is at its full capacity.
 * `rate_limit` (Optional) - The API request steady-state rate limit.
+
+##### Api Stages Method Throttling arguments
+
+* `method` (Required) - Method for which to configure custom throttling, for example, "/pets/GET".
+* `throttle_settings` (Required) - The [throttling limits](#throttling-settings-arguments) of the method.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

based on:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-usageplan-apistage.html


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
