### PR TITLE
aws_ami_launch_permission: support group permissions

### DIFF
--- a/.changelog/20677.txt
+++ b/.changelog/20677.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ami_launch_permission: Add `group` support for making public AMIs
+```

--- a/aws/resource_aws_ami_launch_permission.go
+++ b/aws/resource_aws_ami_launch_permission.go
@@ -19,14 +19,32 @@ func resourceAwsAmiLaunchPermission() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), "/")
-				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-					return nil, fmt.Errorf("Unexpected format of ID (%q), expected ACCOUNT-ID/IMAGE-ID", d.Id())
+
+				parseError := fmt.Errorf("Unexpected format of ID (%q), expected ACCOUNT-ID/IMAGE-ID or group/GROUP-NAME/ACCOUNT-ID", d.Id())
+				if len(idParts) == 2 {
+					// Parsing the ACCOUNT-ID/IMAGE-ID branch
+					if idParts[0] == "" || idParts[1] == "" {
+						return nil, parseError
+					}
+					accountId := idParts[0]
+					imageId := idParts[1]
+					d.Set("account_id", accountId)
+					d.Set("image_id", imageId)
+					d.SetId(fmt.Sprintf("%s-account-%s", imageId, accountId))
+				} else if len(idParts) == 3 && idParts[0] == "group" {
+					// Parsing the group/GROUP-NAME/ACCOUNT-ID branch
+					if idParts[1] == "" || idParts[2] == "" {
+						return nil, parseError
+					}
+					groupName := idParts[1]
+					imageId := idParts[2]
+					d.Set("group_name", groupName)
+					d.Set("image_id", imageId)
+					d.SetId(fmt.Sprintf("%s-group-%s", imageId, groupName))
+				} else {
+					return nil, parseError
 				}
-				accountId := idParts[0]
-				imageId := idParts[1]
-				d.Set("account_id", accountId)
-				d.Set("image_id", imageId)
-				d.SetId(fmt.Sprintf("%s-%s", imageId, accountId))
+
 				return []*schema.ResourceData{d}, nil
 			},
 		},
@@ -39,8 +57,21 @@ func resourceAwsAmiLaunchPermission() *schema.Resource {
 			},
 			"account_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				ExactlyOneOf: []string{
+					"account_id",
+					"group_name",
+				},
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ExactlyOneOf: []string{
+					"account_id",
+					"group_name",
+				},
 			},
 		},
 	}
@@ -51,13 +82,22 @@ func resourceAwsAmiLaunchPermissionCreate(d *schema.ResourceData, meta interface
 
 	image_id := d.Get("image_id").(string)
 	account_id := d.Get("account_id").(string)
+	group_name := d.Get("group_name").(string)
+
+	var launch_permission *ec2.LaunchPermission
+
+	if account_id != "" {
+		launch_permission = &ec2.LaunchPermission{UserId: aws.String(account_id)}
+	} else {
+		launch_permission = &ec2.LaunchPermission{Group: aws.String(group_name)}
+	}
 
 	_, err := conn.ModifyImageAttribute(&ec2.ModifyImageAttributeInput{
 		ImageId:   aws.String(image_id),
 		Attribute: aws.String(ec2.ImageAttributeNameLaunchPermission),
 		LaunchPermission: &ec2.LaunchPermissionModifications{
 			Add: []*ec2.LaunchPermission{
-				{UserId: aws.String(account_id)},
+				launch_permission,
 			},
 		},
 	})
@@ -65,14 +105,19 @@ func resourceAwsAmiLaunchPermissionCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error creating AMI launch permission: %w", err)
 	}
 
-	d.SetId(fmt.Sprintf("%s-%s", image_id, account_id))
+	if account_id != "" {
+		d.SetId(fmt.Sprintf("%s-account-%s", image_id, account_id))
+	} else {
+		d.SetId(fmt.Sprintf("%s-group-%s", image_id, group_name))
+	}
+
 	return nil
 }
 
 func resourceAwsAmiLaunchPermissionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	exists, err := hasLaunchPermission(conn, d.Get("image_id").(string), d.Get("account_id").(string))
+	exists, err := hasLaunchPermission(conn, d.Get("image_id").(string), d.Get("account_id").(string), d.Get("group_name").(string))
 	if err != nil {
 		return fmt.Errorf("error reading AMI launch permission (%s): %w", d.Id(), err)
 	}
@@ -94,13 +139,21 @@ func resourceAwsAmiLaunchPermissionDelete(d *schema.ResourceData, meta interface
 
 	image_id := d.Get("image_id").(string)
 	account_id := d.Get("account_id").(string)
+	group_name := d.Get("group_name").(string)
 
+	var launch_permission *ec2.LaunchPermission
+
+	if account_id != "" {
+		launch_permission = &ec2.LaunchPermission{UserId: aws.String(account_id)}
+	} else {
+		launch_permission = &ec2.LaunchPermission{Group: aws.String(group_name)}
+	}
 	_, err := conn.ModifyImageAttribute(&ec2.ModifyImageAttributeInput{
 		ImageId:   aws.String(image_id),
 		Attribute: aws.String(ec2.ImageAttributeNameLaunchPermission),
 		LaunchPermission: &ec2.LaunchPermissionModifications{
 			Remove: []*ec2.LaunchPermission{
-				{UserId: aws.String(account_id)},
+				launch_permission,
 			},
 		},
 	})
@@ -111,7 +164,7 @@ func resourceAwsAmiLaunchPermissionDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func hasLaunchPermission(conn *ec2.EC2, image_id string, account_id string) (bool, error) {
+func hasLaunchPermission(conn *ec2.EC2, image_id string, account_id string, group_name string) (bool, error) {
 	attrs, err := conn.DescribeImageAttribute(&ec2.DescribeImageAttributeInput{
 		ImageId:   aws.String(image_id),
 		Attribute: aws.String(ec2.ImageAttributeNameLaunchPermission),
@@ -127,7 +180,9 @@ func hasLaunchPermission(conn *ec2.EC2, image_id string, account_id string) (boo
 	}
 
 	for _, lp := range attrs.LaunchPermissions {
-		if aws.StringValue(lp.UserId) == account_id {
+		if account_id != "" && aws.StringValue(lp.UserId) == account_id {
+			return true, nil
+		} else if group_name != "" && aws.StringValue(lp.Group) == group_name {
 			return true, nil
 		}
 	}

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -19,23 +19,38 @@ resource "aws_ami_launch_permission" "example" {
 }
 ```
 
+```terraform
+resource "aws_ami_launch_permission" "example" {
+  image_id   = "ami-12345678"
+  group_name = "all"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `image_id` - (required) A region-unique name for the AMI.
-* `account_id` - (required) An AWS Account ID to add launch permissions.
+
+One of the following launch permission arguments must be supplied:
+
+* `account_id` - (Optional) An AWS Account ID to grant launch permissions.
+* `group_name` - (Optional) The name of the group to grant launch permissions.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A combination of "`image_id`-`account_id`".
+* `id` - A combination of "`image_id`-account-`account_id`" or "`image_id`-group-`group_name`".
 
 ## Import
 
-AWS AMI Launch Permission can be imported using the `ACCOUNT-ID/IMAGE-ID`, e.g.
+AWS AMI Launch Permission can be imported using the `ACCOUNT-ID/IMAGE-ID` or `group/GROUP-NAME/IMAGE-ID`, , e.g.
 
 ```sh
 $ terraform import aws_ami_launch_permission.example 123456789012/ami-12345678
+```
+
+```sh
+$ terraform import aws_ami_launch_permission.example group/all/ami-12345678
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11101

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ time make fmt testacc TESTARGS='-run=TestAccAWSAMILaunchPermission'
==> Fixing source code with gofmt...
gofmt -s -w ./aws ./awsproviderlint/helper ./awsproviderlint/main.go ./awsproviderlint/passes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAMILaunchPermission -timeout 180m
=== RUN   TestAccAWSAMILaunchPermission_Account_basic
=== PAUSE TestAccAWSAMILaunchPermission_Account_basic
=== RUN   TestAccAWSAMILaunchPermission_Group_basic
=== PAUSE TestAccAWSAMILaunchPermission_Group_basic
=== RUN   TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission
=== PAUSE TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission
=== RUN   TestAccAWSAMILaunchPermission_Group_Disappears_LaunchPermission
=== PAUSE TestAccAWSAMILaunchPermission_Group_Disappears_LaunchPermission
=== RUN   TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission_Public
=== PAUSE TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission_Public
=== RUN   TestAccAWSAMILaunchPermission_Account_Disappears_AMI
=== PAUSE TestAccAWSAMILaunchPermission_Account_Disappears_AMI
=== RUN   TestAccAWSAMILaunchPermission_Group_Disappears_AMI
=== PAUSE TestAccAWSAMILaunchPermission_Group_Disappears_AMI
=== CONT  TestAccAWSAMILaunchPermission_Account_basic
=== CONT  TestAccAWSAMILaunchPermission_Group_Disappears_AMI
=== CONT  TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission
=== CONT  TestAccAWSAMILaunchPermission_Group_Disappears_LaunchPermission
=== CONT  TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission_Public
=== CONT  TestAccAWSAMILaunchPermission_Account_Disappears_AMI
=== CONT  TestAccAWSAMILaunchPermission_Group_basic
--- PASS: TestAccAWSAMILaunchPermission_Group_Disappears_LaunchPermission (361.20s)
--- PASS: TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission (361.62s)
--- PASS: TestAccAWSAMILaunchPermission_Account_Disappears_LaunchPermission_Public (362.57s)
--- PASS: TestAccAWSAMILaunchPermission_Group_basic (366.17s)
--- PASS: TestAccAWSAMILaunchPermission_Account_basic (374.68s)
--- PASS: TestAccAWSAMILaunchPermission_Account_Disappears_AMI (404.18s)
--- PASS: TestAccAWSAMILaunchPermission_Group_Disappears_AMI (404.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	404.495s

real	6m55.521s
user	1m54.557s
sys	0m8.773s
```
