### PR TITLE
use configuration_set name instead of arn in aws_pinpoint_email_channel_resource

### DIFF
--- a/.changelog/20691.txt
+++ b/.changelog/20691.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_pinpoint_email_channel: When specifying the `configuration_set` parameter, use the name of the set instead of the ARN.
+```

--- a/aws/resource_aws_pinpoint_email_channel.go
+++ b/aws/resource_aws_pinpoint_email_channel.go
@@ -26,9 +26,8 @@ func resourceAwsPinpointEmailChannel() *schema.Resource {
 				ForceNew: true,
 			},
 			"configuration_set": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateArn,
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_pinpoint_email_channel_test.go
+++ b/aws/resource_aws_pinpoint_email_channel_test.go
@@ -72,7 +72,7 @@ func TestAccAWSPinpointEmailChannel_configurationSet(t *testing.T) {
 				Config: testAccAWSPinpointEmailChannelConfigConfigurationSet(domain, address, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEmailChannelExists(resourceName, &channel),
-					resource.TestCheckResourceAttrPair(resourceName, "configuration_set", "aws_ses_configuration_set.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_set", "aws_ses_configuration_set.test", "name"),
 				),
 			},
 			{
@@ -239,7 +239,7 @@ resource "aws_pinpoint_email_channel" "test" {
   from_address      = %[2]q
   identity          = aws_ses_domain_identity.test.arn
   role_arn          = aws_iam_role.test.arn
-  configuration_set = aws_ses_configuration_set.test.arn
+  configuration_set = aws_ses_configuration_set.test.name
 }
 
 resource "aws_ses_domain_identity" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20295

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSPinpointEmailChannel_'                                      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSPinpointEmailChannel_ -timeout 180m
=== RUN   TestAccAWSPinpointEmailChannel_basic
=== PAUSE TestAccAWSPinpointEmailChannel_basic
=== RUN   TestAccAWSPinpointEmailChannel_configurationSet
=== PAUSE TestAccAWSPinpointEmailChannel_configurationSet
=== RUN   TestAccAWSPinpointEmailChannel_noRole
=== PAUSE TestAccAWSPinpointEmailChannel_noRole
=== RUN   TestAccAWSPinpointEmailChannel_disappears
=== PAUSE TestAccAWSPinpointEmailChannel_disappears
=== CONT  TestAccAWSPinpointEmailChannel_basic
=== CONT  TestAccAWSPinpointEmailChannel_noRole
=== CONT  TestAccAWSPinpointEmailChannel_configurationSet
=== CONT  TestAccAWSPinpointEmailChannel_disappears
--- PASS: TestAccAWSPinpointEmailChannel_disappears (11.08s)
--- PASS: TestAccAWSPinpointEmailChannel_noRole (12.19s)
--- PASS: TestAccAWSPinpointEmailChannel_configurationSet (12.54s)
--- PASS: TestAccAWSPinpointEmailChannel_basic (19.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       19.560s
```
