### PR TITLE
Update aws_servicecatalog_provisioned_product example

### DIFF
--- a/website/docs/r/servicecatalog_provisioned_product.html.markdown
+++ b/website/docs/r/servicecatalog_provisioned_product.html.markdown
@@ -24,12 +24,13 @@ Like this resource, the `aws_servicecatalog_record` data source also provides in
 
 ```terraform
 resource "aws_servicecatalog_provisioned_product" "example" {
-  name  = "example"
-  owner = [aws_security_group.example.id]
-  type  = aws_subnet.main.id
+  name                       = "example"
+  product_name               = "Example product"
+  provisioning_artifact_name = "Example version"
 
-  provisioning_artifact_parameters {
-    template_url = "https://s3.amazonaws.com/cf-templates-ozkq9d3hgiq2-us-east-1/temp1.json"
+  provisioning_parameters {
+    key   = "foo"
+    value = "bar"
   }
 
   tags = {


### PR DESCRIPTION
Update aws_servicecatalog_provisioned_product documentation with a valid example. The existing example looks like it was copied from aws_servicecatalog_product.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

N/A - doc changes only.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
