### PR TITLE
Fix missing default value in cloudfront_distribution's origin.origin_path

### DIFF
--- a/.changelog/20709.txt
+++ b/.changelog/20709.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution: Fix default value of `origin_path` in `origin` block
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -577,6 +577,7 @@ func ResourceDistribution() *schema.Resource {
 						"origin_path": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"origin_shield": {
 							Type:     schema.TypeList,


### PR DESCRIPTION
The default value of `origin_path` parameter in `origin` block is blank string (`""`), not `null`.
It is known problem in https://github.com/hashicorp/terraform-provider-aws/issues/12065.  The workaround is described in the issue.
Without this PR, modifing `aws_cloudfront_distrtibution` will **crash** and state get **broken**.

It is apparently a bug in the provider and it should be handled by provider.

I have confirmed CLI (`aws cloudfront get-distribution`) returns blank string (`""`) as default value if create resource without setting `origin_path` explicitly.

According to the document, the default value is not noted though.
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_Origin.html

This problem is work-arounded https://github.com/jmgreg31/terraform-aws-cloudfront/pull/38.

Relates: #12065

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request



Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccAWSCloudFrontDistribution*'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution* -timeout 180m
(RUN, PAUSE, and CONT are omitted)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (84.70s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (88.44s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (378.55s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (381.56s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedKeyGroups (425.97s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (430.12s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_RealtimeLogConfigArn (435.36s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_RealtimeLogConfigArn (442.50s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (455.09s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (483.63s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (504.55s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (559.72s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (560.71s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (565.85s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (567.32s)
--- PASS: TestAccAWSCloudFrontDistribution_originPolicyOrdered (482.98s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehaviorCachePolicy (480.73s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_ConnectionTimeout (610.52s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_ConnectionAttempts (610.79s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_OriginShield (611.74s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (236.41s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (265.15s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (306.66s)
--- PASS: TestAccAWSCloudFrontDistribution_forwardedValuesToCachePolicy (751.16s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (392.02s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (473.06s)
--- PASS: TestAccAWSCloudFrontDistribution_originPolicyDefault (469.09s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (479.67s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (905.76s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (531.50s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (374.37s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (449.19s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (577.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1086.053s
```
