### PR TITLE
feat: add `platform_identifier` to `r/aws_sagemaker_notebook_instance`

### DIFF
--- a/.changelog/20711.txt
+++ b/.changelog/20711.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_notebook_instance: Add `platform_identifier` argument
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## 3.57.0 (Unreleased)
 ## 3.56.0 (August 26, 2021)
 
 FEATURES:

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the notebook instance (must be unique).
 * `role_arn` - (Required) The ARN of the IAM role to be used by the notebook instance which allows SageMaker to call other services on your behalf.
 * `instance_type` - (Required) The name of ML compute instance type.
+* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1` or `notebook-al2-v1`, depending on which version of Amazon Linux you require.
 * `volume_size` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #20706

Release notes for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```
resource_aws_sagemaker_notebook_instance - add `platform_identifier` parameter
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSagemakerNotebookInstance_basic -timeout 180m
=== RUN   TestAccAWSSagemakerNotebookInstance_basic
=== PAUSE TestAccAWSSagemakerNotebookInstance_basic
=== CONT  TestAccAWSSagemakerNotebookInstance_basic
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (482.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       482.954s

$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_platform_identifier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSagemakerNotebookInstance_platform_identifier -timeout 180m
=== RUN   TestAccAWSSagemakerNotebookInstance_platform_identifier
=== PAUSE TestAccAWSSagemakerNotebookInstance_platform_identifier
=== CONT  TestAccAWSSagemakerNotebookInstance_platform_identifier
--- PASS: TestAccAWSSagemakerNotebookInstance_platform_identifier (882.85s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       882.949s
```
