### PR TITLE
Fix: Add settings field to ecs.DescribeClustersInput

### DIFF
--- a/.changelog/20720.txt
+++ b/.changelog/20720.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_cluster: Ensure that `setting` attribute is set consistently
+```

--- a/aws/internal/service/ecs/finder/finder.go
+++ b/aws/internal/service/ecs/finder/finder.go
@@ -40,7 +40,11 @@ func CapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider, er
 func ClusterByARN(conn *ecs.ECS, arn string) (*ecs.DescribeClustersOutput, error) {
 	input := &ecs.DescribeClustersInput{
 		Clusters: []*string{aws.String(arn)},
-		Include:  []*string{aws.String(ecs.ClusterFieldTags), aws.String(ecs.ClusterFieldConfigurations)},
+		Include: []*string{
+			aws.String(ecs.ClusterFieldTags),
+			aws.String(ecs.ClusterFieldConfigurations),
+			aws.String(ecs.ClusterFieldSettings),
+		},
 	}
 
 	output, err := conn.DescribeClusters(input)


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-aws/issues/20684.

In some cases, the result of `settings` item by ecs `describe-clusters` call was empty.
Therefore, I added the `Include` input parameter to explicitly get `settings` item.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #20684 

Output from acceptance testing:

Sorry I couldn't run the acceptance test.
But I locally confirmed that https://github.com/hashicorp/terraform-provider-aws/issues/20684 was resolved after this fix.