### PR TITLE
Add recovery control health check type

### DIFF
--- a/.changelog/20731.txt
+++ b/.changelog/20731.txt
@@ -1,0 +1,4 @@
+
+```release-note:enhancement
+resoucre_aws_route53_health_check: Add `RECOVERY_CONTROL` health check type and `routing_control_arn` attriute
+```

--- a/.changelog/20731.txt
+++ b/.changelog/20731.txt
@@ -1,4 +1,3 @@
-
 ```release-note:enhancement
-resoucre_aws_route53_health_check: Add `RECOVERY_CONTROL` health check type and `routing_control_arn` attriute
+resource_aws_route53_health_check: Add `RECOVERY_CONTROL` health check type and `routing_control_arn` argument
 ```

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -37,16 +37,7 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				StateFunc: func(val interface{}) string {
 					return strings.ToUpper(val.(string))
 				},
-				ValidateFunc: validation.StringInSlice([]string{
-					route53.HealthCheckTypeCalculated,
-					route53.HealthCheckTypeCloudwatchMetric,
-					route53.HealthCheckTypeHttp,
-					route53.HealthCheckTypeHttpStrMatch,
-					route53.HealthCheckTypeHttps,
-					route53.HealthCheckTypeHttpsStrMatch,
-					route53.HealthCheckTypeTcp,
-					route53.HealthCheckTypeRecoveryControl,
-				}, true),
+				ValidateFunc: validation.StringInSlice(route53.HealthCheckType_Values(), true),
 			},
 			"failure_threshold": {
 				Type:         schema.TypeInt,

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -156,9 +156,10 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			},
 
 			"routing_control_arn": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"tags":     tagsSchema(),

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -717,8 +717,8 @@ resource "aws_route53_health_check" "test" {
 `, disabled)
 }
 
-func testAccRoute53HealthCheckConfigRoutingControlArn (rName string) string {
-    return fmt.Sprintf(`
+func testAccRoute53HealthCheckConfigRoutingControlArn(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_route53recoverycontrolconfig_cluster" "test" {
   name = %[1]q
 }

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -335,6 +335,7 @@ func TestAccAWSRoute53HealthCheck_Disabled(t *testing.T) {
 
 func TestAccAWSRoute53HealthCheck_withRoutingControlArn(t *testing.T) {
 	var check route53.HealthCheck
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -343,7 +344,7 @@ func TestAccAWSRoute53HealthCheck_withRoutingControlArn(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckConfigRoutingControlArn,
+				Config: testAccRoute53HealthCheckConfigRoutingControlArn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "type", "RECOVERY_CONTROL"),
@@ -716,18 +717,18 @@ resource "aws_route53_health_check" "test" {
 `, disabled)
 }
 
-const testAccRoute53HealthCheckConfigRoutingControlArn = `
+func testAccRoute53HealthCheckConfigRoutingControlArn (rName string) string {
+    return fmt.Sprintf(`
 resource "aws_route53recoverycontrolconfig_cluster" "test" {
-  name = "tf-acc-test-cluster"
+  name = %[1]q
 }
-
 resource "aws_route53recoverycontrolconfig_routing_control" "test" {
-  name        = "tf-acc-test"
+  name        = %[1]q
   cluster_arn = aws_route53recoverycontrolconfig_cluster.test.arn
 }
-
 resource "aws_route53_health_check" "test" {
   type                = "RECOVERY_CONTROL"
   routing_control_arn = aws_route53recoverycontrolconfig_routing_control.test.arn
 }
-`
+`, rName)
+}

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -82,7 +82,6 @@ resource "aws_route53_health_check" "foo" {
 ### Recovery control health check
 
 ```terraform
-
 resource "aws_route53recoverycontrolconfig_cluster" "test" {
   name = "tf-acc-test-cluster"
 }

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -110,7 +110,7 @@ The following arguments are supported:
 * `cloudwatch_alarm_region` - (Optional) The CloudWatchRegion that the CloudWatch alarm was created in.
 * `insufficient_data_health_status` - (Optional) The status of the health check when CloudWatch has insufficient data about the state of associated alarm. Valid values are `Healthy` , `Unhealthy` and `LastKnownStatus`.
 * `regions` - (Optional) A list of AWS regions that you want Amazon Route 53 health checkers to check the specified endpoint from.
-* `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is `RECOVERY_CONTROL`
+* `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is `RECOVERY_CONTROL` 
 * `tags` - (Optional) A map of tags to assign to the health check. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -110,7 +110,7 @@ The following arguments are supported:
 * `cloudwatch_alarm_region` - (Optional) The CloudWatchRegion that the CloudWatch alarm was created in.
 * `insufficient_data_health_status` - (Optional) The status of the health check when CloudWatch has insufficient data about the state of associated alarm. Valid values are `Healthy` , `Unhealthy` and `LastKnownStatus`.
 * `regions` - (Optional) A list of AWS regions that you want Amazon Route 53 health checkers to check the specified endpoint from.
-* `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is `RECOVERY_CONTROL` 
+* `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is `RECOVERY_CONTROL`
 * `tags` - (Optional) A map of tags to assign to the health check. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -79,24 +79,6 @@ resource "aws_route53_health_check" "foo" {
 }
 ```
 
-### Recovery control health check
-
-```terraform
-resource "aws_route53recoverycontrolconfig_cluster" "test" {
-  name = "tf-acc-test-cluster"
-}
-
-resource "aws_route53recoverycontrolconfig_routing_control" "test" {
-  name        = "tf-acc-test"
-  cluster_arn = aws_route53recoverycontrolconfig_cluster.test.arn
-}
-
-resource "aws_route53_health_check" "test" {
-  type                = "RECOVERY_CONTROL"
-  routing_control_arn = aws_route53recoverycontrolconfig_routing_control.test.arn
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -128,7 +110,7 @@ The following arguments are supported:
 * `cloudwatch_alarm_region` - (Optional) The CloudWatchRegion that the CloudWatch alarm was created in.
 * `insufficient_data_health_status` - (Optional) The status of the health check when CloudWatch has insufficient data about the state of associated alarm. Valid values are `Healthy` , `Unhealthy` and `LastKnownStatus`.
 * `regions` - (Optional) A list of AWS regions that you want Amazon Route 53 health checkers to check the specified endpoint from.
-* `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is RECOVERY_CONTROL
+* `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is `RECOVERY_CONTROL`
 * `tags` - (Optional) A map of tags to assign to the health check. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
 Closes [#20730](https://github.com/hashicorp/terraform-provider-aws/issues/20730)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53HealthCheck_withRoutingControlArn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53HealthCheck_withRoutingControlArn -timeout 180m
=== RUN   TestAccAWSRoute53HealthCheck_withRoutingControlArn
=== PAUSE TestAccAWSRoute53HealthCheck_withRoutingControlArn
=== CONT  TestAccAWSRoute53HealthCheck_withRoutingControlArn
--- PASS: TestAccAWSRoute53HealthCheck_withRoutingControlArn (94.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	104.767s

...
```
