### PR TITLE
Run `go get github.com/zclconf/go-cty/cty/msgpack@v1.9.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/pquerna/otp v1.3.0
 	github.com/shopspring/decimal v1.2.0
+	github.com/zclconf/go-cty v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -325,7 +325,9 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
+github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
@@ -336,6 +338,8 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.4 h1:pwhhz5P+Fjxse7S7UriBrMu6AUJSZM5pKqGem1PjGAs=
 github.com/zclconf/go-cty v1.8.4/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.9.0 h1:IgJxw5b4LPXCPeqFjjhLaNEA8NKXMyaEUdAd399acts=
+github.com/zclconf/go-cty v1.9.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Fixes

```
Run cd tools && go install github.com/terraform-linters/tflint
go: downloading github.com/terraform-linters/tflint v0.31.0
go: downloading github.com/mattn/go-colorable v0.1.8
go: downloading github.com/fatih/color v1.12.0
go: downloading github.com/hashicorp/hcl v1.0.0
go: downloading github.com/jessevdk/go-flags v1.5.0
go: downloading github.com/sourcegraph/jsonrpc2 v0.1.0
go: downloading github.com/hashicorp/hcl/v2 v2.10.1
go: downloading github.com/spf13/afero v1.6.0
go: downloading github.com/terraform-linters/tflint-plugin-sdk v0.9.1
go: downloading github.com/terraform-linters/tflint-ruleset-aws v0.6.0
go: downloading golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
go: downloading github.com/hashicorp/go-hclog v0.16.2
go: downloading github.com/hashicorp/go-plugin v1.4.2
go: downloading github.com/zclconf/go-cty v1.9.0
go: downloading github.com/agext/levenshtein v1.2.3
go: downloading github.com/aws/aws-sdk-go v1.40.17
go: downloading github.com/jstemmer/go-junit-report v0.9.1
go: downloading github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
go: downloading github.com/google/go-github v17.0.0+incompatible
go: downloading golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
go: downloading github.com/google/go-github/v35 v35.3.0
go: downloading golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
go: downloading github.com/golang/mock v1.6.0
go: downloading github.com/google/go-cmp v0.5.6
go: downloading github.com/golang/protobuf v1.5.2
go: downloading google.golang.org/grpc v1.38.0
go: downloading github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
go: downloading github.com/vmihailenco/msgpack/v4 v4.3.12
go: downloading github.com/google/go-querystring v1.0.0
go: downloading github.com/Masterminds/semver v1.5.0
go: downloading github.com/hashicorp/go-getter v1.5.6
go: downloading github.com/Masterminds/semver/v3 v3.1.1
go: downloading github.com/zclconf/go-cty-yaml v1.0.2
go: downloading google.golang.org/protobuf v1.26.0
go: downloading google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c
go: downloading github.com/hashicorp/errwrap v1.1.0
go: downloading github.com/apparentlymart/go-versions v1.0.1
go: downloading github.com/apparentlymart/go-cidr v1.1.0
go: downloading github.com/bmatcuk/doublestar v1.3.4
go: downloading github.com/google/uuid v1.3.0
go: downloading github.com/hashicorp/go-uuid v1.0.2
go: downloading cloud.google.com/go v0.81.0
go: downloading google.golang.org/api v0.44.0
go: downloading go.opencensus.io v0.23.0
Error: ../../../../go/pkg/mod/github.com/zclconf/go-cty@v1.9.0/cty/msgpack/dynamic.go:6:2: missing go.sum entry needed to verify package github.com/vmihailenco/msgpack/v4 (imported by github.com/zclconf/go-cty/cty/msgpack) is provided by exactly one module; to add:
	go get github.com/zclconf/go-cty/cty/msgpack@v1.9.0
Error: ../../../../go/pkg/mod/github.com/zclconf/go-cty@v1.9.0/cty/msgpack/type_implied.go:9:2: missing go.sum entry needed to verify package github.com/vmihailenco/msgpack/v4/codes (imported by github.com/zclconf/go-cty/cty/msgpack) is provided by exactly one module; to add:
	go get github.com/zclconf/go-cty/cty/msgpack@v1.9.0
Error: Process completed with exit code 1.
```
