### PR TITLE
docs/contributing: how to find undocumented new region values

### DIFF
--- a/docs/contributing/contribution-checklists.md
+++ b/docs/contributing/contribution-checklists.md
@@ -904,7 +904,9 @@ of this guide as appropriate.
 
 While region validation is automatically added with SDK updates, new regions
 are generally limited in which services they support. Below are some
-manually sourced values from documentation.
+manually sourced values from documentation. Amazon employees can code search
+previous region values to find new region values in internal packages like
+RIPStaticConfig if they are not documented yet.
 
 - [ ] Check [Elastic Load Balancing endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/elb.html#elb_region) and add Route53 Hosted Zone ID if available to `aws/data_source_aws_elb_hosted_zone_id.go`
 - [ ] Check [Amazon Simple Storage Service endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) and add Route53 Hosted Zone ID if available to `aws/hosted_zones.go`


### PR DESCRIPTION
Recently left Amazon, so documenting how I found undocumented new region account and hosted zone ID values for the last couple AWS regions:
https://github.com/hashicorp/terraform-provider-aws/pull/12967
https://github.com/hashicorp/terraform-provider-aws/pull/13061
https://github.com/hashicorp/terraform-provider-aws/pull/12976
so someone else at Amazon can carry the torch for new AWS regions :)
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->