### PR TITLE
Fix issue #18590 | Allow ListAccountsPages call when not root account

### DIFF
--- a/aws/data_source_aws_organizations_organization.go
+++ b/aws/data_source_aws_organizations_organization.go
@@ -156,75 +156,73 @@ func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta int
 	d.Set("master_account_email", org.Organization.MasterAccountEmail)
 	d.Set("master_account_id", org.Organization.MasterAccountId)
 
-	if aws.StringValue(org.Organization.MasterAccountId) == meta.(*AWSClient).accountid {
-		var accounts []*organizations.Account
-		var nonMasterAccounts []*organizations.Account
-		err = conn.ListAccountsPages(&organizations.ListAccountsInput{}, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
-			for _, account := range page.Accounts {
-				if aws.StringValue(account.Id) != aws.StringValue(org.Organization.MasterAccountId) {
-					nonMasterAccounts = append(nonMasterAccounts, account)
-				}
-
-				accounts = append(accounts, account)
+	var accounts []*organizations.Account
+	var nonMasterAccounts []*organizations.Account
+	err = conn.ListAccountsPages(&organizations.ListAccountsInput{}, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
+		for _, account := range page.Accounts {
+			if aws.StringValue(account.Id) != aws.StringValue(org.Organization.MasterAccountId) {
+				nonMasterAccounts = append(nonMasterAccounts, account)
 			}
 
-			return !lastPage
-		})
-		if err != nil {
-			return fmt.Errorf("error listing AWS Organization (%s) accounts: %w", d.Id(), err)
+			accounts = append(accounts, account)
 		}
 
-		var roots []*organizations.Root
-		err = conn.ListRootsPages(&organizations.ListRootsInput{}, func(page *organizations.ListRootsOutput, lastPage bool) bool {
-			roots = append(roots, page.Roots...)
-			return !lastPage
-		})
-		if err != nil {
-			return fmt.Errorf("error listing AWS Organization (%s) roots: %w", d.Id(), err)
-		}
-
-		awsServiceAccessPrincipals := make([]string, 0)
-		// ConstraintViolationException: The request failed because the organization does not have all features enabled. Please enable all features in your organization and then retry.
-		if aws.StringValue(org.Organization.FeatureSet) == organizations.OrganizationFeatureSetAll {
-			err = conn.ListAWSServiceAccessForOrganizationPages(&organizations.ListAWSServiceAccessForOrganizationInput{}, func(page *organizations.ListAWSServiceAccessForOrganizationOutput, lastPage bool) bool {
-				for _, enabledServicePrincipal := range page.EnabledServicePrincipals {
-					awsServiceAccessPrincipals = append(awsServiceAccessPrincipals, aws.StringValue(enabledServicePrincipal.ServicePrincipal))
-				}
-				return !lastPage
-			})
-
-			if err != nil {
-				return fmt.Errorf("error listing AWS Service Access for Organization (%s): %w", d.Id(), err)
-			}
-		}
-
-		enabledPolicyTypes := make([]string, 0)
-		for _, policyType := range roots[0].PolicyTypes {
-			if aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusEnabled {
-				enabledPolicyTypes = append(enabledPolicyTypes, aws.StringValue(policyType.Type))
-			}
-		}
-
-		if err := d.Set("accounts", flattenOrganizationsAccounts(accounts)); err != nil {
-			return fmt.Errorf("error setting accounts: %w", err)
-		}
-
-		if err := d.Set("aws_service_access_principals", awsServiceAccessPrincipals); err != nil {
-			return fmt.Errorf("error setting aws_service_access_principals: %w", err)
-		}
-
-		if err := d.Set("enabled_policy_types", enabledPolicyTypes); err != nil {
-			return fmt.Errorf("error setting enabled_policy_types: %w", err)
-		}
-
-		if err := d.Set("non_master_accounts", flattenOrganizationsAccounts(nonMasterAccounts)); err != nil {
-			return fmt.Errorf("error setting non_master_accounts: %w", err)
-		}
-
-		if err := d.Set("roots", flattenOrganizationsRoots(roots)); err != nil {
-			return fmt.Errorf("error setting roots: %w", err)
-		}
-
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("error listing AWS Organization (%s) accounts: %w", d.Id(), err)
 	}
+
+	var roots []*organizations.Root
+	err = conn.ListRootsPages(&organizations.ListRootsInput{}, func(page *organizations.ListRootsOutput, lastPage bool) bool {
+		roots = append(roots, page.Roots...)
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("error listing AWS Organization (%s) roots: %w", d.Id(), err)
+	}
+
+	awsServiceAccessPrincipals := make([]string, 0)
+	// ConstraintViolationException: The request failed because the organization does not have all features enabled. Please enable all features in your organization and then retry.
+	if aws.StringValue(org.Organization.FeatureSet) == organizations.OrganizationFeatureSetAll {
+		err = conn.ListAWSServiceAccessForOrganizationPages(&organizations.ListAWSServiceAccessForOrganizationInput{}, func(page *organizations.ListAWSServiceAccessForOrganizationOutput, lastPage bool) bool {
+			for _, enabledServicePrincipal := range page.EnabledServicePrincipals {
+				awsServiceAccessPrincipals = append(awsServiceAccessPrincipals, aws.StringValue(enabledServicePrincipal.ServicePrincipal))
+			}
+			return !lastPage
+		})
+
+		if err != nil {
+			return fmt.Errorf("error listing AWS Service Access for Organization (%s): %w", d.Id(), err)
+		}
+	}
+
+	enabledPolicyTypes := make([]string, 0)
+	for _, policyType := range roots[0].PolicyTypes {
+		if aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusEnabled {
+			enabledPolicyTypes = append(enabledPolicyTypes, aws.StringValue(policyType.Type))
+		}
+	}
+
+	if err := d.Set("accounts", flattenOrganizationsAccounts(accounts)); err != nil {
+		return fmt.Errorf("error setting accounts: %w", err)
+	}
+
+	if err := d.Set("aws_service_access_principals", awsServiceAccessPrincipals); err != nil {
+		return fmt.Errorf("error setting aws_service_access_principals: %w", err)
+	}
+
+	if err := d.Set("enabled_policy_types", enabledPolicyTypes); err != nil {
+		return fmt.Errorf("error setting enabled_policy_types: %w", err)
+	}
+
+	if err := d.Set("non_master_accounts", flattenOrganizationsAccounts(nonMasterAccounts)); err != nil {
+		return fmt.Errorf("error setting non_master_accounts: %w", err)
+	}
+
+	if err := d.Set("roots", flattenOrganizationsRoots(roots)); err != nil {
+		return fmt.Errorf("error setting roots: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
This call is allowed in sub-accounts if that account is made a "delegated administrator for an AWS service"

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18590

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
