### PR TITLE
r/vpn_connection: replace `DescribeTransitGatewayAttachments` with paginated method

### DIFF
--- a/.changelog/20775.txt
+++ b/.changelog/20775.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource_vpn_connection: Handle paginated response when reading Transit Gateway Attachments
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Notes

* (From Customer): At a large number of AWS Transit Gateway Attachments (999+), the AWS API call `DescribeTransitGatewayAttachments` will return an initial empty response with pagination token even when querying for a unique TGW Attachment. This results in the error  "error finding EC2 VPN Connection (%s) Transit Gateway Attachment: empty response". 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSVpnConnection_tunnelOptions (338.05s)
--- PASS: TestAccAWSVpnConnection_Tunnel1PresharedKey (229.08s)
--- PASS: TestAccAWSVpnConnection_Tunnel1InsideCidr (310.85s)
--- PASS: TestAccAWSVpnConnection_specifyIpv4 (311.84s)
--- PASS: TestAccAWSVpnConnection_tunnelOptionsLesser (313.71s)
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (390.94s)
--- PASS: TestAccAWSVpnConnection_disappears (531.94s)
--- PASS: TestAccAWSVpnConnection_tags (570.34s)
--- PASS: TestAccAWSVpnConnection_withIpv6 (648.72s)
--- PASS: TestAccAWSVpnConnection_withEnableAcceleration (652.61s)
--- PASS: TestAccAWSVpnConnection_TransitGatewayID (652.65s)
--- PASS: TestAccAWSVpnConnection_Tunnel1InsideIpv6Cidr (712.52s)
--- PASS: TestAccAWSVpnConnection_basic (795.24s)
--- PASS: TestAccAWSVpnConnection_specifyIpv6 (476.51s)
```
