### PR TITLE
configuration_set on aws_cognito_user_pool always detected as a change

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -1357,6 +1357,10 @@ func flattenCognitoUserPoolEmailConfiguration(s *cognitoidentityprovider.EmailCo
 		m["email_sending_account"] = aws.StringValue(s.EmailSendingAccount)
 	}
 
+	if s.ConfigurationSet != nil {
+		m["configuration_set"] = aws.StringValue(s.ConfigurationSet)
+	}
+
 	if len(m) > 0 {
 		return []map[string]interface{}{m}
 	}


### PR DESCRIPTION
closes #20755 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
root@47307cab8cc7:/go/src/github.com/terraform-providers/terraform-provider-aws# TEST_AWS_SES_VERIFIED_EMAIL_ARN=arn:aws:ses:us-east-1:01234567890:identity/pn@foo.com make testacc ACCTEST_PARALLELISM=1 TESTARGS='-run=TestAccAWSCognitoUserPool_withEmailConfigurationSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAWSCognitoUserPool_withEmailConfigurationSource -timeout 180m
=== RUN   TestAccAWSCognitoUserPool_withEmailConfigurationSource
=== PAUSE TestAccAWSCognitoUserPool_withEmailConfigurationSource
=== CONT  TestAccAWSCognitoUserPool_withEmailConfigurationSource
--- PASS: TestAccAWSCognitoUserPool_withEmailConfigurationSource (46.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.716s
root@47307cab8cc7:/go/src/github.com/terraform-providers/terraform-provider-aws#
```
