### PR TITLE
Adding error during plan for dashes in Sid

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -176,12 +176,12 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 
 			if sid, ok := cfgStmt["sid"]; ok {
 				invalidChar := "-"
+				stmt.Sid = sid.(string)
 				if _, ok := sidMap[sid.(string)]; ok {
 					return fmt.Errorf("duplicate Sid (%s). Remove the Sid or ensure the Sid is unique.", sid.(string))
-				} else if strings.Contains(sid.(string), invalidChar) {
+				} else if strings.Contains(stmt.Sid, invalidChar) {
 					return fmt.Errorf("Invalid character. Remove the '-' from the Sid.")
 				}
-				stmt.Sid = sid.(string)
 				if len(stmt.Sid) > 0 {
 					sidMap[stmt.Sid] = struct{}{}
 				}

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -178,7 +178,7 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 				invalidChar := "-"
 				if _, ok := sidMap[sid.(string)]; ok {
 					return fmt.Errorf("duplicate Sid (%s). Remove the Sid or ensure the Sid is unique.", sid.(string))
-				} else if strings.Contains(stmt.Sid, invalidChar) {
+				} else if strings.Contains(sid.(string), invalidChar) {
 					return fmt.Errorf("Invalid character. Remove the '-' from the Sid.")
 				}
 				stmt.Sid = sid.(string)

--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -175,8 +175,11 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 			}
 
 			if sid, ok := cfgStmt["sid"]; ok {
+				invalidChar := "-"
 				if _, ok := sidMap[sid.(string)]; ok {
 					return fmt.Errorf("duplicate Sid (%s). Remove the Sid or ensure the Sid is unique.", sid.(string))
+				} else if strings.Contains(stmt.Sid, invalidChar) {
+					return fmt.Errorf("Invalid character. Remove the '-' from the Sid.")
 				}
 				stmt.Sid = sid.(string)
 				if len(stmt.Sid) > 0 {

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -110,6 +110,20 @@ func TestAccAWSDataSourceIAMPolicyDocument_sourceListConflicting(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, iam.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSIAMPolicyDocumentInvalidCharacter,
+				ExpectError: regexp.MustCompile(`Invalid character.*`),
+			},
+		},
+	})
+}
+
 func TestAccAWSDataSourceIAMPolicyDocument_override(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
@@ -789,6 +803,33 @@ data "aws_iam_policy_document" "test_source_list_conflicting" {
     data.aws_iam_policy_document.policy_a.json,
     data.aws_iam_policy_document.policy_b.json,
     data.aws_iam_policy_document.policy_c.json
+  ]
+}
+`
+
+var testAccAWSIAMPolicyDocumentInvalidCharacter = `
+data "aws_iam_policy_document" "policy_a" {
+  statement {
+    sid     = "sid-invalid"
+    effect  = "Allow"
+    actions = ["foo:ActionOne"]
+  }
+}
+
+data "aws_iam_policy_document" "policy_b" {
+  statement {
+    sid     = "validSid"
+    effect  = "Deny"
+    actions = ["foo:ActionTwo"]
+  }
+}
+
+data "aws_iam_policy_document" "test_source_list_conflicting" {
+  version = "2012-10-17"
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.policy_a.json,
+    data.aws_iam_policy_document.policy_b.json
   ]
 }
 `


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20767

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter -timeout 180m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_invalidCharacter (2.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2.273s

...
```
