### PR TITLE
r/route53_health_check - allow updating `ip_address` + sweeper

### DIFF
--- a/.changelog/20795.txt
+++ b/.changelog/20795.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource_aws_route53_health_check: Add plan time validation for `regions`.
+resource/aws_route53_health_check: Add plan time validation for `regions`
 ```
 
 ```release-note:bug
-resource_aws_route53_health_check: fix update for `ip_address`
+resource/aws_route53_health_check: Fix update for `ip_address`
 ```

--- a/.changelog/20795.txt
+++ b/.changelog/20795.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource_aws_route53_health_check: Add plan time validation for `regions`.
+```
+
+```release-note:bug
+resource_aws_route53_health_check: fix update for `ip_address`
+```

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -186,7 +186,7 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
 
-	if d.HasChangeExcept("tags_all") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		updateHealthCheck := &route53.UpdateHealthCheckInput{
 			HealthCheckId: aws.String(d.Id()),
 		}
@@ -253,6 +253,7 @@ func resourceAwsRoute53HealthCheckUpdate(d *schema.ResourceData, meta interface{
 		}
 
 		_, err := conn.UpdateHealthCheck(updateHealthCheck)
+
 		if err != nil {
 			return fmt.Errorf("error updating Route53 Health Check (%s): %w", d.Id(), err)
 		}
@@ -465,8 +466,9 @@ func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{})
 func resourceAwsRoute53HealthCheckDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
 
-	log.Printf("[DEBUG] Deleting Route53 health check: %s", d.Id())
+	log.Printf("[DEBUG] Deleting Route53 Health Check: %s", d.Id())
 	_, err := conn.DeleteHealthCheck(&route53.DeleteHealthCheckInput{HealthCheckId: aws.String(d.Id())})
+
 	if isAWSErr(err, route53.ErrCodeNoSuchHealthCheck, "") {
 		return nil
 	}

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,7 +43,7 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			"failure_threshold": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      3,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 10),
 			},
 			"request_interval": {
@@ -148,14 +149,14 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
-						"us-east-1",
-						"us-west-1",
-						"us-west-2",
-						"eu-west-1",
-						"ap-southeast-1",
-						"ap-southeast-2",
-						"ap-northeast-1",
-						"sa-east-1",
+						endpoints.UsWest1RegionID,
+						endpoints.UsWest2RegionID,
+						endpoints.UsEast1RegionID,
+						endpoints.EuWest1RegionID,
+						endpoints.SaEast1RegionID,
+						endpoints.ApSoutheast1RegionID,
+						endpoints.ApSoutheast2RegionID,
+						endpoints.ApNortheast1RegionID,
 					}, true),
 				},
 				Optional: true,

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -166,7 +166,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckConfigWithSearchString,
+				Config: testAccRoute53HealthCheckSearchStringConfig("OK"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "false"),
@@ -179,7 +179,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoute53HealthCheckConfigWithSearchStringUpdate,
+				Config: testAccRoute53HealthCheckSearchStringConfig("FAILED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "true"),
@@ -249,7 +249,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckIpConfig,
+				Config: testAccRoute53HealthCheckIpConfig("1.2.3.4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "1.2.3.4"),
@@ -261,7 +261,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoute53HealthCheckIpConfig,
+				Config: testAccRoute53HealthCheckIpConfig("1.2.3.5"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "1.2.3.5"),
@@ -281,7 +281,7 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53HealthCheckIpv6Config,
+				Config: testAccRoute53HealthCheckIpConfig("1234:5678:9abc:6811:0:0:0:4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "1234:5678:9abc:6811:0:0:0:4"),
@@ -293,7 +293,7 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:   testAccRoute53HealthCheckIpv6ExpandedConfig,
+				Config:   testAccRoute53HealthCheckIpConfig("1234:5678:9abc:6811:0:0:0:4"),
 				PlanOnly: true,
 			},
 		},
@@ -347,14 +347,14 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoute53HealthCheckConfigWithSNIDisabled,
+				Config: testAccRoute53HealthCheckSNIConfig(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "enable_sni", "false"),
 				),
 			},
 			{
-				Config: testAccRoute53HealthCheckConfigWithSNI,
+				Config: testAccRoute53HealthCheckSNIConfig(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "enable_sni", "true"),
@@ -577,9 +577,10 @@ resource "aws_route53_health_check" "test" {
 }
 `
 
-const testAccRoute53HealthCheckIpConfig = `
+func testAccRoute53HealthCheckIpConfig(ip string) string {
+	return fmt.Sprintf(`
 resource "aws_route53_health_check" "test" {
-  ip_address        = "1.2.3.4"
+  ip_address        = %[1]q
   port              = 80
   type              = "HTTP"
   resource_path     = "/"
@@ -590,37 +591,8 @@ resource "aws_route53_health_check" "test" {
     Name = "tf-test-health-check"
   }
 }
-`
-
-const testAccRoute53HealthCheckIpv6Config = `
-resource "aws_route53_health_check" "test" {
-  ip_address        = "1234:5678:9abc:6811::4"
-  port              = 80
-  type              = "HTTP"
-  resource_path     = "/"
-  failure_threshold = "2"
-  request_interval  = "30"
-
-  tags = {
-    Name = "tf-test-health-check"
-  }
+`, ip)
 }
-`
-
-const testAccRoute53HealthCheckIpv6ExpandedConfig = `
-resource "aws_route53_health_check" "test" {
-  ip_address        = "1234:5678:9abc:6811:0:0:0:4"
-  port              = 80
-  type              = "HTTP"
-  resource_path     = "/"
-  failure_threshold = "2"
-  request_interval  = "30"
-
-  tags = {
-    Name = "tf-test-health-check"
-  }
-}
-`
 
 const testAccRoute53HealthCheckConfig_withChildHealthChecks = `
 resource "aws_route53_health_check" "child1" {
@@ -685,7 +657,8 @@ resource "aws_route53_health_check" "test" {
 }
 `
 
-const testAccRoute53HealthCheckConfigWithSearchString = `
+func testAccRoute53HealthCheckSearchStringConfig(search string) string {
+	return fmt.Sprintf(`
 resource "aws_route53_health_check" "test" {
   fqdn               = "dev.example.com"
   port               = 80
@@ -695,31 +668,14 @@ resource "aws_route53_health_check" "test" {
   request_interval   = "30"
   measure_latency    = true
   invert_healthcheck = false
-  search_string      = "OK"
+  search_string      = %[1]q
 
   tags = {
     Name = "tf-test-health-check"
   }
 }
-`
-
-const testAccRoute53HealthCheckConfigWithSearchStringUpdate = `
-resource "aws_route53_health_check" "test" {
-  fqdn               = "dev.example.com"
-  port               = 80
-  type               = "HTTP_STR_MATCH"
-  resource_path      = "/"
-  failure_threshold  = "5"
-  request_interval   = "30"
-  measure_latency    = true
-  invert_healthcheck = true
-  search_string      = "FAILED"
-
-  tags = {
-    Name = "tf-test-health-check"
-  }
+`, search)
 }
-`
 
 const testAccRoute53HealthCheckConfigWithoutSNI = `
 resource "aws_route53_health_check" "test" {
@@ -738,7 +694,8 @@ resource "aws_route53_health_check" "test" {
 }
 `
 
-const testAccRoute53HealthCheckConfigWithSNI = `
+func testAccRoute53HealthCheckSNIConfig(enable bool) string {
+	return fmt.Sprintf(`
 resource "aws_route53_health_check" "test" {
   fqdn               = "dev.example.com"
   port               = 443
@@ -748,31 +705,14 @@ resource "aws_route53_health_check" "test" {
   request_interval   = "30"
   measure_latency    = true
   invert_healthcheck = true
-  enable_sni         = true
+  enable_sni         = %[1]t
 
   tags = {
     Name = "tf-test-health-check"
   }
 }
-`
-
-const testAccRoute53HealthCheckConfigWithSNIDisabled = `
-resource "aws_route53_health_check" "test" {
-  fqdn               = "dev.example.com"
-  port               = 443
-  type               = "HTTPS"
-  resource_path      = "/"
-  failure_threshold  = "2"
-  request_interval   = "30"
-  measure_latency    = true
-  invert_healthcheck = true
-  enable_sni         = false
-
-  tags = {
-    Name = "tf-test-health-check"
-  }
+`, enable)
 }
-`
 
 func testAccRoute53HealthCheckConfigDisabled(disabled bool) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -523,6 +523,7 @@ resource "aws_route53_health_check" "test" {
   failure_threshold  = %[1]q
   request_interval   = "30"
   measure_latency    = true
+  invert_healthcheck = %[2]t
 }
 `, thershold, invert)
 }

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/route53"
+	r53rcc "github.com/aws/aws-sdk-go/service/route53recoverycontrolconfig"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -412,7 +413,7 @@ func TestAccAWSRoute53HealthCheck_withRoutingControlArn(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(r53rcc.EndpointsID, t) },
 		ErrorCheck:   testAccErrorCheck(t, route53.EndpointsID),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53HealthCheck_'
--- PASS: TestAccAWSRoute53HealthCheck_disappears (106.97s)
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (138.27s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (143.96s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (145.49s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (176.19s)
--- PASS: TestAccAWSRoute53HealthCheck_withRoutingControlArn (186.51s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (192.33s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (192.66s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (193.79s)
--- PASS: TestAccAWSRoute53HealthCheck_Disabled (228.15s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (228.68s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (231.12s)
```
