### PR TITLE
r/launch_template - add support for `http_protocol_ipv6 ` to `metadata_options`

### DIFF
--- a/.changelog/20796.txt
+++ b/.changelog/20796.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_launch_template: add support for `http_protocol_ipv6` to `metadata_options`.
+```
+
+```release-note:enhancement
+resource/aws_launch_template: add plan time validation to `spot_options.block_duration_minutes`
+```

--- a/aws/internal/service/ec2/enum.go
+++ b/aws/internal/service/ec2/enum.go
@@ -1,6 +1,19 @@
 package ec2
 
 const (
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreditSpecificationRequest.html#API_CreditSpecificationRequest_Contents
+	CpuCreditsStandard  = "standard"
+	CpuCreditsUnlimited = "unlimited"
+)
+
+func CpuCredits_Values() []string {
+	return []string{
+		CpuCreditsStandard,
+		CpuCreditsUnlimited,
+	}
+}
+
+const (
 	// https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html#vpce-interface-lifecycle
 	VpcEndpointStateAvailable         = "available"
 	VpcEndpointStateDeleted           = "deleted"

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
 func resourceAwsLaunchTemplate() *schema.Resource {
@@ -214,7 +215,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						"cpu_credits": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"standard", "unlimited"}, false),
+							ValidateFunc: validation.StringInSlice(tfec2.CpuCredits_Values(), false),
 						},
 					},
 				},

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -184,12 +184,9 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"capacity_reservation_preference": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ec2.CapacityReservationPreferenceOpen,
-								ec2.CapacityReservationPreferenceNone,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(ec2.CapacityReservationPreference_Values(), false),
 						},
 						"capacity_reservation_target": {
 							Type:     schema.TypeList,
@@ -215,8 +212,9 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cpu_credits": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"standard", "unlimited"}, false),
 						},
 					},
 				},
@@ -291,12 +289,9 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			},
 
 			"instance_initiated_shutdown_behavior": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.ShutdownBehaviorStop,
-					ec2.ShutdownBehaviorTerminate,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.ShutdownBehavior_Values(), false),
 			},
 
 			"instance_market_options": {
@@ -308,7 +303,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						"market_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{ec2.MarketTypeSpot}, false),
+							ValidateFunc: validation.StringInSlice(ec2.MarketType_Values(), false),
 						},
 						"spot_options": {
 							Type:     schema.TypeList,
@@ -317,24 +312,23 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"block_duration_minutes": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntDivisibleBy(60),
 									},
 									"instance_interruption_behavior": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ec2.InstanceInterruptionBehavior_Values(), false),
 									},
 									"max_price": {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
 									"spot_instance_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											ec2.SpotInstanceTypeOneTime,
-											ec2.SpotInstanceTypePersistent,
-										}, false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ec2.SpotInstanceType_Values(), false),
 									},
 									"valid_until": {
 										Type:         schema.TypeString,
@@ -389,13 +383,19 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.StringInSlice([]string{ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled, ec2.LaunchTemplateInstanceMetadataEndpointStateDisabled}, false),
+							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateInstanceMetadataEndpointState_Values(), false),
+						},
+						"http_protocol_ipv6": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled,
+							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values(), false),
 						},
 						"http_tokens": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.StringInSlice([]string{ec2.LaunchTemplateHttpTokensStateOptional, ec2.LaunchTemplateHttpTokensStateRequired}, false),
+							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateHttpTokensState_Values(), false),
 						},
 						"http_put_response_hop_limit": {
 							Type:         schema.TypeInt,
@@ -1119,7 +1119,8 @@ func expandLaunchTemplateInstanceMetadataOptions(l []interface{}) *ec2.LaunchTem
 	m := l[0].(map[string]interface{})
 
 	opts := &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
-		HttpEndpoint: aws.String(m["http_endpoint"].(string)),
+		HttpEndpoint:     aws.String(m["http_endpoint"].(string)),
+		HttpProtocolIpv6: aws.String(m["http_protocol_ipv6"].(string)),
 	}
 
 	if m["http_endpoint"].(string) == ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled {
@@ -1144,6 +1145,7 @@ func flattenLaunchTemplateInstanceMetadataOptions(opts *ec2.LaunchTemplateInstan
 
 	m := map[string]interface{}{
 		"http_endpoint":               aws.StringValue(opts.HttpEndpoint),
+		"http_protocol_ipv6":          aws.StringValue(opts.HttpProtocolIpv6),
 		"http_put_response_hop_limit": aws.Int64Value(opts.HttpPutResponseHopLimit),
 		"http_tokens":                 aws.StringValue(opts.HttpTokens),
 	}

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -177,7 +177,7 @@ func TestAccAWSLaunchTemplate_disappears(t *testing.T) {
 				Config: testAccAWSLaunchTemplateConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &launchTemplate),
-					testAccCheckAWSLaunchTemplateDisappears(&launchTemplate),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsLaunchTemplate(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -1443,20 +1443,6 @@ func testAccCheckAWSLaunchTemplateDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAWSLaunchTemplateDisappears(launchTemplate *ec2.LaunchTemplate) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-
-		input := &ec2.DeleteLaunchTemplateInput{
-			LaunchTemplateId: launchTemplate.LaunchTemplateId,
-		}
-
-		_, err := conn.DeleteLaunchTemplate(input)
-
-		return err
-	}
 }
 
 func testAccAWSLaunchTemplateConfigName(rName string) string {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -1178,12 +1178,24 @@ func TestAccAWSLaunchTemplate_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "disabled"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_metadataOptionsIpv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "enabled"),
+				),
 			},
 		},
 	})
@@ -2264,6 +2276,21 @@ resource "aws_launch_template" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
+  }
+}
+`, rName)
+}
+
+func testAccAWSLaunchTemplateConfig_metadataOptionsIpv6(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+	http_protocol_ipv6          = "enabled"
   }
 }
 `, rName)

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -2276,7 +2276,7 @@ resource "aws_launch_template" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
-	http_protocol_ipv6          = "enabled"
+    http_protocol_ipv6          = "enabled"
   }
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20768

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_'
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (126.00s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (127.37s)
--- PASS: TestAccAWSLaunchTemplate_basic (155.95s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceType (160.34s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (164.18s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (165.21s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (165.34s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (165.95s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (166.59s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (194.49s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (233.89s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (235.55s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (264.61s)
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (267.38s)
--- PASS: TestAccAWSLaunchTemplate_disappears (118.06s)
--- PASS: TestAccAWSLaunchTemplate_Placement_HostResourceGroupArn (171.55s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (308.73s)
--- PASS: TestAccAWSLaunchTemplate_Name_Prefix (155.45s)
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (259.03s)
--- PASS: TestAccAWSLaunchTemplate_Name_Generated (160.40s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_Gp3 (185.56s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (350.24s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (160.42s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (136.84s)
--- PASS: TestAccAWSLaunchTemplate_data (124.98s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (411.90s)
--- PASS: TestAccAWSLaunchTemplate_update (250.00s)
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (433.72s)
--- PASS: TestAccAWSLaunchTemplate_enclaveOptions (289.93s)
--- PASS: TestAccAWSLaunchTemplate_hibernation (290.76s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (225.70s)
--- PASS: TestAccAWSLaunchTemplate_description (171.06s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (470.69s)
--- PASS: TestAccAWSLaunchTemplate_Tags (233.99s)
--- PASS: TestAccAWSLaunchTemplate_associateCarrierIPAddress (380.76s)
--- PASS: TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination (273.83s)
```
