### PR TITLE
r/ec2_managed_prefix_list - allow updating `max_entries`

### DIFF
--- a/.changelog/20797.txt
+++ b/.changelog/20797.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_managed_prefix_list: allow updating `max_entries`.
+```

--- a/aws/resource_aws_ec2_managed_prefix_list.go
+++ b/aws/resource_aws_ec2_managed_prefix_list.go
@@ -69,7 +69,6 @@ func resourceAwsEc2ManagedPrefixList() *schema.Resource {
 			"max_entries": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"name": {
@@ -293,6 +292,11 @@ func resourceAwsEc2ManagedPrefixListUpdate(d *schema.ResourceData, meta interfac
 				//   InvalidRequest: The request received was invalid.
 				input.RemoveEntries = nil
 			}
+		}
+
+		if d.HasChange("max_entries") {
+			input.MaxEntries = aws.Int64(int64(d.Get("max_entries").(int)))
+			wait = true
 		}
 
 		_, err := conn.ModifyManagedPrefixList(input)

--- a/aws/resource_aws_ec2_managed_prefix_list_test.go
+++ b/aws/resource_aws_ec2_managed_prefix_list_test.go
@@ -44,6 +44,14 @@ func TestAccAwsEc2ManagedPrefixList_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config:       testAccAwsEc2ManagedPrefixListConfigUpdated(rName),
+				ResourceName: resourceName,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccAwsEc2ManagedPrefixListExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "max_entries", "2"),
+				),
+			},
 		},
 	})
 }
@@ -438,6 +446,16 @@ func testAccAwsEc2ManagedPrefixListConfig_Name(rName string) string {
 resource "aws_ec2_managed_prefix_list" "test" {
   address_family = "IPv4"
   max_entries    = 1
+  name           = %[1]q
+}
+`, rName)
+}
+
+func testAccAwsEc2ManagedPrefixListConfigUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  address_family = "IPv4"
+  max_entries    = 2
   name           = %[1]q
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20738

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsEc2ManagedPrefixList_'
--- PASS: TestAccAwsEc2ManagedPrefixList_disappears (59.41s)
--- PASS: TestAccAwsEc2ManagedPrefixList_AddressFamily_IPv6 (77.35s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Name (118.78s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Entry_Description (122.32s)
--- PASS: TestAccAwsEc2ManagedPrefixList_basic (123.64s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Entry_Cidr (132.05s)
--- PASS: TestAccAwsEc2ManagedPrefixList_Tags (160.31s)
```
