### PR TITLE
Erroring plan when name or policy is not supplied in inline policy

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -736,7 +736,7 @@ func addIamInlinePolicies(policies []*iam.PutRolePolicyInput, meta interface{}) 
 	var errs *multierror.Error
 	for _, policy := range policies {
 		if len(aws.StringValue(policy.PolicyName)) == 0 || len(aws.StringValue(policy.PolicyDocument)) == 0 {
-			continue
+			return fmt.Errorf("You must supply both a name and a policy")
 		}
 
 		if _, err := conn.PutRolePolicy(policy); err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19145

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMRole_policy_nameOrPolicyEmpty'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIAMRole_policy_nameOrPolicyEmpty -timeout 180m
=== RUN   TestAccAWSIAMRole_policy_nameOrPolicyEmpty
=== PAUSE TestAccAWSIAMRole_policy_nameOrPolicyEmpty
=== CONT  TestAccAWSIAMRole_policy_nameOrPolicyEmpty
--- PASS: TestAccAWSIAMRole_policy_nameOrPolicyEmpty (3.94s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       3.992s
...
```
