### PR TITLE
AWS ConfigService KMS encryption support

### DIFF
--- a/.changelog/20600.txt
+++ b/.changelog/20600.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_config_delivery_channel: Add `s3_kms_key_arn` attribute
+```

--- a/.changelog/20600.txt
+++ b/.changelog/20600.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_config_delivery_channel: Add `s3_kms_key_arn` attribute
+resource/aws_config_delivery_channel: Add `s3_kms_key_arn` argument
 ```

--- a/aws/resource_aws_config_delivery_channel.go
+++ b/aws/resource_aws_config_delivery_channel.go
@@ -159,8 +159,8 @@ func resourceAwsConfigDeliveryChannelRead(d *schema.ResourceData, meta interface
 	d.Set("name", channel.Name)
 	d.Set("s3_bucket_name", channel.S3BucketName)
 	d.Set("s3_key_prefix", channel.S3KeyPrefix)
-	d.Set("sns_topic_arn", channel.SnsTopicARN)
 	d.Set("s3_kms_key_arn", channel.S3KmsKeyArn)
+	d.Set("sns_topic_arn", channel.SnsTopicARN)
 
 	if channel.ConfigSnapshotDeliveryProperties != nil {
 		d.Set("snapshot_delivery_properties", flattenConfigSnapshotDeliveryProperties(channel.ConfigSnapshotDeliveryProperties))

--- a/aws/resource_aws_config_delivery_channel.go
+++ b/aws/resource_aws_config_delivery_channel.go
@@ -41,6 +41,11 @@ func resourceAwsConfigDeliveryChannel() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"s3_kms_key_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
 			"sns_topic_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -75,6 +80,9 @@ func resourceAwsConfigDeliveryChannelPut(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("s3_key_prefix"); ok {
 		channel.S3KeyPrefix = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("s3_kms_key_arn"); ok {
+		channel.S3KmsKeyArn = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("sns_topic_arn"); ok {
 		channel.SnsTopicARN = aws.String(v.(string))
@@ -152,6 +160,7 @@ func resourceAwsConfigDeliveryChannelRead(d *schema.ResourceData, meta interface
 	d.Set("s3_bucket_name", channel.S3BucketName)
 	d.Set("s3_key_prefix", channel.S3KeyPrefix)
 	d.Set("sns_topic_arn", channel.SnsTopicARN)
+	d.Set("s3_kms_key_arn", channel.S3KmsKeyArn)
 
 	if channel.ConfigSnapshotDeliveryProperties != nil {
 		d.Set("snapshot_delivery_properties", flattenConfigSnapshotDeliveryProperties(channel.ConfigSnapshotDeliveryProperties))

--- a/aws/resource_aws_config_delivery_channel_test.go
+++ b/aws/resource_aws_config_delivery_channel_test.go
@@ -360,19 +360,7 @@ resource "aws_kms_key" "k" {
       },
       "Action": "kms:*",
       "Resource": "*"
-    },
-    {
-        "Sid" : "AWSConfigKMSPolicy",
-        "Effect" : "Allow",
-        "Principal" : {
-          "Service" : "config.amazonaws.com"
-        },
-        "Action" : [
-          "kms:Decrypt",
-          "kms:GenerateDataKey"
-        ],
-        "Resource" : "*"
-      }
+    }
   ]
 }
 POLICY

--- a/aws/resource_aws_config_delivery_channel_test.go
+++ b/aws/resource_aws_config_delivery_channel_test.go
@@ -117,6 +117,7 @@ func testAccConfigDeliveryChannel_allParams(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", expectedName),
 					resource.TestCheckResourceAttr(resourceName, "s3_bucket_name", expectedBucketName),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", "one/two/three"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_kms_key_arn", "aws_kms_key.k", "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "sns_topic_arn", "aws_sns_topic.t", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_delivery_properties.0.delivery_frequency", "Six_Hours"),
 				),
@@ -320,6 +321,14 @@ resource "aws_iam_role_policy" "p" {
         "${aws_s3_bucket.b.arn}",
         "${aws_s3_bucket.b.arn}/*"
       ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
+            ],
+            "Resource": "${aws_kms_key.k.arn}"
     }
   ]
 }
@@ -335,10 +344,45 @@ resource "aws_sns_topic" "t" {
   name = "tf-acc-test-%d"
 }
 
+resource "aws_kms_key" "k" {
+  description = "tf-acc-test-awsconfig-%d"
+  deletion_window_in_days = 7
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "tf-acc-test-awsconfig-%d",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+        "Sid" : "AWSConfigKMSPolicy",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "config.amazonaws.com"
+        },
+        "Action" : [
+          "kms:Decrypt",
+          "kms:GenerateDataKey"
+        ],
+        "Resource" : "*"
+      }
+  ]
+}
+POLICY
+}
+
 resource "aws_config_delivery_channel" "foo" {
   name           = "tf-acc-test-awsconfig-%d"
   s3_bucket_name = aws_s3_bucket.b.bucket
   s3_key_prefix  = "one/two/three"
+  s3_kms_key_arn = aws_kms_key.k.arn
   sns_topic_arn  = aws_sns_topic.t.arn
 
   snapshot_delivery_properties {
@@ -347,5 +391,5 @@ resource "aws_config_delivery_channel" "foo" {
 
   depends_on = [aws_config_configuration_recorder.foo]
 }
-`, randInt, randInt, randInt, randInt, randInt, randInt)
+`, randInt, randInt, randInt, randInt, randInt, randInt, randInt, randInt)
 }

--- a/aws/resource_aws_config_delivery_channel_test.go
+++ b/aws/resource_aws_config_delivery_channel_test.go
@@ -345,8 +345,9 @@ resource "aws_sns_topic" "t" {
 }
 
 resource "aws_kms_key" "k" {
-  description = "tf-acc-test-awsconfig-%d"
+  description             = "tf-acc-test-awsconfig-%d"
   deletion_window_in_days = 7
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -82,6 +82,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the delivery channel. Defaults to `default`. Changing it recreates the resource.
 * `s3_bucket_name` - (Required) The name of the S3 bucket used to store the configuration history.
 * `s3_key_prefix` - (Optional) The prefix for the specified S3 bucket.
+* `s3_kms_key_arn` - (Optional) The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config. Must belong to the same Region as the destination S3 bucket.
 * `sns_topic_arn` - (Optional) The ARN of the SNS topic that AWS Config delivers notifications to.
 * `snapshot_delivery_properties` - (Optional) Options for how AWS Config delivers configuration snapshots. See below
 


### PR DESCRIPTION
Adds `s3_kms_key_arn` allowing Config to encrypt files to the target S3 bucket. Does not support AWS Managed keys, has to be a Customer Managed one.

Updates DeliveryChannel Schema to v1.9.0 https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/configservice@v1.9.0/types#DeliveryChannel
https://docs.aws.amazon.com/config/latest/developerguide/DocumentHistory.html (February 16, 2021)

Notes: adds a KMS key for testing, adds IAM permission to the role to use the KMS key.
Verified bucket ConfigWritabilityCheckFile file generated by AWSConfig, within its SSE details, is using the KMS key correctly.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20600

Output from acceptance testing:


```
user:terraform-provider-aws user$ make testacc TESTARGS="-run=TestAccAWSConfig_serial/DeliveryChannel"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSConfig_serial/DeliveryChannel -timeout 180m
=== RUN   TestAccAWSConfig_serial
=== RUN   TestAccAWSConfig_serial/DeliveryChannel
=== RUN   TestAccAWSConfig_serial/DeliveryChannel/basic
=== RUN   TestAccAWSConfig_serial/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig_serial/DeliveryChannel/importBasic
--- PASS: TestAccAWSConfig_serial (156.14s)
    --- PASS: TestAccAWSConfig_serial/DeliveryChannel (156.14s)
        --- PASS: TestAccAWSConfig_serial/DeliveryChannel/basic (51.05s)
        --- PASS: TestAccAWSConfig_serial/DeliveryChannel/allParams (49.53s)
        --- PASS: TestAccAWSConfig_serial/DeliveryChannel/importBasic (55.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       156.257s
```
