### PR TITLE
r/sagemaker_endpoint_config - add support for `async_inference_config`

### DIFF
--- a/.changelog/20809.txt
+++ b/.changelog/20809.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuraton: Add `async_inference_config`.
+```

--- a/.changelog/20809.txt
+++ b/.changelog/20809.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sagemaker_endpoint_configuration: Add `async_inference_config`.
+resource/aws_sagemaker_endpoint_configuration: Add `async_inference_config` argument
 ```

--- a/.changelog/20809.txt
+++ b/.changelog/20809.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sagemaker_endpoint_configuraton: Add `async_inference_config`.
+resource/aws_sagemaker_endpoint_configuration: Add `async_inference_config`.
 ```

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 // CodeRepositoryByName returns the code repository corresponding to the specified name.
@@ -103,10 +104,7 @@ func DeviceFleetByName(conn *sagemaker.SageMaker, id string) (*sagemaker.Describ
 	}
 
 	if output == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil
@@ -150,10 +148,7 @@ func FeatureGroupByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Desc
 	}
 
 	if output == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil
@@ -239,10 +234,7 @@ func WorkforceByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Workfor
 	}
 
 	if output == nil || output.Workforce == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.Workforce, nil
@@ -267,10 +259,7 @@ func WorkteamByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Workteam
 	}
 
 	if output == nil || output.Workteam == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.Workteam, nil
@@ -295,10 +284,7 @@ func HumanTaskUiByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Descr
 	}
 
 	if output == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil
@@ -323,10 +309,7 @@ func EndpointConfigByName(conn *sagemaker.SageMaker, name string) (*sagemaker.De
 	}
 
 	if output == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -303,3 +303,31 @@ func HumanTaskUiByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Descr
 
 	return output, nil
 }
+
+func EndpointConfigByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeEndpointConfigOutput, error) {
+	input := &sagemaker.DescribeEndpointConfigInput{
+		EndpointConfigName: aws.String(name),
+	}
+
+	output, err := conn.DescribeEndpointConfig(input)
+
+	if tfawserr.ErrMessageContains(err, "ValidationException", "Could not find endpoint configuration") {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -637,7 +637,7 @@ func expandSagemakerEndpointConfigNotificationConfig(configured []interface{}) *
 		c.ErrorTopic = aws.String(v.(string))
 	}
 
-	if v, ok := m["sucess_topic"]; ok {
+	if v, ok := m["success_topic"]; ok {
 		c.SuccessTopic = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -391,7 +392,7 @@ func resourceAwsSagemakerEndpointConfigurationDelete(d *schema.ResourceData, met
 
 	_, err := conn.DeleteEndpointConfig(deleteOpts)
 
-	if isAWSErr(err, sagemaker.ErrCodeResourceNotFound, "") {
+	if tfawserr.ErrMessageContains(err, "ValidationException", "Could not find endpoint configuration") {
 		return nil
 	}
 

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -299,7 +299,7 @@ func TestAccAWSSagemakerEndpointConfiguration_async(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "async_inference_config.0.output_config.0.s3_output_path"),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.0.notification_config.#", "0"),
-					resource.TestCheckResourceAttrPair(resourceName, "async_inference_config.0.output_config.kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "async_inference_config.0.output_config.0.kms_key_id", "aws_kms_key.test", "arn"),
 				),
 			},
 			{

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -271,6 +271,7 @@ func TestAccAWSSagemakerEndpointConfiguration_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerEndpointConfiguration(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerEndpointConfiguration(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -268,7 +268,7 @@ func TestAccAWSSagemakerEndpointConfiguration_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_async_client(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_async(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_endpoint_configuration.test"
 
@@ -283,7 +283,37 @@ func TestAccAWSSagemakerEndpointConfiguration_async_client(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.client_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "async_inference_config.0.output_config.0.s3_output_path"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerEndpointConfiguration_async_client(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigurationConfigAsyncClientConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.client_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.client_config.0.max_concurrent_invocations_per_instance", "1"),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.#", "1"),
@@ -552,6 +582,45 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
+
+  async_inference_config {
+    output_config {
+      s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
+	  kms_key_id     = aws_kms_key.test.arn
+	}
+  }
+}
+`, rName)
+}
+
+func testAccSagemakerEndpointConfigurationConfigAsyncClientConfig(rName string) string {
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
 
@@ -570,6 +639,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
     output_config {
       s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
+	  kms_key_id     = aws_kms_key.test.arn
 	}
   }
 }

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -375,7 +375,7 @@ func testAccCheckSagemakerEndpointConfigurationExists(n string) resource.TestChe
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
-		output, err := finder.EndpointConfigByName(conn, rs.Primary.ID)
+		_, err := finder.EndpointConfigByName(conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -605,7 +605,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
   async_inference_config {
     output_config {
       s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
-	  kms_key_id     = aws_kms_key.test.arn
+      kms_key_id     = aws_kms_key.test.arn
     }
   }
 }
@@ -643,7 +643,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 
     output_config {
       s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
-	  kms_key_id     = aws_kms_key.test.arn
+      kms_key_id     = aws_kms_key.test.arn
     }
   }
 }

--- a/aws/resource_aws_sagemaker_test.go
+++ b/aws/resource_aws_sagemaker_test.go
@@ -2,7 +2,21 @@ package aws
 
 import (
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+func init() {
+	RegisterServiceErrorCheckFunc(sagemaker.EndpointsID, testAccErrorCheckSkipSagemaker)
+}
+
+func testAccErrorCheckSkipSagemaker(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"is not supported in region",
+		"is not supported for the chosen region",
+	)
+}
 
 // Tests are serialized as SagmMaker Domain resources are limited to 1 per account by default.
 // SageMaker UserProfile and App depend on the Domain resources and as such are also part of the serialized test suite.

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A mapping of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `data_capture_config` - (Optional) Specifies the parameters to capture input/output of Sagemaker models endpoints. Fields are documented below.
+* `async_inference_config` - (Optional) Specifies configuration for how an endpoint performs asynchronous inference.
 
 The `production_variants` block supports:
 
@@ -68,6 +69,26 @@ The `capture_content_type_header` block supports:
 
 * `csv_content_types` - (Optional) The CSV content type headers to capture.
 * `json_content_types` - (Optional) The JSON content type headers to capture.
+
+The `async_inference_config` block supports:
+
+* `output_config` - (Required) Specifies the configuration for asynchronous inference invocation outputs.
+* `client_config` - (Optional) Configures the behavior of the client used by Amazon SageMaker to interact with the model container during asynchronous inference.
+
+The `client_config` block supports:
+
+* `max_concurrent_invocations_per_instance` - (Optional) The maximum number of concurrent requests sent by the SageMaker client to the model container. If no value is provided, Amazon SageMaker will choose an optimal value for you.
+
+The `output_config` block supports:
+
+* `s3_output_path` - (Required) The Amazon S3 location to upload inference responses to.
+* `kms_key_id` - (Optional) The Amazon Web Services Key Management Service (Amazon Web Services KMS) key that Amazon SageMaker uses to encrypt the asynchronous inference output in Amazon S3.
+* `notification_config` - (Optional) Specifies the configuration for notifications of inference results for asynchronous inference.
+
+The `notification_config` block supports:
+
+* `error_topic` - (Optional) Amazon SNS topic to post a notification to when inference fails. If no topic is provided, no notification is sent on failure.
+* `success_topic` - (Optional) Amazon SNS topic to post a notification to when inference completes successfully. If no topic is provided, no notification is sent on success.
 
 ## Attributes Reference
 

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -51,6 +51,12 @@ The `production_variants` block supports:
 * `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
 * `model_name` - (Required) The name of the model to use.
 * `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+* `core_dump_config` - (Optional) Specifies configuration for a core dump from the model container when the process crashes.
+
+The `core_dump_config` block supports:
+
+* `destination_s3_uri` - (Required) The Amazon S3 bucket to send the core dump to.
+* `kms_key_id` - (Optional) The Amazon Web Services Key Management Service (Amazon Web Services KMS) key that Amazon SageMaker uses to encrypt the core dump data at rest using Amazon S3 server-side encryption.
 
 The `data_capture_config` block supports:
 

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -51,12 +51,6 @@ The `production_variants` block supports:
 * `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
 * `model_name` - (Required) The name of the model to use.
 * `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
-* `core_dump_config` - (Optional) Specifies configuration for a core dump from the model container when the process crashes.
-
-The `core_dump_config` block supports:
-
-* `destination_s3_uri` - (Required) The Amazon S3 bucket to send the core dump to.
-* `kms_key_id` - (Optional) The Amazon Web Services Key Management Service (Amazon Web Services KMS) key that Amazon SageMaker uses to encrypt the core dump data at rest using Amazon S3 server-side encryption.
 
 The `data_capture_config` block supports:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20699

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerEndpointConfiguration_'
--- PASS: TestAccAWSSagemakerEndpointConfiguration_disappears (86.12s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_basic (89.85s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_kmsKeyId (94.09s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_productionVariants_AcceleratorType (102.03s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_productionVariants_InitialVariantWeight (103.61s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_async (95.42s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_async_client (99.87s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_dataCaptureConfig (129.81s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_tags (210.39s)
--- PASS: TestAccAWSSagemakerEndpointConfiguration_async_notifConfig (186.70s)
```
