### PR TITLE
r/sagemaker_flow_definition

### DIFF
--- a/.changelog/20825.txt
+++ b/.changelog/20825.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sagemaker_flow_definition
+```

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -314,3 +314,31 @@ func EndpointConfigByName(conn *sagemaker.SageMaker, name string) (*sagemaker.De
 
 	return output, nil
 }
+
+func FlowDefinitionByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeFlowDefinitionOutput, error) {
+	input := &sagemaker.DescribeFlowDefinitionInput{
+		FlowDefinitionName: aws.String(name),
+	}
+
+	output, err := conn.DescribeFlowDefinition(input)
+
+	if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfsagemaker "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
@@ -16,6 +17,7 @@ func CodeRepositoryByName(conn *sagemaker.SageMaker, name string) (*sagemaker.De
 	}
 
 	output, err := conn.DescribeCodeRepository(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -35,6 +37,7 @@ func ModelPackageGroupByName(conn *sagemaker.SageMaker, name string) (*sagemaker
 	}
 
 	output, err := conn.DescribeModelPackageGroup(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -54,6 +57,7 @@ func ImageByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeIma
 	}
 
 	output, err := conn.DescribeImage(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -73,6 +77,7 @@ func ImageVersionByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Desc
 	}
 
 	output, err := conn.DescribeImageVersion(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +97,8 @@ func DeviceFleetByName(conn *sagemaker.SageMaker, id string) (*sagemaker.Describ
 	}
 
 	output, err := conn.DescribeDeviceFleet(input)
-	if tfawserr.ErrMessageContains(err, "ValidationException", "No devicefleet with name") {
+
+	if tfawserr.ErrMessageContains(err, tfsagemaker.ErrCodeValidationException, "No devicefleet with name") {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -118,6 +124,7 @@ func DomainByName(conn *sagemaker.SageMaker, domainID string) (*sagemaker.Descri
 	}
 
 	output, err := conn.DescribeDomain(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -163,6 +170,7 @@ func UserProfileByName(conn *sagemaker.SageMaker, domainID, userProfileName stri
 	}
 
 	output, err := conn.DescribeUserProfile(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -182,6 +190,7 @@ func AppImageConfigByName(conn *sagemaker.SageMaker, appImageConfigID string) (*
 	}
 
 	output, err := conn.DescribeAppImageConfig(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -204,6 +213,7 @@ func AppByName(conn *sagemaker.SageMaker, domainID, userProfileName, appType, ap
 	}
 
 	output, err := conn.DescribeApp(input)
+
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +232,7 @@ func WorkforceByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Workfor
 
 	output, err := conn.DescribeWorkforce(input)
 
-	if tfawserr.ErrMessageContains(err, "ValidationException", "No workforce") {
+	if tfawserr.ErrMessageContains(err, tfsagemaker.ErrCodeValidationException, "No workforce") {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -247,7 +257,7 @@ func WorkteamByName(conn *sagemaker.SageMaker, name string) (*sagemaker.Workteam
 
 	output, err := conn.DescribeWorkteam(input)
 
-	if tfawserr.ErrMessageContains(err, "ValidationException", "The work team") {
+	if tfawserr.ErrMessageContains(err, tfsagemaker.ErrCodeValidationException, "The work team") {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -297,7 +307,7 @@ func EndpointConfigByName(conn *sagemaker.SageMaker, name string) (*sagemaker.De
 
 	output, err := conn.DescribeEndpointConfig(input)
 
-	if tfawserr.ErrMessageContains(err, "ValidationException", "Could not find endpoint configuration") {
+	if tfawserr.ErrMessageContains(err, tfsagemaker.ErrCodeValidationException, "Could not find endpoint configuration") {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -334,10 +344,7 @@ func FlowDefinitionByName(conn *sagemaker.SageMaker, name string) (*sagemaker.De
 	}
 
 	if output == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/aws/internal/service/sagemaker/waiter/status.go
+++ b/aws/internal/service/sagemaker/waiter/status.go
@@ -172,6 +172,26 @@ func FeatureGroupStatus(conn *sagemaker.SageMaker, name string) resource.StateRe
 	}
 }
 
+func FlowDefinitionStatus(conn *sagemaker.SageMaker, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := finder.FlowDefinitionByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if aws.StringValue(output.FlowDefinitionStatus) == sagemaker.FlowDefinitionStatusFailed {
+			return output, sagemaker.FlowDefinitionStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
+		}
+
+		return output, aws.StringValue(output.FlowDefinitionStatus), nil
+	}
+}
+
 // UserProfileStatus fetches the UserProfile and its Status
 func UserProfileStatus(conn *sagemaker.SageMaker, domainID, userProfileName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/aws/internal/service/sagemaker/waiter/status.go
+++ b/aws/internal/service/sagemaker/waiter/status.go
@@ -184,10 +184,6 @@ func FlowDefinitionStatus(conn *sagemaker.SageMaker, name string) resource.State
 			return nil, "", err
 		}
 
-		if aws.StringValue(output.FlowDefinitionStatus) == sagemaker.FlowDefinitionStatusFailed {
-			return output, sagemaker.FlowDefinitionStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
-		}
-
 		return output, aws.StringValue(output.FlowDefinitionStatus), nil
 	}
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1037,6 +1037,7 @@ func Provider() *schema.Provider {
 			"aws_sagemaker_endpoint":                                  resourceAwsSagemakerEndpoint(),
 			"aws_sagemaker_endpoint_configuration":                    resourceAwsSagemakerEndpointConfiguration(),
 			"aws_sagemaker_feature_group":                             resourceAwsSagemakerFeatureGroup(),
+			"aws_sagemaker_flow_definition":                           resourceAwsSagemakerFlowDefinition(),
 			"aws_sagemaker_image":                                     resourceAwsSagemakerImage(),
 			"aws_sagemaker_image_version":                             resourceAwsSagemakerImageVersion(),
 			"aws_sagemaker_human_task_ui":                             resourceAwsSagemakerHumanTaskUi(),

--- a/aws/resource_aws_sagemaker_flow_definition.go
+++ b/aws/resource_aws_sagemaker_flow_definition.go
@@ -427,7 +427,7 @@ func expandSagemakerFlowDefinitionHumanLoopActivationConditionsConfig(l []interf
 	}
 
 	config := &sagemaker.HumanLoopActivationConditionsConfig{
-		HumanLoopActivationConditions: aws.JSONValue(v),
+		HumanLoopActivationConditions: v,
 	}
 
 	return config, nil

--- a/aws/resource_aws_sagemaker_flow_definition.go
+++ b/aws/resource_aws_sagemaker_flow_definition.go
@@ -1,0 +1,494 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func resourceAwsSagemakerFlowDefinition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerFlowDefinitionCreate,
+		Read:   resourceAwsSagemakerFlowDefinitionRead,
+		Update: resourceAwsSagemakerFlowDefinitionUpdate,
+		Delete: resourceAwsSagemakerFlowDefinitionDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flow_definition_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-z0-9](-*[a-z0-9])*$`), "Valid characters are a-z, 0-9, and - (hyphen)."),
+				),
+			},
+			"human_loop_activation_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"human_loop_activation_conditions_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"human_loop_activation_conditions": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 10240),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"human_loop_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"human_task_ui_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
+						},
+						"task_availability_lifetime_in_seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntBetween(1, 864000),
+						},
+						"task_count": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntBetween(1, 3),
+						},
+						"task_description": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+						"task_keywords": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 5,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 30),
+									validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9]+( [A-Za-z0-9]+)*$`), ""),
+								),
+							},
+						},
+						"task_time_limit_in_seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ForceNew:     true,
+							Default:      3600,
+							ValidateFunc: validation.IntBetween(30, 28800),
+						},
+						"task_title": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 128),
+						},
+						"workteam_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"human_loop_request_source": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"aws_managed_human_loop_request_source": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.AwsManagedHumanLoopRequestSource_Values(), false),
+						},
+					},
+				},
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"output_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_key_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
+						},
+						"s3_output_path": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile(`^(https|s3)://([^/])/?(.*)$`), ""),
+								validation.StringLenBetween(1, 512),
+							),
+						},
+					},
+				},
+			},
+			"tags":     tagsSchema(),
+			"tags_all": tagsSchemaComputed(),
+		},
+
+		CustomizeDiff: SetTagsDiff,
+	}
+}
+
+func resourceAwsSagemakerFlowDefinitionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(keyvaluetags.New(d.Get("tags").(map[string]interface{})))
+
+	name := d.Get("flow_definition_name").(string)
+	input := &sagemaker.CreateFlowDefinitionInput{
+		FlowDefinitionName: aws.String(name),
+		HumanLoopConfig:    expandSagemakerFlowDefinitionHumanLoopConfig(d.Get("human_loop_config").([]interface{})),
+		RoleArn:            aws.String(d.Get("role_arn").(string)),
+		OutputConfig:       expandSagemakerFlowDefinitionOutputConfig(d.Get("output_config").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("human_loop_activation_config"); ok && (len(v.([]interface{})) > 0) {
+		input.HumanLoopActivationConfig = expandSagemakerFlowDefinitionHumanLoopActivationConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("human_loop_request_source"); ok && (len(v.([]interface{})) > 0) {
+		input.HumanLoopRequestSource = expandSagemakerFlowDefinitionHumanLoopRequestSource(v.([]interface{}))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = tags.IgnoreAws().SagemakerTags()
+	}
+
+	log.Printf("[DEBUG] Creating SageMaker Flow Definition: %s", input)
+	_, err := conn.CreateFlowDefinition(input)
+	if err != nil {
+		return fmt.Errorf("error creating SageMaker Flow Definition (%s): %w", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceAwsSagemakerFlowDefinitionRead(d, meta)
+}
+
+func resourceAwsSagemakerFlowDefinitionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+	defaultTagsConfig := meta.(*AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	flowDefinition, err := finder.FlowDefinitionByName(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SageMaker Flow Definition (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading SageMaker Flow Definition (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(flowDefinition.FlowDefinitionArn)
+	d.Set("arn", arn)
+	d.Set("role_arn", flowDefinition.RoleArn)
+	d.Set("flow_definition_name", flowDefinition.FlowDefinitionName)
+
+	if err := d.Set("human_loop_activation_config", flattenSagemakerFlowDefinitionHumanLoopActivationConfig(flowDefinition.HumanLoopActivationConfig)); err != nil {
+		return fmt.Errorf("error setting human_loop_activation_config: %w", err)
+	}
+
+	if err := d.Set("human_loop_config", flattenSagemakerFlowDefinitionHumanLoopConfig(flowDefinition.HumanLoopConfig)); err != nil {
+		return fmt.Errorf("error setting human_loop_config: %w", err)
+	}
+
+	if err := d.Set("human_loop_request_source", flattenSagemakerFlowDefinitionHumanLoopRequestSource(flowDefinition.HumanLoopRequestSource)); err != nil {
+		return fmt.Errorf("error setting human_loop_request_source: %w", err)
+	}
+
+	if err := d.Set("output_config", flattenSagemakerFlowDefinitionOutputConfig(flowDefinition.OutputConfig)); err != nil {
+		return fmt.Errorf("error setting output_config: %w", err)
+	}
+
+	tags, err := keyvaluetags.SagemakerListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for SageMaker Flow Definition (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerFlowDefinitionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := keyvaluetags.SagemakerUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating SageMaker Flow Definition (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSagemakerFlowDefinitionRead(d, meta)
+}
+
+func resourceAwsSagemakerFlowDefinitionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	log.Printf("[DEBUG] Deleting SageMaker Flow Definition: %s", d.Id())
+	_, err := conn.DeleteFlowDefinition(&sagemaker.DeleteFlowDefinitionInput{
+		FlowDefinitionName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrMessageContains(err, "ValidationException", "The work team") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting SageMaker Flow Definition (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandSagemakerFlowDefinitionHumanLoopActivationConfig(l []interface{}) *sagemaker.HumanLoopActivationConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.HumanLoopActivationConfig{
+		HumanLoopActivationConditionsConfig: expandSagemakerFlowDefinitionHumanLoopActivationConditionsConfig(m["human_loop_activation_conditions_config"].([]interface{})),
+	}
+
+	return config
+}
+
+func flattenSagemakerFlowDefinitionHumanLoopActivationConfig(config *sagemaker.HumanLoopActivationConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"human_loop_activation_conditions_config": flattenSagemakerFlowDefinitionHumanLoopActivationConditionsConfig(config.HumanLoopActivationConditionsConfig),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandSagemakerFlowDefinitionHumanLoopActivationConditionsConfig(l []interface{}) *sagemaker.HumanLoopActivationConditionsConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	v, _ := protocol.DecodeJSONValue(m["human_loop_activation_conditions"].(string), protocol.NoEscape)
+	// if err != nil {
+	// 	return err
+	// }
+
+	config := &sagemaker.HumanLoopActivationConditionsConfig{
+		HumanLoopActivationConditions: aws.JSONValue(v),
+	}
+
+	return config
+}
+
+func flattenSagemakerFlowDefinitionHumanLoopActivationConditionsConfig(config *sagemaker.HumanLoopActivationConditionsConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	v, _ := protocol.EncodeJSONValue(config.HumanLoopActivationConditions, protocol.NoEscape)
+	// if err != nil {
+	// 	return err
+	// }
+
+	m := map[string]interface{}{
+		"human_loop_activation_conditions": v,
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandSagemakerFlowDefinitionOutputConfig(l []interface{}) *sagemaker.FlowDefinitionOutputConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.FlowDefinitionOutputConfig{
+		S3OutputPath: aws.String(m["s3_output_path"].(string)),
+	}
+
+	if v, ok := m["kms_key_id"].(string); ok && v != "" {
+		config.KmsKeyId = aws.String(v)
+	}
+
+	return config
+}
+
+func flattenSagemakerFlowDefinitionOutputConfig(config *sagemaker.FlowDefinitionOutputConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"kms_key_id":     aws.StringValue(config.KmsKeyId),
+		"s3_output_path": aws.StringValue(config.S3OutputPath),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandSagemakerFlowDefinitionHumanLoopRequestSource(l []interface{}) *sagemaker.HumanLoopRequestSource {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.HumanLoopRequestSource{
+		AwsManagedHumanLoopRequestSource: aws.String(m["aws_managed_human_loop_request_source"].(string)),
+	}
+
+	return config
+}
+
+func flattenSagemakerFlowDefinitionHumanLoopRequestSource(config *sagemaker.HumanLoopRequestSource) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"aws_managed_human_loop_request_source": aws.StringValue(config.AwsManagedHumanLoopRequestSource),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandSagemakerFlowDefinitionHumanLoopConfig(l []interface{}) *sagemaker.HumanLoopConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.HumanLoopConfig{
+		HumanTaskUiArn:  aws.String(m["human_task_ui_arn"].(string)),
+		TaskCount:       aws.Int64(int64(m["task_count"].(int))),
+		TaskDescription: aws.String(m["task_description"].(string)),
+		TaskTitle:       aws.String(m["task_title"].(string)),
+		WorkteamArn:     aws.String(m["workteam_arn"].(string)),
+	}
+
+	if v, ok := m["task_keywords"].(*schema.Set); ok && v.Len() > 0 {
+		config.TaskKeywords = expandStringSet(v)
+	}
+
+	if v, ok := m["task_availability_lifetime_in_seconds"].(int); ok {
+		config.TaskAvailabilityLifetimeInSeconds = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["task_time_limit_in_seconds"].(int); ok {
+		config.TaskTimeLimitInSeconds = aws.Int64(int64(v))
+	}
+
+	return config
+}
+
+func flattenSagemakerFlowDefinitionHumanLoopConfig(config *sagemaker.HumanLoopConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"human_task_ui_arn": aws.StringValue(config.HumanTaskUiArn),
+		"task_count":        aws.Int64Value(config.TaskCount),
+		"task_description":  aws.StringValue(config.TaskDescription),
+		"task_title":        aws.StringValue(config.TaskTitle),
+		"workteam_arn":      aws.StringValue(config.WorkteamArn),
+	}
+
+	if config.TaskKeywords != nil {
+		m["task_keywords"] = flattenStringSet(config.TaskKeywords)
+	}
+
+	if config.TaskAvailabilityLifetimeInSeconds != nil {
+		m["task_availability_lifetime_in_seconds"] = aws.Int64Value(config.TaskAvailabilityLifetimeInSeconds)
+	}
+
+	if config.TaskTimeLimitInSeconds != nil {
+		m["task_time_limit_in_seconds"] = aws.Int64Value(config.TaskTimeLimitInSeconds)
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/resource_aws_sagemaker_flow_definition_test.go
+++ b/aws/resource_aws_sagemaker_flow_definition_test.go
@@ -390,12 +390,12 @@ resource "aws_sagemaker_flow_definition" "test" {
     task_title                            = %[1]q
     workteam_arn                          = "arn:aws:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
 
-	public_workforce_task_price {
+    public_workforce_task_price {
       amount_in_usd {
         cents                     = 1
         tenth_fractions_of_a_cent = 2 
-	  }
-	}
+      }
+    }
   }
 
   output_config {

--- a/aws/resource_aws_sagemaker_flow_definition_test.go
+++ b/aws/resource_aws_sagemaker_flow_definition_test.go
@@ -393,7 +393,7 @@ resource "aws_sagemaker_flow_definition" "test" {
     public_workforce_task_price {
       amount_in_usd {
         cents                     = 1
-        tenth_fractions_of_a_cent = 2 
+        tenth_fractions_of_a_cent = 2
       }
     }
   }

--- a/aws/resource_aws_sagemaker_flow_definition_test.go
+++ b/aws/resource_aws_sagemaker_flow_definition_test.go
@@ -1,0 +1,362 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_flow_definition", &resource.Sweeper{
+		Name: "aws_sagemaker_flow_definition",
+		F:    testSweepSagemakerFlowDefinitions,
+	})
+}
+
+func testSweepSagemakerFlowDefinitions(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListFlowDefinitionsPages(&sagemaker.ListFlowDefinitionsInput{}, func(page *sagemaker.ListFlowDefinitionsOutput, lastPage bool) bool {
+		for _, flowDefinition := range page.FlowDefinitionSummaries {
+
+			r := resourceAwsSagemakerFlowDefinition()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(flowDefinition.FlowDefinitionName))
+			err := r.Delete(d, client)
+			if err != nil {
+				log.Printf("[ERROR] %s", err)
+				sweeperErrs = multierror.Append(sweeperErrs, err)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker Flow Definition sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Sagemaker Flow Definitions: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func TestAccAWSSagemakerFlowDefinition_basic(t *testing.T) {
+	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_flow_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerFlowDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerFlowDefinitionBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerFlowDefinitionExists(resourceName, &flowDefinition),
+					resource.TestCheckResourceAttr(resourceName, "flow_definition_name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("flow-definition/%s", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "human_loop_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "human_loop_config.0.human_task_ui_arn", "aws_sagemaker_human_task_ui.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "human_loop_config.0.task_availability_lifetime_in_seconds", "1"),
+					resource.TestCheckResourceAttr(resourceName, "human_loop_config.0.task_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "human_loop_config.0.task_description", rName),
+					resource.TestCheckResourceAttr(resourceName, "human_loop_config.0.task_title", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "human_loop_config.0.workteam_arn", "aws_sagemaker_workteam.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "output_config.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "output_config.0.s3_output_path"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerFlowDefinition_tags(t *testing.T) {
+	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_flow_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerFlowDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerFlowDefinitionTagsConfig1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerFlowDefinitionExists(resourceName, &flowDefinition),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerFlowDefinitionTagsConfig2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerFlowDefinitionExists(resourceName, &flowDefinition),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerFlowDefinitionTagsConfig1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerFlowDefinitionExists(resourceName, &flowDefinition),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerFlowDefinition_disappears(t *testing.T) {
+	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_flow_definition.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerFlowDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerFlowDefinitionBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerFlowDefinitionExists(resourceName, &flowDefinition),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerFlowDefinition(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerFlowDefinition(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerFlowDefinitionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_flow_definition" {
+			continue
+		}
+
+		_, err := finder.FlowDefinitionByName(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("SageMaker Flow Definition %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSagemakerFlowDefinitionExists(n string, flowDefinition *sagemaker.DescribeFlowDefinitionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SageMaker Flow Definition ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+		output, err := finder.FlowDefinitionByName(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*flowDefinition = *output
+
+		return nil
+	}
+}
+
+func testAccAWSSagemakerFlowDefinitionBaseConfig(rName string) string {
+	return composeConfig(testAccAWSSagemakerWorkteamCognitoConfig(rName),
+		fmt.Sprintf(`
+resource "aws_sagemaker_human_task_ui" "test" {
+  human_task_ui_name = %[1]q
+
+  ui_template {
+    content = file("test-fixtures/sagemaker-human-task-ui-tmpl.html")
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+`, rName))
+}
+
+func testAccAWSSagemakerFlowDefinitionBasicConfig(rName string) string {
+	return composeConfig(testAccAWSSagemakerFlowDefinitionBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_sagemaker_flow_definition" "test" {
+  flow_definition_name = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  human_loop_config {
+    human_task_ui_arn                     = aws_sagemaker_human_task_ui.test.arn
+    task_availability_lifetime_in_seconds = 1
+    task_count                            = 1
+    task_description                      = %[1]q
+    task_title                            = %[1]q
+    workteam_arn                          = aws_sagemaker_workteam.test.arn
+  }
+
+  output_config {
+    s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
+  }
+}
+`, rName))
+}
+
+func testAccAWSSagemakerFlowDefinitionTagsConfig1(rName, tagKey1, tagValue1 string) string {
+	return composeConfig(testAccAWSSagemakerFlowDefinitionBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_sagemaker_flow_definition" "test" {
+  flow_definition_name = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  human_loop_config {
+    human_task_ui_arn                     = aws_sagemaker_human_task_ui.test.arn
+    task_availability_lifetime_in_seconds = 1
+    task_count                            = 1
+    task_description                      = %[1]q
+    task_title                            = %[1]q
+    workteam_arn                          = aws_sagemaker_workteam.test.arn
+  }
+
+  output_config {
+    s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccAWSSagemakerFlowDefinitionTagsConfig2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return composeConfig(testAccAWSSagemakerFlowDefinitionBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_sagemaker_flow_definition" "test" {
+  flow_definition_name = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  human_loop_config {
+    human_task_ui_arn                     = aws_sagemaker_human_task_ui.test.arn
+    task_availability_lifetime_in_seconds = 1
+    task_count                            = 1
+    task_description                      = %[1]q
+    task_title                            = %[1]q
+    workteam_arn                          = aws_sagemaker_workteam.test.arn
+  }
+
+  output_config {
+    s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/aws/resource_aws_sagemaker_flow_definition_test.go
+++ b/aws/resource_aws_sagemaker_flow_definition_test.go
@@ -59,7 +59,7 @@ func testSweepSagemakerFlowDefinitions(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSSagemakerFlowDefinition_basic(t *testing.T) {
+func testAccAWSSagemakerFlowDefinition_basic(t *testing.T) {
 	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_flow_definition.test"
@@ -101,7 +101,7 @@ func TestAccAWSSagemakerFlowDefinition_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFlowDefinition_humanLoopConfig_publicWorkforce(t *testing.T) {
+func testAccAWSSagemakerFlowDefinition_humanLoopConfig_publicWorkforce(t *testing.T) {
 	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_flow_definition.test"
@@ -133,7 +133,7 @@ func TestAccAWSSagemakerFlowDefinition_humanLoopConfig_publicWorkforce(t *testin
 	})
 }
 
-func TestAccAWSSagemakerFlowDefinition_humanLoopRequestSource(t *testing.T) {
+func testAccAWSSagemakerFlowDefinition_humanLoopRequestSource(t *testing.T) {
 	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_flow_definition.test"
@@ -165,7 +165,7 @@ func TestAccAWSSagemakerFlowDefinition_humanLoopRequestSource(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFlowDefinition_tags(t *testing.T) {
+func testAccAWSSagemakerFlowDefinition_tags(t *testing.T) {
 	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_flow_definition.test"
@@ -210,7 +210,7 @@ func TestAccAWSSagemakerFlowDefinition_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerFlowDefinition_disappears(t *testing.T) {
+func testAccAWSSagemakerFlowDefinition_disappears(t *testing.T) {
 	var flowDefinition sagemaker.DescribeFlowDefinitionOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_flow_definition.test"

--- a/aws/resource_aws_sagemaker_flow_definition_test.go
+++ b/aws/resource_aws_sagemaker_flow_definition_test.go
@@ -378,6 +378,8 @@ func testAccAWSSagemakerFlowDefinitionPublicWorkforceConfig(rName string) string
 		fmt.Sprintf(`
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_sagemaker_flow_definition" "test" {
   flow_definition_name = %[1]q
   role_arn             = aws_iam_role.test.arn
@@ -388,7 +390,7 @@ resource "aws_sagemaker_flow_definition" "test" {
     task_count                            = 1
     task_description                      = %[1]q
     task_title                            = %[1]q
-    workteam_arn                          = "arn:aws:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
+    workteam_arn                          = "arn:${data.aws_partition.current.partition}:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
 
     public_workforce_task_price {
       amount_in_usd {

--- a/aws/resource_aws_sagemaker_flow_definition_test.go
+++ b/aws/resource_aws_sagemaker_flow_definition_test.go
@@ -428,7 +428,7 @@ resource "aws_sagemaker_flow_definition" "test" {
 
   human_loop_activation_config {
     human_loop_activation_conditions_config {
-		human_loop_activation_conditions = <<EOF
+      human_loop_activation_conditions = <<EOF
         {
 			"Conditions": [
 			  {
@@ -440,7 +440,7 @@ resource "aws_sagemaker_flow_definition" "test" {
 			]
 		}
         EOF
-	}
+    }
   }
 
   output_config {

--- a/aws/resource_aws_sagemaker_test.go
+++ b/aws/resource_aws_sagemaker_test.go
@@ -42,6 +42,13 @@ func TestAccAWSSagemaker_serial(t *testing.T) {
 			"securityGroup":                        testAccAWSSagemakerDomain_securityGroup,
 			"sharingSettings":                      testAccAWSSagemakerDomain_sharingSettings,
 		},
+		"FlowDefinition": {
+			"basic":                          testAccAWSSagemakerFlowDefinition_basic,
+			"disappears":                     testAccAWSSagemakerFlowDefinition_disappears,
+			"HumanLoopConfigPublicWorkforce": testAccAWSSagemakerFlowDefinition_humanLoopConfig_publicWorkforce,
+			"HumanLoopRequestSource":         testAccAWSSagemakerFlowDefinition_humanLoopRequestSource,
+			"Tags":                           testAccAWSSagemakerFlowDefinition_tags,
+		},
 		"UserProfile": {
 			"basic":                           testAccAWSSagemakerUserProfile_basic,
 			"disappears":                      testAccAWSSagemakerUserProfile_tags,

--- a/website/docs/r/sagemaker_flow_definition.html.markdown
+++ b/website/docs/r/sagemaker_flow_definition.html.markdown
@@ -49,12 +49,12 @@ resource "aws_sagemaker_flow_definition" "example" {
     task_title                            = "example"
     workteam_arn                          = "arn:aws:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
 
-	  public_workforce_task_price {
+    public_workforce_task_price {
       amount_in_usd {
         cents                     = 1
-        tenth_fractions_of_a_cent = 2 
-	    }
-	  }
+        tenth_fractions_of_a_cent = 2
+      }
+    }
   }
 
   output_config {

--- a/website/docs/r/sagemaker_flow_definition.html.markdown
+++ b/website/docs/r/sagemaker_flow_definition.html.markdown
@@ -1,0 +1,175 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_flow_definition"
+description: |-
+  Provides a Sagemaker Flow Definition resource.
+---
+
+# Resource: aws_sagemaker_flow_definition
+
+Provides a Sagemaker Flow Definition resource.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_sagemaker_flow_definition" "example" {
+  flow_definition_name = "example"
+  role_arn             = aws_iam_role.example.arn
+
+  human_loop_config {
+    human_task_ui_arn                     = aws_sagemaker_human_task_ui.example.arn
+    task_availability_lifetime_in_seconds = 1
+    task_count                            = 1
+    task_description                      = "example"
+    task_title                            = "example"
+    workteam_arn                          = aws_sagemaker_workteam.example.arn
+  }
+
+  output_config {
+    s3_output_path = "s3://${aws_s3_bucket.example.bucket}/"
+  }
+}
+```
+
+### Public Workteam Usage
+
+```terraform
+resource "aws_sagemaker_flow_definition" "example" {
+  flow_definition_name = "example"
+  role_arn             = aws_iam_role.example.arn
+
+  human_loop_config {
+    human_task_ui_arn                     = aws_sagemaker_human_task_ui.example.arn
+    task_availability_lifetime_in_seconds = 1
+    task_count                            = 1
+    task_description                      = "example"
+    task_title                            = "example"
+    workteam_arn                          = "arn:aws:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
+
+	  public_workforce_task_price {
+      amount_in_usd {
+        cents                     = 1
+        tenth_fractions_of_a_cent = 2 
+	    }
+	  }
+  }
+
+  output_config {
+    s3_output_path = "s3://${aws_s3_bucket.example.bucket}/"
+  }
+}
+```
+
+### Human Loop Activation Config Usage
+
+```terraform
+resource "aws_sagemaker_flow_definition" "example" {
+  flow_definition_name = "example"
+  role_arn             = aws_iam_role.example.arn
+
+  human_loop_config {
+    human_task_ui_arn                     = aws_sagemaker_human_task_ui.example.arn
+    task_availability_lifetime_in_seconds = 1
+    task_count                            = 1
+    task_description                      = "example"
+    task_title                            = "example"
+    workteam_arn                          = aws_sagemaker_workteam.example.arn
+  }
+
+  human_loop_request_source {
+    aws_managed_human_loop_request_source = "AWS/Textract/AnalyzeDocument/Forms/V1"
+  }
+
+  human_loop_activation_config {
+    human_loop_activation_conditions_config {
+      human_loop_activation_conditions = <<EOF
+        {
+			"Conditions": [
+			  {
+				"ConditionType": "Sampling",
+				"ConditionParameters": {
+				  "RandomSamplingPercentage": 5
+				}
+			  }
+			]
+		}
+        EOF
+    }
+  }
+
+  output_config {
+    s3_output_path = "s3://${aws_s3_bucket.example.bucket}/"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `flow_definition_name` - (Required) The name of your flow definition.
+* `human_loop_config` - (Required)  An object containing information about the tasks the human reviewers will perform. See [Human Loop Config](#human-loop-config) details below.
+* `role_arn` - (Required) The Amazon Resource Name (ARN) of the role needed to call other services on your behalf.
+* `output_config` - (Required) An object containing information about where the human review results will be uploaded. See [Output Config](#output-config) details below.
+* `human_loop_activation_config` - (Optional) An object containing information about the events that trigger a human workflow. See [Human Loop Activation Config](#human-loop-activation-config) details below.
+* `human_loop_request_source` - (Optional) Container for configuring the source of human task requests. Use to specify if Amazon Rekognition or Amazon Textract is used as an integration source. See [Human Loop Request Source](#human-loop-request-source) details below.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Human Loop Config
+
+* `human_task_ui_arn` - (Required) The Amazon Resource Name (ARN) of the human task user interface.
+* `public_workforce_task_price` - (Optional) Defines the amount of money paid to an Amazon Mechanical Turk worker for each task performed. See [Public Workforce Task Price](#public-workforce-task-price) details below.
+* `task_availability_lifetime_in_seconds` - (Required) The length of time that a task remains available for review by human workers. Valid value range between `1` and `864000`.
+* `task_count` - (Required) The number of distinct workers who will perform the same task on each object. Valid value range between `1` and `3`.
+* `task_description` - (Required) A description for the human worker task.
+* `task_keywords` - (Optional) An array of keywords used to describe the task so that workers can discover the task.
+* `task_time_limit_in_seconds` - (Optional) The amount of time that a worker has to complete a task. The default value is `3600` seconds.
+* `task_title` - (Required) A title for the human worker task.
+* `workteam_arn` - (Required) The Amazon Resource Name (ARN) of the human task user interface. Amazon Resource Name (ARN) of a team of workers. For Public workforces see [AWS Docs](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-workforce-management-public.html).
+
+#### Public Workforce Task Price
+
+* `amount_in_usd` - (Optional) Defines the amount of money paid to an Amazon Mechanical Turk worker in United States dollars. See [Amount In Usd](#amount-in-usd) details below.
+
+##### Amount In Usd
+
+* `cents` - (Optional) The fractional portion, in cents, of the amount. Valid value range between `0` and `99`.
+* `dollars` - (Optional) The whole number of dollars in the amount. Valid value range between `0` and `2`.
+* `tenth_fractions_of_a_cent` - (Optional) Fractions of a cent, in tenths. Valid value range between `0` and `9`.
+
+
+### Human Loop Activation Config
+
+* `human_loop_activation_conditions_config` - (Required) defines under what conditions SageMaker creates a human loop. See [Human Loop Activation Conditions Config](#human-loop-activation-conditions-config) details below.
+
+#### Human Loop Activation Conditions Config
+
+* `human_loop_activation_conditions` - (Required) A JSON expressing use-case specific conditions declaratively. If any condition is matched, atomic tasks are created against the configured work team. For more information about how to structure the JSON, see [JSON Schema for Human Loop Activation Conditions in Amazon Augmented AI](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-human-fallback-conditions-json-schema.html).
+
+### Human Loop Request Source
+
+* `aws_managed_human_loop_request_source` - (Required) Specifies whether Amazon Rekognition or Amazon Textract are used as the integration source. Valid values are: `AWS/Rekognition/DetectModerationLabels/Image/V3` and `AWS/Textract/AnalyzeDocument/Forms/V1`.
+
+### Output Config
+
+* `s3_output_path` - (Required) The Amazon S3 path where the object containing human output will be made available.
+* `kms_key_id` - (Optional) The Amazon Key Management Service (KMS) key ARN for server-side encryption.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Flow Definition.
+* `id` - The name of the Flow Definition.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Sagemaker Flow Definitions can be imported using the `flow_definition_name`, e.g.
+
+```
+$ terraform import aws_sagemaker_flow_definition.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerFlowDefinition_'
--- PASS: TestAccAWSSagemakerFlowDefinition_basic (211.82s)
--- PASS: TestAccAWSSagemakerFlowDefinition_humanLoopConfig_publicWorkforce (107.37s)
--- PASS: TestAccAWSSagemakerFlowDefinition_humanLoopRequestSource (153.40s)
--- PASS: TestAccAWSSagemakerFlowDefinition_tags (303.88s)
--- PASS: TestAccAWSSagemakerFlowDefinition_disappears (144.54s)
```
