### PR TITLE
Update vpc_id attribute description for aws_db_snapshot

### DIFF
--- a/website/docs/r/db_snapshot.html.markdown
+++ b/website/docs/r/db_snapshot.html.markdown
@@ -61,7 +61,7 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - Specifies the status of this DB snapshot.
 * `storage_type` - Specifies the storage type associated with DB snapshot.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
-* `vpc_id` - Specifies the storage type associated with DB snapshot.
+* `vpc_id` - Provides the VPC ID associated with the DB snapshot.
 
 ## Timeouts
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #19455

### Reference:
[func (*RDS) CreateDBSnapshot](https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#RDS.CreateDBSnapshot) returns a [*CreateDBSnapshotOutput](https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#CreateDBSnapshotOutput), which has a [*DBSnapshot](https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#DBSnapshot) field, which has the following field that I pulled the description from:

```golfing
    // Provides the VPC ID associated with the DB snapshot.
    VpcId *string `type:"string"`
```