### PR TITLE
r/ec2_transit_gateway: replace `GetTransitGatewayRouteTablePropagations` with pagination method in ec2/finder

### DIFF
--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -580,7 +580,11 @@ func TransitGatewayRouteTablePropagation(conn *ec2.EC2, transitGatewayRouteTable
 		return !lastPage
 	})
 
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // VpcAttribute looks up a VPC attribute.

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -549,6 +549,10 @@ func TransitGatewayPrefixListReferenceByID(conn *ec2.EC2, resourceID string) (*e
 }
 
 func TransitGatewayRouteTablePropagation(conn *ec2.EC2, transitGatewayRouteTableID string, transitGatewayAttachmentID string) (*ec2.TransitGatewayRouteTablePropagation, error) {
+	if transitGatewayRouteTableID == "" {
+		return nil, nil
+	}
+
 	input := &ec2.GetTransitGatewayRouteTablePropagationsInput{
 		Filters: []*ec2.Filter{
 			{

--- a/aws/resource_aws_ec2_transit_gateway_route_table_propagation.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_propagation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
 )
 
@@ -80,7 +81,7 @@ func resourceAwsEc2TransitGatewayRouteTablePropagationRead(d *schema.ResourceDat
 		return err
 	}
 
-	transitGatewayPropagation, err := ec2DescribeTransitGatewayRouteTablePropagation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
+	transitGatewayPropagation, err := finder.TransitGatewayRouteTablePropagation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidRouteTableIDNotFound) {
 		log.Printf("[WARN] EC2 Transit Gateway Route Table (%s) not found, removing from state", transitGatewayRouteTableID)

--- a/aws/resource_aws_ec2_transit_gateway_route_table_propagation_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_propagation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 func TestAccAWSEc2TransitGatewayRouteTablePropagation_basic(t *testing.T) {
@@ -60,7 +61,7 @@ func testAccCheckAWSEc2TransitGatewayRouteTablePropagationExists(resourceName st
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-		propagation, err := ec2DescribeTransitGatewayRouteTablePropagation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
+		propagation, err := finder.TransitGatewayRouteTablePropagation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
 
 		if err != nil {
 			return err
@@ -94,7 +95,7 @@ func testAccCheckAWSEc2TransitGatewayRouteTablePropagationDestroy(s *terraform.S
 			return err
 		}
 
-		propagation, err := ec2DescribeTransitGatewayRouteTablePropagation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
+		propagation, err := finder.TransitGatewayRouteTablePropagation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
 
 		if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
 			continue

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 func init() {
@@ -623,7 +624,7 @@ func testAccCheckAWSEc2TransitGatewayPropagationDefaultRouteTableVpcAttachmentNo
 
 		attachmentID := aws.StringValue(transitGatewayVpcAttachment.TransitGatewayAttachmentId)
 		routeTableID := aws.StringValue(transitGateway.Options.AssociationDefaultRouteTableId)
-		propagation, err := ec2DescribeTransitGatewayRouteTablePropagation(conn, routeTableID, attachmentID)
+		propagation, err := finder.TransitGatewayRouteTablePropagation(conn, routeTableID, attachmentID)
 
 		if err != nil {
 			return err
@@ -643,7 +644,7 @@ func testAccCheckAWSEc2TransitGatewayPropagationDefaultRouteTableVpcAttachmentPr
 
 		attachmentID := aws.StringValue(transitGatewayVpcAttachment.TransitGatewayAttachmentId)
 		routeTableID := aws.StringValue(transitGateway.Options.AssociationDefaultRouteTableId)
-		propagation, err := ec2DescribeTransitGatewayRouteTablePropagation(conn, routeTableID, attachmentID)
+		propagation, err := finder.TransitGatewayRouteTablePropagation(conn, routeTableID, attachmentID)
 
 		if err != nil {
 			return err

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 func resourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
@@ -191,7 +192,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, meta 
 		}
 
 		transitGatewayPropagationDefaultRouteTableID := aws.StringValue(transitGateway.Options.PropagationDefaultRouteTableId)
-		transitGatewayDefaultRouteTablePropagation, err = ec2DescribeTransitGatewayRouteTablePropagation(conn, transitGatewayPropagationDefaultRouteTableID, d.Id())
+		transitGatewayDefaultRouteTablePropagation, err = finder.TransitGatewayRouteTablePropagation(conn, transitGatewayPropagationDefaultRouteTableID, d.Id())
 		if err != nil {
 			return fmt.Errorf("error determining EC2 Transit Gateway Attachment (%s) propagation to Route Table (%s): %s", d.Id(), transitGatewayPropagationDefaultRouteTableID, err)
 		}

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 func resourceAwsEc2TransitGatewayVpcAttachmentAccepter() *schema.Resource {
@@ -167,7 +168,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentAccepterRead(d *schema.ResourceDat
 	}
 
 	transitGatewayPropagationDefaultRouteTableID := aws.StringValue(transitGateway.Options.PropagationDefaultRouteTableId)
-	transitGatewayDefaultRouteTablePropagation, err := ec2DescribeTransitGatewayRouteTablePropagation(conn, transitGatewayPropagationDefaultRouteTableID, d.Id())
+	transitGatewayDefaultRouteTablePropagation, err := finder.TransitGatewayRouteTablePropagation(conn, transitGatewayPropagationDefaultRouteTableID, d.Id())
 	if err != nil {
 		return fmt.Errorf("error determining EC2 Transit Gateway Attachment (%s) propagation to Route Table (%s): %s", d.Id(), transitGatewayPropagationDefaultRouteTableID, err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #20775 

### Notes:
* Paginated method already available in ec2/finder.go, though needed to be updated:

https://github.com/hashicorp/terraform-provider-aws/blob/30873bd1d158b85cb4616b8304fe3fd9cb4d3539/aws/internal/service/ec2/finder/finder.go#L551-L584
* Test failure for `TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support` seen in GovCloud partition as well on `main` branch 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEc2TransitGatewayRoute_blackhole (393.16s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears (400.34s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (510.64s) <-- same error seen in Gov Cloud
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (326.22s)
--- PASS: TestAccAWSEc2TransitGatewayDataSource_Filter (256.37s)
--- PASS: TestAccAWSEc2TransitGatewayDataSource_ID (258.88s)
--- PASS: TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId (1302.11s)
--- PASS: TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter (1299.09s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount (840.07s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount (807.18s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount (396.95s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount (399.72s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Tags (406.39s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount (455.21s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_basic (440.60s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_disappears (398.56s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableAssociation_basic (516.93s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter (344.94s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_ID (345.03s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTablePropagation_basic (412.72s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_Tags (314.11s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_basic (330.13s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears (320.29s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway (243.64s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_basic (548.58s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_basic_ipv6 (502.63s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment (527.59s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (420.30s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (421.13s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport (510.24s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (459.94s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (598.74s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (459.67s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (540.19s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (452.44s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (434.90s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (420.35s)
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId (580.73s)
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter (660.14s)
--- PASS: TestAccAWSEc2TransitGateway_AmazonSideASN (483.48s)
--- PASS: TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments (197.69s)
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation (550.17s)
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled (222.46s)
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation (526.03s)
--- PASS: TestAccAWSEc2TransitGateway_Description (272.38s)
--- PASS: TestAccAWSEc2TransitGateway_DnsSupport (281.41s)
--- PASS: TestAccAWSEc2TransitGateway_Tags (264.47s)
--- PASS: TestAccAWSEc2TransitGateway_VpnEcmpSupport (273.90s)
--- PASS: TestAccAWSEc2TransitGateway_basic (244.15s)
--- PASS: TestAccAWSEc2TransitGateway_disappears (251.55s)
--- SKIP: TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount (1.21s)
--- SKIP: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAccount (1.30s)
--- SKIP: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount (1.81s)
--- SKIP: TestAccAWSEc2TransitGatewayPeeringAttachment_differentAccount (2.05s)
--- SKIP: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags (1.73s)
--- SKIP: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation (1.36s)
--- SKIP: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic (1.31s)
--- SKIP: TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway (1.00s)
```
