### PR TITLE
docs: Add link to the supported statistics for cloudwatch alarm

### DIFF
--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -230,7 +230,7 @@ The following values are supported: `ignore`, and `evaluate`.
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 * `period` - (Required) The period in seconds over which the specified `stat` is applied.
 * `stat` - (Required) The statistic to apply to this metric.
-   Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`
+   See docs for [supported statistics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html).
 * `unit` - (Optional) The unit for this metric.
 
 


### PR DESCRIPTION
CloudWatch metric alarm supports more statistics than `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum` when using MetricStat. Keeping these values in documentation may confuse users thinking only these values are supported.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Replaces the closed PR #20827. Couldn't reopen it.
