### PR TITLE
BugFix: Add bypass_file_system_lockout_safety_check to efs efs_file_system_policy

### DIFF
--- a/.changelog/20838.txt
+++ b/.changelog/20838.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_efs_file_system_policy: Add `bypass_policy_lockout_safety_check` argument
+```

--- a/aws/resource_aws_efs_file_system_policy.go
+++ b/aws/resource_aws_efs_file_system_policy.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/efs"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/efs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsEfsFileSystemPolicy() *schema.Resource {
@@ -16,13 +19,12 @@ func resourceAwsEfsFileSystemPolicy() *schema.Resource {
 		Read:   resourceAwsEfsFileSystemPolicyRead,
 		Update: resourceAwsEfsFileSystemPolicyPut,
 		Delete: resourceAwsEfsFileSystemPolicyDelete,
-
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"bypass_file_system_lockout_safety_check": {
+			"bypass_policy_lockout_safety_check": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -45,20 +47,21 @@ func resourceAwsEfsFileSystemPolicy() *schema.Resource {
 func resourceAwsEfsFileSystemPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).efsconn
 
-	fsId := d.Get("file_system_id").(string)
-	bypassPolicyLockoutSafetyCheck := d.Get("bypass_file_system_lockout_safety_check").(bool)
+	fsID := d.Get("file_system_id").(string)
 	input := &efs.PutFileSystemPolicyInput{
-		BypassPolicyLockoutSafetyCheck: aws.Bool(bypassPolicyLockoutSafetyCheck),
-		FileSystemId:                   aws.String(fsId),
+		BypassPolicyLockoutSafetyCheck: aws.Bool(d.Get("bypass_policy_lockout_safety_check").(bool)),
+		FileSystemId:                   aws.String(fsID),
 		Policy:                         aws.String(d.Get("policy").(string)),
 	}
-	log.Printf("[DEBUG] Adding EFS File System Policy: %#v", input)
+
+	log.Printf("[DEBUG] Putting EFS File System Policy: %s", input)
 	_, err := conn.PutFileSystemPolicy(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating EFS File System Policy %q: %s", d.Id(), err.Error())
+		return fmt.Errorf("error putting EFS File System Policy (%s): %w", fsID, err)
 	}
 
-	d.SetId(fsId)
+	d.SetId(fsID)
 
 	return resourceAwsEfsFileSystemPolicyRead(d, meta)
 }
@@ -66,26 +69,20 @@ func resourceAwsEfsFileSystemPolicyPut(d *schema.ResourceData, meta interface{})
 func resourceAwsEfsFileSystemPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).efsconn
 
-	var policyRes *efs.DescribeFileSystemPolicyOutput
-	policyRes, err := conn.DescribeFileSystemPolicy(&efs.DescribeFileSystemPolicyInput{
-		FileSystemId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if isAWSErr(err, efs.ErrCodeFileSystemNotFound, "") {
-			log.Printf("[WARN] EFS File System (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		if isAWSErr(err, efs.ErrCodePolicyNotFound, "") {
-			log.Printf("[WARN] EFS File System Policy (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error describing policy for EFS file system (%s): %s", d.Id(), err)
+	output, err := finder.FileSystemPolicyByID(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] EFS File System Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	d.Set("file_system_id", policyRes.FileSystemId)
-	d.Set("policy", policyRes.Policy)
+	if err != nil {
+		return fmt.Errorf("error reading EFS File System Policy (%s): %w", d.Id(), err)
+	}
+
+	d.Set("file_system_id", output.FileSystemId)
+	d.Set("policy", output.Policy)
 
 	return nil
 }
@@ -97,11 +94,14 @@ func resourceAwsEfsFileSystemPolicyDelete(d *schema.ResourceData, meta interface
 	_, err := conn.DeleteFileSystemPolicy(&efs.DeleteFileSystemPolicyInput{
 		FileSystemId: aws.String(d.Id()),
 	})
-	if err != nil {
-		return fmt.Errorf("error deleting EFS File System Policy: %s with err %s", d.Id(), err.Error())
+
+	if tfawserr.ErrCodeEquals(err, efs.ErrCodeFileSystemNotFound) {
+		return nil
 	}
 
-	log.Printf("[DEBUG] EFS File System Policy %q deleted.", d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting EFS File System Policy (%s): %w", d.Id(), err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_efs_file_system_policy.go
+++ b/aws/resource_aws_efs_file_system_policy.go
@@ -22,6 +22,11 @@ func resourceAwsEfsFileSystemPolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"bypass_file_system_lockout_safety_check": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"file_system_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -41,9 +46,11 @@ func resourceAwsEfsFileSystemPolicyPut(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).efsconn
 
 	fsId := d.Get("file_system_id").(string)
+	bypassPolicyLockoutSafetyCheck := d.Get("bypass_file_system_lockout_safety_check").(bool)
 	input := &efs.PutFileSystemPolicyInput{
-		FileSystemId: aws.String(fsId),
-		Policy:       aws.String(d.Get("policy").(string)),
+		BypassPolicyLockoutSafetyCheck: aws.Bool(bypassPolicyLockoutSafetyCheck),
+		FileSystemId:                   aws.String(fsId),
+		Policy:                         aws.String(d.Get("policy").(string)),
 	}
 	log.Printf("[DEBUG] Adding EFS File System Policy: %#v", input)
 	_, err := conn.PutFileSystemPolicy(input)

--- a/aws/resource_aws_efs_file_system_policy_test.go
+++ b/aws/resource_aws_efs_file_system_policy_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/efs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func TestAccAWSEFSFileSystemPolicy_basic(t *testing.T) {
@@ -20,24 +21,25 @@ func TestAccAWSEFSFileSystemPolicy_basic(t *testing.T) {
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, efs.EndpointsID),
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEFSFileSystemPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicy(resourceName, &desc),
+					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bypass_policy_lockout_safety_check"},
 			},
 			{
 				Config: testAccAWSEFSFileSystemPolicyConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicy(resourceName, &desc),
+					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
 			},
@@ -59,7 +61,7 @@ func TestAccAWSEFSFileSystemPolicy_disappears(t *testing.T) {
 			{
 				Config: testAccAWSEFSFileSystemPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystemPolicy(resourceName, &desc),
+					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsEfsFileSystemPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -68,52 +70,85 @@ func TestAccAWSEFSFileSystemPolicy_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSEFSFileSystemPolicy_PolicyBypass(t *testing.T) {
+	var desc efs.DescribeFileSystemPolicyOutput
+	resourceName := "aws_efs_file_system_policy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, efs.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsFileSystemPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSFileSystemPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "false"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"bypass_policy_lockout_safety_check"},
+			},
+			{
+				Config: testAccAWSEFSFileSystemPolicyBypassConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsFileSystemPolicyExists(resourceName, &desc),
+					resource.TestCheckResourceAttr(resourceName, "bypass_policy_lockout_safety_check", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckEfsFileSystemPolicyDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).efsconn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_efs_file_system_policy" {
 			continue
 		}
 
-		resp, err := conn.DescribeFileSystemPolicy(&efs.DescribeFileSystemPolicyInput{
-			FileSystemId: aws.String(rs.Primary.ID),
-		})
-		if err != nil {
-			if isAWSErr(err, efs.ErrCodeFileSystemNotFound, "") ||
-				isAWSErr(err, efs.ErrCodePolicyNotFound, "") {
-				return nil
-			}
-			return fmt.Errorf("error describing EFS file system policy in tests: %s", err)
-		}
-		if resp != nil {
-			return fmt.Errorf("EFS file system policy %q still exists", rs.Primary.ID)
-		}
-	}
+		_, err := finder.FileSystemPolicyByID(conn, rs.Primary.ID)
 
-	return nil
-}
-
-func testAccCheckEfsFileSystemPolicy(resourceID string, efsFsPolicy *efs.DescribeFileSystemPolicyOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceID]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceID)
+		if tfresource.NotFound(err) {
+			continue
 		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).efsconn
-		fs, err := conn.DescribeFileSystemPolicy(&efs.DescribeFileSystemPolicyInput{
-			FileSystemId: aws.String(rs.Primary.ID),
-		})
 
 		if err != nil {
 			return err
 		}
 
-		*efsFsPolicy = *fs
+		return fmt.Errorf("EFS File System Policy %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckEfsFileSystemPolicyExists(n string, v *efs.DescribeFileSystemPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EFS File System Policy ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).efsconn
+
+		output, err := finder.FileSystemPolicyByID(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
 
 		return nil
 	}
@@ -122,7 +157,7 @@ func testAccCheckEfsFileSystemPolicy(resourceID string, efsFsPolicy *efs.Describ
 func testAccAWSEFSFileSystemPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
-  creation_token = %q
+  creation_token = %[1]q
 }
 
 resource "aws_efs_file_system_policy" "test" {
@@ -160,7 +195,7 @@ POLICY
 func testAccAWSEFSFileSystemPolicyConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
-  creation_token = %q
+  creation_token = %[1]q
 }
 
 resource "aws_efs_file_system_policy" "test" {
@@ -190,4 +225,44 @@ resource "aws_efs_file_system_policy" "test" {
 POLICY
 }
 `, rName)
+}
+
+func testAccAWSEFSFileSystemPolicyBypassConfig(rName string, bypass bool) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = %[1]q
+}
+
+resource "aws_efs_file_system_policy" "test" {
+  file_system_id = aws_efs_file_system.test.id
+
+  bypass_policy_lockout_safety_check = %[2]t
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "ExamplePolicy01",
+    "Statement": [
+        {
+            "Sid": "ExampleSatement01",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Resource": "${aws_efs_file_system.test.arn}",
+            "Action": [
+                "elasticfilesystem:ClientMount",
+                "elasticfilesystem:ClientWrite"
+            ],
+            "Condition": {
+                "Bool": {
+                    "aws:SecureTransport": "true"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}
+`, rName, bypass)
 }

--- a/website/docs/r/efs_file_system_policy.html.markdown
+++ b/website/docs/r/efs_file_system_policy.html.markdown
@@ -20,7 +20,7 @@ resource "aws_efs_file_system" "fs" {
 resource "aws_efs_file_system_policy" "policy" {
   file_system_id = aws_efs_file_system.fs.id
 
-  bypass_file_system_lockout_safety_check = true
+  bypass_policy_lockout_safety_check = true
 
   policy = <<POLICY
 {
@@ -55,7 +55,7 @@ POLICY
 The following arguments are supported:
 
 * `file_system_id` - (Required) The ID of the EFS file system.
-* `bypass_file_system_lockout_safety_check` - (Optional) A flag to indicate whether to bypass the FileSystemPolicy lockout safety check, see [Docs](https://docs.aws.amazon.com/efs/latest/ug/API_PutFileSystemPolicy.html#API_PutFileSystemPolicy_RequestSyntax)
+* `bypass_policy_lockout_safety_check` - (Optional) A flag to indicate whether to bypass the `aws_efs_file_system_policy` lockout safety check. The policy lockout safety check determines whether the policy in the request will prevent the principal making the request will be locked out from making future `PutFileSystemPolicy` requests on the file system. Set `bypass_policy_lockout_safety_check` to `true` only when you intend to prevent the principal that is making the request from making a subsequent `PutFileSystemPolicy` request on the file system. The default value is `false`.
 * `policy` - (Required) The JSON formatted file system policy for the EFS file system. see [Docs](https://docs.aws.amazon.com/efs/latest/ug/access-control-overview.html#access-control-manage-access-intro-resource-policies) for more info.
 
 ## Attributes Reference

--- a/website/docs/r/efs_file_system_policy.html.markdown
+++ b/website/docs/r/efs_file_system_policy.html.markdown
@@ -20,6 +20,8 @@ resource "aws_efs_file_system" "fs" {
 resource "aws_efs_file_system_policy" "policy" {
   file_system_id = aws_efs_file_system.fs.id
 
+  bypass_file_system_lockout_safety_check = true
+
   policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -53,6 +55,7 @@ POLICY
 The following arguments are supported:
 
 * `file_system_id` - (Required) The ID of the EFS file system.
+* `bypass_file_system_lockout_safety_check` - (Optional) A flag to indicate whether to bypass the FileSystemPolicy lockout safety check, see [Docs](https://docs.aws.amazon.com/efs/latest/ug/API_PutFileSystemPolicy.html#API_PutFileSystemPolicy_RequestSyntax)
 * `policy` - (Required) The JSON formatted file system policy for the EFS file system. see [Docs](https://docs.aws.amazon.com/efs/latest/ug/access-control-overview.html#access-control-manage-access-intro-resource-policies) for more info.
 
 ## Attributes Reference


### PR DESCRIPTION
Allow the ability to bypass the EFS file system lockout protection.

The fix is to allow pass through from of the 'BypassPolicyLockoutSafetyCheck' to the underlying GoSDK.

This is the error that the fix is for, where unable to create or update an filesystem policy.
```
Error: error creating EFS File System Policy "": InvalidPolicyException: This policy would prevent future FileSystemPolicy updates. Retry the request with the BypassPolicyLockoutSafetyCheck parameter to apply this policy.
```

Tested against our test environment.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
