### PR TITLE
Remove invalid maintenance_window attribute from aws_docdb_cluster

### DIFF
--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -85,7 +85,6 @@ In addition to all arguments above, the following attributes are exported:
 * `endpoint` - The DNS address of the DocDB instance
 * `hosted_zone_id` - The Route53 Hosted Zone ID of the endpoint
 * `id` - The DocDB Cluster Identifier
-* `maintenance_window` - The instance maintenance window
 * `reader_endpoint` - A read-only endpoint for the DocDB cluster, automatically load-balanced across replicas
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #20829

In reviewing the [source for this resource](https://github.com/hashicorp/terraform-provider-aws/blob/main/aws/resource_aws_docdb_cluster.go) and the underlying SDK (notes below), there is indeed no attribute named `maintenance_window`. Instead, the `preferred_maintenance_window` should be used. Since `preferred_maintenance_window` is an argument, we can remove this line, as it's covered by "In addition to all arguments above..."

SDK reference:
- [func (c *DocDB) CreateDBCluster](https://docs.aws.amazon.com/sdk-for-go/api/service/docdb/#DocDB.CreateDBCluster) returns a `*CreateDBClusterOutput`.
- [type CreateDBClusterOutput](https://docs.aws.amazon.com/sdk-for-go/api/service/docdb/#CreateDBClusterOutput) is a struct with a `DBCluster` field.
- [type DBCluster](https://docs.aws.amazon.com/sdk-for-go/api/service/docdb/#DBCluster) has a `PreferredMaintenanceWindow`, but no `MaintenanceWindow` field.