### PR TITLE
Improve message of name validation error

### DIFF
--- a/.changelog/20842.txt
+++ b/.changelog/20842.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_imagebuilder_distribution_configuration: Improve validation error message of `name` argument
+```

--- a/aws/resource_aws_imagebuilder_distribution_configuration.go
+++ b/aws/resource_aws_imagebuilder_distribution_configuration.go
@@ -94,7 +94,7 @@ func resourceAwsImageBuilderDistributionConfiguration() *schema.Resource {
 										Optional: true,
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(0, 127),
-											validation.StringMatch(regexp.MustCompile(`^[-_A-Za-z0-9{][-_A-Za-z0-9\s:{}]+[-_A-Za-z0-9}]$`), "must contain only alphanumeric characters, periods, underscores, and hyphens"),
+											validation.StringMatch(regexp.MustCompile(`^[-_A-Za-z0-9{][-_A-Za-z0-9\s:{}]+[-_A-Za-z0-9}]$`), "must contain only alphanumeric characters, underscores, and hyphens"),
 										),
 									},
 									"target_account_ids": {


### PR DESCRIPTION
This PR removes invalid suggestion of `periods` in name argument of the Distribution Configuration.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #20117

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAwsImageBuilderDistributionConfiguration_Distribution_BAmiDistributionConfiguration_Name'  х INT 3s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsImageBuilderDistributionConfiguration_Distribution_BAmiDistributionConfiguration_Name -timeout 180m
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       7.703s [no tests to run]
~/Projects/terraform-provider-aws b-imagebuild…dation-error ❯                                        
```
