### PR TITLE
Update max_instance_lifetime limit

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -393,7 +393,7 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
    Auto Scaling Group will not select instances with this setting for termination
    during scale in events.
 * `service_linked_role_arn` (Optional) The ARN of the service-linked role that the ASG will use to call other AWS services
-* `max_instance_lifetime` (Optional) The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds.
+* `max_instance_lifetime` (Optional) The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 86400 and 31536000 seconds.
 * `instance_refresh` - (Optional) If this block is configured, start an
    [Instance Refresh](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
    when this Auto Scaling Group is updated. Defined [below](#instance_refresh).


### PR DESCRIPTION
As per [docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html) and API error message (see below), this PR updates acceptable values for `max_instance_lifetime` argument.
```
Error: Error updating Auto Scaling Group: ValidationError: maxInstanceLifetime must be either equal to 0 or between 86400 and 31536000 seconds (inclusive). A value of 0 is used to remove a previously set value.
        status code: 400, request id: 3c1243cf-d8c2-492e-8539-5fb5c207d453
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #19669.