### PR TITLE
Extend MWAA create timeout to 2 hours

### DIFF
--- a/.changelog/20861.txt
+++ b/.changelog/20861.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mwaa_environment: Increase resource creation timeout to 2 hours
+```

--- a/aws/internal/service/mwaa/waiter/waiter.go
+++ b/aws/internal/service/mwaa/waiter/waiter.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Maximum amount of time to wait for an environment creation
-	EnvironmentCreatedTimeout = 90 * time.Minute
+	EnvironmentCreatedTimeout = 120 * time.Minute
 
 	// Maximum amount of time to wait for an environment update
 	EnvironmentUpdatedTimeout = 90 * time.Minute


### PR DESCRIPTION
I've observed under normal enough conditions MWAA creation taking about 2 hours even outside of Terraform.
The environment does create successfully. Killing it early can taint an otherwise working resource requiring a manual `untaint`.

Thanks in advance to the reviewers for taking the time review this PR!

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->



