### PR TITLE
Use better ARN as an example for importing aws_imagebuilder_infrastructure_configuration

### DIFF
--- a/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
@@ -88,5 +88,5 @@ In addition to all arguments above, the following attributes are exported:
 `aws_imagebuilder_infrastructure_configuration` can be imported using the Amazon Resource Name (ARN), e.g.
 
 ```
-$ terraform import aws_imagebuilder_infrastructure_configuration.example arn:aws:imagebuilder:us-east-1:123456789012:infrastructure-component/example
+$ terraform import aws_imagebuilder_infrastructure_configuration.example arn:aws:imagebuilder:us-east-1:123456789012:infrastructure-configuration/example
 ```


### PR DESCRIPTION
A tiny fix. An example of import is suggesting ARN for different resource which might be misleading.