### PR TITLE
r/efs_file_system - support transition to primary storage class

### DIFF
--- a/.changelog/20874.txt
+++ b/.changelog/20874.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_efs_file_system: Add `lifecycle_policy.transition_to_primary_storage_class` argument to support Intelligent-Tiering
+```

--- a/aws/internal/service/efs/finder/finder.go
+++ b/aws/internal/service/efs/finder/finder.go
@@ -8,34 +8,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
-func FileSystemByID(conn *efs.EFS, id string) (*efs.FileSystemDescription, error) {
-	input := &efs.DescribeFileSystemsInput{
-		FileSystemId: aws.String(id),
-	}
-
-	output, err := conn.DescribeFileSystems(input)
-
-	if tfawserr.ErrCodeEquals(err, efs.ErrCodeFileSystemNotFound) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if output == nil || output.FileSystems == nil || len(output.FileSystems) == 0 || output.FileSystems[0] == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
-	}
-
-	return output.FileSystems[0], nil
-}
-
 func BackupPolicyByID(conn *efs.EFS, id string) (*efs.BackupPolicy, error) {
 	input := &efs.DescribeBackupPolicyInput{
 		FileSystemId: aws.String(id),
@@ -59,6 +31,31 @@ func BackupPolicyByID(conn *efs.EFS, id string) (*efs.BackupPolicy, error) {
 	}
 
 	return output.BackupPolicy, nil
+}
+
+func FileSystemByID(conn *efs.EFS, id string) (*efs.FileSystemDescription, error) {
+	input := &efs.DescribeFileSystemsInput{
+		FileSystemId: aws.String(id),
+	}
+
+	output, err := conn.DescribeFileSystems(input)
+
+	if tfawserr.ErrCodeEquals(err, efs.ErrCodeFileSystemNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.FileSystems == nil || len(output.FileSystems) == 0 || output.FileSystems[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.FileSystems[0], nil
 }
 
 func FileSystemPolicyByID(conn *efs.EFS, id string) (*efs.DescribeFileSystemPolicyOutput, error) {

--- a/aws/internal/service/efs/finder/finder.go
+++ b/aws/internal/service/efs/finder/finder.go
@@ -8,6 +8,34 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
+func FileSystemByID(conn *efs.EFS, id string) (*efs.FileSystemDescription, error) {
+	input := &efs.DescribeFileSystemsInput{
+		FileSystemId: aws.String(id),
+	}
+
+	output, err := conn.DescribeFileSystems(input)
+
+	if tfawserr.ErrCodeEquals(err, efs.ErrCodeFileSystemNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.FileSystems == nil || len(output.FileSystems) == 0 || output.FileSystems[0] == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "Empty result",
+			LastRequest: input,
+		}
+	}
+
+	return output.FileSystems[0], nil
+}
+
 func BackupPolicyByID(conn *efs.EFS, id string) (*efs.BackupPolicy, error) {
 	input := &efs.DescribeBackupPolicyInput{
 		FileSystemId: aws.String(id),

--- a/aws/internal/service/efs/waiter/status.go
+++ b/aws/internal/service/efs/waiter/status.go
@@ -47,25 +47,18 @@ func BackupPolicyStatus(conn *efs.EFS, id string) resource.StateRefreshFunc {
 	}
 }
 
-// FileSystemLifeCycleState fetches the Access Point and its LifecycleState
-func FileSystemLifeCycleState(conn *efs.EFS, fileSystemID string) resource.StateRefreshFunc {
+func FileSystemLifeCycleState(conn *efs.EFS, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &efs.DescribeFileSystemsInput{
-			FileSystemId: aws.String(fileSystemID),
-		}
+		output, err := finder.FileSystemByID(conn, id)
 
-		output, err := conn.DescribeFileSystems(input)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
 
 		if err != nil {
 			return nil, "", err
 		}
 
-		if output == nil || len(output.FileSystems) == 0 || output.FileSystems[0] == nil {
-			return nil, "", nil
-		}
-
-		mt := output.FileSystems[0]
-
-		return mt, aws.StringValue(mt.LifeCycleState), nil
+		return output, aws.StringValue(output.LifeCycleState), nil
 	}
 }

--- a/aws/internal/service/efs/waiter/waiter.go
+++ b/aws/internal/service/efs/waiter/waiter.go
@@ -58,7 +58,6 @@ func AccessPointDeleted(conn *efs.EFS, accessPointId string) (*efs.AccessPointDe
 	return nil, err
 }
 
-// FileSystemAvailable waits for an Operation to return Available
 func FileSystemAvailable(conn *efs.EFS, fileSystemID string) (*efs.FileSystemDescription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{efs.LifeCycleStateCreating, efs.LifeCycleStateUpdating},
@@ -78,7 +77,6 @@ func FileSystemAvailable(conn *efs.EFS, fileSystemID string) (*efs.FileSystemDes
 	return nil, err
 }
 
-// FileSystemDeleted waits for an Operation to return Deleted
 func FileSystemDeleted(conn *efs.EFS, fileSystemID string) (*efs.FileSystemDescription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{efs.LifeCycleStateAvailable, efs.LifeCycleStateDeleting},

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -444,10 +444,11 @@ func testAccCheckEfsFileSystem(resourceID string, fDesc *efs.FileSystemDescripti
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("No EFS file system ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).efsconn
+
 		fs, err := finder.FileSystemByID(conn, rs.Primary.ID)
 
 		if err != nil {

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/efs/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -60,26 +62,6 @@ func testSweepEfsFileSystems(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestResourceAWSEFSFileSystem_hasEmptyFileSystems(t *testing.T) {
-	fs := &efs.DescribeFileSystemsOutput{
-		FileSystems: []*efs.FileSystemDescription{},
-	}
-
-	actual := hasEmptyFileSystems(fs)
-	if !actual {
-		t.Fatalf("Expected return value to be true, got %t", actual)
-	}
-
-	// Add an empty file system.
-	fs.FileSystems = append(fs.FileSystems, &efs.FileSystemDescription{})
-
-	actual = hasEmptyFileSystems(fs)
-	if actual {
-		t.Fatalf("Expected return value to be false, got %t", actual)
-	}
-
-}
-
 func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 	var desc efs.FileSystemDescription
 	resourceName := "aws_efs_file_system.test"
@@ -101,6 +83,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 					testAccCheckEfsFileSystem(resourceName, &desc),
 					testAccCheckEfsFileSystemPerformanceMode(resourceName, "generalPurpose"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "size_in_bytes.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "size_in_bytes.0.value"),
 					resource.TestCheckResourceAttrSet(resourceName, "size_in_bytes.0.value_in_ia"),
@@ -382,91 +365,30 @@ func TestAccAWSEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(resourceName, &desc),
-					testAccCheckEfsFileSystemLifecyclePolicy(resourceName, "badExpectation"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", efs.TransitionToIARulesAfter30Days),
 				),
-				ExpectError: regexp.MustCompile(`Expected: badExpectation`),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSEFSFileSystemConfigWithLifecyclePolicy(
-					"transition_to_ia",
-					efs.TransitionToIARulesAfter30Days,
+					"transition_to_primary_storage_class",
+					efs.TransitionToPrimaryStorageClassRulesAfter1Access,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(resourceName, &desc),
-					testAccCheckEfsFileSystemLifecyclePolicy(resourceName, efs.TransitionToIARulesAfter30Days),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEFSFileSystem_lifecyclePolicy_update(t *testing.T) {
-	var desc efs.FileSystemDescription
-	resourceName := "aws_efs_file_system.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, efs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEFSFileSystemConfigWithLifecyclePolicy("transition_to_ia", efs.TransitionToIARulesAfter30Days),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
-					testAccCheckEfsFileSystemLifecyclePolicy(resourceName, efs.TransitionToIARulesAfter30Days),
-				),
-			},
-			{
-				Config: testAccAWSEFSFileSystemConfigWithLifecyclePolicy("transition_to_ia", efs.TransitionToIARulesAfter90Days),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
-					testAccCheckEfsFileSystemLifecyclePolicy(resourceName, efs.TransitionToIARulesAfter90Days),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEFSFileSystem_lifecyclePolicy_removal(t *testing.T) {
-	var desc efs.FileSystemDescription
-	resourceName := "aws_efs_file_system.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, efs.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEFSFileSystemConfigWithLifecyclePolicy("transition_to_ia", efs.TransitionToIARulesAfter14Days),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(resourceName, &desc),
-					testAccCheckEfsFileSystemLifecyclePolicy(resourceName, efs.TransitionToIARulesAfter14Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", efs.TransitionToPrimaryStorageClassRulesAfter1Access),
 				),
 			},
 			{
 				Config: testAccAWSEFSFileSystemConfigRemovedLifecyclePolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(resourceName, &desc),
-					testAccCheckEfsFileSystemLifecyclePolicy(resourceName, efs.TransitionToIARulesAfter14Days),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "0"),
 				),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Expected: %s`, efs.TransitionToIARulesAfter14Days)),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -488,6 +410,7 @@ func TestAccAWSEFSFileSystem_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(resourceName, &desc),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsEfsFileSystem(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEfsFileSystem(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -502,19 +425,17 @@ func testAccCheckEfsFileSystemDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, err := conn.DescribeFileSystems(&efs.DescribeFileSystemsInput{
-			FileSystemId: aws.String(rs.Primary.ID),
-		})
+		_, err := finder.FileSystemByID(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
-			if isAWSErr(err, efs.ErrCodeFileSystemNotFound, "") {
-				// gone
-				return nil
-			}
-			return fmt.Errorf("Error describing EFS in tests: %s", err)
+			return err
 		}
-		if len(resp.FileSystems) > 0 {
-			return fmt.Errorf("EFS file system %q still exists", rs.Primary.ID)
-		}
+
+		return fmt.Errorf("EFS file system %s still exists", rs.Primary.ID)
 	}
 
 	return nil
@@ -532,19 +453,13 @@ func testAccCheckEfsFileSystem(resourceID string, fDesc *efs.FileSystemDescripti
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).efsconn
-		fs, err := conn.DescribeFileSystems(&efs.DescribeFileSystemsInput{
-			FileSystemId: aws.String(rs.Primary.ID),
-		})
+		fs, err := finder.FileSystemByID(conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		if len(fs.FileSystems) == 0 {
-			return fmt.Errorf("EFS File System not found")
-		}
-
-		*fDesc = *fs.FileSystems[0]
+		*fDesc = *fs
 
 		return nil
 	}
@@ -603,50 +518,6 @@ func testAccCheckEfsFileSystemPerformanceMode(resourceID string, expectedMode st
 		}
 
 		return nil
-	}
-}
-
-func testAccCheckEfsFileSystemLifecyclePolicy(resourceID string, expectedVal string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceID]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceID)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).efsconn
-		resp, err := conn.DescribeFileSystems(&efs.DescribeFileSystemsInput{
-			FileSystemId: aws.String(rs.Primary.ID),
-		})
-		if err != nil {
-			return fmt.Errorf("Error describing EFS file systems: %s", err.Error())
-		}
-
-		fs := resp.FileSystems[0]
-
-		res, err := conn.DescribeLifecycleConfiguration(&efs.DescribeLifecycleConfigurationInput{
-			FileSystemId: fs.FileSystemId,
-		})
-		if err != nil {
-			return fmt.Errorf("Error describing lifecycle policy for EFS file system (%s): %s",
-				aws.StringValue(fs.FileSystemId), err.Error())
-		}
-		lp := res.LifecyclePolicies
-
-		newLP := make([]*map[string]interface{}, len(lp))
-
-		for i := 0; i < len(lp); i++ {
-			config := lp[i]
-			data := make(map[string]interface{})
-			newLP[i] = &data
-			if *config.TransitionToIA == expectedVal {
-				return nil
-			}
-		}
-		return fmt.Errorf("Lifecycle Policy mismatch.\nExpected: %s\nFound: %+v", expectedVal, lp)
 	}
 }
 

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -56,7 +56,8 @@ user guide for more information.
 ### Lifecycle Policy Arguments
 For **lifecycle_policy** the following attributes are supported:
 
-* `transition_to_ia` - (Required) Indicates how long it takes to transition files to the IA storage class. Valid values: `AFTER_7_DAYS`, `AFTER_14_DAYS`, `AFTER_30_DAYS`, `AFTER_60_DAYS`, or `AFTER_90_DAYS`.
+* `transition_to_ia` - (Optional) Indicates how long it takes to transition files to the IA storage class. Valid values: `AFTER_7_DAYS`, `AFTER_14_DAYS`, `AFTER_30_DAYS`, `AFTER_60_DAYS`, or `AFTER_90_DAYS`.
+* `transition_to_primary_storage_class` - (Optional) Describes the policy used to transition a file from infequent access storage to primary storage. Valid values: `AFTER_1_ACCESS`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20773

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEFSFileSystem_'
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (39.57s)
--- PASS: TestAccAWSEFSFileSystem_disappears (71.82s)
--- PASS: TestAccAWSEFSFileSystem_pagedTags (87.75s)
--- PASS: TestAccAWSEFSFileSystem_availabilityZoneName (104.74s)
--- PASS: TestAccAWSEFSFileSystem_kmsKey (114.76s)
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (138.76s)
--- PASS: TestAccAWSEFSFileSystem_basic (139.38s)
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (145.72s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy (186.05s)
--- PASS: TestAccAWSEFSFileSystem_tags (229.45s)
```
