### PR TITLE
aws_networkfirewall_rule_group - add example in docs

### DIFF
--- a/website/docs/r/networkfirewall_rule_group.html.markdown
+++ b/website/docs/r/networkfirewall_rule_group.html.markdown
@@ -125,6 +125,45 @@ resource "aws_networkfirewall_rule_group" "example" {
 }
 ```
 
+### Stateful Inspection from rule group specifications using rule variables and Suricata format rules
+
+```terraform
+resource "aws_networkfirewall_rule_group" "example" {
+  capacity = 100
+  name     = "example"
+  type     = "STATEFUL"
+  rule_group {
+    rule_variables {
+      ip_sets {
+        key = "WEBSERVERS_HOSTS"
+        ip_set {
+          definition = ["10.0.0.0/16", "10.0.1.0/24", "192.168.0.0/16"]
+        }
+      }
+      ip_sets {
+        key = "EXTERNAL_HOST"
+        ip_set {
+          definition = ["1.2.3.4/32"]
+        }
+      }
+      port_sets {
+        key = "HTTP_PORTS"
+        port_set {
+          definition = ["443", "80"]
+        }
+      }
+    }
+    rules_source {
+      rules_string = file("suricata_rules_file")
+    }
+  }
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}
+```
+
 ### Stateless Inspection with a Custom Action
 
 ```terraform


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20867


This is just documentation update with one example which was missing and is very useful for more advanced and complex rules