### PR TITLE
d/aws_eks_clusters: New data source

### DIFF
--- a/.changelog/20315.txt
+++ b/.changelog/20315.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_eks_clusters
+```

--- a/aws/data_source_aws_eks_clusters.go
+++ b/aws/data_source_aws_eks_clusters.go
@@ -4,7 +4,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -35,7 +34,8 @@ func dataSourceAwsEksClustersRead(d *schema.ResourceData, meta interface{}) erro
 		},
 	)
 
-	d.SetId(resource.UniqueId())
+	d.SetId(meta.(*AWSClient).region)
+
 	if err != nil {
 		log.Printf("[DEBUG] There was an error while listing EKS Clusters: %v", err)
 	}

--- a/aws/data_source_aws_eks_clusters.go
+++ b/aws/data_source_aws_eks_clusters.go
@@ -12,7 +12,7 @@ func dataSourceAwsEksClusters() *schema.Resource {
 		Read: dataSourceAwsEksClustersRead,
 
 		Schema: map[string]*schema.Schema{
-			"clusters": {
+			"names": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -39,7 +39,7 @@ func dataSourceAwsEksClustersRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		log.Printf("[DEBUG] There was an error while listing EKS Clusters: %v", err)
 	}
-	d.Set("clusters", clusters)
+	d.Set("names", clusters)
 
 	return nil
 }

--- a/aws/data_source_aws_eks_clusters.go
+++ b/aws/data_source_aws_eks_clusters.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsEksClusters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEksClustersRead,
+
+		Schema: map[string]*schema.Schema{
+			"clusters": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsEksClustersRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).eksconn
+
+	var clusters []*string
+
+	log.Printf("[DEBUG] Listing EKS Clusters")
+	err := conn.ListClustersPages(&eks.ListClustersInput{},
+		func(page *eks.ListClustersOutput, lastPage bool) bool {
+			clusters = append(clusters, page.Clusters...)
+			return true
+		},
+	)
+
+	d.SetId(resource.UniqueId())
+	if err != nil {
+		log.Printf("[DEBUG] There was an error while listing EKS Clusters: %v", err)
+	}
+	d.Set("clusters", clusters)
+
+	return nil
+}

--- a/aws/data_source_aws_eks_clusters_test.go
+++ b/aws/data_source_aws_eks_clusters_test.go
@@ -1,0 +1,64 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSEksClustersDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceResourceName := "data.aws_eks_clusters.clusters"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		ErrorCheck:   testAccErrorCheck(t, eks.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksClustersDataSourceConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceResourceName, "clusters.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "clusters.0", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksClustersDataSource_empty(t *testing.T) {
+	dataSourceResourceName := "data.aws_eks_clusters.clusters"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		ErrorCheck:   testAccErrorCheck(t, eks.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksClustersDataSourceConfig_empty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceResourceName, "clusters.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSEksClustersDataSourceConfig_Basic(rName1 string) string {
+	return composeConfig(
+		testAccAWSEksClusterConfig_Required(rName1), `
+data "aws_eks_clusters" "clusters" {
+	depends_on = [aws_eks_cluster.test]
+}
+`)
+}
+
+func testAccAWSEksClustersDataSourceConfig_empty() string {
+	return `
+data "aws_eks_clusters" "clusters" {}
+`
+}

--- a/aws/data_source_aws_eks_clusters_test.go
+++ b/aws/data_source_aws_eks_clusters_test.go
@@ -52,7 +52,7 @@ func testAccAWSEksClustersDataSourceConfig_Basic(rName1 string) string {
 	return composeConfig(
 		testAccAWSEksClusterConfig_Required(rName1), `
 data "aws_eks_clusters" "clusters" {
-	depends_on = [aws_eks_cluster.test]
+  depends_on = [aws_eks_cluster.test]
 }
 `)
 }

--- a/aws/data_source_aws_eks_clusters_test.go
+++ b/aws/data_source_aws_eks_clusters_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccAWSEksClustersDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	dataSourceResourceName := "data.aws_eks_clusters.clusters"
+	dataSourceResourceName := "data.aws_eks_clusters.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
@@ -21,44 +21,18 @@ func TestAccAWSEksClustersDataSource_basic(t *testing.T) {
 			{
 				Config: testAccAWSEksClustersDataSourceConfig_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceResourceName, "names.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceResourceName, "names.0", rName),
+					testCheckResourceAttrGreaterThanValue(dataSourceResourceName, "names.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSEksClustersDataSource_empty(t *testing.T) {
-	dataSourceResourceName := "data.aws_eks_clusters.clusters"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
-		ErrorCheck:   testAccErrorCheck(t, eks.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEksClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEksClustersDataSourceConfig_empty(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceResourceName, "names.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func testAccAWSEksClustersDataSourceConfig_Basic(rName1 string) string {
+func testAccAWSEksClustersDataSourceConfig_Basic(rName string) string {
 	return composeConfig(
-		testAccAWSEksClusterConfig_Required(rName1), `
-data "aws_eks_clusters" "clusters" {
+		testAccAWSEksClusterConfig_Required(rName), `
+data "aws_eks_clusters" "test" {
   depends_on = [aws_eks_cluster.test]
 }
 `)
-}
-
-func testAccAWSEksClustersDataSourceConfig_empty() string {
-	return `
-data "aws_eks_clusters" "clusters" {}
-`
 }

--- a/aws/data_source_aws_eks_clusters_test.go
+++ b/aws/data_source_aws_eks_clusters_test.go
@@ -21,8 +21,8 @@ func TestAccAWSEksClustersDataSource_basic(t *testing.T) {
 			{
 				Config: testAccAWSEksClustersDataSourceConfig_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceResourceName, "clusters.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceResourceName, "clusters.0", rName),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "names.0", rName),
 				),
 			},
 		},
@@ -41,7 +41,7 @@ func TestAccAWSEksClustersDataSource_empty(t *testing.T) {
 			{
 				Config: testAccAWSEksClustersDataSourceConfig_empty(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceResourceName, "clusters.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "names.#", "0"),
 				),
 			},
 		},

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -285,6 +285,7 @@ func Provider() *schema.Provider {
 			"aws_eip":                                        dataSourceAwsEip(),
 			"aws_eks_addon":                                  dataSourceAwsEksAddon(),
 			"aws_eks_cluster":                                dataSourceAwsEksCluster(),
+			"aws_eks_clusters":                               dataSourceAwsEksClusters(),
 			"aws_eks_cluster_auth":                           dataSourceAwsEksClusterAuth(),
 			"aws_elastic_beanstalk_application":              dataSourceAwsElasticBeanstalkApplication(),
 			"aws_elastic_beanstalk_hosted_zone":              dataSourceAwsElasticBeanstalkHostedZone(),

--- a/website/docs/d/eks_clusters.html.markdown
+++ b/website/docs/d/eks_clusters.html.markdown
@@ -23,4 +23,5 @@ data "aws_eks_cluster" "example" {
 
 ## Attributes Reference
 
-* `names` - The list of EKS clusters names
+* `id` - AWS Region.
+* `names` - Set of EKS clusters names

--- a/website/docs/d/eks_clusters.html.markdown
+++ b/website/docs/d/eks_clusters.html.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "EKS"
+layout: "aws"
+page_title: "AWS: aws_eks_clusters"
+description: |-
+  Retrieve EKS Clusters list
+---
+
+# Data Source: aws_eks_cluster
+
+Retrieve EKS Clusters list
+
+## Example Usage
+
+```terraform
+data "aws_eks_clusters" "example" {}
+
+data "aws_eks_cluster" "example" {
+  for_each = toset(data.aws_eks_clusters.example.clusters)
+  name     = each.value
+}
+```
+
+## Attributes Reference
+
+* `clusters` - The list of EKS clusters names

--- a/website/docs/d/eks_clusters.html.markdown
+++ b/website/docs/d/eks_clusters.html.markdown
@@ -16,11 +16,11 @@ Retrieve EKS Clusters list
 data "aws_eks_clusters" "example" {}
 
 data "aws_eks_cluster" "example" {
-  for_each = toset(data.aws_eks_clusters.example.clusters)
+  for_each = toset(data.aws_eks_clusters.example.names)
   name     = each.value
 }
 ```
 
 ## Attributes Reference
 
-* `clusters` - The list of EKS clusters names
+* `names` - The list of EKS clusters names


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20251.
Closes #13719.
Supersedes #20315.
Supersedes #15204.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Commercial

```console
% make testacc TESTARGS='-run=TestAccAWSEksClustersDataSource_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksClustersDataSource_ -timeout 180m
=== RUN   TestAccAWSEksClustersDataSource_basic
=== PAUSE TestAccAWSEksClustersDataSource_basic
=== CONT  TestAccAWSEksClustersDataSource_basic
--- PASS: TestAccAWSEksClustersDataSource_basic (918.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	923.589s
```

#### GovCloud

```console
% make testacc TESTARGS='-run=TestAccAWSEksClustersDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksClustersDataSource_ -timeout 180m
=== RUN   TestAccAWSEksClustersDataSource_basic
=== PAUSE TestAccAWSEksClustersDataSource_basic
=== CONT  TestAccAWSEksClustersDataSource_basic
--- PASS: TestAccAWSEksClustersDataSource_basic (769.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	773.404s
```
