### PR TITLE
docs: update outdated info regarding dns resolution for inter-region VPC peering

### DIFF
--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -123,9 +123,7 @@ the peering connection (a maximum of one).
 must have support for the DNS hostnames enabled. This can be done using the [`enable_dns_hostnames`](vpc.html#enable_dns_hostnames) attribute in the [`aws_vpc`](vpc.html) resource. See [Using DNS with Your VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html) user guide for more information.
 
 * `allow_remote_vpc_dns_resolution` - (Optional) Allow a local VPC to resolve public DNS hostnames to
-private IP addresses when queried from instances in the peer VPC. This is
-[not supported](https://docs.aws.amazon.com/vpc/latest/peering/modify-peering-connections.html) for
-inter-region VPC peering.
+private IP addresses when queried from instances in the peer VPC.
 * `allow_classic_link_to_remote_vpc` - (Optional) Allow a local linked EC2-Classic instance to communicate
 with instances in a peer VPC. This enables an outbound communication from the local ClassicLink connection
 to the remote VPC.


### PR DESCRIPTION
Small change to update _outdated_ docs for dns resolution over inter-region VPC peering. Support was added back in 2018 [https://aws.amazon.com/about-aws/whats-new/2018/11/announcing-support-for-dns-resolution-over-inter-region-vpc-peering/](https://aws.amazon.com/about-aws/whats-new/2018/11/announcing-support-for-dns-resolution-over-inter-region-vpc-peering/) 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
