### PR TITLE
Fix "Dependabot can't resolve your Go dependency files"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/gdavison/terraform-plugin-sdk/v2 v2.0.2-0.20210714181518-b5a3dc95a675
+replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/gdavison/terraform-plugin-sdk/v2 v2.7.1-0.20210913224932-c7c2dbd9e010

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gdavison/terraform-plugin-sdk/v2 v2.0.2-0.20210714181518-b5a3dc95a675 h1:2QEdOgyP5bC4Cjkf4DZ7rBcCXfLaf+ceTY95U3axacI=
 github.com/gdavison/terraform-plugin-sdk/v2 v2.0.2-0.20210714181518-b5a3dc95a675/go.mod h1:grseeRo9g3yNkYW09iFlV8LG78jTa1ssBgouogQg/RU=
+github.com/gdavison/terraform-plugin-sdk/v2 v2.7.1-0.20210913224932-c7c2dbd9e010 h1:05JaIuXKUa+nXrb/LUDvlGQ7qvAdxCCGiIf/XIv7sYA=
+github.com/gdavison/terraform-plugin-sdk/v2 v2.7.1-0.20210913224932-c7c2dbd9e010/go.mod h1:O4vVRy2W0P3810kdyNmG4wKcm4wLX/arLxuxjPA1IpA=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

See https://github.com/hashicorp/terraform-provider-aws/network/updates/202211158:

> go: github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.1 (replaced by github.com/gdavison/terraform-plugin-sdk/v2@v2.0.2-0.20210714181518-b5a3dc95a675): version "v2.0.2-0.20210714181518-b5a3dc95a675" invalid: unknown revision b5a3dc95a675

It looks like https://github.com/gdavison/terraform-plugin-sdk/commits/instrument-sweeper-timing was updated yesterday.
This PR updates dependencies to the latest commit on that branch.