### PR TITLE
f/aws_ses_email_mail_from

### DIFF
--- a/.changelog/20900.txt
+++ b/.changelog/20900.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ses_email_mail_from
+```

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1054,7 +1054,7 @@ func Provider() *schema.Provider {
 			"aws_ses_domain_dkim":                                     resourceAwsSesDomainDkim(),
 			"aws_ses_domain_mail_from":                                resourceAwsSesDomainMailFrom(),
 			"aws_ses_email_identity":                                  resourceAwsSesEmailIdentity(),
-			"aws_ses_identity_from_mail":                              resourceAwsSesIdentityMailFrom(),
+			"aws_ses_email_from_mail":                                 resourceAwsSesEmailMailFrom(),
 			"aws_ses_identity_policy":                                 resourceAwsSesIdentityPolicy(),
 			"aws_ses_receipt_filter":                                  resourceAwsSesReceiptFilter(),
 			"aws_ses_receipt_rule":                                    resourceAwsSesReceiptRule(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1054,7 +1054,7 @@ func Provider() *schema.Provider {
 			"aws_ses_domain_dkim":                                     resourceAwsSesDomainDkim(),
 			"aws_ses_domain_mail_from":                                resourceAwsSesDomainMailFrom(),
 			"aws_ses_email_identity":                                  resourceAwsSesEmailIdentity(),
-			"aws_ses_email_from_mail":                                 resourceAwsSesEmailMailFrom(),
+			"aws_ses_email_mail_from":                                 resourceAwsSesEmailMailFrom(),
 			"aws_ses_identity_policy":                                 resourceAwsSesIdentityPolicy(),
 			"aws_ses_receipt_filter":                                  resourceAwsSesReceiptFilter(),
 			"aws_ses_receipt_rule":                                    resourceAwsSesReceiptRule(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1054,6 +1054,7 @@ func Provider() *schema.Provider {
 			"aws_ses_domain_dkim":                                     resourceAwsSesDomainDkim(),
 			"aws_ses_domain_mail_from":                                resourceAwsSesDomainMailFrom(),
 			"aws_ses_email_identity":                                  resourceAwsSesEmailIdentity(),
+			"aws_ses_identity_from_mail":                              resourceAwsSesIdentityMailFrom(),
 			"aws_ses_identity_policy":                                 resourceAwsSesIdentityPolicy(),
 			"aws_ses_receipt_filter":                                  resourceAwsSesReceiptFilter(),
 			"aws_ses_receipt_rule":                                    resourceAwsSesReceiptRule(),

--- a/aws/resource_aws_ses_email_mail_from_test.go
+++ b/aws/resource_aws_ses_email_mail_from_test.go
@@ -1,0 +1,231 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSSESEmailMailFrom_basic(t *testing.T) {
+	dn := testAccRandomDomain()
+	email := testAccDefaultEmailAddress
+	mailFromDomain1 := dn.Subdomain("bounce1").String()
+	mailFromDomain2 := dn.Subdomain("bounce2").String()
+	resourceName := "aws_ses_email_mail_from.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESEmailMailFromDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSESEmailMailFromConfig(email, mailFromDomain1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailMailFromExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", ses.BehaviorOnMXFailureUseDefaultValue),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "mail_from_domain", mailFromDomain1),
+				),
+			},
+			{
+				Config: testAccAwsSESEmailMailFromConfig(email, mailFromDomain2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailMailFromExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", ses.BehaviorOnMXFailureUseDefaultValue),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "mail_from_domain", mailFromDomain2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESEmailMailFrom_disappears(t *testing.T) {
+	dn := testAccRandomDomain()
+	email := testAccDefaultEmailAddress
+	mailFromDomain := dn.Subdomain("bounce").String()
+	resourceName := "aws_ses_domain_mail_from.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESEmailMailFromDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSESEmailMailFromConfig(email, mailFromDomain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailMailFromExists(resourceName),
+					testAccCheckAwsSESEmailMailFromDisappears(email),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESEmailMailFrom_disappears_Identity(t *testing.T) {
+	dn := testAccRandomDomain()
+	email := testAccDefaultEmailAddress
+	mailFromDomain := dn.Subdomain("bounce").String()
+	resourceName := "aws_ses_email_mail_from.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESEmailMailFromDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSESEmailMailFromConfig(email, mailFromDomain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailMailFromExists(resourceName),
+					testAccCheckAwsSESEmailMailFromDisappears(email),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESEmailMailFrom_behaviorOnMxFailure(t *testing.T) {
+	email := testAccDefaultEmailAddress
+	resourceName := "aws_ses_email_mail_from.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		ErrorCheck:   testAccErrorCheck(t, ses.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESEmailMailFromDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSESEmailMailFromConfig_behaviorOnMxFailure(email, ses.BehaviorOnMXFailureUseDefaultValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailMailFromExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", ses.BehaviorOnMXFailureUseDefaultValue),
+				),
+			},
+			{
+				Config: testAccAwsSESEmailMailFromConfig_behaviorOnMxFailure(email, ses.BehaviorOnMXFailureRejectMessage),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailMailFromExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", ses.BehaviorOnMXFailureRejectMessage),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsSESEmailMailFromExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("SES Email Identity not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("SES Email Identity name not set")
+		}
+
+		email := rs.Primary.ID
+		conn := testAccProvider.Meta().(*AWSClient).sesconn
+
+		params := &ses.GetIdentityMailFromDomainAttributesInput{
+			Identities: []*string{
+				aws.String(email),
+			},
+		}
+
+		response, err := conn.GetIdentityMailFromDomainAttributes(params)
+		if err != nil {
+			return err
+		}
+
+		if response.MailFromDomainAttributes[email] == nil {
+			return fmt.Errorf("SES Domain MAIL FROM %s not found in AWS", email)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSESEmailMailFromDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sesconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ses_email_mail_from" {
+			continue
+		}
+
+		input := &ses.GetIdentityMailFromDomainAttributesInput{
+			Identities: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		out, err := conn.GetIdentityMailFromDomainAttributes(input)
+		if err != nil {
+			return fmt.Errorf("error fetching MAIL FROM domain attributes: %s", err)
+		}
+		if v, ok := out.MailFromDomainAttributes[rs.Primary.ID]; ok && v.MailFromDomain != nil && *v.MailFromDomain != "" {
+			return fmt.Errorf("MAIL FROM domain was not removed, found: %s", *v.MailFromDomain)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsSESEmailMailFromDisappears(identity string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).sesconn
+
+		input := &ses.SetIdentityMailFromDomainInput{
+			Identity:       aws.String(identity),
+			MailFromDomain: nil,
+		}
+
+		_, err := conn.SetIdentityMailFromDomain(input)
+
+		return err
+	}
+}
+
+func testAccAwsSESEmailMailFromConfig(email, mailFromDomain string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_email_identity" "test" {
+  email = "%s"
+}
+
+resource "aws_ses_email_mail_from" "test" {
+  email            = aws_ses_email_identity.test.email
+  mail_from_domain = "%s"
+}
+`, email, mailFromDomain)
+}
+
+func testAccAwsSESEmailMailFromConfig_behaviorOnMxFailure(email, behaviorOnMxFailure string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_email_identity" "test" {
+  email = "%s"
+}
+
+resource "aws_ses_email_mail_from" "test" {
+  behavior_on_mx_failure = "%s"
+  email                  = aws_ses_email_identity.test.email
+  mail_from_domain       = "bounce.${aws_ses_domain_identity.test.domain}"
+}
+`, email, behaviorOnMxFailure)
+}

--- a/aws/resource_aws_ses_identity_mail_from.go
+++ b/aws/resource_aws_ses_identity_mail_from.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsSesIdentityMailFrom() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSesIdentityMailFromSet,
+		Read:   resourceAwsSesIdentityMailFromRead,
+		Update: resourceAwsSesIdentityMailFromSet,
+		Delete: resourceAwsSesIdentityMailFromDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"identity": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"mail_from_domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"behavior_on_mx_failure": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ses.BehaviorOnMXFailureUseDefaultValue,
+			},
+		},
+	}
+}
+
+func resourceAwsSesIdentityMailFromSet(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesconn
+
+	behaviorOnMxFailure := d.Get("behavior_on_mx_failure").(string)
+	identityName := d.Get("identity").(string)
+	mailFromDomain := d.Get("mail_from_domain").(string)
+
+	input := &ses.SetIdentityMailFromDomainInput{
+		BehaviorOnMXFailure: aws.String(behaviorOnMxFailure),
+		Identity:            aws.String(identityName),
+		MailFromDomain:      aws.String(mailFromDomain),
+	}
+
+	_, err := conn.SetIdentityMailFromDomain(input)
+	if err != nil {
+		return fmt.Errorf("Error setting MAIL FROM domain: %s", err)
+	}
+
+	d.SetId(identityName)
+
+	return resourceAwsSesIdentityMailFromRead(d, meta)
+}
+
+func resourceAwsSesIdentityMailFromRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesconn
+
+	identityName := d.Id()
+
+	readOpts := &ses.GetIdentityMailFromDomainAttributesInput{
+		Identities: []*string{
+			aws.String(identityName),
+		},
+	}
+
+	out, err := conn.GetIdentityMailFromDomainAttributes(readOpts)
+
+	if err != nil {
+		return fmt.Errorf("error fetching SES MAIL FROM domain attributes for %s: %s", identityName, err)
+	}
+
+	if out == nil {
+		return fmt.Errorf("error fetching SES MAIL FROM domain attributes for %s: empty response", identityName)
+	}
+
+	attributes, ok := out.MailFromDomainAttributes[identityName]
+
+	if !ok {
+		log.Printf("[WARN] SES Domain Identity (%s) not found, removing from state", identityName)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("behavior_on_mx_failure", attributes.BehaviorOnMXFailure)
+	d.Set("identity", identityName)
+	d.Set("mail_from_domain", attributes.MailFromDomain)
+
+	return nil
+}
+
+func resourceAwsSesIdentityMailFromDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesconn
+
+	identityName := d.Id()
+
+	deleteOpts := &ses.SetIdentityMailFromDomainInput{
+		Identity:       aws.String(identityName),
+		MailFromDomain: nil,
+	}
+
+	_, err := conn.SetIdentityMailFromDomain(deleteOpts)
+	if err != nil {
+		return fmt.Errorf("Error deleting SES domain identity: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/14378

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSESEmailMailFrom'                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSESEmailMailFrom -timeout 180m
=== RUN   TestAccAWSSESEmailMailFrom_basic
=== PAUSE TestAccAWSSESEmailMailFrom_basic
=== RUN   TestAccAWSSESEmailMailFrom_disappears
=== PAUSE TestAccAWSSESEmailMailFrom_disappears
=== RUN   TestAccAWSSESEmailMailFrom_disappears_Identity
=== PAUSE TestAccAWSSESEmailMailFrom_disappears_Identity
=== RUN   TestAccAWSSESEmailMailFrom_behaviorOnMxFailure
=== PAUSE TestAccAWSSESEmailMailFrom_behaviorOnMxFailure
=== CONT  TestAccAWSSESEmailMailFrom_basic
=== CONT  TestAccAWSSESEmailMailFrom_behaviorOnMxFailure
=== CONT  TestAccAWSSESEmailMailFrom_disappears_Identity
=== CONT  TestAccAWSSESEmailMailFrom_disappears
--- PASS: TestAccAWSSESEmailMailFrom_disappears_Identity (32.93s)
--- PASS: TestAccAWSSESEmailMailFrom_disappears (33.30s)
--- PASS: TestAccAWSSESEmailMailFrom_basic (57.60s)
--- PASS: TestAccAWSSESEmailMailFrom_behaviorOnMxFailure (57.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       59.571s
