### PR TITLE
Correct non-tags change detection

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -628,3 +628,13 @@ rules:
       - pattern-regex: 'ssh-rsa [A-Za-z0-9/]+'
       - pattern-inside: '($X : string)'
     severity: WARNING
+
+  - id: non-tags-change-detection
+    languages: [go]
+    message: Incorrect form of non-tags change detection. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#resource-tagging-code-implementation
+    paths:
+      include:
+        - aws/
+    patterns:
+      - pattern: 'if d.HasChangeExcept("tags_all") {...}'
+    severity: WARNING

--- a/aws/resource_aws_elasticache_user.go
+++ b/aws/resource_aws_elasticache_user.go
@@ -159,7 +159,7 @@ func resourceAwsElasticacheUserUpdate(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).elasticacheconn
 	hasChange := false
 
-	if d.HasChangeExcept("tags_all") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		req := &elasticache.ModifyUserInput{
 			UserId: aws.String(d.Id()),
 		}

--- a/aws/resource_aws_elasticache_user_group.go
+++ b/aws/resource_aws_elasticache_user_group.go
@@ -160,7 +160,7 @@ func resourceAwsElasticacheUserGroupUpdate(d *schema.ResourceData, meta interfac
 	conn := meta.(*AWSClient).elasticacheconn
 	hasChange := false
 
-	if d.HasChangeExcept("tags_all") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		req := &elasticache.ModifyUserGroupInput{
 			UserGroupId: aws.String(d.Get("user_group_id").(string)),
 		}

--- a/aws/resource_aws_elasticache_user_group_test.go
+++ b/aws/resource_aws_elasticache_user_group_test.go
@@ -202,26 +202,8 @@ func testAccCheckAWSElasticacheUserGroupExistsWithProvider(n string, v *elastica
 
 func testAccAWSElasticacheUserGroupConfigBasic(rName string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
-resource "aws_elasticache_user" "test" {
-  user_id       = %[1]q
-  user_name     = "default"
-  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
-  passwords     = ["password123456789"]
-}
-
-resource "aws_elasticache_user_group" "test" {
-  user_group_id = %[1]q
-  engine        = "REDIS"
-  user_ids      = [aws_elasticache_user.test.user_id]
-}
-`, rName))
-}
-
-func testAccAWSElasticacheUserGroupConfigMultiple(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
-resource "aws_elasticache_user" "test" {
-  user_id       = %[1]q
+resource "aws_elasticache_user" "test1" {
+  user_id       = "%[1]s-1"
   user_name     = "default"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
   engine        = "REDIS"
@@ -239,7 +221,33 @@ resource "aws_elasticache_user" "test2" {
 resource "aws_elasticache_user_group" "test" {
   user_group_id = %[1]q
   engine        = "REDIS"
-  user_ids      = [aws_elasticache_user.test.user_id, aws_elasticache_user.test2.user_id]
+  user_ids      = [aws_elasticache_user.test1.user_id]
+}
+`, rName))
+}
+
+func testAccAWSElasticacheUserGroupConfigMultiple(rName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test1" {
+  user_id       = "%[1]s-1"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user" "test2" {
+  user_id       = "%[1]s-2"
+  user_name     = "username1"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[1]q
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test1.user_id, aws_elasticache_user.test2.user_id]
 }
 `, rName))
 }

--- a/aws/resource_aws_neptune_cluster_endpoint.go
+++ b/aws/resource_aws_neptune_cluster_endpoint.go
@@ -168,7 +168,7 @@ func resourceAwsNeptuneClusterEndpointRead(d *schema.ResourceData, meta interfac
 func resourceAwsNeptuneClusterEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).neptuneconn
 
-	if d.HasChangeExcept("tags_all") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		req := &neptune.ModifyDBClusterEndpointInput{
 			DBClusterEndpointIdentifier: aws.String(d.Get("cluster_endpoint_identifier").(string)),
 		}

--- a/aws/resource_aws_sagemaker_device_fleet.go
+++ b/aws/resource_aws_sagemaker_device_fleet.go
@@ -171,7 +171,7 @@ func resourceAwsSagemakerDeviceFleetRead(d *schema.ResourceData, meta interface{
 func resourceAwsSagemakerDeviceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	if d.HasChangeExcept("tags_all") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		input := &sagemaker.UpdateDeviceFleetInput{
 			DeviceFleetName:    aws.String(d.Id()),
 			EnableIotRoleAlias: aws.Bool(d.Get("enable_iot_role_alias").(bool)),

--- a/aws/resource_aws_sagemaker_workteam.go
+++ b/aws/resource_aws_sagemaker_workteam.go
@@ -216,7 +216,7 @@ func resourceAwsSagemakerWorkteamRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsSagemakerWorkteamUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	if d.HasChangeExcept("tags_all") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		input := &sagemaker.UpdateWorkteamInput{
 			WorkteamName:      aws.String(d.Id()),
 			MemberDefinitions: expandSagemakerWorkteamMemberDefinition(d.Get("member_definition").([]interface{})),

--- a/aws/resource_aws_sagemaker_workteam_test.go
+++ b/aws/resource_aws_sagemaker_workteam_test.go
@@ -509,10 +509,10 @@ resource "aws_sns_topic_policy" "test" {
         "Sid" : "%[1]s",
         "Effect" : "Allow",
         "Principal" : {
-          "AWS" : "*"
+          "Service": "sagemaker.amazonaws.com"
         },
         "Action" : [
-          "sns:publish"
+          "sns:Publish"
         ],
         "Resource" : "${aws_sns_topic.test.arn}"
       }

--- a/aws/resource_aws_sagemaker_workteam_test.go
+++ b/aws/resource_aws_sagemaker_workteam_test.go
@@ -509,7 +509,7 @@ resource "aws_sns_topic_policy" "test" {
         "Sid" : "%[1]s",
         "Effect" : "Allow",
         "Principal" : {
-          "Service": "sagemaker.amazonaws.com"
+          "Service" : "sagemaker.amazonaws.com"
         },
         "Action" : [
           "sns:Publish"


### PR DESCRIPTION
This PR adds new semgrep rule to find incorrect form of non-`tags` change detection. It also fixes all 5 findings of new rule.

Before fix:
```
$ make semgrep                                                                                                                           ≡
==> Running Semgrep static analysis...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
running 27 rules...
aws/resource_aws_elasticache_user.go
severity:warning rule:non-tags-change-detection: Incorrect form of non-tags change detection. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#resource-tagging-code-implementation
autofix: if d.HasChangesExcept("tags", "tags_all") {...}
162:	if d.HasChangeExcept("tags_all") {
163:		req := &elasticache.ModifyUserInput{
164:			UserId: aws.String(d.Id()),
165:		}
166:
167:		if d.HasChange("access_string") {
168:			req.AccessString = aws.String(d.Get("access_string").(string))
169:			hasChange = true
170:		}
171:
-------- [hid 22 additional lines, adjust with --max-lines-per-finding] --------

aws/resource_aws_elasticache_user_group.go
severity:warning rule:non-tags-change-detection: Incorrect form of non-tags change detection. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#resource-tagging-code-implementation
autofix: if d.HasChangesExcept("tags", "tags_all") {...}
163:	if d.HasChangeExcept("tags_all") {
164:		req := &elasticache.ModifyUserGroupInput{
165:			UserGroupId: aws.String(d.Get("user_group_id").(string)),
166:		}
167:
168:		if d.HasChange("user_ids") {
169:			o, n := d.GetChange("user_ids")
170:			usersRemove := o.(*schema.Set).Difference(n.(*schema.Set))
171:			usersAdd := n.(*schema.Set).Difference(o.(*schema.Set))
172:
-------- [hid 31 additional lines, adjust with --max-lines-per-finding] --------

aws/resource_aws_neptune_cluster_endpoint.go
severity:warning rule:non-tags-change-detection: Incorrect form of non-tags change detection. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#resource-tagging-code-implementation
autofix: if d.HasChangesExcept("tags", "tags_all") {...}
171:	if d.HasChangeExcept("tags_all") {
172:		req := &neptune.ModifyDBClusterEndpointInput{
173:			DBClusterEndpointIdentifier: aws.String(d.Get("cluster_endpoint_identifier").(string)),
174:		}
175:
176:		if d.HasChange("endpoint_type") {
177:			req.EndpointType = aws.String(d.Get("endpoint_type").(string))
178:		}
179:
180:		if d.HasChange("static_members") {
-------- [hid 17 additional lines, adjust with --max-lines-per-finding] --------

aws/resource_aws_sagemaker_device_fleet.go
severity:warning rule:non-tags-change-detection: Incorrect form of non-tags change detection. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#resource-tagging-code-implementation
autofix: if d.HasChangesExcept("tags", "tags_all") {...}
174:	if d.HasChangeExcept("tags_all") {
175:		input := &sagemaker.UpdateDeviceFleetInput{
176:			DeviceFleetName:    aws.String(d.Id()),
177:			EnableIotRoleAlias: aws.Bool(d.Get("enable_iot_role_alias").(bool)),
178:			OutputConfig:       expandSagemakerFeatureDeviceFleetOutputConfig(d.Get("output_config").([]interface{})),
179:			RoleArn:            aws.String(d.Get("role_arn").(string)),
180:		}
181:
182:		if d.HasChange("description") {
183:			input.Description = aws.String(d.Get("description").(string))
-------- [hid 8 additional lines, adjust with --max-lines-per-finding] ---------

aws/resource_aws_sagemaker_workteam.go
severity:warning rule:non-tags-change-detection: Incorrect form of non-tags change detection. https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#resource-tagging-code-implementation
autofix: if d.HasChangesExcept("tags", "tags_all") {...}
219:	if d.HasChangeExcept("tags_all") {
220:		input := &sagemaker.UpdateWorkteamInput{
221:			WorkteamName:      aws.String(d.Id()),
222:			MemberDefinitions: expandSagemakerWorkteamMemberDefinition(d.Get("member_definition").([]interface{})),
223:		}
224:
225:		if d.HasChange("description") {
226:			input.Description = aws.String(d.Get("description").(string))
227:		}
228:
-------- [hid 11 additional lines, adjust with --max-lines-per-finding] --------
ran 27 rules on 2828 files: 5 findings
```

After fix:
```
$ make semgrep
==> Running Semgrep static analysis...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
running 27 rules...
ran 27 rules on 2828 files: 0 findings
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20868.

Output from acceptance testing:
- Did not run acceptance tests.