### PR TITLE
resource/aws_kms_key: Updates policy and tag propagation time to 5 minutes

### DIFF
--- a/.changelog/20914.txt
+++ b/.changelog/20914.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_key: Extends timeouts for policy and tag propagation to 5 minutes each
+```

--- a/aws/internal/service/kms/waiter/waiter.go
+++ b/aws/internal/service/kms/waiter/waiter.go
@@ -22,8 +22,10 @@ const (
 	KeyDeletedTimeout                = 20 * time.Minute
 	KeyDescriptionPropagationTimeout = 5 * time.Minute
 	KeyMaterialImportedTimeout       = 10 * time.Minute
+	KeyPolicyPropagationTimeout      = 5 * time.Minute
 	KeyRotationUpdatedTimeout        = 10 * time.Minute
 	KeyStatePropagationTimeout       = 20 * time.Minute
+	KeyTagsPropagationTimeout        = 5 * time.Minute
 	KeyValidToPropagationTimeout     = 5 * time.Minute
 
 	PropagationTimeout = 2 * time.Minute
@@ -116,7 +118,7 @@ func KeyPolicyPropagated(conn *kms.KMS, id, policy string) error {
 		MinTimeout:                1 * time.Second,
 	}
 
-	return tfresource.WaitUntil(PropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(KeyPolicyPropagationTimeout, checkFunc, opts)
 }
 
 func KeyRotationEnabledPropagated(conn *kms.KMS, id string, enabled bool) error {
@@ -138,7 +140,7 @@ func KeyRotationEnabledPropagated(conn *kms.KMS, id string, enabled bool) error 
 		MinTimeout:                1 * time.Second,
 	}
 
-	return tfresource.WaitUntil(PropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(KeyRotationUpdatedTimeout, checkFunc, opts)
 }
 
 func KeyStatePropagated(conn *kms.KMS, id string, enabled bool) error {
@@ -208,5 +210,5 @@ func TagsPropagated(conn *kms.KMS, id string, tags keyvaluetags.KeyValueTags) er
 		MinTimeout:                1 * time.Second,
 	}
 
-	return tfresource.WaitUntil(PropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(KeyTagsPropagationTimeout, checkFunc, opts)
 }

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -394,7 +394,7 @@ func updateKmsKeyEnabled(conn *kms.KMS, keyID string, enabled bool) error {
 		return nil, err
 	}
 
-	_, err := tfresource.RetryWhenAwsErrCodeEquals(waiter.KeyRotationUpdatedTimeout, updateFunc, kms.ErrCodeNotFoundException)
+	_, err := tfresource.RetryWhenAwsErrCodeEquals(waiter.PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException)
 
 	if err != nil {
 		return fmt.Errorf("error updating KMS Key (%s) key enabled (%t): %w", keyID, enabled, err)


### PR DESCRIPTION
Updates policy and tag propagation time to 5 minutes from 2 minutes.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20588

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSKmsKey'

--- PASS: TestAccAWSKmsKey_disappears (24.53s)
--- PASS: TestAccAWSKmsKey_asymmetricKey (24.96s)
--- PASS: TestAccAWSKmsKey_basic (27.23s)
--- PASS: TestAccAWSKmsKey_policy (45.64s)
--- PASS: TestAccAWSKmsKey_policyBypassUpdate (47.42s)
--- PASS: TestAccAWSKmsKey_Policy_IamRole (51.40s)
--- PASS: TestAccAWSKmsKey_Policy_IamServiceLinkedRole (58.23s)
--- PASS: TestAccAWSKmsKey_tags (90.22s)
--- PASS: TestAccAWSKmsKey_policyBypass (152.64s)
--- PASS: TestAccAWSKmsKey_isEnabled (219.20s)
```
