### PR TITLE
Update documentation for aws cloudfront key group

### DIFF
--- a/website/docs/r/cloudfront_key_group.html.markdown
+++ b/website/docs/r/cloudfront_key_group.html.markdown
@@ -40,3 +40,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `etag` - The identifier for this version of the key group.
 * `id` - The identifier for the key group.
+
+## Import
+
+CloudFront Key Group can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_cloudfront_key_group.example 4b4f2r1c-315d-5c2e-f093-216t50jed10f
+```


### PR DESCRIPTION
The documentation for aws cloudfront key group was missing the import section.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
