### PR TITLE
waf_web_acl: add hint on the example

### DIFF
--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -12,6 +12,8 @@ Provides a WAF Web ACL Resource
 
 ## Example Usage
 
+This example blocks requests coming from `192.0.7.0/24` and allows everything else.
+
 ```terraform
 resource "aws_waf_ipset" "ipset" {
   name = "tfIPSet"


### PR DESCRIPTION
One may think the example configuration *allows* the given IP block and blocks everything else.

I think being explicit here may improve the documentation.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
