### PR TITLE
Fix AppRunner Documentation: Valid values are PYTHON_3 / NODEJS_12, not python3 / nodejs12

### DIFF
--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -27,7 +27,7 @@ resource "aws_apprunner_service" "example" {
         code_configuration_values {
           build_command = "python setup.py develop"
           port          = "8000"
-          runtime       = "python3"
+          runtime       = "PYTHON_3"
           start_command = "python runapp.py"
         }
         configuration_source = "API"
@@ -160,7 +160,7 @@ The `code_configuration_values` blocks supports the following arguments:
 
 * `build_command` - (Optional) The command App Runner runs to build your application.
 * `port` - (Optional) The port that your application listens to in the container. Defaults to `"8080"`.
-* `runtime` - (Required) A runtime environment type for building and running an App Runner service. Represents a programming language runtime. Valid values: `python3`, `nodejs12`.
+* `runtime` - (Required) A runtime environment type for building and running an App Runner service. Represents a programming language runtime. Valid values: `PYTHON_3`, `NODEJS_12`.
 * `runtime_environment_variables` - (Optional) Environment variables available to your running App Runner service. A map of key/value pairs. Keys with a prefix of `AWSAPPRUNNER` are reserved for system use and aren't valid.
 * `start_command` - (Optional) The command App Runner runs to start your application.
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Description

When I apply apprunner_service resource with the example I see in this document ( with `python3` or `nodejs12` runtime value), I get these errors.

```
❯ terraform apply

Error: expected source_configuration.0.code_repository.0.code_configuration.0.code_configuration_values.0.runtime to be one of [PYTHON_3 NODEJS_12], got python3

  on test.tf line 10, in resource "aws_apprunner_service" "example":
  10:           runtime       = "python3"
```

```
❯ terraform apply

Error: expected source_configuration.0.code_repository.0.code_configuration.0.code_configuration_values.0.runtime to be one of [PYTHON_3 NODEJS_12], got nodejs12

  on test.tf line 10, in resource "aws_apprunner_service" "example":
  10:           runtime       = "nodejs12"
```

As described in official document, valid value form is `PYTHON_3` or `NODEJS_12` .
https://docs.aws.amazon.com/ja_jp/apprunner/latest/api/API_CodeConfigurationValues.html

