### PR TITLE
feat: adding support for rate based statements in wafv2rulegroup

### DIFF
--- a/.changelog/20932.txt
+++ b/.changelog/20932.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add rate_based_statement block for rule
+```

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -413,54 +413,6 @@ func wafv2ExcludedRuleSchema() *schema.Schema {
 	}
 }
 
-func wafv2RateBasedStatementSchema(level int) *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				// Required field
-				"aggregate_key_type": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Default:      wafv2.RateBasedStatementAggregateKeyTypeIp,
-					ValidateFunc: validation.StringInSlice(wafv2.RateBasedStatementAggregateKeyType_Values(), false),
-				},
-				"forwarded_ip_config": wafv2ForwardedIPConfig(),
-				"limit": {
-					Type:         schema.TypeInt,
-					Required:     true,
-					ValidateFunc: validation.IntBetween(100, 2000000000),
-				},
-				"scope_down_statement": wafv2ScopeDownStatementSchema(level - 1),
-			},
-		},
-	}
-}
-
-func wafv2ScopeDownStatementSchema(level int) *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"and_statement":                         wafv2StatementSchema(level),
-				"byte_match_statement":                  wafv2ByteMatchStatementSchema(),
-				"geo_match_statement":                   wafv2GeoMatchStatementSchema(),
-				"ip_set_reference_statement":            wafv2IpSetReferenceStatementSchema(),
-				"not_statement":                         wafv2StatementSchema(level),
-				"or_statement":                          wafv2StatementSchema(level),
-				"regex_pattern_set_reference_statement": wafv2RegexPatternSetReferenceStatementSchema(),
-				"size_constraint_statement":             wafv2SizeConstraintSchema(),
-				"sqli_match_statement":                  wafv2SqliMatchStatementSchema(),
-				"xss_match_statement":                   wafv2XssMatchStatementSchema(),
-			},
-		},
-	}
-}
-
 func wafv2RuleGroupReferenceStatementSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,

--- a/aws/wafv2_helper.go
+++ b/aws/wafv2_helper.go
@@ -46,7 +46,7 @@ func wafv2RootStatementSchema(level int) *schema.Schema {
 				"ip_set_reference_statement":            wafv2IpSetReferenceStatementSchema(),
 				"not_statement":                         wafv2StatementSchema(level - 1),
 				"or_statement":                          wafv2StatementSchema(level - 1),
-				"rate_based_statement":                  wafv2RateBasedStatementSchema(level - 1),
+				"rate_based_statement":                  wafv2RateBasedStatementSchema(level), // not reducing to allow for deeper scope_down_statements
 				"regex_pattern_set_reference_statement": wafv2RegexPatternSetReferenceStatementSchema(),
 				"size_constraint_statement":             wafv2SizeConstraintSchema(),
 				"sqli_match_statement":                  wafv2SqliMatchStatementSchema(),
@@ -75,7 +75,6 @@ func wafv2StatementSchema(level int) *schema.Schema {
 								"ip_set_reference_statement":            wafv2IpSetReferenceStatementSchema(),
 								"not_statement":                         wafv2StatementSchema(level - 1),
 								"or_statement":                          wafv2StatementSchema(level - 1),
-								"rate_based_statement":                  wafv2RateBasedStatementSchema(level - 1),
 								"regex_pattern_set_reference_statement": wafv2RegexPatternSetReferenceStatementSchema(),
 								"size_constraint_statement":             wafv2SizeConstraintSchema(),
 								"sqli_match_statement":                  wafv2SqliMatchStatementSchema(),

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -365,6 +365,7 @@ The `statement` block supports the following arguments:
 * `ip_set_reference_statement` - (Optional) A rule statement used to detect web requests coming from particular IP addresses or address ranges. See [IP Set Reference Statement](#ip-set-reference-statement) below for details.
 * `not_statement` - (Optional) A logical rule statement used to negate the results of another rule statement. See [NOT Statement](#not-statement) below for details.
 * `or_statement` - (Optional) A logical rule statement used to combine other rule statements with OR logic. See [OR Statement](#or-statement) below for details.
+* `rate_based_statement` - (Optional) A rate-based rule tracks the rate of requests for each originating `IP address`, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any `5-minute` time span. This statement can not be nested. See [Rate Based Statement](#rate-based-statement) below for details.
 * `regex_pattern_set_reference_statement` - (Optional) A rule statement used to search web request components for matches with regular expressions. See [Regex Pattern Set Reference Statement](#regex-pattern-set-reference-statement) below for details.
 * `size_constraint_statement` - (Optional) A rule statement that compares a number of bytes against the size of a request component, using a comparison operator, such as greater than (>) or less than (<). See [Size Constraint Statement](#size-constraint-statement) below for more details.
 * `sqli_match_statement` - (Optional) An SQL injection match condition identifies the part of web requests, such as the URI or the query string, that you want AWS WAF to inspect. See [SQL Injection Match Statement](#sql-injection-match-statement) below for details.
@@ -420,6 +421,21 @@ A logical rule statement used to combine other rule statements with `OR` logic. 
 The `or_statement` block supports the following arguments:
 
 * `statement` - (Required) The statements to combine with `OR` logic. You can use any statements that can be nested. See [Statement](#statement) above for details.
+
+### Rate Based Statement
+
+A rate-based rule tracks the rate of requests for each originating IP address, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any 5-minute time span. You can use this to put a temporary block on requests from an IP address that is sending excessive requests. See the [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedStatement.html) for more information.
+
+You can't nest a `rate_based_statement`, for example for use inside a `not_statement` or `or_statement`. It can only be referenced as a `top-level` statement within a `rule`.
+
+~> **NOTE:** Only `block` or `count` are allowed as actions for a `rate_based_statement`. Ensure your rule's `action` is set to `block` or `count`.
+
+The `rate_based_statement` block supports the following arguments:
+
+* `aggregate_key_type` - (Optional) Setting that indicates how to aggregate the request counts. Valid values include: `FORWARDED_IP` or `IP`. Default: `IP`.
+* `forwarded_ip_config` - (Optional) The configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. If `aggregate_key_type` is set to `FORWARDED_IP`, this block is required. See [Forwarded IP Config](#forwarded-ip-config) below for details.
+* `limit` - (Required) The limit on requests per 5-minute period for a single originating IP address.
+* `scope_down_statement` - (Optional) An optional nested statement that narrows the scope of the rate-based statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [Statement](#statement) above for details.
 
 ### Regex Pattern Set Reference Statement
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20908

* Adds `rate_based_statement` to `rule` block in `aws_wafv2_rule_group`

I moved shared code around `rate_based_statement` to the `wafv2_helper` module from the `aws_waf_v2_web_acl` module, and added code for `aws_wafv2_rule_group` to consume it.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAwsWafv2RuleGroup_RateBasedStatement'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWafv2RuleGroup_RateBasedStatement -timeout 180m
=== RUN   TestAccAwsWafv2RuleGroup_RateBasedStatement_Basic
=== PAUSE TestAccAwsWafv2RuleGroup_RateBasedStatement_Basic
=== RUN   TestAccAwsWafv2RuleGroup_RateBasedStatement_ScopeDownStatement
=== PAUSE TestAccAwsWafv2RuleGroup_RateBasedStatement_ScopeDownStatement
=== CONT  TestAccAwsWafv2RuleGroup_RateBasedStatement_Basic
=== CONT  TestAccAwsWafv2RuleGroup_RateBasedStatement_ScopeDownStatement
--- PASS: TestAccAwsWafv2RuleGroup_RateBasedStatement_ScopeDownStatement (30.70s)
--- PASS: TestAccAwsWafv2RuleGroup_RateBasedStatement_Basic (34.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       34.738s
```

In addition, all Wafv2RuleGroup and AwsWafv2WebACL tests pass with my changes (code I moved impacted these two modules).
