### PR TITLE
r/cognito_user_pool - remove lambda config

### DIFF
--- a/.changelog/20952.txt
+++ b/.changelog/20952.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Fix removal of `lambda_config`
+```

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -212,7 +212,6 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			"lambda_config": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1069,6 +1069,13 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "lambda_config.0.verify_auth_challenge_response", lambdaUpdatedResourceName, "arn"),
 				),
 			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_Name(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName, nil),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "0"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20949

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_'
--- PASS: TestAccAWSCognitoUserPool_disappears (80.25s)
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (101.44s)
--- PASS: TestAccAWSCognitoUserPool_basic (101.51s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesRemoved (104.54s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributesModified (106.06s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (152.38s)
--- PASS: TestAccAWSCognitoUserPool_schemaAttributes (152.41s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameAttributes (152.58s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (153.09s)
--- PASS: TestAccAWSCognitoUserPool_SmsVerificationMessage (155.69s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (155.76s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration (179.40s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId (189.68s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn (196.68s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_emailConfig (205.50s)
--- PASS: TestAccAWSCognitoUserPool_withTags (205.71s)
--- PASS: TestAccAWSCognitoUserPool_withUsernameConfiguration (137.91s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig_smsConfig (219.41s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration (221.65s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (131.74s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (81.32s)
--- PASS: TestAccAWSCognitoUserPool_SmsAuthenticationMessage (136.30s)
--- PASS: TestAccAWSCognitoUserPool_update (246.17s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration (152.36s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (259.21s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (123.08s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (121.75s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration (197.20s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration (158.51s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (159.20s)
--- PASS: TestAccAWSCognitoUserPool_recovery (150.08s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration (192.36s)
```
