### PR TITLE
[WIP] Add support for maximum Spot price set equal to the On-Demand price On EMR

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -268,6 +268,16 @@ func resourceAwsEMRCluster() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"market": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								emr.MarketTypeOnDemand,
+								emr.MarketTypeSpot,
+								"",
+							}, false),
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -337,6 +347,15 @@ func resourceAwsEMRCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
+						},
+						"market": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								emr.MarketTypeOnDemand,
+								emr.MarketTypeSpot,
+							}, false),
 						},
 						"name": {
 							Type:     schema.TypeString,
@@ -733,8 +752,15 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 			InstanceCount: aws.Int64(int64(m["instance_count"].(int))),
 			InstanceRole:  aws.String(emr.InstanceRoleTypeMaster),
 			InstanceType:  aws.String(m["instance_type"].(string)),
-			Market:        aws.String(emr.MarketTypeOnDemand),
 			Name:          aws.String(m["name"].(string)),
+		}
+
+		if v, ok := m["market"]; ok {
+			if v.(string) == "SPOT" {
+				instanceGroup.Market = aws.String(emr.MarketTypeSpot)
+			} else {
+				instanceGroup.Market = aws.String(emr.MarketTypeOnDemand)
+			}
 		}
 
 		if v, ok := m["bid_price"]; ok && v.(string) != "" {
@@ -754,7 +780,6 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 			InstanceCount: aws.Int64(int64(m["instance_count"].(int))),
 			InstanceRole:  aws.String(emr.InstanceRoleTypeCore),
 			InstanceType:  aws.String(m["instance_type"].(string)),
-			Market:        aws.String(emr.MarketTypeOnDemand),
 			Name:          aws.String(m["name"].(string)),
 		}
 
@@ -766,6 +791,14 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 			}
 
 			instanceGroup.AutoScalingPolicy = autoScalingPolicy
+		}
+
+		if v, ok := m["market"]; ok {
+			if v.(string) == "SPOT" {
+				instanceGroup.Market = aws.String(emr.MarketTypeSpot)
+			} else {
+				instanceGroup.Market = aws.String(emr.MarketTypeOnDemand)
+			}
 		}
 
 		if v, ok := m["bid_price"]; ok && v.(string) != "" {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -379,8 +379,9 @@ Supported arguments for the `core_instance_group` configuration block:
 
 * `instance_type` - (Required) EC2 instance type for all instances in the instance group.
 * `autoscaling_policy` - (Optional) String containing the [EMR Auto Scaling Policy](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-automatic-scaling.html) JSON.
-* `bid_price` - (Optional) Bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances.
+* `bid_price` - (Optional) If set, the bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance and will implicitly create a Spot request. If not set while `market` is configured to `SPOT`, the maximum price is set equal to the On-Demand price.
 * `ebs_config` - (Optional) Configuration block(s) for EBS volumes attached to each instance in the instance group. Detailed below.
+* `market` - (Optional) The instance purchasing option. Valid values are `ON_DEMAND` or `SPOT`. Defaults to `ON_DEMAND` unless `bid_price` is set to a non-empty value.
 * `instance_count` - (Optional) Target number of instances for the instance group. Must be at least 1. Defaults to 1.
 * `name` - (Optional) Friendly name given to the instance group.
 
@@ -428,9 +429,10 @@ Attributes for Kerberos configuration
 Supported nested arguments for the `master_instance_group` configuration block:
 
 * `instance_type` - (Required) EC2 instance type for all instances in the instance group.
-* `bid_price` - (Optional) Bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances.
+* `bid_price` - (Optional) If set, the bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance and will implicitly create a Spot request. If not set while `market` is configured to `SPOT`, the maximum price is set equal to the On-Demand price.
 * `ebs_config` - (Optional) Configuration block(s) for EBS volumes attached to each instance in the instance group. Detailed below.
 * `instance_count` - (Optional) Target number of instances for the instance group. Must be 1 or 3. Defaults to 1. Launching with multiple master nodes is only supported in EMR version 5.23.0+, and requires this resource's `core_instance_group` to be configured. Public (Internet accessible) instances must be created in VPC subnets that have [map public IP on launch](/docs/providers/aws/r/subnet.html#map_public_ip_on_launch) enabled. Termination protection is automatically enabled when launched with multiple master nodes and Terraform must have the `termination_protection = false` configuration applied before destroying this resource.
+* `market` - (Optional) The instance purchasing option. Valid values are `ON_DEMAND` or `SPOT`. Defaults to `ON_DEMAND` unless `bid_price` is set to a non-empty value.
 * `name` - (Optional) Friendly name given to the instance group.
 
 ## ebs_config


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
This pull request adds the `market` attribute to the aws_emr_cluster resource in the `core_instance_group` and `master_instance_group` property. This allows to set the price for spot instances to the maximum of the on demand price.

The `market` attribute is optional and the old `bid_price` logic is in place, so we keep backward compability. It is possible to set the max on demand price by keeping the `bid_price` empty and setting `market = "SPOT"`. I also tried to include the remarks on #9833

I still need support for the acceptance testing. I don't know why my test are failing, so hopefully someone have a hint for me. I looked at the created resources and could see here that they were created exactly as expected.

It is my first contribution so let me know if I did something wrong.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7155

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEMRCluster_CoreInstanceGroup_Market'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEMRCluster_CoreInstanceGroup_Market -timeout 180m
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Market
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Market
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Market
    resource_aws_emr_cluster_test.go:378: Step 1/3 error: Check failed: Check 3/3 error: aws_emr_cluster.test: Attribute 'core_instance_group.0.market' expected "ON_DEMAND", got ""
--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_Market (448.43s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       448.541s
FAIL
make: *** [GNUmakefile:30: testacc] Error 1

...
```
