### PR TITLE
Serialize Transit Gateway tests

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId(t *testing.T) {
+func testAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -37,14 +37,14 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAn
 	})
 }
 
-func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
+func testAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)

--- a/aws/data_source_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_ec2_transit_gateway_peering_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
-	resource.ParallelTest(t, resource.TestCase{
+
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -38,13 +39,14 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount(t
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAccount(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_ec2_transit_gateway_peering_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
-	resource.ParallelTest(t, resource.TestCase{
+
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -68,12 +70,13 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAcco
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_ec2_transit_gateway_peering_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
-	resource.ParallelTest(t, resource.TestCase{
+
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -97,13 +100,14 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount(t *te
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_ec2_transit_gateway_peering_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
-	resource.ParallelTest(t, resource.TestCase{
+
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -127,12 +131,13 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount(
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Tags(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Tags(t *testing.T) {
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_ec2_transit_gateway_peering_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
-	resource.ParallelTest(t, resource.TestCase{
+
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)

--- a/aws/data_source_aws_ec2_transit_gateway_route_table_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTableDataSource_Filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway_route_table.test"
 	resourceName := "aws_ec2_transit_gateway_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -31,11 +31,11 @@ func TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRouteTableDataSource_ID(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTableDataSource_ID(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway_route_table.test"
 	resourceName := "aws_ec2_transit_gateway_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/data_source_aws_ec2_transit_gateway_route_tables_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_tables_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceAwsEc2TransitGatewayRouteTables_basic(t *testing.T) {
+func testAccDataSourceAwsEc2TransitGatewayRouteTables_basic(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway_route_tables.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck: testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:  testAccProviders,
@@ -25,10 +25,10 @@ func TestAccDataSourceAwsEc2TransitGatewayRouteTables_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsEc2TransitGatewayRouteTables_Filter(t *testing.T) {
+func testAccDataSourceAwsEc2TransitGatewayRouteTables_Filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway_route_tables.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck: testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:  testAccProviders,

--- a/aws/data_source_aws_ec2_transit_gateway_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_test.go
@@ -7,11 +7,59 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSEc2TransitGatewayDataSource_Filter(t *testing.T) {
+func TestAccAWSEc2TransitGatewayDataSource_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"DxGatewayAttachment": {
+			"Filter":                         testAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter,
+			"TransitGatewayIdAndDxGatewayId": testAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId,
+		},
+		"Gateway": {
+			"Filter": testAccAWSEc2TransitGatewayDataSource_Filter,
+			"ID":     testAccAWSEc2TransitGatewayDataSource_ID,
+		},
+		"PeeringAttachment": {
+			"FilterSameAccount":      testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount,
+			"FilterDifferentAccount": testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAccount,
+			"IDSameAccount":          testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount,
+			"IDDifferentAccount":     testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount,
+			"Tags":                   testAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Tags,
+		},
+		"RouteTable": {
+			"Filter": testAccAWSEc2TransitGatewayRouteTableDataSource_Filter,
+			"ID":     testAccAWSEc2TransitGatewayRouteTableDataSource_ID,
+		},
+		"RouteTables": {
+			"basic":  testAccDataSourceAwsEc2TransitGatewayRouteTables_basic,
+			"Filter": testAccDataSourceAwsEc2TransitGatewayRouteTables_Filter,
+		},
+		"VpcAttachment": {
+			"Filter": testAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter,
+			"ID":     testAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID,
+		},
+		"VpnAttachment": {
+			"Filter":                             testAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter,
+			"TransitGatewayIdAndVpnConnectionId": testAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
+func testAccAWSEc2TransitGatewayDataSource_Filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway.test"
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -38,11 +86,11 @@ func TestAccAWSEc2TransitGatewayDataSource_Filter(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayDataSource_ID(t *testing.T) {
+func testAccAWSEc2TransitGatewayDataSource_ID(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway.test"
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway_vpc_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -34,11 +34,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID(t *testing.T) {
 	dataSourceName := "data.aws_ec2_transit_gateway_vpc_attachment.test"
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId(t *testing.T) {
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_vpn_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	vpnConnectionResourceName := "aws_vpn_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -36,13 +36,13 @@ func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnCo
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter(t *testing.T) {
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_vpn_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	vpnConnectionResourceName := "aws_vpn_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_accepter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	resourceName := "aws_ec2_transit_gateway_peering_attachment_accepter.test"
@@ -19,7 +19,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *t
 	transitGatewayResourceNamePeer := "aws_ec2_transit_gateway.peer"
 	rName := fmt.Sprintf("tf-testacc-tgwpeerattach-%s", acctest.RandString(8))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
@@ -51,13 +51,13 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *t
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	resourceName := "aws_ec2_transit_gateway_peering_attachment_accepter.test"
 	rName := fmt.Sprintf("tf-testacc-tgwpeerattach-%s", acctest.RandString(8))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
@@ -99,7 +99,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *te
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	resourceName := "aws_ec2_transit_gateway_peering_attachment_accepter.test"
@@ -108,7 +108,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount
 	transitGatewayResourceNamePeer := "aws_ec2_transit_gateway.peer"
 	rName := fmt.Sprintf("tf-testacc-tgwpeerattach-%s", acctest.RandString(8))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -79,7 +79,7 @@ func testSweepEc2TransitGatewayPeeringAttachments(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -87,7 +87,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	transitGatewayResourceNamePeer := "aws_ec2_transit_gateway.peer"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -118,13 +118,13 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachment_disappears(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachment_disappears(t *testing.T) {
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -146,13 +146,13 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T) {
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ec2_transit_gateway_peering_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -198,7 +198,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T)
 	})
 }
 
-func TestAccAWSEc2TransitGatewayPeeringAttachment_differentAccount(t *testing.T) {
+func testAccAWSEc2TransitGatewayPeeringAttachment_differentAccount(t *testing.T) {
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -206,7 +206,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_differentAccount(t *testing.T)
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	transitGatewayResourceNamePeer := "aws_ec2_transit_gateway.peer"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)

--- a/aws/resource_aws_ec2_transit_gateway_prefix_list_reference_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_prefix_list_reference_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
-func TestAccAwsEc2TransitGatewayPrefixListReference_basic(t *testing.T) {
+func testAccAwsEc2TransitGatewayPrefixListReference_basic(t *testing.T) {
 	managedPrefixListResourceName := "aws_ec2_managed_prefix_list.test"
 	resourceName := "aws_ec2_transit_gateway_prefix_list_reference.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -49,11 +49,11 @@ func TestAccAwsEc2TransitGatewayPrefixListReference_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsEc2TransitGatewayPrefixListReference_disappears(t *testing.T) {
+func testAccAwsEc2TransitGatewayPrefixListReference_disappears(t *testing.T) {
 	resourceName := "aws_ec2_transit_gateway_prefix_list_reference.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -75,12 +75,12 @@ func TestAccAwsEc2TransitGatewayPrefixListReference_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsEc2TransitGatewayPrefixListReference_disappears_TransitGateway(t *testing.T) {
+func testAccAwsEc2TransitGatewayPrefixListReference_disappears_TransitGateway(t *testing.T) {
 	resourceName := "aws_ec2_transit_gateway_prefix_list_reference.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
@@ -102,13 +102,13 @@ func TestAccAwsEc2TransitGatewayPrefixListReference_disappears_TransitGateway(t 
 	})
 }
 
-func TestAccAwsEc2TransitGatewayPrefixListReference_TransitGatewayAttachmentId(t *testing.T) {
+func testAccAwsEc2TransitGatewayPrefixListReference_TransitGatewayAttachmentId(t *testing.T) {
 	resourceName := "aws_ec2_transit_gateway_prefix_list_reference.test"
 	transitGatewayVpcAttachmentResourceName1 := "aws_ec2_transit_gateway_vpc_attachment.test.0"
 	transitGatewayVpcAttachmentResourceName2 := "aws_ec2_transit_gateway_vpc_attachment.test.1"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)

--- a/aws/resource_aws_ec2_transit_gateway_route_table_association_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_association_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAWSEc2TransitGatewayRouteTableAssociation_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTableAssociation_basic(t *testing.T) {
 	var transitGatewayRouteTablePropagtion1 ec2.TransitGatewayRouteTableAssociation
 	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
 	transitGatewayRouteTableResourceName := "aws_ec2_transit_gateway_route_table.test"
 	transitGatewayVpcAttachmentResourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_ec2_transit_gateway_route_table_propagation_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_propagation_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
-func TestAccAWSEc2TransitGatewayRouteTablePropagation_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTablePropagation_basic(t *testing.T) {
 	var transitGatewayRouteTablePropagtion1 ec2.TransitGatewayRouteTablePropagation
 	resourceName := "aws_ec2_transit_gateway_route_table_propagation.test"
 	transitGatewayRouteTableResourceName := "aws_ec2_transit_gateway_route_table.test"
 	transitGatewayVpcAttachmentResourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_ec2_transit_gateway_route_table_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAWSEc2TransitGatewayRouteTable_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTable_basic(t *testing.T) {
 	var transitGatewayRouteTable1 ec2.TransitGatewayRouteTable
 	resourceName := "aws_ec2_transit_gateway_route_table.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -43,11 +43,11 @@ func TestAccAWSEc2TransitGatewayRouteTable_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRouteTable_disappears(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTable_disappears(t *testing.T) {
 	var transitGatewayRouteTable1 ec2.TransitGatewayRouteTable
 	resourceName := "aws_ec2_transit_gateway_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -65,13 +65,13 @@ func TestAccAWSEc2TransitGatewayRouteTable_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	var transitGatewayRouteTable1 ec2.TransitGatewayRouteTable
 	resourceName := "aws_ec2_transit_gateway_route_table.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -90,11 +90,11 @@ func TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway(t *testing.
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRouteTable_Tags(t *testing.T) {
+func testAccAWSEc2TransitGatewayRouteTable_Tags(t *testing.T) {
 	var transitGatewayRouteTable1, transitGatewayRouteTable2, transitGatewayRouteTable3 ec2.TransitGatewayRouteTable
 	resourceName := "aws_ec2_transit_gateway_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_ec2_transit_gateway_route_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAWSEc2TransitGatewayRoute_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayRoute_basic(t *testing.T) {
 	var transitGatewayRoute1 ec2.TransitGatewayRoute
 	resourceName := "aws_ec2_transit_gateway_route.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	transitGatewayVpcAttachmentResourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -40,13 +40,13 @@ func TestAccAWSEc2TransitGatewayRoute_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRoute_basic_ipv6(t *testing.T) {
+func testAccAWSEc2TransitGatewayRoute_basic_ipv6(t *testing.T) {
 	var transitGatewayRoute1 ec2.TransitGatewayRoute
 	resourceName := "aws_ec2_transit_gateway_route.test_ipv6"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	transitGatewayVpcAttachmentResourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -71,12 +71,12 @@ func TestAccAWSEc2TransitGatewayRoute_basic_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRoute_blackhole(t *testing.T) {
+func testAccAWSEc2TransitGatewayRoute_blackhole(t *testing.T) {
 	var transitGatewayRoute1 ec2.TransitGatewayRoute
 	resourceName := "aws_ec2_transit_gateway_route.test_blackhole"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -101,13 +101,13 @@ func TestAccAWSEc2TransitGatewayRoute_blackhole(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRoute_disappears(t *testing.T) {
+func testAccAWSEc2TransitGatewayRoute_disappears(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	var transitGatewayRoute1 ec2.TransitGatewayRoute
 	resourceName := "aws_ec2_transit_gateway_route.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -126,7 +126,7 @@ func TestAccAWSEc2TransitGatewayRoute_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment(t *testing.T) {
+func testAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	var transitGatewayRoute1 ec2.TransitGatewayRoute
 	var transitGatewayVpcAttachment1 ec2.TransitGatewayVpcAttachment
@@ -134,7 +134,7 @@ func TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment(t *tes
 	transitGatewayVpcAttachmentResourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -109,11 +109,94 @@ func testSweepEc2TransitGateways(region string) error {
 	return nil
 }
 
-func TestAccAWSEc2TransitGateway_basic(t *testing.T) {
+func TestAccAWSEc2TransitGateway_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Gateway": {
+			"basic":                       testAccAWSEc2TransitGateway_basic,
+			"disappears":                  testAccAWSEc2TransitGateway_disappears,
+			"AmazonSideASN":               testAccAWSEc2TransitGateway_AmazonSideASN,
+			"AutoAcceptSharedAttachments": testAccAWSEc2TransitGateway_AutoAcceptSharedAttachments,
+			"DefaultRouteTableAssociationAndPropagationDisabled": testAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled,
+			"DefaultRouteTableAssociation":                       testAccAWSEc2TransitGateway_DefaultRouteTableAssociation,
+			"DefaultRouteTablePropagation":                       testAccAWSEc2TransitGateway_DefaultRouteTablePropagation,
+			"Description":                                        testAccAWSEc2TransitGateway_Description,
+			"DnsSupport":                                         testAccAWSEc2TransitGateway_DnsSupport,
+			"Tags":                                               testAccAWSEc2TransitGateway_Tags,
+			"VpnEcmpSupport":                                     testAccAWSEc2TransitGateway_VpnEcmpSupport,
+		},
+		"PeeringAttachment": {
+			"basic":            testAccAWSEc2TransitGatewayPeeringAttachment_basic,
+			"disappears":       testAccAWSEc2TransitGatewayPeeringAttachment_disappears,
+			"DifferentAccount": testAccAWSEc2TransitGatewayPeeringAttachment_differentAccount,
+			"TagsSameAccount":  testAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount,
+		},
+		"PeeringAttachmentAccepter": {
+			"basicSameAccount":      testAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount,
+			"TagsSameAccount":       testAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount,
+			"basicDifferentAccount": testAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount,
+		},
+		"PrefixListReference": {
+			"basic":                      testAccAwsEc2TransitGatewayPrefixListReference_basic,
+			"disappears":                 testAccAwsEc2TransitGatewayPrefixListReference_disappears,
+			"disappearsTransitGateway":   testAccAwsEc2TransitGatewayPrefixListReference_disappears_TransitGateway,
+			"TransitGatewayAttachmentId": testAccAwsEc2TransitGatewayPrefixListReference_TransitGatewayAttachmentId,
+		},
+		"Route": {
+			"basic":                              testAccAWSEc2TransitGatewayRoute_basic,
+			"basicIpv6":                          testAccAWSEc2TransitGatewayRoute_basic_ipv6,
+			"blackhole":                          testAccAWSEc2TransitGatewayRoute_blackhole,
+			"disappears":                         testAccAWSEc2TransitGatewayRoute_disappears,
+			"disappearsTransitGatewayAttachment": testAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment,
+		},
+		"RouteTable": {
+			"basic":                    testAccAWSEc2TransitGatewayRouteTable_basic,
+			"disappears":               testAccAWSEc2TransitGatewayRouteTable_disappears,
+			"disappearsTransitGateway": testAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway,
+			"Tags":                     testAccAWSEc2TransitGatewayRouteTable_Tags,
+		},
+		"RouteTableAssociation": {
+			"basic": testAccAWSEc2TransitGatewayRouteTableAssociation_basic,
+		},
+		"RouteTablePropagation": {
+			"basic": testAccAWSEc2TransitGatewayRouteTablePropagation_basic,
+		},
+		"VpcAttachment": {
+			"basic":                testAccAWSEc2TransitGatewayVpcAttachment_basic,
+			"disappears":           testAccAWSEc2TransitGatewayVpcAttachment_disappears,
+			"ApplianceModeSupport": testAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport,
+			"DnsSupport":           testAccAWSEc2TransitGatewayVpcAttachment_DnsSupport,
+			"Ipv6Support":          testAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support,
+			"SharedTransitGateway": testAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway,
+			"SubnetIds":            testAccAWSEc2TransitGatewayVpcAttachment_SubnetIds,
+			"Tags":                 testAccAWSEc2TransitGatewayVpcAttachment_Tags,
+			"TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
+			"TransitGatewayDefaultRouteTablePropagation":                       testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation,
+		},
+		"VpcAttachmentAccepter": {
+			"basic": testAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic,
+			"Tags":  testAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags,
+			"TransitGatewayDefaultRouteTableAssociationAndPropagation": testAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
+func testAccAWSEc2TransitGateway_basic(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -146,11 +229,11 @@ func TestAccAWSEc2TransitGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_disappears(t *testing.T) {
+func testAccAWSEc2TransitGateway_disappears(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -168,11 +251,11 @@ func TestAccAWSEc2TransitGateway_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_AmazonSideASN(t *testing.T) {
+func testAccAWSEc2TransitGateway_AmazonSideASN(t *testing.T) {
 	var transitGateway1, transitGateway2 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -202,11 +285,11 @@ func TestAccAWSEc2TransitGateway_AmazonSideASN(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
+func testAccAWSEc2TransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
 	var transitGateway1, transitGateway2 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -236,11 +319,11 @@ func TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled(t *testing.T) {
+func testAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -263,11 +346,11 @@ func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisab
 	})
 }
 
-func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation(t *testing.T) {
+func testAccAWSEc2TransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -305,11 +388,11 @@ func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation(t *testing.T) {
+func testAccAWSEc2TransitGateway_DefaultRouteTablePropagation(t *testing.T) {
 	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -347,11 +430,11 @@ func TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_DnsSupport(t *testing.T) {
+func testAccAWSEc2TransitGateway_DnsSupport(t *testing.T) {
 	var transitGateway1, transitGateway2 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -381,11 +464,11 @@ func TestAccAWSEc2TransitGateway_DnsSupport(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_VpnEcmpSupport(t *testing.T) {
+func testAccAWSEc2TransitGateway_VpnEcmpSupport(t *testing.T) {
 	var transitGateway1, transitGateway2 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -415,11 +498,11 @@ func TestAccAWSEc2TransitGateway_VpnEcmpSupport(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_Description(t *testing.T) {
+func testAccAWSEc2TransitGateway_Description(t *testing.T) {
 	var transitGateway1, transitGateway2 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -449,11 +532,11 @@ func TestAccAWSEc2TransitGateway_Description(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGateway_Tags(t *testing.T) {
+func testAccAWSEc2TransitGateway_Tags(t *testing.T) {
 	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -169,6 +169,7 @@ func TestAccAWSEc2TransitGateway_serial(t *testing.T) {
 			"SharedTransitGateway": testAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway,
 			"SubnetIds":            testAccAWSEc2TransitGatewayVpcAttachment_SubnetIds,
 			"Tags":                 testAccAWSEc2TransitGatewayVpcAttachment_Tags,
+			"TransitGatewayDefaultRouteTableAssociation":                       testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation,
 			"TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
 			"TransitGatewayDefaultRouteTablePropagation":                       testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation,
 		},

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGatewayVpcAttachment ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment_accepter.test"
@@ -20,7 +20,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic(t *testing.T) {
 	callerIdentityDatasourceName := "data.aws_caller_identity.creator"
 	rName := fmt.Sprintf("tf-testacc-tgwvpcattach-%s", acctest.RandString(8))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
@@ -57,7 +57,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGatewayVpcAttachment ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment_accepter.test"
@@ -67,7 +67,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
 	callerIdentityDatasourceName := "data.aws_caller_identity.creator"
 	rName := fmt.Sprintf("tf-testacc-tgwvpcattach-%s", acctest.RandString(8))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
@@ -129,7 +129,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGateway ec2.TransitGateway
 	var transitGatewayVpcAttachment ec2.TransitGatewayVpcAttachment
@@ -137,7 +137,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRoute
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-tgwvpcattach-%s", acctest.RandString(8))
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -83,13 +83,13 @@ func testSweepEc2TransitGatewayVpcAttachments(region string) error {
 	return nil
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_basic(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_basic(t *testing.T) {
 	var transitGatewayVpcAttachment1 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	vpcResourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -119,11 +119,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_disappears(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_disappears(t *testing.T) {
 	var transitGatewayVpcAttachment1 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -141,11 +141,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport(t *testing.T) {
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -183,11 +183,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_ApplianceModeSupport(t *testing.T)
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_DnsSupport(t *testing.T) {
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -217,11 +217,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support(t *testing.T) {
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -252,13 +252,13 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway(t *testing.T) {
 	var providers []*schema.Provider
 	var transitGatewayVpcAttachment1 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
@@ -284,11 +284,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway(t *testing.T)
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_SubnetIds(t *testing.T) {
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -326,11 +326,11 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_Tags(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_Tags(t *testing.T) {
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -372,13 +372,13 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_Tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled(t *testing.T) {
 	var transitGateway1 ec2.TransitGateway
 	var transitGatewayVpcAttachment1 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -404,13 +404,13 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAss
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation(t *testing.T) {
 	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,
@@ -454,13 +454,13 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAss
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation(t *testing.T) {
+func testAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation(t *testing.T) {
 	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2TransitGateway(t) },
 		ErrorCheck:   testAccErrorCheck(t, ec2.EndpointsID),
 		Providers:    testAccProviders,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

In nightly CI we get many failures with error messages like

```
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
data_source_aws_ec2_transit_gateway_vpc_attachment_test.go:14: Step 1/1 error: Error running apply: exit status 1
Error: error creating EC2 Transit Gateway: TransitGatewayLimitExceeded: TransitGateway limit exceeded
  status code: 400, request id: 8e9e507a-7ffa-4184-a278-6e17f15df3e7
on terraform_plugin_test.tf line 30, in resource "aws_ec2_transit_gateway" "test":
30: resource "aws_ec2_transit_gateway" "test" {}
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (18.28s)
```

This PR serializes Transit Gateway tests.