### PR TITLE
Add support for importing root CA certs to aws_acmpca_certificate resource

### DIFF
--- a/website/docs/r/acmpca_certificate.html.markdown
+++ b/website/docs/r/acmpca_certificate.html.markdown
@@ -78,4 +78,15 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_acmpca_certificate` can not be imported at this time.
+`aws_acmpca_certificate` can be imported by using the certificate ARN, e.g,
+
+```
+$ terraform import aws_acmpca_certificate.example 	arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
+```
+
+Or for a root CA certificates, the root CA certificate authority's ARN, e.g,
+
+```
+$ terraform import aws_acmpca_certificate.example_root 	arn:aws:acm:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012
+```
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19350

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ $ rg '^func TestAcc' aws/resource_aws_acmpca_certificate_test.go | cut -d ' ' -f 2 | cut -d '(' -f 1 | xargs -I'{}' make testacc TESTARGS="-run={}"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAcmpcaCertificate_RootCertificate -timeout 180m
=== RUN   TestAccAwsAcmpcaCertificate_RootCertificate
=== PAUSE TestAccAwsAcmpcaCertificate_RootCertificate
=== CONT  TestAccAwsAcmpcaCertificate_RootCertificate
--- PASS: TestAccAwsAcmpcaCertificate_RootCertificate (26.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       28.099s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAcmpcaCertificate_SubordinateCertificate -timeout 180m
=== RUN   TestAccAwsAcmpcaCertificate_SubordinateCertificate
=== PAUSE TestAccAwsAcmpcaCertificate_SubordinateCertificate
=== CONT  TestAccAwsAcmpcaCertificate_SubordinateCertificate
--- PASS: TestAccAwsAcmpcaCertificate_SubordinateCertificate (34.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       36.600s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAcmpcaCertificate_EndEntityCertificate -timeout 180m
=== RUN   TestAccAwsAcmpcaCertificate_EndEntityCertificate
=== PAUSE TestAccAwsAcmpcaCertificate_EndEntityCertificate
=== CONT  TestAccAwsAcmpcaCertificate_EndEntityCertificate
--- PASS: TestAccAwsAcmpcaCertificate_EndEntityCertificate (38.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       40.080s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAcmpcaCertificate_Validity_EndDate -timeout 180m
=== RUN   TestAccAwsAcmpcaCertificate_Validity_EndDate
=== PAUSE TestAccAwsAcmpcaCertificate_Validity_EndDate
=== CONT  TestAccAwsAcmpcaCertificate_Validity_EndDate
--- PASS: TestAccAwsAcmpcaCertificate_Validity_EndDate (36.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       38.436s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAcmpcaCertificate_Validity_Absolute -timeout 180m
=== RUN   TestAccAwsAcmpcaCertificate_Validity_Absolute
=== PAUSE TestAccAwsAcmpcaCertificate_Validity_Absolute
=== CONT  TestAccAwsAcmpcaCertificate_Validity_Absolute
--- PASS: TestAccAwsAcmpcaCertificate_Validity_Absolute (32.71s)
PASS
```
