### PR TITLE
Fix AWS EKS node groups example docs

### DIFF
--- a/website/docs/d/eks_node_groups.html.markdown
+++ b/website/docs/d/eks_node_groups.html.markdown
@@ -18,7 +18,7 @@ data "aws_eks_node_groups" "example" {
 }
 
 data "aws_eks_node_group" "example" {
-  for_each = data.aws_eks_node_group_names.example.names
+  for_each = data.aws_eks_node_groups.example.names
 
   cluster_name    = "example"
   node_group_name = each.value


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Small change to fix example of new resource introduced in https://github.com/hashicorp/terraform-provider-aws/pull/13564.  Fixes reference error:

```terraform
╷
│ Error: Reference to undeclared resource
│
│   on .../main.tf line 81, in data "aws_eks_node_group" "example":
│   81:   for_each = data.aws_eks_node_group_names.example.names
│
│ A data resource "aws_eks_node_group_names" "example" has not been declared
│ in module.eks-cluster.
```