### PR TITLE
fix: remove extra kms_key_arn from ttl

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -301,12 +301,6 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
-						"kms_key_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validateArn,
-						},
 					},
 				},
 				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #19344

Based on the AWS documentation for the [update-time-to-live command](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/update-time-to-live.html), it only accepts 2 attributes 
- `Enabled`
- `AttributeName`

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDynamoDbTable_Ttl'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDynamoDbTable_Ttl -timeout 180m
=== RUN   TestAccAWSDynamoDbTable_Ttl_enabled
=== PAUSE TestAccAWSDynamoDbTable_Ttl_enabled
=== RUN   TestAccAWSDynamoDbTable_Ttl_disabled
=== PAUSE TestAccAWSDynamoDbTable_Ttl_disabled
=== CONT  TestAccAWSDynamoDbTable_Ttl_enabled
=== CONT  TestAccAWSDynamoDbTable_Ttl_disabled
--- PASS: TestAccAWSDynamoDbTable_Ttl_enabled (60.80s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_disabled (100.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	100.789s
```

Additional note: Prior to making changes, I ran the full suite of tests using `make testacc TESTARGS='-run=TestAccAWSDynamoDbTable'` but faced issues with the `TestAccAWSDynamoDbTable_BillingMode_GSI_provisionedToPayPerRequest` test case. In the test case, there was no mention of `ttl` so this error is probably due to some other issue and is not related to this PR and the issue that the PR addresses.
