### PR TITLE
Enhancement add Elasticache (Redis) LogDeliveryConfigurations issue #20068

### DIFF
--- a/.changelog/20068.txt
+++ b/.changelog/20068.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_elasticache_cluster: Add `log_delivery_configurations` attribute
+resource/aws_elasticache_replication_group: Add `log_delivery_configurations` attribute
+data_source/aws_elasticache_cluster: Add `log_delivery_configurations` attribute
+data_source/aws_elasticache_replication_group: Add `log_delivery_configurations` attribute
+```

--- a/aws/data_source_aws_elasticache_cluster.go
+++ b/aws/data_source_aws_elasticache_cluster.go
@@ -174,6 +174,7 @@ func dataSourceAwsElastiCacheClusterRead(d *schema.ResourceData, meta interface{
 	d.Set("subnet_group_name", cluster.CacheSubnetGroupName)
 	d.Set("engine", cluster.Engine)
 	d.Set("engine_version", cluster.EngineVersion)
+	d.Set("log_delivery_configurations", flattenAwsElasticacheLogDeliveryConfigurations(cluster.LogDeliveryConfigurations))
 	d.Set("security_group_names", flattenElastiCacheSecurityGroupNames(cluster.CacheSecurityGroups))
 	d.Set("security_group_ids", flattenElastiCacheSecurityGroupIds(cluster.SecurityGroups))
 

--- a/aws/data_source_aws_elasticache_cluster.go
+++ b/aws/data_source_aws_elasticache_cluster.go
@@ -78,7 +78,11 @@ func dataSourceAwsElastiCacheCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"log_delivery_configurations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     getAwsElasticacheLogDeliveryConfigurationsComputedSchema(),
+			},
 			"snapshot_window": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_elasticache_cluster_test.go
+++ b/aws/data_source_aws_elasticache_cluster_test.go
@@ -56,6 +56,29 @@ func TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Clo
 		},
 	})
 }
+
+func TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_elasticache_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSElastiCacheClusterConfigWithDataSource(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
@@ -122,6 +145,73 @@ resource "aws_elasticache_cluster" "test" {
       }
       destination_type = "cloudwatch-logs"
       log_format       = "text"
+      log_type         = "slow-log"
+    }
+  }
+}
+
+data "aws_elasticache_cluster" "test" {
+  cluster_id = aws_elasticache_cluster.test.cluster_id
+}
+`, rName, enableLogDelivery)
+}
+
+func testAccAWSElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName string, enableLogDelivery bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "b" {
+  count         = tobool("%[2]t") ? 1 : 0
+  acl           = "private"
+  force_destroy = true
+}
+resource "aws_iam_role" "r" {
+  count               = tobool("%[2]t") ? 1 : 0
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "firehose.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+resource "aws_kinesis_firehose_delivery_stream" "ds" {
+  count       = tobool("%[2]t") ? 1 : 0
+  name        = "%[1]s"
+  destination = "s3"
+  s3_configuration {
+    role_arn   = aws_iam_role.r[0].arn
+    bucket_arn = aws_s3_bucket.b[0].arn
+  }
+  lifecycle {
+    ignore_changes = [
+      tags["LogDeliveryEnabled"],
+    ]
+  }
+}
+resource "aws_elasticache_cluster" "test" {
+  cluster_id        = "%[1]s"
+  engine            = "redis"
+  node_type         = "cache.t3.micro"
+  num_cache_nodes   = 1
+  port              = 6379
+  apply_immediately = true
+
+  dynamic "log_delivery_configurations" {
+    for_each = tobool("%[2]t") ? [""] : []
+    content {
+      destination_details {
+        kinesis_firehose {
+          delivery_stream = aws_kinesis_firehose_delivery_stream.ds[0].name
+        }
+      }
+      destination_type = "kinesis-firehose"
+      log_format       = "json"
       log_type         = "slow-log"
     }
   }

--- a/aws/data_source_aws_elasticache_cluster_test.go
+++ b/aws/data_source_aws_elasticache_cluster_test.go
@@ -35,6 +35,27 @@ func TestAccAWSDataElasticacheCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_elasticache_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+		},
+	})
+}
 func testAccAWSElastiCacheClusterConfigWithDataSource(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
@@ -49,4 +70,65 @@ data "aws_elasticache_cluster" "test" {
   cluster_id = aws_elasticache_cluster.test.cluster_id
 }
 `, rName)
+}
+
+func testAccAWSElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName string, enableLogDelivery bool) string {
+	return fmt.Sprintf(`
+data "aws_iam_policy_document" "p" {
+  count = tobool("%[2]t") ? 1 : 0
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["${aws_cloudwatch_log_group.lg[0].arn}:log-stream:*"]
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "rp" {
+  count           = tobool("%[2]t") ? 1 : 0
+  policy_document = data.aws_iam_policy_document.p[0].json
+  policy_name     = "%[1]s"
+  depends_on = [
+    aws_cloudwatch_log_group.lg[0]
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "lg" {
+  count             = tobool("%[2]t") ? 1 : 0
+  retention_in_days = 1
+  name              = "%[1]s"
+}
+
+resource "aws_elasticache_cluster" "test" {
+  cluster_id        = "%[1]s"
+  engine            = "redis"
+  node_type         = "cache.t3.micro"
+  num_cache_nodes   = 1
+  port              = 6379
+  apply_immediately = true
+
+  dynamic "log_delivery_configurations" {
+    for_each = tobool("%[2]t") ? [""] : []
+    content {
+      destination_details {
+        cloudwatch_logs {
+          log_group = aws_cloudwatch_log_group.lg[0].name
+        }
+      }
+      destination_type = "cloudwatch-logs"
+      log_format       = "text"
+      log_type         = "slow-log"
+    }
+  }
+}
+
+data "aws_elasticache_cluster" "test" {
+  cluster_id = aws_elasticache_cluster.test.cluster_id
+}
+`, rName, enableLogDelivery)
 }

--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -69,6 +69,11 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"log_delivery_configurations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     getAwsElasticacheLogDeliveryConfigurationsComputedSchema(),
+			},
 			"snapshot_window": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -110,6 +110,8 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		}
 	}
 
+	d.Set("log_delivery_configurations", flattenAwsElasticacheLogDeliveryConfigurations(rg.LogDeliveryConfigurations))
+
 	if rg.MultiAZ != nil {
 		switch strings.ToLower(aws.StringValue(rg.MultiAZ)) {
 		case elasticache.MultiAZStatusEnabled:

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -126,6 +126,29 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryCon
 		},
 	})
 }
+
+func TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsElasticacheReplicationGroupConfig_basic(rName string) string {
 	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
@@ -254,6 +277,108 @@ data "aws_elasticache_replication_group" "test" {
 }
 `, rName, enableLogDelivery, enableClusterMode)
 }
+
+func testAccDataSourceAwsElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName string, enableLogDelivery bool, enableClusterMode bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "b" {
+  count         = tobool("%[2]t") ? 1 : 0
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_iam_role" "r" {
+  count = tobool("%[2]t") ? 1 : 0
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "firehose.amazonaws.com"
+        }
+      },
+    ]
+  })
+  inline_policy {
+    name = "my_inline_s3_policy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "s3:AbortMultipartUpload",
+            "s3:GetBucketLocation",
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:ListBucketMultipartUploads",
+            "s3:PutObject",
+            "s3:PutObjectAcl",
+          ]
+          Effect   = "Allow"
+          Resource = ["${aws_s3_bucket.b[0].arn}", "${aws_s3_bucket.b[0].arn}/*"]
+        },
+      ]
+    })
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "ds" {
+  count       = tobool("%[2]t") ? 1 : 0
+  name        = "%[1]s"
+  destination = "s3"
+  s3_configuration {
+    role_arn   = aws_iam_role.r[0].arn
+    bucket_arn = aws_s3_bucket.b[0].arn
+  }
+  lifecycle {
+    ignore_changes = [
+      tags["LogDeliveryEnabled"],
+    ]
+  }
+}
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = "%[1]s"
+  replication_group_description = "test description"
+  node_type                     = "cache.t3.small"
+  port                          = 6379
+  apply_immediately             = true
+  auto_minor_version_upgrade    = false
+  maintenance_window            = "tue:06:30-tue:07:30"
+  snapshot_window               = "01:00-02:00"
+  parameter_group_name          = tobool("%[3]t") ? "default.redis6.x.cluster.on" : "default.redis6.x"
+  automatic_failover_enabled    = tobool("%[3]t")
+
+  dynamic "cluster_mode" {
+    for_each = tobool("%[3]t") ? [""] : []
+    content {
+      num_node_groups         = 1
+      replicas_per_node_group = 0
+    }
+  }
+
+  dynamic "log_delivery_configurations" {
+    for_each = tobool("%[2]t") ? [""] : []
+    content {
+      destination_details {
+        kinesis_firehose {
+          delivery_stream = aws_kinesis_firehose_delivery_stream.ds[0].name
+        }
+      }
+      destination_type = "kinesis-firehose"
+      log_format       = "json"
+      log_type         = "slow-log"
+    }
+  }
+}
+
+data "aws_elasticache_replication_group" "test" {
+  replication_group_id = aws_elasticache_replication_group.test.replication_group_id
+}
+`, rName, enableLogDelivery, enableClusterMode)
+}
+
 const testAccDataSourceAwsElasticacheReplicationGroupConfig_NonExistent = `
 data "aws_elasticache_replication_group" "test" {
   replication_group_id = "tf-acc-test-nonexistent"

--- a/aws/elasticache_logdeliveryconfigurations.go
+++ b/aws/elasticache_logdeliveryconfigurations.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -133,4 +135,50 @@ func getAwsElasticacheLogDeliveryConfigurationsComputedSchema() *schema.Resource
 		},
 	}
 
+}
+
+func expandAwsElasticacheLogDeliveryConfigurations(d *schema.ResourceData) []*elasticache.LogDeliveryConfigurationRequest {
+	logDeliveryConfigurationRequest := elasticache.LogDeliveryConfigurationRequest{}
+
+	if _, ok := d.GetOk("log_delivery_configurations"); !ok { // if d.HasChange() removed the block, send a `delete` request to the API.
+		logDeliveryConfigurationRequest.SetEnabled(false)
+		logDeliveryConfigurationRequest.SetLogType(elasticache.LogTypeSlowLog)
+		logDeliveryConfigurations := []*elasticache.LogDeliveryConfigurationRequest{
+			&logDeliveryConfigurationRequest,
+		}
+		return logDeliveryConfigurations
+	}
+
+	if _, ok := d.GetOk("log_delivery_configurations.0.destination_details"); ok {
+		logDeliveryConfigurationRequest.DestinationDetails = expandAwsElasticacheDestinationDetails(d)
+	}
+	if v, ok := d.GetOk("log_delivery_configurations.0.destination_type"); ok {
+		logDeliveryConfigurationRequest.DestinationType = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("log_delivery_configurations.0.log_format"); ok {
+		logDeliveryConfigurationRequest.LogFormat = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("log_delivery_configurations.0.log_type"); ok {
+		logDeliveryConfigurationRequest.LogType = aws.String(v.(string))
+	}
+
+	logDeliveryConfigurations := []*elasticache.LogDeliveryConfigurationRequest{
+		&logDeliveryConfigurationRequest,
+	}
+	return logDeliveryConfigurations
+}
+
+func expandAwsElasticacheDestinationDetails(d *schema.ResourceData) *elasticache.DestinationDetails {
+	destinationDetails := elasticache.DestinationDetails{}
+	if v, ok := d.GetOk("log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"); ok {
+		destinationDetails.CloudWatchLogsDetails = &elasticache.CloudWatchLogsDestinationDetails{
+			LogGroup: aws.String(v.(string)),
+		}
+	}
+	if v, ok := d.GetOk("log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"); ok {
+		destinationDetails.KinesisFirehoseDetails = &elasticache.KinesisFirehoseDestinationDetails{
+			DeliveryStream: aws.String(v.(string)),
+		}
+	}
+	return &destinationDetails
 }

--- a/aws/elasticache_logdeliveryconfigurations.go
+++ b/aws/elasticache_logdeliveryconfigurations.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/aws/elasticache_logdeliveryconfigurations.go
+++ b/aws/elasticache_logdeliveryconfigurations.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func getAwsElasticacheLogDeliveryConfigurationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"destination_details": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_logs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"log_group": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							ConflictsWith: []string{"log_delivery_configurations.0.destination_details.0.kinesis_firehose"},
+						},
+						"kinesis_firehose": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delivery_stream": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							ConflictsWith: []string{"log_delivery_configurations.0.destination_details.0.cloudwatch_logs"},
+						},
+					},
+				},
+			},
+			"destination_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(elasticache.DestinationType_Values(), false),
+			},
+			"log_format": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(elasticache.LogFormat_Values(), false),
+			},
+			"log_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      elasticache.LogTypeSlowLog,
+				ValidateFunc: validation.StringInSlice(elasticache.LogType_Values(), false),
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+
+}

--- a/aws/elasticache_logdeliveryconfigurations.go
+++ b/aws/elasticache_logdeliveryconfigurations.go
@@ -182,3 +182,49 @@ func expandAwsElasticacheDestinationDetails(d *schema.ResourceData) *elasticache
 	}
 	return &destinationDetails
 }
+
+func flattenAwsElasticacheLogDeliveryConfigurations(logDeliveryConfiguration []*elasticache.LogDeliveryConfiguration) []map[string]interface{} {
+	if len(logDeliveryConfiguration) == 0 || logDeliveryConfiguration[0] == nil {
+		return nil
+	}
+	config := make(map[string]interface{})
+	config["destination_details"] = flattenAwsElasticacheDestinationDetails(logDeliveryConfiguration[0].DestinationDetails)
+	config["destination_type"] = aws.StringValue(logDeliveryConfiguration[0].DestinationType)
+	config["log_format"] = aws.StringValue(logDeliveryConfiguration[0].LogFormat)
+	config["log_type"] = aws.StringValue(logDeliveryConfiguration[0].LogType)
+	config["message"] = aws.StringValue(logDeliveryConfiguration[0].Message)
+	config["status"] = aws.StringValue(logDeliveryConfiguration[0].Status)
+	result := []map[string]interface{}{config}
+	return result
+}
+
+func flattenAwsElasticacheDestinationDetails(destinationDetails *elasticache.DestinationDetails) []map[string]interface{} {
+	if destinationDetails == nil {
+		return nil
+	}
+	config := make(map[string]interface{})
+	config["cloudwatch_logs"] = flattenAwsElasticacheCloudWatchLogsDestinationDetails(destinationDetails.CloudWatchLogsDetails)
+	config["kinesis_firehose"] = flattenAwsElasticacheKinesisFirehoseDestinationDetails(destinationDetails.KinesisFirehoseDetails)
+	result := []map[string]interface{}{config}
+	return result
+}
+
+func flattenAwsElasticacheCloudWatchLogsDestinationDetails(cloudWatchLogsDestinationDetails *elasticache.CloudWatchLogsDestinationDetails) []map[string]interface{} {
+	if cloudWatchLogsDestinationDetails == nil {
+		return nil
+	}
+	config := make(map[string]interface{})
+	config["log_group"] = aws.StringValue(cloudWatchLogsDestinationDetails.LogGroup)
+	result := []map[string]interface{}{config}
+	return result
+}
+
+func flattenAwsElasticacheKinesisFirehoseDestinationDetails(kinesisFirehoseDestinationDetails *elasticache.KinesisFirehoseDestinationDetails) []map[string]interface{} {
+	if kinesisFirehoseDestinationDetails == nil {
+		return nil
+	}
+	config := make(map[string]interface{})
+	config["delivery_stream"] = aws.StringValue(kinesisFirehoseDestinationDetails.DeliveryStream)
+	result := []map[string]interface{}{config}
+	return result
+}

--- a/aws/elasticache_logdeliveryconfigurations.go
+++ b/aws/elasticache_logdeliveryconfigurations.go
@@ -74,3 +74,63 @@ func getAwsElasticacheLogDeliveryConfigurationsSchema() *schema.Resource {
 	}
 
 }
+
+func getAwsElasticacheLogDeliveryConfigurationsComputedSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"destination_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_logs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"log_group": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"kinesis_firehose": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delivery_stream": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"destination_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+
+}

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -314,6 +314,14 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		req.EngineVersion = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("log_delivery_configurations"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		validateError := validateAwsElasticacheLogDeliveryConfigurations(d)
+		if validateError != nil {
+			return validateError
+		}
+		req.LogDeliveryConfigurations = expandAwsElasticacheLogDeliveryConfigurations(d)
+	}
+
 	if v, ok := d.GetOk("port"); ok {
 		req.Port = aws.Int64(int64(v.(int)))
 	}

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -130,6 +130,12 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"log_delivery_configurations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     getAwsElasticacheLogDeliveryConfigurationsSchema(),
+			},
 			"maintenance_window": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -533,6 +533,15 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		requestUpdate = true
 	}
 
+	if d.HasChange("log_delivery_configurations") {
+		validateError := validateAwsElasticacheLogDeliveryConfigurations(d)
+		if validateError != nil {
+			return validateError
+		}
+		req.LogDeliveryConfigurations = expandAwsElasticacheLogDeliveryConfigurations(d)
+		requestUpdate = true
+	}
+
 	if d.HasChange("maintenance_window") {
 		req.PreferredMaintenanceWindow = aws.String(d.Get("maintenance_window").(string))
 		requestUpdate = true

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -408,7 +408,7 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 	if err := elasticacheSetResourceDataFromCacheCluster(d, c); err != nil {
 		return err
 	}
-
+	d.Set("log_delivery_configurations", flattenAwsElasticacheLogDeliveryConfigurations(c.LogDeliveryConfigurations))
 	d.Set("snapshot_window", c.SnapshotWindow)
 	d.Set("snapshot_retention_limit", c.SnapshotRetentionLimit)
 

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -855,6 +855,72 @@ func TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwa
 		},
 	})
 }
+
+func TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable(t *testing.T) {
+	var ec elasticache.CacheCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
 func testAccCheckAWSElasticacheClusterAttributes(v *elasticache.CacheCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if v.NotificationConfiguration == nil {

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -790,6 +790,71 @@ func TestAccAWSElasticacheCluster_Redis_FinalSnapshot(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update(t *testing.T) {
+	var ec elasticache.CacheCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
 func testAccCheckAWSElasticacheClusterAttributes(v *elasticache.CacheCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if v.NotificationConfiguration == nil {

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -921,6 +921,73 @@ func TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwa
 		},
 	})
 }
+
+func TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable(t *testing.T) {
+	var ec elasticache.CacheCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
 func testAccCheckAWSElasticacheClusterAttributes(v *elasticache.CacheCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if v.NotificationConfiguration == nil {

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -1422,3 +1422,123 @@ resource "aws_elasticache_cluster" "test" {
 }
 `, rName)
 }
+
+func testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName string, enableLogDelivery bool) string {
+	return fmt.Sprintf(`
+data "aws_iam_policy_document" "p" {
+  count = tobool("%[2]t") ? 1 : 0
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["${aws_cloudwatch_log_group.lg[0].arn}:log-stream:*"]
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "rp" {
+  count           = tobool("%[2]t") ? 1 : 0
+  policy_document = data.aws_iam_policy_document.p[0].json
+  policy_name     = "%[1]s"
+  depends_on = [
+    aws_cloudwatch_log_group.lg[0]
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "lg" {
+  count             = tobool("%[2]t") ? 1 : 0
+  retention_in_days = 1
+  name              = "%[1]s"
+}
+
+resource "aws_elasticache_cluster" "test" {
+  cluster_id        = "%[1]s"
+  engine            = "redis"
+  node_type         = "cache.t3.micro"
+  num_cache_nodes   = 1
+  port              = 6379
+  apply_immediately = true
+
+  dynamic "log_delivery_configurations" {
+    for_each = tobool("%[2]t") ? [""] : []
+    content {
+      destination_details {
+        cloudwatch_logs {
+          log_group = aws_cloudwatch_log_group.lg[0].name
+        }
+      }
+      destination_type = "cloudwatch-logs"
+      log_format       = "text"
+      log_type         = "slow-log"
+    }
+  }
+}
+`, rName, enableLogDelivery)
+}
+
+func testAccAWSElasticacheClusterConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName string, enableLogDelivery bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "b" {
+  count         = tobool("%[2]t") ? 1 : 0
+  acl           = "private"
+  force_destroy = true
+}
+resource "aws_iam_role" "r" {
+  count               = tobool("%[2]t") ? 1 : 0
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "firehose.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+resource "aws_kinesis_firehose_delivery_stream" "ds" {
+  count       = tobool("%[2]t") ? 1 : 0
+  name        = "%[1]s"
+  destination = "s3"
+  s3_configuration {
+    role_arn   = aws_iam_role.r[0].arn
+    bucket_arn = aws_s3_bucket.b[0].arn
+  }
+  lifecycle {
+    ignore_changes = [
+      tags["LogDeliveryEnabled"],
+    ]
+  }
+}
+resource "aws_elasticache_cluster" "test" {
+  cluster_id        = "%[1]s"
+  engine            = "redis"
+  node_type         = "cache.t3.micro"
+  num_cache_nodes   = 1
+  port              = 6379
+  apply_immediately = true
+
+  dynamic "log_delivery_configurations" {
+    for_each = tobool("%[2]t") ? [""] : []
+    content {
+      destination_details {
+        kinesis_firehose {
+          delivery_stream = aws_kinesis_firehose_delivery_stream.ds[0].name
+        }
+      }
+      destination_type = "kinesis-firehose"
+      log_format       = "json"
+      log_type         = "slow-log"
+    }
+  }
+}
+`, rName, enableLogDelivery)
+}

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -1685,9 +1685,9 @@ resource "aws_s3_bucket" "b" {
   acl           = "private"
   force_destroy = true
 }
+
 resource "aws_iam_role" "r" {
-  count               = tobool("%[2]t") ? 1 : 0
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  count = tobool("%[2]t") ? 1 : 0
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -1701,7 +1701,29 @@ resource "aws_iam_role" "r" {
       },
     ]
   })
+  inline_policy {
+    name = "my_inline_s3_policy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "s3:AbortMultipartUpload",
+            "s3:GetBucketLocation",
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:ListBucketMultipartUploads",
+            "s3:PutObject",
+            "s3:PutObjectAcl",
+          ]
+          Effect   = "Allow"
+          Resource = ["${aws_s3_bucket.b[0].arn}", "${aws_s3_bucket.b[0].arn}/*"]
+        },
+      ]
+    })
+  }
 }
+
 resource "aws_kinesis_firehose_delivery_stream" "ds" {
   count       = tobool("%[2]t") ? 1 : 0
   name        = "%[1]s"

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -393,6 +393,14 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		params.KmsKeyId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("log_delivery_configurations"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		validateError := validateAwsElasticacheLogDeliveryConfigurations(d)
+		if validateError != nil {
+			return validateError
+		}
+		params.LogDeliveryConfigurations = expandAwsElasticacheLogDeliveryConfigurations(d)
+	}
+
 	if v, ok := d.GetOk("snapshot_retention_limit"); ok {
 		params.SnapshotRetentionLimit = aws.Int64(int64(v.(int)))
 	}

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -632,6 +632,15 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 		requestUpdate = true
 	}
 
+	if d.HasChange("log_delivery_configurations") {
+		validateError := validateAwsElasticacheLogDeliveryConfigurations(d)
+		if validateError != nil {
+			return validateError
+		}
+		params.LogDeliveryConfigurations = expandAwsElasticacheLogDeliveryConfigurations(d)
+		requestUpdate = true
+	}
+
 	if d.HasChange("auto_minor_version_upgrade") {
 		params.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
 		requestUpdate = true

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -514,6 +514,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 	}
 
 	d.Set("kms_key_id", rgp.KmsKeyId)
+	d.Set("log_delivery_configurations", flattenAwsElasticacheLogDeliveryConfigurations(rgp.LogDeliveryConfigurations))
 	d.Set("replication_group_description", rgp.Description)
 	d.Set("number_cache_clusters", len(rgp.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringSet(rgp.MemberClusters)); err != nil {

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -139,6 +139,12 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 					"snapshot_name",
 				},
 			},
+			"log_delivery_configurations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     getAwsElasticacheLogDeliveryConfigurationsSchema(),
+			},
 			"maintenance_window": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -2029,6 +2029,82 @@ func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryC
 		},
 	})
 }
+
+func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_KinesisFirehose_EnableDisable(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
 // Test for out-of-band deletion
 // Naming to allow grouping all TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_* tests
 func TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_disappears(t *testing.T) { // nosemgrep: acceptance-test-naming-parent-disappears

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1954,6 +1954,81 @@ func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryC
 		},
 	})
 }
+
+func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_EnableDisable(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
 // Test for out-of-band deletion
 // Naming to allow grouping all TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_* tests
 func TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_disappears(t *testing.T) { // nosemgrep: acceptance-test-naming-parent-disappears

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1678,6 +1678,74 @@ func TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_ClusterMode_
 	})
 }
 
+func TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
 // Test for out-of-band deletion
 // Naming to allow grouping all TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_* tests
 func TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_disappears(t *testing.T) { // nosemgrep: acceptance-test-naming-parent-disappears

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1746,6 +1746,76 @@ func TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfiguration
 		},
 	})
 }
+
+func TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
 func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update(t *testing.T) {
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1816,6 +1816,70 @@ func TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfiguration
 		},
 	})
 }
+
+func TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.destination_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_format"),
+					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configurations.0.log_type"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update(t *testing.T) {
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1746,6 +1746,80 @@ func TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfiguration
 		},
 	})
 }
+func TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, elasticache.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.kinesis_firehose.0.delivery_stream", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "kinesis-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Engine_Redis_LogDeliveryConfigurations_Cloudwatch(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_details.0.cloudwatch_logs.0.log_group", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.destination_type", "cloudwatch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_format", "text"),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configurations.0.log_type", "slow-log"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
 // Test for out-of-band deletion
 // Naming to allow grouping all TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_* tests
 func TestAccAWSElasticacheReplicationGroup_GlobalReplicationGroupId_disappears(t *testing.T) { // nosemgrep: acceptance-test-naming-parent-disappears

--- a/website/docs/d/elasticache_cluster.html.markdown
+++ b/website/docs/d/elasticache_cluster.html.markdown
@@ -33,6 +33,7 @@ In addition to all arguments above, the following attributes are exported:
 * `num_cache_nodes` – The number of cache nodes that the cache cluster has.
 * `engine` – Name of the cache engine.
 * `engine_version` – Version number of the cache engine.
+* `log_delivery_configurations` - Redis [SLOWLOG](https://redis.io/commands/slowlog) delivery settings.
 * `subnet_group_name` – Name of the subnet group associated to the cache cluster.
 * `security_group_names` – List of security group names associated with this cache cluster.
 * `security_group_ids` – List VPC security groups associated with the cache cluster.

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -32,6 +32,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) of the created ElastiCache Replication Group.
 * `auth_token_enabled` - Specifies whether an AuthToken (password) is enabled.
 * `automatic_failover_enabled` - A flag whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails.
+* `log_delivery_configurations` - Redis [SLOWLOG](https://redis.io/commands/slowlog) delivery settings.
 * `node_type` – The cluster node type.
 * `number_cache_clusters` – The number of cache clusters that the replication group has.
 * `member_clusters` - The identifiers of all the nodes that are part of this replication group.

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -114,7 +114,9 @@ resource "aws_elasticache_cluster" "test" {
   }
 }
 ```
+
 ### Redis SLOWLOG configuration with Kinesis Data Firehose delivery stream as destination
+
 ```terraform
 resource "aws_s3_bucket" "b" {
   acl           = "private"
@@ -243,10 +245,12 @@ The `log_delivery_configurations` block allows the streaming of Redis [SLOWLOG](
 The `destination_details` block contains the target delivery stream or log group attribute. Only one of `kinesis_firehose` or `cloudwatch_logs` can be specified at a time.
 
 The `kinesis_firehose` block supports the following:
-  * `delivery_stream` - The name of an existing Kinesis Firehose delivery stream.
+
+* `delivery_stream` - The name of an existing Kinesis Firehose delivery stream.
 
 The `cloudwatch_logs` block supports the following:
-  * `log_group` - The name of an existing CloudWatch Logs log group.
+
+* `log_group` - The name of an existing CloudWatch Logs log group.
 
 ## Attributes Reference
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -136,6 +136,7 @@ resource "aws_elasticache_replication_group" "primary" {
   number_cache_clusters = 1
 }
 ```
+
 ### Redis SLOWLOG configuration with CloudWatch Logs log group as destination
 
 ```terraform
@@ -187,6 +188,7 @@ resource "aws_elasticache_replication_group" "test" {
 ```
 
 ### Redis SLOWLOG configuration with Kinesis Data Firehose delivery stream as destination
+
 ```terraform
 resource "aws_s3_bucket" "b" {
   acl           = "private"
@@ -325,9 +327,11 @@ The `log_delivery_configurations` block allows the streaming of Redis [SLOWLOG](
 The `destination_details` block contains the target delivery stream or log group attribute. Only one of `kinesis_firehose` or `cloudwatch_logs` can be specified at a time.
 
 The `kinesis_firehose` block supports the following:
+
 * `delivery_stream` - The name of an existing Kinesis Firehose delivery stream.
 
 The `cloudwatch_logs` block supports the following:
+
 * `log_group` - The name of an existing CloudWatch Logs log group.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
This is a somewhat long PR (each commit is isolated tho), but the majority of the logic is within `elasticache_logdeliveryconfigurations.go`
`aws_elasticache_cluster`, `aws_elasticache_replication_group` resources along their `data` counterparts are using the same implementation, so it seemed reasonable for me to create a file to encapsulate these changes, let me know if there's a better location or approach for this.

+14 tests, covers enable/disable and updates in different scenarios.

Website, examples and docs added as-well.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #20068

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS="-run=TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_" && \
make testacc TESTARGS="-run=TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_" && \
make testacc TESTARGS="-run=TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_" && \
make testacc TESTARGS="-run=TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_" && \
make testacc TESTARGS="-run=TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_ -timeout 180m
=== RUN   TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch
=== PAUSE TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch
=== RUN   TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose
=== PAUSE TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose
=== CONT  TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch
=== CONT  TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose
--- PASS: TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch (632.17s)
--- PASS: TestAccAWSDataElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose (729.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       729.370s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ -timeout 180m
=== RUN   TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_CloudWatch
=== PAUSE TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_CloudWatch
=== RUN   TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose
=== PAUSE TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose
=== CONT  TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_CloudWatch
=== CONT  TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_CloudWatch (669.38s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose (683.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       683.109s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ -timeout 180m
=== RUN   TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== PAUSE TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== RUN   TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable
=== PAUSE TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable
=== RUN   TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== PAUSE TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== CONT  TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== CONT  TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== CONT  TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable
--- PASS: TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable (782.05s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable (926.78s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update (927.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       927.296s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_ -timeout 180m
=== RUN   TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== PAUSE TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== RUN   TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_EnableDisable
=== PAUSE TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_EnableDisable
=== RUN   TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== PAUSE TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== CONT  TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== CONT  TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== CONT  TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_EnableDisable
--- PASS: TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_EnableDisable (789.85s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_KinesisFirehose_EnableDisable (854.05s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Engine_Redis_ClusterMode_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update (1007.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1007.739s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_ -timeout 180m
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== PAUSE TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable
=== PAUSE TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== PAUSE TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== CONT  TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update
=== CONT  TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable
=== CONT  TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_EnableDisable (755.09s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_KinesisFirehose_EnableDisable (894.02s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_LogDeliveryConfigurations_Cloudwatch_KinesisFirehose_Update (900.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       900.317s

...
```
