### PR TITLE
r/devicefarm_device_pool - new resource + use finder for devicefarm project

### DIFF
--- a/.changelog/21025.txt
+++ b/.changelog/21025.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_devicefarm_device_pool
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -987,7 +987,8 @@ func Provider() *schema.Provider {
 			"aws_dax_parameter_group": dax.ResourceParameterGroup(),
 			"aws_dax_subnet_group":    dax.ResourceSubnetGroup(),
 
-			"aws_devicefarm_project": devicefarm.ResourceProject(),
+			"aws_devicefarm_project":     devicefarm.ResourceProject(),
+			"aws_devicefarm_device_pool": devicefarm.ResourceDevicePool(),
 
 			"aws_detective_graph": detective.ResourceGraph(),
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -987,8 +987,8 @@ func Provider() *schema.Provider {
 			"aws_dax_parameter_group": dax.ResourceParameterGroup(),
 			"aws_dax_subnet_group":    dax.ResourceSubnetGroup(),
 
-			"aws_devicefarm_project":     devicefarm.ResourceProject(),
 			"aws_devicefarm_device_pool": devicefarm.ResourceDevicePool(),
+			"aws_devicefarm_project":     devicefarm.ResourceProject(),
 
 			"aws_detective_graph": detective.ResourceGraph(),
 

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -232,10 +232,12 @@ func resourceDevicePoolDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting DeviceFarm DevicePool: %s", d.Id())
 	_, err := conn.DeleteDevicePool(input)
+
+	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, devicefarm.ErrCodeNotFoundException, "") {
-			return nil
-		}
 		return fmt.Errorf("Error deleting DeviceFarm DevicePool: %w", err)
 	}
 

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -1,0 +1,317 @@
+package devicefarm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceDevicePool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDevicePoolCreate,
+		Read:   resourceDevicePoolRead,
+		Update: resourceDevicePoolUpdate,
+		Delete: resourceDevicePoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 16384),
+			},
+			"max_devices": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"project_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"rule": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"attribute": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(devicefarm.DeviceAttribute_Values(), false),
+						},
+						"operator": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(devicefarm.RuleOperator_Values(), false),
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceDevicePoolCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	name := d.Get("name").(string)
+	input := &devicefarm.CreateDevicePoolInput{
+		Name:       aws.String(name),
+		ProjectArn: aws.String(d.Get("project_arn").(string)),
+		Rules:      expandAwsDevicefarmDevicePoolRules(d.Get("rule").(*schema.Set)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_devices"); ok {
+		input.MaxDevices = aws.Int64(int64(v.(int)))
+	}
+
+	log.Printf("[DEBUG] Creating DeviceFarm DevicePool: %s", name)
+	out, err := conn.CreateDevicePool(input)
+	if err != nil {
+		return fmt.Errorf("Error creating DeviceFarm DevicePool: %w", err)
+	}
+
+	arn := aws.StringValue(out.DevicePool.Arn)
+	log.Printf("[DEBUG] Successsfully Created DeviceFarm DevicePool: %s", arn)
+	d.SetId(arn)
+
+	if len(tags) > 0 {
+		if err := UpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error updating DeviceFarm DevicePool (%s) tags: %w", arn, err)
+		}
+	}
+
+	return resourceDevicePoolRead(d, meta)
+}
+
+func resourceDevicePoolRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	devicePool, err := FindDevicepoolByArn(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DeviceFarm DevicePool (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading DeviceFarm DevicePool (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(devicePool.Arn)
+	d.Set("name", devicePool.Name)
+	d.Set("arn", arn)
+	d.Set("description", devicePool.Description)
+	d.Set("max_devices", devicePool.MaxDevices)
+
+	projectArn, err := decodeDevicefarmProjectArn(arn, meta)
+	if err != nil {
+		return fmt.Errorf("error decoding project_arn (%s): %w", arn, err)
+	}
+
+	d.Set("project_arn", projectArn)
+
+	if err := d.Set("rule", flattenAwsDevicefarmDevicePoolRules(devicePool.Rules)); err != nil {
+		return fmt.Errorf("error setting rule: %w", err)
+	}
+
+	tags, err := ListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for DeviceFarm DevicePool (%s): %w", arn, err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceDevicePoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &devicefarm.UpdateDevicePoolInput{
+			Arn: aws.String(d.Id()),
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("description") {
+			input.Description = aws.String(d.Get("description").(string))
+		}
+
+		if d.HasChange("rule") {
+			input.Rules = expandAwsDevicefarmDevicePoolRules(d.Get("rule").(*schema.Set))
+		}
+
+		if d.HasChange("max_devices") {
+			if v, ok := d.GetOk("max_devices"); ok {
+				input.MaxDevices = aws.Int64(int64(v.(int)))
+			} else {
+				input.ClearMaxDevices = aws.Bool(true)
+			}
+		}
+
+		log.Printf("[DEBUG] Updating DeviceFarm DevicePool: %s", d.Id())
+		_, err := conn.UpdateDevicePool(input)
+		if err != nil {
+			return fmt.Errorf("Error Updating DeviceFarm DevicePool: %w", err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating DeviceFarm DevicePool (%s) tags: %w", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceDevicePoolRead(d, meta)
+}
+
+func resourceDevicePoolDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+
+	input := &devicefarm.DeleteDevicePoolInput{
+		Arn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DeviceFarm DevicePool: %s", d.Id())
+	_, err := conn.DeleteDevicePool(input)
+	if err != nil {
+		if tfawserr.ErrMessageContains(err, devicefarm.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting DeviceFarm DevicePool: %w", err)
+	}
+
+	return nil
+}
+
+func expandAwsDevicefarmDevicePoolRules(s *schema.Set) []*devicefarm.Rule {
+	rules := make([]*devicefarm.Rule, 0)
+
+	for _, r := range s.List() {
+		rule := &devicefarm.Rule{}
+		tfMap := r.(map[string]interface{})
+
+		if v, ok := tfMap["attribute"].(string); ok && v != "" {
+			rule.Attribute = aws.String(v)
+		}
+
+		if v, ok := tfMap["operator"].(string); ok && v != "" {
+			rule.Operator = aws.String(v)
+		}
+
+		if v, ok := tfMap["value"].(string); ok && v != "" {
+			rule.Value = aws.String(v)
+		}
+
+		rules = append(rules, rule)
+	}
+	return rules
+}
+
+func flattenAwsDevicefarmDevicePoolRules(list []*devicefarm.Rule) []map[string]interface{} {
+	if len(list) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, setting := range list {
+		l := map[string]interface{}{}
+
+		if setting.Attribute != nil {
+			l["attribute"] = aws.StringValue(setting.Attribute)
+		}
+
+		if setting.Operator != nil {
+			l["operator"] = aws.StringValue(setting.Operator)
+		}
+
+		if setting.Value != nil {
+			l["value"] = aws.StringValue(setting.Value)
+		}
+
+		result = append(result, l)
+	}
+	return result
+}
+
+func decodeDevicefarmProjectArn(id string, meta interface{}) (string, error) {
+	poolArn, err := arn.Parse(id)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing '%s': %w", id, err)
+	}
+
+	poolArnResouce := poolArn.Resource
+	parts := strings.Split(strings.TrimPrefix(poolArnResouce, "devicepool:"), "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("Unexpected format of ID (%q), expected project-id/pool-id", poolArnResouce)
+	}
+
+	projectId := parts[0]
+	projectArn := arn.ARN{
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Partition: meta.(*conns.AWSClient).Partition,
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("project:%s", projectId),
+		Service:   devicefarm.ServiceName,
+	}.String()
+
+	return projectArn, nil
+}

--- a/internal/service/devicefarm/device_pool_test.go
+++ b/internal/service/devicefarm/device_pool_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccAWSDeviceFarmDevicePool_basic(t *testing.T) {
+func TestAccDeviceFarmDevicePool_basic(t *testing.T) {
 	var pool devicefarm.DevicePool
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdated := sdkacctest.RandomWithPrefix("tf-acc-test-updated")
@@ -62,7 +62,7 @@ func TestAccAWSDeviceFarmDevicePool_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDeviceFarmDevicePool_tags(t *testing.T) {
+func TestAccDeviceFarmDevicePool_tags(t *testing.T) {
 	var pool devicefarm.DevicePool
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_devicefarm_device_pool.test"
@@ -113,7 +113,7 @@ func TestAccAWSDeviceFarmDevicePool_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSDeviceFarmDevicePool_disappears(t *testing.T) {
+func TestAccDeviceFarmDevicePool_disappears(t *testing.T) {
 	var pool devicefarm.DevicePool
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_devicefarm_device_pool.test"
@@ -143,7 +143,7 @@ func TestAccAWSDeviceFarmDevicePool_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSDeviceFarmDevicePool_disappears_project(t *testing.T) {
+func TestAccDeviceFarmDevicePool_disappears_project(t *testing.T) {
 	var pool devicefarm.DevicePool
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_devicefarm_device_pool.test"

--- a/internal/service/devicefarm/device_pool_test.go
+++ b/internal/service/devicefarm/device_pool_test.go
@@ -1,0 +1,273 @@
+package devicefarm_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdevicefarm "github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccAWSDeviceFarmDevicePool_basic(t *testing.T) {
+	var pool devicefarm.DevicePool
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix("tf-acc-test-updated")
+	resourceName := "aws_devicefarm_device_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmDevicePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmDevicePoolConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "project_arn", "aws_devicefarm_project.test", "arn"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`devicepool:.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmDevicePoolConfig(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`devicepool:.+`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDeviceFarmDevicePool_tags(t *testing.T) {
+	var pool devicefarm.DevicePool
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_device_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmDevicePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmDevicePoolConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmDevicePoolConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDeviceFarmDevicePoolConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDeviceFarmDevicePool_disappears(t *testing.T) {
+	var pool devicefarm.DevicePool
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_device_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmDevicePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmDevicePoolConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceDevicePool(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceDevicePool(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDeviceFarmDevicePool_disappears_project(t *testing.T) {
+	var pool devicefarm.DevicePool
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_device_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmDevicePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmDevicePoolConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmDevicePoolExists(resourceName, &pool),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceProject(), "aws_devicefarm_project.test"),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceDevicePool(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDeviceFarmDevicePoolExists(n string, v *devicefarm.DevicePool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
+		resp, err := tfdevicefarm.FindDevicepoolByArn(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if resp == nil {
+			return fmt.Errorf("DeviceFarm Device Pool not found")
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckDeviceFarmDevicePoolDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_devicefarm_device_pool" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := tfdevicefarm.FindDevicepoolByArn(conn, rs.Primary.ID)
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("DeviceFarm Device Pool %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccDeviceFarmDevicePoolConfig(rName string) string {
+	return testAccDeviceFarmProjectConfig(rName) + fmt.Sprintf(`
+resource "aws_devicefarm_device_pool" "test" {
+  name        = %[1]q
+  project_arn = aws_devicefarm_project.test.arn
+  rule {
+    attribute = "OS_VERSION"
+    operator  = "EQUALS"
+    value     = "\"AVAILABLE\""
+  }
+}
+`, rName)
+}
+
+func testAccDeviceFarmDevicePoolConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccDeviceFarmProjectConfig(rName) + fmt.Sprintf(`
+resource "aws_devicefarm_device_pool" "test" {
+  name        = %[1]q
+  project_arn = aws_devicefarm_project.test.arn
+  rule {
+    attribute = "AVAILABILITY"
+    operator  = "EQUALS"
+    value     = "\"AVAILABLE\""
+  }
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccDeviceFarmDevicePoolConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccDeviceFarmProjectConfig(rName) + fmt.Sprintf(`
+resource "aws_devicefarm_device_pool" "test" {
+  name        = %[1]q
+  project_arn = aws_devicefarm_project.test.arn
+  rule {
+    attribute = "AVAILABILITY"
+    operator  = "EQUALS"
+    value     = "\"AVAILABLE\""
+  }
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/devicefarm/find.go
+++ b/internal/service/devicefarm/find.go
@@ -1,0 +1,59 @@
+package devicefarm
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func FindDevicepoolByArn(conn *devicefarm.DeviceFarm, arn string) (*devicefarm.DevicePool, error) {
+
+	input := &devicefarm.GetDevicePoolInput{
+		Arn: aws.String(arn),
+	}
+	output, err := conn.GetDevicePool(input)
+
+	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.DevicePool == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.DevicePool, nil
+}
+
+func FindProjectByArn(conn *devicefarm.DeviceFarm, arn string) (*devicefarm.Project, error) {
+
+	input := &devicefarm.GetProjectInput{
+		Arn: aws.String(arn),
+	}
+	output, err := conn.GetProject(input)
+
+	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Project == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Project, nil
+}

--- a/internal/service/devicefarm/project.go
+++ b/internal/service/devicefarm/project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -84,22 +85,18 @@ func resourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	input := &devicefarm.GetProjectInput{
-		Arn: aws.String(d.Id()),
+	project, err := FindProjectByArn(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DeviceFarm Project (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	log.Printf("[DEBUG] Reading DeviceFarm Project: %s", d.Id())
-	out, err := conn.GetProject(input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, devicefarm.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] DeviceFarm Project (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error reading DeviceFarm Project: %w", err)
+		return fmt.Errorf("error reading DeviceFarm Project (%s): %w", d.Id(), err)
 	}
 
-	project := out.Project
 	arn := aws.StringValue(project.Arn)
 	d.Set("name", project.Name)
 	d.Set("arn", arn)

--- a/internal/service/devicefarm/project_test.go
+++ b/internal/service/devicefarm/project_test.go
@@ -5,16 +5,15 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfdevicefarm "github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccDeviceFarmProject_basic(t *testing.T) {
@@ -176,6 +175,7 @@ func TestAccDeviceFarmProject_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFarmProjectExists(resourceName, &proj),
 					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceProject(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceProject(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -195,16 +195,15 @@ func testAccCheckDeviceFarmProjectExists(n string, v *devicefarm.Project) resour
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
-		resp, err := conn.GetProject(
-			&devicefarm.GetProjectInput{Arn: aws.String(rs.Primary.ID)})
+		resp, err := tfdevicefarm.FindProjectByArn(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		if resp.Project == nil {
-			return fmt.Errorf("DeviceFarmProject not found")
+		if resp == nil {
+			return fmt.Errorf("DeviceFarm Project not found")
 		}
 
-		*v = *resp.Project
+		*v = *resp
 
 		return nil
 	}
@@ -219,19 +218,16 @@ func testAccCheckDeviceFarmProjectDestroy(s *terraform.State) error {
 		}
 
 		// Try to find the resource
-		resp, err := conn.GetProject(
-			&devicefarm.GetProjectInput{Arn: aws.String(rs.Primary.ID)})
-		if err == nil {
-			if resp.Project != nil {
-				return fmt.Errorf("still exist.")
-			}
-
-			return nil
+		_, err := tfdevicefarm.FindProjectByArn(conn, rs.Primary.ID)
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		if tfawserr.ErrMessageContains(err, devicefarm.ErrCodeNotFoundException, "") {
-			return nil
+		if err != nil {
+			return err
 		}
+
+		return fmt.Errorf("DeviceFarm Project %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/internal/service/devicefarm/sweep.go
+++ b/internal/service/devicefarm/sweep.go
@@ -1,0 +1,73 @@
+//go:build sweep
+// +build sweep
+
+package devicefarm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_devicefarm_project", &resource.Sweeper{
+		Name: "aws_devicefarm_project",
+		F:    sweepProjects,
+	})
+}
+
+func sweepProjects(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).DeviceFarm
+
+	input := &devicefarm.ListProjectsInput{}
+	for {
+		output, err := conn.ListProjectsPages(input)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping DeviceFarm Project sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving DeviceFarm Projects: %s", err)
+		}
+
+		if len(output.Projects) == 0 {
+			log.Print("[DEBUG] No DeviceFarm Projects to sweep")
+			return nil
+		}
+
+		for _, project := range output.Projects {
+			arn := aws.StringValue(project.Arn)
+
+			log.Printf("[INFO] Deleting DeviceFarm Project: %s", arn)
+			r := ResourceProject()
+			d := r.Data(nil)
+			d.SetId(arn)
+			err = r.Delete(d, client)
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete DeviceFarm Project (%s): %s", uri, err)
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}

--- a/website/docs/r/devicefarm_device_pool.html.markdown
+++ b/website/docs/r/devicefarm_device_pool.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Device Farm"
+layout: "aws"
+page_title: "AWS: aws_devicefarm_device_pool"
+description: |-
+  Provides a Devicefarm device_pool
+---
+
+# Resource: aws_devicefarm_device_pool
+
+Provides a resource to manage AWS Device Farm Device Pools.
+
+## Example Usage
+
+
+```terraform
+resource "aws_devicefarm_device_pool" "example" {
+  name        = "example"
+  project_arn = aws_devicefarm_project.example.arn
+  rule {
+    attribute = "OS_VERSION"
+    operator  = "EQUALS"
+    value     = "\"AVAILABLE\""
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Device Pool
+* `project_arn` - (Required) The ARN of the project for the device pool.
+* `rule` - (Required) The device pool's rules. See [Rule](#rule).
+* `description` - (Optional) The device pool's description.
+* `max_devices` - (Optional) The number of devices that Device Farm can add to your device pool.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Rule
+
+* `attribute` - (Optional) The rule's stringified attribute. Valid values are: `APPIUM_VERSION`, `ARN`, `AVAILABILITY`, `FLEET_TYPE`, `FORM_FACTOR`, `INSTANCE_ARN`, `INSTANCE_LABELS`, `MANUFACTURER`, `MODEL`, `OS_VERSION`, `PLATFORM`, `REMOTE_ACCESS_ENABLED`, `REMOTE_DEBUG_ENABLED`.
+* `operator` - (Optional) Specifies how Device Farm compares the rule's attribute to the value. For the operators that are supported by each attribute. Valid values are: `EQUALS`, `NOT_IN`, `IN`, `GREATER_THAN`, `GREATER_THAN_OR_EQUALS`, `LESS_THAN`, `LESS_THAN_OR_EQUALS`, `CONTAINS`.
+* `value` - (Optional) The rule's value.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name of this Device Pool
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+DeviceFarm Device Pools can be imported by their arn:
+
+```
+$ terraform import aws_devicefarm_device_pool.example arn:aws:devicefarm:us-west-2:123456789012:devicepool:4fa784c7-ccb4-4dbf-ba4f-02198320daa1/4fa784c7-ccb4-4dbf-ba4f-02198320daa1
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20969

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDeviceFarmProject_'
--- PASS: TestAccDeviceFarmProject_disappears (67.95s)
--- PASS: TestAccDeviceFarmProject_timeout (165.83s)
--- PASS: TestAccDeviceFarmProject_basic (172.33s)
--- PASS: TestAccDeviceFarmProject_tags (237.86s)

$ make testacc TESTARGS='-run=TestAccAWSDeviceFarmDevicePool_'
--- PASS: TestAccAWSDeviceFarmDevicePool_disappears_project (63.02s)
--- PASS: TestAccAWSDeviceFarmDevicePool_disappears (64.10s)
--- PASS: TestAccAWSDeviceFarmDevicePool_basic (125.88s)
--- PASS: TestAccAWSDeviceFarmDevicePool_tags (174.19s)
```

Special Thanks to @AdamTylerLynch for the help making this work!