### PR TITLE
fix: add validation of GuardDuty filter name

### DIFF
--- a/aws/resource_aws_guardduty_filter.go
+++ b/aws/resource_aws_guardduty_filter.go
@@ -40,7 +40,11 @@ func resourceAwsGuardDutyFilter() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 64),
+				validateFunc: validation.All(
+					validation.StringLenBetween(3, 64),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`),
+						"only alphanumeric characters, hyphens, underscores, and periods are allowed"),
+				)
 			},
 			"description": {
 				Type:         schema.TypeString,

--- a/website/docs/r/guardduty_filter.html.markdown
+++ b/website/docs/r/guardduty_filter.html.markdown
@@ -49,7 +49,7 @@ resource "aws_guardduty_filter" "MyFilter" {
 The following arguments are supported:
 
 * `detector_id` - (Required) ID of a GuardDuty detector, attached to your account.
-* `name` - (Required) The name of your filter.
+* `name` - (Required) The name of your filter. Names can be between 3 and 64 characters long and the valid characters are a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), and '.' (period).
 * `description` - (Optional) Description of the filter.
 * `rank` - (Required) Specifies the position of the filter in the list of current filters. Also specifies the order in which this filter is applied to the findings.
 * `action` - (Required) Specifies the action that is to be applied to the findings that match the filter. Can be one of `ARCHIVE` or `NOOP`.


### PR DESCRIPTION
If there is a good example of implementing validation tests, I'd be happy to add one; most resources I checked either don't test validation, or have a custom function (which seems to predate composing validators via `validation.All`) and test that function explicitly. The latter doesn't seems appropriate in this case.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19893

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
