### PR TITLE
Add support for include filters in AWS DataSync task

### DIFF
--- a/internal/service/datasync/task.go
+++ b/internal/service/datasync/task.go
@@ -64,6 +64,24 @@ func ResourceTask() *schema.Resource {
 					},
 				},
 			},
+			"includes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"filter_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(datasync.FilterType_Values(), false),
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -208,6 +226,10 @@ func resourceTaskCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Excludes = expandFilterRules(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("includes"); ok {
+		input.Includes = expandFilterRules(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("name"); ok {
 		input.Name = aws.String(v.(string))
 	}
@@ -255,6 +277,9 @@ func resourceTaskRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("excludes", flattenFilterRules(output.Excludes)); err != nil {
 		return fmt.Errorf("error setting excludes: %w", err)
 	}
+	if err := d.Set("includes", flattenFilterRules(output.Includes)); err != nil {
+		return fmt.Errorf("error setting includes: %w", err)
+	}
 	d.Set("name", output.Name)
 	if err := d.Set("options", flattenDataSyncOptions(output.Options)); err != nil {
 		return fmt.Errorf("error setting options: %w", err)
@@ -298,6 +323,10 @@ func resourceTaskUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if d.HasChanges("excludes") {
 			input.Excludes = expandFilterRules(d.Get("excludes").([]interface{}))
+		}
+
+		if d.HasChanges("includes") {
+			input.Includes = expandFilterRules(d.Get("includes").([]interface{}))
 		}
 
 		if d.HasChanges("name") {

--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -50,6 +50,11 @@ resource "aws_datasync_task" "example" {
     filter_type = "SIMPLE_PATTERN"
     value       = "/folder1|/folder2"
   }
+
+  includes {
+    filter_type = "SIMPLE_PATTERN"
+    value       = "/folder1|/folder2"
+  }
 }
 ```
 
@@ -61,6 +66,7 @@ The following arguments are supported:
 * `source_location_arn` - (Required) Amazon Resource Name (ARN) of source DataSync Location.
 * `cloudwatch_log_group_arn` - (Optional) Amazon Resource Name (ARN) of the CloudWatch Log Group that is used to monitor and log events in the sync task.
 * `excludes` - (Optional) Filter rules that determines which files to exclude from a task.
+* `includes` - (Optional) Filter rules that determines which files to include in a task.
 * `name` - (Optional) Name of the DataSync Task.
 * `options` - (Optional) Configuration block containing option that controls the default behavior when you start an execution of this DataSync Task. For each individual task execution, you can override these options by specifying an overriding configuration in those executions.
 * `schedule` - (Optional) Specifies a schedule used to periodically transfer files from a source to a destination location.

--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -99,7 +99,12 @@ The following arguments are supported inside the `options` configuration block:
 ### excludes Argument Reference
 
 * `filter_type` - (Optional) The type of filter rule to apply. Valid values: `SIMPLE_PATTERN`.
-* `value` - (Optional) A single filter string that consists of the patterns to include or exclude. The patterns are delimited by "|" (that is, a pipe), for example: `/folder1|/folder2`
+* `value` - (Optional) A single filter string that consists of the patterns to exclude. The patterns are delimited by "|" (that is, a pipe), for example: `/folder1|/folder2`
+
+### includes Argument Reference
+
+* `filter_type` - (Optional) The type of filter rule to apply. Valid values: `SIMPLE_PATTERN`.
+* `value` - (Optional) A single filter string that consists of the patterns to include. The patterns are delimited by "|" (that is, a pipe), for example: `/folder1|/folder2`
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20849

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccAWSDataSyncTask_Includes"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSyncTask_Includes -timeout 180m
=== RUN   TestAccAWSDataSyncTask_Includes
=== PAUSE TestAccAWSDataSyncTask_Includes
=== CONT  TestAccAWSDataSyncTask_Includes
--- PASS: TestAccAWSDataSyncTask_Includes (303.66s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       305.091s
```
