### PR TITLE
r/sagemaker_app_image_config - tagging support

### DIFF
--- a/.changelog/21037.txt
+++ b/.changelog/21037.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_app_image_config: Add tagging support.
+```

--- a/aws/resource_aws_sagemaker_app_image_config_test.go
+++ b/aws/resource_aws_sagemaker_app_image_config_test.go
@@ -387,7 +387,7 @@ resource "aws_sagemaker_app_image_config" "test" {
 
   tags = {
     %[2]q = %[3]q
-  }  
+  }
 }
 `, rName, tagKey1, tagValue1)
 }
@@ -400,7 +400,7 @@ resource "aws_sagemaker_app_image_config" "test" {
   tags = {
     %[2]q = %[3]q
     %[4]q = %[5]q
-  }  
+  }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_sagemaker_app_image_config_test.go
+++ b/aws/resource_aws_sagemaker_app_image_config_test.go
@@ -190,6 +190,51 @@ func TestAccAWSSagemakerAppImageConfig_kernelGatewayImageConfig_fileSystemConfig
 	})
 }
 
+func TestAccAWSSagemakerAppImageConfig_tags(t *testing.T) {
+	var app sagemaker.DescribeAppImageConfigOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_app_image_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerAppConfigImageConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerAppImageConfigExists(resourceName, &app),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerAppConfigImageConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerAppImageConfigExists(resourceName, &app),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerAppConfigImageConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerAppImageConfigExists(resourceName, &app),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSagemakerAppImageConfig_disappears(t *testing.T) {
 	var config sagemaker.DescribeAppImageConfigOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -333,4 +378,29 @@ resource "aws_sagemaker_app_image_config" "test" {
   }
 }
 `, rName)
+}
+
+func testAccAWSSagemakerAppConfigImageConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_app_image_config" "test" {
+  app_image_config_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }  
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSSagemakerAppConfigImageConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_app_image_config" "test" {
+  app_image_config_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }  
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/sagemaker_app_image_config.html.markdown
+++ b/website/docs/r/sagemaker_app_image_config.html.markdown
@@ -48,6 +48,7 @@ The following arguments are supported:
 
 * `app_image_config_name` - (Required) The name of the App Image Config.
 * `kernel_gateway_image_config` - (Optional) The configuration for the file system and kernels in a SageMaker image running as a KernelGateway app. See [Kernel Gateway Image Config](#kernel-gateway-image-config) details below.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Kernel Gateway Image Config
 
@@ -73,6 +74,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the App Image Config.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this App Image Config.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17267

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerAppImageConfig_'
--- PASS: TestAccAWSSagemakerAppImageConfig_tags (126.57s)
--- PASS: TestAccAWSSagemakerAppImageConfig_disappears (38.97s)
--- PASS: TestAccAWSSagemakerAppImageConfig_basic (54.48s)
--- PASS: TestAccAWSSagemakerAppImageConfig_kernelGatewayImageConfig_fileSystemConfig (92.85s)
--- PASS: TestAccAWSSagemakerAppImageConfig_kernelGatewayImageConfig_kernalSpecs (93.16s)
```
