### PR TITLE
r/db_proxy - fix permanent diff on plan

### DIFF
--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -89,6 +89,7 @@ func ResourceProxy() *schema.Resource {
 						"auth_scheme": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default: 	  "SECRETS",
 							ValidateFunc: validation.StringInSlice(rds.AuthScheme_Values(), false),
 						},
 						"description": {
@@ -98,6 +99,7 @@ func ResourceProxy() *schema.Resource {
 						"iam_auth": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default:      "DISABLED",
 							ValidateFunc: validation.StringInSlice(rds.IAMAuthMode_Values(), false),
 						},
 						"secret_arn": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->
Closes #20119. If `auth_scheme` or `iam_auth` are not specified in config, they are implicitly set to `SECRETS` and `DISABLED` accordingly, when resource is created.
```
auth {
  secret_arn = "arn:aws:secretsmanager:eu-central-1:[REDACTED]"
}
```

That's why after that all the time such change is detected:
```
      + auth {
          + secret_arn = "arn:aws:secretsmanager:eu-central-1:[REDACTED]"
        }
      - auth {
          - auth_scheme = "SECRETS" -> null
          - iam_auth    = "DISABLED" -> null
          - secret_arn  = "arn:aws:secretsmanager:eu-central-1:[REDACTED]" -> null
        }
```
Setting default values in resource schema for both of them fixes the issue. Difference is no longer detected. Like below:
```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:
- Manual tests were performed. Did not run the acceptance tests. They should be fine as all of them explicitly specify all four arguments of `auth` block.
