### PR TITLE
d/db_proxy - new data source

### DIFF
--- a/.changelog/21053.txt
+++ b/.changelog/21053.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_db_proxy
+```

--- a/aws/data_source_aws_db_proxy.go
+++ b/aws/data_source_aws_db_proxy.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsDbProxy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDbProxyRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"auth": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_scheme": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"iam_auth": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"secret_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"debug_logging": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_family": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"idle_client_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"require_tls": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_security_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vpc_subnet_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsDbProxyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	opts := &rds.DescribeDBProxiesInput{
+		DBProxyName: aws.String(d.Get("name").(string)),
+	}
+
+	resp, err := conn.DescribeDBProxies(opts)
+	if err != nil {
+		return fmt.Errorf("error reading DB proxies: %w", err)
+	}
+
+	dbProxy := resp.DBProxies[0]
+
+	d.SetId(d.Get("name").(string))
+	d.Set("auth", flattenDbProxyAuths(dbProxy.Auth))
+	d.Set("arn", dbProxy.DBProxyArn)
+	d.Set("debug_logging", dbProxy.DebugLogging)
+	d.Set("endpoint", dbProxy.Endpoint)
+	d.Set("engine_family", dbProxy.EngineFamily)
+	d.Set("idle_client_timeout", dbProxy.IdleClientTimeout)
+	d.Set("require_tls", dbProxy.RequireTLS)
+	d.Set("role_arn", dbProxy.RoleArn)
+	d.Set("vpc_id", dbProxy.VpcId)
+	d.Set("vpc_security_group_ids", aws.StringValueSlice(dbProxy.VpcSecurityGroupIds))
+	d.Set("vpc_subnet_ids", aws.StringValueSlice(dbProxy.VpcSubnetIds))
+
+	return nil
+}

--- a/aws/data_source_aws_db_proxy_test.go
+++ b/aws/data_source_aws_db_proxy_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/aws/data_source_aws_db_proxy_test.go
+++ b/aws/data_source_aws_db_proxy_test.go
@@ -1,0 +1,163 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSDBProxyDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_db_proxy.test"
+	resourceName := "aws_db_proxy.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, rds.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDataSourceConfigBase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth", resourceName, "auth"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "debug_logging", resourceName, "debug_logging"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint", resourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_family", resourceName, "engine_family"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "idle_client_timeout", resourceName, "idle_client_timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "require_tls", resourceName, "require_tls"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "role_arn", resourceName, "role_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", "aws_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_security_group_ids", resourceName, "vpc_security_group_ids"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_subnet_ids", resourceName, "vpc_subnet_ids"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDBProxyDataSourceConfigBase(rName string) string {
+	return fmt.Sprintf(`
+# Secrets Manager setup
+
+resource "aws_secretsmanager_secret" "test" {
+  name                    = "%[1]s"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = "{\"username\":\"db_user\",\"password\":\"db_user_password\"}"
+}
+
+# IAM setup
+
+resource "aws_iam_role" "test" {
+  name               = "%[1]s"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "test" {
+  role   = aws_iam_role.test.id
+  policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = [
+      "secretsmanager:GetRandomPassword",
+      "secretsmanager:CreateSecret",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["secretsmanager:*"]
+    resources = [aws_secretsmanager_secret.test.arn]
+  }
+}
+
+# VPC setup
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "%[1]s"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = "%[1]s"
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  count             = 2
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "%[1]s-${count.index}"
+  }
+}
+
+resource "aws_db_proxy" "test" {
+  depends_on = [
+    aws_secretsmanager_secret_version.test,
+    aws_iam_role_policy.test
+  ]
+
+  name                   = "%[1]s"
+  debug_logging          = false
+  engine_family          = "MYSQL"
+  idle_client_timeout    = 1800
+  require_tls            = true
+  role_arn               = aws_iam_role.test.arn
+  vpc_security_group_ids = [aws_security_group.test.id]
+  vpc_subnet_ids         = aws_subnet.test.*.id
+
+  auth {
+    auth_scheme = "SECRETS"
+    description = "test"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.test.arn
+  }
+
+  tags = {
+    Name = "%[1]s"
+  }
+}
+
+data "aws_db_proxy" "test" {
+  depends_on = [
+    aws_db_proxy.test
+  ]
+  name = "%[1]s"
+}
+`, rName)
+}

--- a/aws/internal/service/rds/finder/finder.go
+++ b/aws/internal/service/rds/finder/finder.go
@@ -119,6 +119,27 @@ func DBClusterByID(conn *rds.RDS, id string) (*rds.DBCluster, error) {
 	return dbCluster, nil
 }
 
+func DBProxyByName(conn *rds.RDS, name string) (*rds.DBProxy, error) {
+	input := &rds.DescribeDBProxiesInput{
+		DBProxyName: aws.String(name),
+	}
+
+	output, err := conn.DescribeDBProxies(input)
+
+	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if output == nil || len(output.DBProxies) == 0 || output.DBProxies[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.DBProxies[0], nil
+}
+
 func EventSubscriptionByID(conn *rds.RDS, id string) (*rds.EventSubscription, error) {
 	input := &rds.DescribeEventSubscriptionsInput{
 		SubscriptionName: aws.String(id),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -243,6 +243,7 @@ func Provider() *schema.Provider {
 			"aws_db_cluster_snapshot":                        dataSourceAwsDbClusterSnapshot(),
 			"aws_db_event_categories":                        dataSourceAwsDbEventCategories(),
 			"aws_db_instance":                                dataSourceAwsDbInstance(),
+			"aws_db_proxy":                                   dataSourceAwsDbProxy(),
 			"aws_db_snapshot":                                dataSourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                            dataSourceAwsDbSubnetGroup(),
 			"aws_directory_service_directory":                dataSourceAwsDirectoryServiceDirectory(),

--- a/website/docs/d/db_proxy.html.markdown
+++ b/website/docs/d/db_proxy.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `auth` - Configuration(s) with authorization mechanisms to connect to the associated instance or cluster.
+* `auth` - The configuration(s) with authorization mechanisms to connect to the associated instance or cluster.
 * `debug_logging` - Whether the proxy includes detailed information about SQL statements in its logs.
 * `endpoint` - The endpoint that you can use to connect to the DB proxy.
 * `engine_family` - The kinds of databases that the proxy can connect to.

--- a/website/docs/d/db_proxy.html.markdown
+++ b/website/docs/d/db_proxy.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the DB Proxy.
 * `auth` - The configuration(s) with authorization mechanisms to connect to the associated instance or cluster.
 * `debug_logging` - Whether the proxy includes detailed information about SQL statements in its logs.
 * `endpoint` - The endpoint that you can use to connect to the DB proxy.

--- a/website/docs/d/db_proxy.html.markdown
+++ b/website/docs/d/db_proxy.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "RDS"
+layout: "aws"
+page_title: "AWS: aws_db_proxy"
+description: |-
+  Get information on a DB Proxy.
+---
+
+# Data Source: aws_db_proxy
+
+Use this data source to get information about a DB Proxy.
+
+## Example Usage
+
+```terraform
+data "aws_db_proxy" "proxy" {
+  name = "my-test-db-proxy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the DB proxy.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `auth` - Configuration(s) with authorization mechanisms to connect to the associated instance or cluster.
+* `debug_logging` - Whether the proxy includes detailed information about SQL statements in its logs.
+* `endpoint` - The endpoint that you can use to connect to the DB proxy.
+* `engine_family` - The kinds of databases that the proxy can connect to.
+* `idle_client_timeout` - The number of seconds a connection to the proxy can have no activity before the proxy drops the client connection.
+* `require_tls` - Indicates whether Transport Layer Security (TLS) encryption is required for connections to the proxy.
+* `role_arn` - The Amazon Resource Name (ARN) for the IAM role that the proxy uses to access Amazon Secrets Manager.
+* `vpc_id` - Provides the VPC ID of the DB proxy.
+* `vpc_security_group_ids` - Provides a list of VPC security groups that the proxy belongs to.
+* `vpc_subnet_ids` - The EC2 subnet IDs for the proxy.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20943.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS="-run=TestAccAWSDBProxyDataSource_basic"                                                                         18m 21s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBProxyDataSource_basic -timeout 180m
=== RUN   TestAccAWSDBProxyDataSource_basic
=== PAUSE TestAccAWSDBProxyDataSource_basic
=== CONT  TestAccAWSDBProxyDataSource_basic
--- PASS: TestAccAWSDBProxyDataSource_basic (692.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       700.260s
```
