### PR TITLE
Add support for kms decrypt with asymmetric keys

### DIFF
--- a/internal/service/kms/secrets_data_source.go
+++ b/internal/service/kms/secrets_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
@@ -29,10 +30,19 @@ func DataSourceSecrets() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"algorithm": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(kms.EncryptionAlgorithmSpec_Values(), false),
+						},
 						"context": {
 							Type:     schema.TypeMap,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"grant_tokens": {
 							Type:     schema.TypeList,
@@ -71,11 +81,17 @@ func dataSourceSecretsRead(d *schema.ResourceData, meta interface{}) error {
 		params := &kms.DecryptInput{
 			CiphertextBlob: payload,
 		}
+		if algorithm, ok := d.GetOk("algorithm"); ok {
+			params.EncryptionAlgorithm = aws.String(algorithm.(string))
+		}
 		if context, exists := secret["context"]; exists {
 			params.EncryptionContext = make(map[string]*string)
 			for k, v := range context.(map[string]interface{}) {
 				params.EncryptionContext[k] = aws.String(v.(string))
 			}
+		}
+		if keyID, ok := d.GetOk("key_id"); ok {
+			params.KeyId = aws.String(keyID.(string))
 		}
 		if grant_tokens, exists := secret["grant_tokens"]; exists {
 			params.GrantTokens = make([]*string, 0)

--- a/website/docs/d/kms_secrets.html.markdown
+++ b/website/docs/d/kms_secrets.html.markdown
@@ -64,7 +64,9 @@ Each `secret` supports the following arguments:
 
 * `name` - (Required) The name to export this secret under in the attributes.
 * `payload` - (Required) Base64 encoded payload, as returned from a KMS encrypt operation.
+* `algorithm` - (Optional) Algorithm used for decrypting the secret.
 * `context` - (Optional) An optional mapping that makes up the Encryption Context for the secret.
+* `key_id` - (Optional) The KMS key id or arn for decrypting the secret.
 * `grant_tokens` (Optional) An optional list of Grant Tokens for the secret.
 
 For more information on `context` and `grant_tokens` see the [KMS


### PR DESCRIPTION
Adds support for algorithm and key_id inputs to the `aws_kms_secrets` data source. This is to support KMS decryption with asymmetric keys where both of these fields are required.

I'm struggling on working out what to do for the acceptance test(s). The test could generate an asymmetric KMS key, then encrypt some plain text from the public key (maybe with the TLS provider, go code, or a mock provider?). I'm not sure how that would fit into the current acceptance test framework. If anyone has any examples or pointers I'd appreciate that.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```