### PR TITLE
Add autoremove_labels action

### DIFF
--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -1,0 +1,17 @@
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+jobs:
+  remove-labels:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        labels: ['needs-triage', 'waiting-response']
+    steps:
+      - name: Remove ${{ matrix.labels }} label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: contains(github.event.*.labels.*.name, matrix.labels)
+        with:
+          labels: ${{ matrix.labels }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20948 

### Info

This PR adds the GitHub Action to automatically remove the `waiting-response` and `needs-triage` labels from issues and PRs when they are closed, as discussed in the above linked proposal.