### PR TITLE
Stricter S3 bucket name validation

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -977,6 +977,20 @@ func validateLogGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 	return
 }
 
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+func validateS3BucketName() schema.SchemaValidateFunc {
+	// skipped due to ease of implementation:
+	// - must not be formatted as an IP(v4?) address
+	return validation.All(
+		// length
+		validation.StringLenBetween(3, 63),
+		// allowable characters, and alphanumeric start + end
+		validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9.-]+[a-z0-9]$`), ""),
+		validation.StringDoesNotMatch(regexp.MustCompile("^xn--")),
+		validation.StringDoesNotMatch(regexp.MustCompile("-s3alias$")),
+	)
+}
+
 func validateS3BucketLifecycleTimestamp(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Lacks tests, but guards against such mistakes as "bucket_with_underscores".

Asking here for a style check - would validation rules like this be accepted here?