### PR TITLE
r/aws_route_table_association: Wait for 40 NotFoundChecks

### DIFF
--- a/.changelog/21062.txt
+++ b/.changelog/21062.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route_table_association: Wait for up to 40 not found checks when creating a new route table association
+```

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -311,7 +311,8 @@ const (
 	RouteTableDeletedTimeout = 5 * time.Minute
 	RouteTableUpdatedTimeout = 5 * time.Minute
 
-	RouteTableNotFoundChecks = 40
+	RouteTableNotFoundChecks                   = 40
+	RouteTableAssociationCreatedNotFoundChecks = 40
 )
 
 func RouteTableReady(conn *ec2.EC2, id string) (*ec2.RouteTable, error) {
@@ -351,10 +352,11 @@ func RouteTableDeleted(conn *ec2.EC2, id string) (*ec2.RouteTable, error) {
 
 func RouteTableAssociationCreated(conn *ec2.EC2, id string) (*ec2.RouteTableAssociationState, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.RouteTableAssociationStateCodeAssociating},
-		Target:  []string{ec2.RouteTableAssociationStateCodeAssociated},
-		Refresh: RouteTableAssociationState(conn, id),
-		Timeout: RouteTableAssociationCreatedTimeout,
+		Pending:        []string{ec2.RouteTableAssociationStateCodeAssociating},
+		Target:         []string{ec2.RouteTableAssociationStateCodeAssociated},
+		Refresh:        RouteTableAssociationState(conn, id),
+		Timeout:        RouteTableAssociationCreatedTimeout,
+		NotFoundChecks: RouteTableAssociationCreatedNotFoundChecks,
 	}
 
 	outputRaw, err := stateConf.WaitForState()


### PR DESCRIPTION
We have many automated tests that create route table associations and have witnessed extreme variance in the duration when waiting for the `aws_route_table_association` resource to be found after it is initially created. Most of the time, the `aws_route_table_association` resource finishes in about 1 second, while in others it'll retry until we hit the default 20 `MaxNotFound` checks in the `StateChangeConf` waiter, which causes the resource to always fail around the 2.5 minute mark when this condition is exhibited. This change increases the max `NotFoundChecks` for the `RouteTableAssociationCreated` `StateChangeConf` waiter to 40, which gets us closer to the max default timeout of 5 minutes. After having built my own copy of the provider plugin with this change we no longer see this issue.

Before:
<img width="1863" alt="Screen Shot 2021-09-21 at 4 10 52 PM" src="https://user-images.githubusercontent.com/65058/134992724-a9d236cf-c89a-46ca-9d04-14810b210cf1.png">

After:
<img width="1459" alt="Screen Shot 2021-09-21 at 4 33 15 PM" src="https://user-images.githubusercontent.com/65058/134992781-1a11ea0d-f65e-461e-9d13-ec7ec496bbc5.png">

I didn't include a modified acceptance test because the issue itself is quite sporadic and we cannot control the conditions of the AWS Ec2 API to sufficiently test the change. Looking further into the waiter and finder themselves, it would appear that testing at that level would require building an `ec2.EC2` connection mock, which in turn means that we'd really only be testing the `StateChangeConf` implementation, which has nothing to do with our changes.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:
```
ACCTEST_PARALLELISM=2 make testacc TESTARGS='-run=TestAccAWSRouteTableAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSRouteTableAssociation -timeout 180m
=== RUN   TestAccAWSRouteTableAssociation_Subnet_basic
=== PAUSE TestAccAWSRouteTableAssociation_Subnet_basic
=== RUN   TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable
=== PAUSE TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable
=== RUN   TestAccAWSRouteTableAssociation_Gateway_basic
=== PAUSE TestAccAWSRouteTableAssociation_Gateway_basic
=== RUN   TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable
=== PAUSE TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable
=== RUN   TestAccAWSRouteTableAssociation_disappears
=== PAUSE TestAccAWSRouteTableAssociation_disappears
=== CONT  TestAccAWSRouteTableAssociation_Subnet_basic
=== CONT  TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable
--- PASS: TestAccAWSRouteTableAssociation_Subnet_basic (39.18s)
=== CONT  TestAccAWSRouteTableAssociation_Gateway_basic
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable (88.16s)
=== CONT  TestAccAWSRouteTableAssociation_disappears
--- PASS: TestAccAWSRouteTableAssociation_Gateway_basic (70.08s)
=== CONT  TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable
--- PASS: TestAccAWSRouteTableAssociation_disappears (36.22s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable (56.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       168.660s
```
Note that ACCTEST_PARALLELISM is at 2 because of the maximum allowed internet gateways in my ec2 account. With the default of 20 we'd run into that limit.