### PR TITLE
Add two missing states for RDS cluster update

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -1470,7 +1470,9 @@ var resourceAwsRdsClusterDeletePendingStates = []string{
 
 var resourceAwsRdsClusterUpdatePendingStates = []string{
 	"backing-up",
+	"configuring-iam-database-auth",
 	"modifying",
+	"renaming",
 	"resetting-master-credentials",
 	"upgrading",
 }


### PR DESCRIPTION
Enabling/disabling IAM auth on an existing RDS cluster led to a fail of
terraform apply as 'configuring-iam-database-auth' was not an expected pending
state.

I also identified another missing pending state: 'renaming'.

This is my first PR ever on a terraform-related project, if things are missing in my PR please let me know.

As I'm not confident with the test codebase, I'm not sure if there is a specific test case to update or add for what I'm changing.

Here is a snippet to reproduce the issue, set `iam_database_authentication_enabled` to `true` after the initial creation:

``` terraform
terraform {
  required_providers {
    aws = {
      source = "hashicorp/aws"
    }
  }
  required_version = ">= 0.13"
}

provider "aws" {
  region = "eu-west-1"
}

resource "aws_rds_cluster" "cluster" {
  cluster_identifier = "cluster-test"

  engine = "aurora-postgresql"
  engine_version = "11.6"
  deletion_protection = false
  backup_retention_period = 1
  skip_final_snapshot = true
  master_username = "root"
  master_password = "whatever"
  apply_immediately = true

  iam_database_authentication_enabled = false
}

resource "aws_rds_cluster_instance" "instance" {
  cluster_identifier = aws_rds_cluster.cluster.id
  identifier = "cluster-test-instance"
  instance_class = "db.t3.medium"
  engine = "aurora-postgresql"
  engine_version = "11.6"
}
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
