### PR TITLE
r/aws_db_event_subscription: Use waiters package

### DIFF
--- a/aws/internal/service/rds/enum.go
+++ b/aws/internal/service/rds/enum.go
@@ -5,3 +5,10 @@ const (
 	DBClusterRoleStatusDeleted = "DELETED"
 	DBClusterRoleStatusPending = "PENDING"
 )
+
+const (
+	EventSubscriptionStatusActive    = "active"
+	EventSubscriptionStatusCreating  = "creating"
+	EventSubscriptionStatusDeleting  = "deleting"
+	EventSubscriptionStatusModifying = "modifying"
+)

--- a/aws/internal/service/rds/finder/finder.go
+++ b/aws/internal/service/rds/finder/finder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	tfrds "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 // DBProxyTarget returns matching DBProxyTarget.
@@ -103,10 +104,7 @@ func DBClusterByID(conn *rds.RDS, id string) (*rds.DBCluster, error) {
 	}
 
 	if output == nil || len(output.DBClusters) == 0 || output.DBClusters[0] == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	dbCluster := output.DBClusters[0]
@@ -119,4 +117,25 @@ func DBClusterByID(conn *rds.RDS, id string) (*rds.DBCluster, error) {
 	}
 
 	return dbCluster, nil
+}
+
+func EventSubscriptionByName(conn *rds.RDS, name string) (*rds.EventSubscription, error) {
+	input := &rds.DescribeEventSubscriptionsInput{
+		SubscriptionName: aws.String(name),
+	}
+
+	output, err := conn.DescribeEventSubscriptions(input)
+
+	if tfawserr.ErrCodeEquals(err, rds.ErrCodeSubscriptionNotFoundFault) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if output == nil || len(output.EventSubscriptionsList) == 0 || output.EventSubscriptionsList[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.EventSubscriptionsList[0], nil
 }

--- a/aws/internal/service/rds/finder/finder.go
+++ b/aws/internal/service/rds/finder/finder.go
@@ -119,9 +119,9 @@ func DBClusterByID(conn *rds.RDS, id string) (*rds.DBCluster, error) {
 	return dbCluster, nil
 }
 
-func EventSubscriptionByName(conn *rds.RDS, name string) (*rds.EventSubscription, error) {
+func EventSubscriptionByID(conn *rds.RDS, id string) (*rds.EventSubscription, error) {
 	input := &rds.DescribeEventSubscriptionsInput{
-		SubscriptionName: aws.String(name),
+		SubscriptionName: aws.String(id),
 	}
 
 	output, err := conn.DescribeEventSubscriptions(input)

--- a/aws/internal/service/rds/waiter/status.go
+++ b/aws/internal/service/rds/waiter/status.go
@@ -9,12 +9,6 @@ import (
 )
 
 const (
-	// EventSubscription NotFound
-	EventSubscriptionStatusNotFound = "NotFound"
-
-	// EventSubscription Unknown
-	EventSubscriptionStatusUnknown = "Unknown"
-
 	// ProxyEndpoint NotFound
 	ProxyEndpointStatusNotFound = "NotFound"
 
@@ -23,23 +17,19 @@ const (
 )
 
 // EventSubscriptionStatus fetches the EventSubscription and its Status
-func EventSubscriptionStatus(conn *rds.RDS, subscriptionName string) resource.StateRefreshFunc {
+func EventSubscriptionStatus(conn *rds.RDS, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &rds.DescribeEventSubscriptionsInput{
-			SubscriptionName: aws.String(subscriptionName),
-		}
+		output, err := finder.EventSubscriptionByName(conn, name)
 
-		output, err := conn.DescribeEventSubscriptions(input)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
 
 		if err != nil {
-			return nil, EventSubscriptionStatusUnknown, err
+			return nil, "", err
 		}
 
-		if len(output.EventSubscriptionsList) == 0 {
-			return nil, EventSubscriptionStatusNotFound, nil
-		}
-
-		return output.EventSubscriptionsList[0], aws.StringValue(output.EventSubscriptionsList[0].Status), nil
+		return output, aws.StringValue(output.Status), nil
 	}
 }
 

--- a/aws/internal/service/rds/waiter/status.go
+++ b/aws/internal/service/rds/waiter/status.go
@@ -16,10 +16,9 @@ const (
 	ProxyEndpointStatusUnknown = "Unknown"
 )
 
-// EventSubscriptionStatus fetches the EventSubscription and its Status
-func EventSubscriptionStatus(conn *rds.RDS, name string) resource.StateRefreshFunc {
+func EventSubscriptionStatus(conn *rds.RDS, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := finder.EventSubscriptionByName(conn, name)
+		output, err := finder.EventSubscriptionByID(conn, id)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/aws/internal/service/rds/waiter/waiter.go
+++ b/aws/internal/service/rds/waiter/waiter.go
@@ -15,11 +15,11 @@ const (
 	DBClusterRoleAssociationDeletedTimeout = 5 * time.Minute
 )
 
-func EventSubscriptionDeleted(conn *rds.RDS, name string, timeout time.Duration) (*rds.EventSubscription, error) {
+func EventSubscriptionDeleted(conn *rds.RDS, id string, timeout time.Duration) (*rds.EventSubscription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{tfrds.EventSubscriptionStatusDeleting},
 		Target:     []string{},
-		Refresh:    EventSubscriptionStatus(conn, name),
+		Refresh:    EventSubscriptionStatus(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/aws/internal/service/rds/waiter/waiter.go
+++ b/aws/internal/service/rds/waiter/waiter.go
@@ -9,27 +9,26 @@ import (
 )
 
 const (
-	// Maximum amount of time to wait for an EventSubscription to return Deleted
-	EventSubscriptionDeletedTimeout  = 10 * time.Minute
 	RdsClusterInitiateUpgradeTimeout = 5 * time.Minute
 
 	DBClusterRoleAssociationCreatedTimeout = 5 * time.Minute
 	DBClusterRoleAssociationDeletedTimeout = 5 * time.Minute
 )
 
-// EventSubscriptionDeleted waits for a EventSubscription to return Deleted
-func EventSubscriptionDeleted(conn *rds.RDS, subscriptionName string) (*rds.EventSubscription, error) {
+func EventSubscriptionDeleted(conn *rds.RDS, name string, timeout time.Duration) (*rds.EventSubscription, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"deleting"},
-		Target:  []string{EventSubscriptionStatusNotFound},
-		Refresh: EventSubscriptionStatus(conn, subscriptionName),
-		Timeout: EventSubscriptionDeletedTimeout,
+		Pending:    []string{tfrds.EventSubscriptionStatusDeleting},
+		Target:     []string{},
+		Refresh:    EventSubscriptionStatus(conn, name),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*rds.EventSubscription); ok {
-		return v, err
+	if output, ok := outputRaw.(*rds.EventSubscription); ok {
+		return output, err
 	}
 
 	return nil, err
@@ -49,8 +48,8 @@ func DBProxyEndpointAvailable(conn *rds.RDS, id string, timeout time.Duration) (
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*rds.DBProxyEndpoint); ok {
-		return v, err
+	if output, ok := outputRaw.(*rds.DBProxyEndpoint); ok {
+		return output, err
 	}
 
 	return nil, err
@@ -67,8 +66,8 @@ func DBProxyEndpointDeleted(conn *rds.RDS, id string, timeout time.Duration) (*r
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*rds.DBProxyEndpoint); ok {
-		return v, err
+	if output, ok := outputRaw.(*rds.DBProxyEndpoint); ok {
+		return output, err
 	}
 
 	return nil, err

--- a/aws/internal/service/rds/waiter/waiter.go
+++ b/aws/internal/service/rds/waiter/waiter.go
@@ -15,10 +15,48 @@ const (
 	DBClusterRoleAssociationDeletedTimeout = 5 * time.Minute
 )
 
+func EventSubscriptionCreated(conn *rds.RDS, id string, timeout time.Duration) (*rds.EventSubscription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{tfrds.EventSubscriptionStatusCreating},
+		Target:     []string{tfrds.EventSubscriptionStatusActive},
+		Refresh:    EventSubscriptionStatus(conn, id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*rds.EventSubscription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func EventSubscriptionDeleted(conn *rds.RDS, id string, timeout time.Duration) (*rds.EventSubscription, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{tfrds.EventSubscriptionStatusDeleting},
 		Target:     []string{},
+		Refresh:    EventSubscriptionStatus(conn, id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*rds.EventSubscription); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func EventSubscriptionUpdated(conn *rds.RDS, id string, timeout time.Duration) (*rds.EventSubscription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{tfrds.EventSubscriptionStatusModifying},
+		Target:     []string{tfrds.EventSubscriptionStatusActive},
 		Refresh:    EventSubscriptionStatus(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,

--- a/aws/internal/tfresource/retry.go
+++ b/aws/internal/tfresource/retry.go
@@ -58,12 +58,8 @@ func RetryWhen(timeout time.Duration, f func() (interface{}, error), retryable R
 // RetryWhenAwsErrCodeEqualsContext retries the specified function when it returns one of the specified AWS error code.
 func RetryWhenAwsErrCodeEqualsContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) {
 	return RetryWhenContext(ctx, timeout, f, func(err error) (bool, error) {
-		// https://github.com/hashicorp/aws-sdk-go-base/pull/55 has been merged.
-		// Once aws-sdk-go-base has been updated, use variadic version of ErrCodeEquals.
-		for _, code := range codes {
-			if tfawserr.ErrCodeEquals(err, code) {
-				return true, err
-			}
+		if tfawserr.ErrCodeEquals(err, codes...) {
+			return true, err
 		}
 
 		return false, err

--- a/aws/resource_aws_db_event_subscription_test.go
+++ b/aws/resource_aws_db_event_subscription_test.go
@@ -417,8 +417,8 @@ resource "aws_sns_topic" "test" {
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = %[1]q
-  sns_topic   = aws_sns_topic.test.arn
+  name      = %[1]q
+  sns_topic = aws_sns_topic.test.arn
 
   tags = {
     %[2]q = %[3]q
@@ -434,8 +434,8 @@ resource "aws_sns_topic" "test" {
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = %[1]q
-  sns_topic   = aws_sns_topic.test.arn
+  name      = %[1]q
+  sns_topic = aws_sns_topic.test.arn
 
   tags = {
     %[2]q = %[3]q
@@ -523,7 +523,7 @@ resource "aws_db_event_subscription" "test" {
 
   source_ids = [
     aws_db_parameter_group.test1.id,
-	aws_db_parameter_group.test2.id,
+    aws_db_parameter_group.test2.id,
   ]
 }
 `, rName))

--- a/aws/resource_aws_db_event_subscription_test.go
+++ b/aws/resource_aws_db_event_subscription_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -321,7 +320,13 @@ func testAccCheckAWSDBEventSubscriptionDisappears(eventSubscription *rds.EventSu
 			return err
 		}
 
-		return waitForRdsEventSubscriptionDeletion(conn, aws.StringValue(eventSubscription.CustSubscriptionId), 10*time.Minute)
+		_, err = waiter.EventSubscriptionDeleted(conn, aws.StringValue(eventSubscription.CustSubscriptionId))
+
+		if isAWSErr(err, rds.ErrCodeSubscriptionNotFoundFault, "") {
+			return nil
+		}
+
+		return err
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13264.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS="-run=TestAccAWSDBEventSubscription"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBEventSubscription -timeout 180m
=== RUN   TestAccAWSDBEventSubscription_basicUpdate
=== PAUSE TestAccAWSDBEventSubscription_basicUpdate
=== RUN   TestAccAWSDBEventSubscription_disappears
=== PAUSE TestAccAWSDBEventSubscription_disappears
=== RUN   TestAccAWSDBEventSubscription_withPrefix
=== PAUSE TestAccAWSDBEventSubscription_withPrefix
=== RUN   TestAccAWSDBEventSubscription_withSourceIds
=== PAUSE TestAccAWSDBEventSubscription_withSourceIds
=== RUN   TestAccAWSDBEventSubscription_categoryUpdate
=== PAUSE TestAccAWSDBEventSubscription_categoryUpdate
=== CONT  TestAccAWSDBEventSubscription_basicUpdate
=== CONT  TestAccAWSDBEventSubscription_withPrefix
=== CONT  TestAccAWSDBEventSubscription_disappears
=== CONT  TestAccAWSDBEventSubscription_withSourceIds
=== CONT  TestAccAWSDBEventSubscription_categoryUpdate
--- PASS: TestAccAWSDBEventSubscription_withPrefix (67.11s)
--- PASS: TestAccAWSDBEventSubscription_disappears (72.99s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (109.72s)
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (123.37s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (142.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	150.263s
```
