### PR TITLE
Add ownership-verification-cert. to API Gateway

### DIFF
--- a/.changelog/21076.txt
+++ b/.changelog/21076.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_api_gateway_domain_name: Add `ownership_verification_certificate_arn` argument.
+```
+
+```release-note:enhancement
+resource/aws_apigatewayv2_domain_name: Add `domain_name_configuration.ownership_verification_certificate_arn` argument.
+```

--- a/.changelog/21076.txt
+++ b/.changelog/21076.txt
@@ -5,3 +5,7 @@ resource/aws_api_gateway_domain_name: Add `ownership_verification_certificate_ar
 ```release-note:enhancement
 resource/aws_apigatewayv2_domain_name: Add `domain_name_configuration.ownership_verification_certificate_arn` argument.
 ```
+
+```release-note:enhancement
+resource/aws_s3_bucket_versioning: Add eventual consistency handling to help ensure bucket versioning is stabilized.
+```

--- a/internal/service/apigateway/acc_test.go
+++ b/internal/service/apigateway/acc_test.go
@@ -19,27 +19,27 @@ import (
 
 // API Gateway Edge-Optimized Domain Name can only be created with ACM Certificates in specific regions.
 
-// testAccApigatewayEdgeDomainNameRegion is the chosen API Gateway Domain Name testing region
+// testAccEdgeDomainNameRegion is the chosen API Gateway Domain Name testing region
 //
 // Cached to prevent issues should multiple regions become available.
-var testAccApigatewayEdgeDomainNameRegion string
+var testAccEdgeDomainNameRegion string
 
-// testAccProviderApigatewayEdgeDomainName is the API Gateway Domain Name provider instance
+// testAccProviderEdgeDomainName is the API Gateway Domain Name provider instance
 //
 // This Provider can be used in testing code for API calls without requiring
 // the use of saving and referencing specific ProviderFactories instances.
 //
-// testAccPreCheckApigatewayEdgeDomainName(t) must be called before using this provider instance.
-var testAccProviderApigatewayEdgeDomainName *schema.Provider
+// testAccPreCheckEdgeDomainName(t) must be called before using this provider instance.
+var testAccProviderEdgeDomainName *schema.Provider
 
-// testAccProviderApigatewayEdgeDomainNameConfigure ensures the provider is only configured once
-var testAccProviderApigatewayEdgeDomainNameConfigure sync.Once
+// testAccProviderEdgeDomainNameConfigure ensures the provider is only configured once
+var testAccProviderEdgeDomainNameConfigure sync.Once
 
-// testAccPreCheckApigatewayEdgeDomainName verifies AWS credentials and that API Gateway Domain Name is supported
-func testAccPreCheckApigatewayEdgeDomainName(t *testing.T) {
+// testAccPreCheckEdgeDomainName verifies AWS credentials and that API Gateway Domain Name is supported
+func testAccPreCheckEdgeDomainName(t *testing.T) {
 	acctest.PreCheckPartitionHasService(apigateway.EndpointsID, t)
 
-	region := testAccGetApigatewayEdgeDomainNameRegion()
+	region := testAccGetEdgeDomainNameRegion()
 
 	if region == "" {
 		t.Skip("API Gateway Domain Name not available in this AWS Partition")
@@ -47,14 +47,14 @@ func testAccPreCheckApigatewayEdgeDomainName(t *testing.T) {
 
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
-	testAccProviderApigatewayEdgeDomainNameConfigure.Do(func() {
-		testAccProviderApigatewayEdgeDomainName = provider.Provider()
+	testAccProviderEdgeDomainNameConfigure.Do(func() {
+		testAccProviderEdgeDomainName = provider.Provider()
 
 		config := map[string]interface{}{
 			"region": region,
 		}
 
-		diags := testAccProviderApigatewayEdgeDomainName.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+		diags := testAccProviderEdgeDomainName.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
 
 		if diags != nil && diags.HasError() {
 			for _, d := range diags {
@@ -66,18 +66,18 @@ func testAccPreCheckApigatewayEdgeDomainName(t *testing.T) {
 	})
 }
 
-// testAccApigatewayEdgeDomainNameRegionProviderConfig is the Terraform provider configuration for API Gateway Domain Name region testing
+// testAccEdgeDomainNameRegionProviderConfig is the Terraform provider configuration for API Gateway Domain Name region testing
 //
 // Testing API Gateway Domain Name assumes no other provider configurations
 // are necessary and overwrites the "aws" provider configuration.
-func testAccApigatewayEdgeDomainNameRegionProviderConfig() string {
-	return acctest.ConfigRegionalProvider(testAccGetApigatewayEdgeDomainNameRegion())
+func testAccEdgeDomainNameRegionProviderConfig() string {
+	return acctest.ConfigRegionalProvider(testAccGetEdgeDomainNameRegion())
 }
 
-// testAccGetApigatewayEdgeDomainNameRegion returns the API Gateway Domain Name region for testing
-func testAccGetApigatewayEdgeDomainNameRegion() string {
-	if testAccApigatewayEdgeDomainNameRegion != "" {
-		return testAccApigatewayEdgeDomainNameRegion
+// testAccEdgeDomainNameRegion returns the API Gateway Domain Name region for testing
+func testAccGetEdgeDomainNameRegion() string {
+	if testAccEdgeDomainNameRegion != "" {
+		return testAccEdgeDomainNameRegion
 	}
 
 	// AWS Commercial: https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html
@@ -85,18 +85,18 @@ func testAccGetApigatewayEdgeDomainNameRegion() string {
 	// AWS China - edge custom domain names not supported: https://docs.amazonaws.cn/en_us/aws/latest/userguide/api-gateway.html
 	switch acctest.Partition() {
 	case endpoints.AwsPartitionID:
-		testAccApigatewayEdgeDomainNameRegion = endpoints.UsEast1RegionID
+		testAccEdgeDomainNameRegion = endpoints.UsEast1RegionID
 	}
 
-	return testAccApigatewayEdgeDomainNameRegion
+	return testAccEdgeDomainNameRegion
 }
 
-// testAccCheckResourceAttrRegionalARNApigatewayEdgeDomainName ensures the Terraform state exactly matches the expected API Gateway Edge Domain Name format
-func testAccCheckResourceAttrRegionalARNApigatewayEdgeDomainName(resourceName, attributeName, arnService string, domain string) resource.TestCheckFunc {
+// testAccCheckResourceAttrRegionalARNEdgeDomainName ensures the Terraform state exactly matches the expected API Gateway Edge Domain Name format
+func testAccCheckResourceAttrRegionalARNEdgeDomainName(resourceName, attributeName, arnService string, domain string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		attributeValue := arn.ARN{
 			Partition: acctest.Partition(),
-			Region:    testAccGetApigatewayEdgeDomainNameRegion(),
+			Region:    testAccGetEdgeDomainNameRegion(),
 			Resource:  fmt.Sprintf("/domainnames/%s", domain),
 			Service:   arnService,
 		}.String()
@@ -105,8 +105,8 @@ func testAccCheckResourceAttrRegionalARNApigatewayEdgeDomainName(resourceName, a
 	}
 }
 
-// testAccCheckResourceAttrRegionalARNApigatewayRegionalDomainName ensures the Terraform state exactly matches the expected API Gateway Regional Domain Name format
-func testAccCheckResourceAttrRegionalARNApigatewayRegionalDomainName(resourceName, attributeName, arnService string, domain string) resource.TestCheckFunc {
+// testAccCheckResourceAttrRegionalARNRegionalDomainName ensures the Terraform state exactly matches the expected API Gateway Regional Domain Name format
+func testAccCheckResourceAttrRegionalARNRegionalDomainName(resourceName, attributeName, arnService string, domain string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		attributeValue := arn.ARN{
 			Partition: acctest.Partition(),

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -368,9 +368,9 @@ func resourceDomainNameUpdateOperations(d *schema.ResourceData) []*apigateway.Pa
 	}
 
 	if d.HasChange("mutual_tls_authentication") {
-		vMutualTlsAuthentication := d.Get("mutual_tls_authentication").([]interface{})
+		mutTLSAuth := d.Get("mutual_tls_authentication").([]interface{})
 
-		if len(vMutualTlsAuthentication) == 0 || vMutualTlsAuthentication[0] == nil {
+		if len(mutTLSAuth) == 0 || mutTLSAuth[0] == nil {
 			// To disable mutual TLS for a custom domain name, remove the truststore from your custom domain name.
 			operations = append(operations, &apigateway.PatchOperation{
 				Op:    aws.String(apigateway.OpReplace),
@@ -381,7 +381,7 @@ func resourceDomainNameUpdateOperations(d *schema.ResourceData) []*apigateway.Pa
 			operations = append(operations, &apigateway.PatchOperation{
 				Op:    aws.String(apigateway.OpReplace),
 				Path:  aws.String("/mutualTlsAuthentication/truststoreVersion"),
-				Value: aws.String(vMutualTlsAuthentication[0].(map[string]interface{})["truststore_version"].(string)),
+				Value: aws.String(mutTLSAuth[0].(map[string]interface{})["truststore_version"].(string)),
 			})
 		}
 	}

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -136,7 +136,6 @@ func ResourceDomainName() *schema.Resource {
 						"truststore_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -141,6 +141,12 @@ func ResourceDomainName() *schema.Resource {
 				},
 			},
 
+			"ownership_verification_certificate_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
+
 			"regional_certificate_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -221,6 +227,10 @@ func resourceDomainNameCreate(d *schema.ResourceData, meta interface{}) error {
 		params.SecurityPolicy = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("ownership_verification_certificate_arn"); ok {
+		params.OwnershipVerificationCertificateArn = aws.String(v.(string))
+	}
+
 	if len(tags) > 0 {
 		params.Tags = Tags(tags.IgnoreAWS())
 	}
@@ -281,6 +291,7 @@ func resourceDomainNameRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cloudfront_zone_id", cloudFrontRoute53ZoneID)
 	d.Set("domain_name", domainName.DomainName)
 	d.Set("security_policy", domainName.SecurityPolicy)
+	d.Set("ownership_verification_certificate_arn", domainName.OwnershipVerificationCertificateArn)
 
 	if err := d.Set("endpoint_configuration", flattenApiGatewayEndpointConfiguration(domainName.EndpointConfiguration)); err != nil {
 		return fmt.Errorf("error setting endpoint_configuration: %s", err)

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -144,7 +144,7 @@ func ResourceDomainName() *schema.Resource {
 			"ownership_verification_certificate_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateArn,
+				ValidateFunc: verify.ValidARN,
 			},
 
 			"regional_certificate_arn": {

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -690,7 +690,7 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "test" {
-  bucket = aws_s3_bucket.test.id
+  bucket = aws_s3_bucket_versioning.test.bucket
   key    = %[1]q
   source = "test-fixtures/apigateway-domain-name-truststore-1.pem"
 }
@@ -708,8 +708,6 @@ resource "aws_api_gateway_domain_name" "test" {
     truststore_uri     = "s3://${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
     truststore_version = aws_s3_object.test.version_id
   }
-
-  depends_on = [aws_s3_bucket_versioning.test]
 }
 `, rName))
 }
@@ -748,7 +746,7 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "test" {
-  bucket = aws_s3_bucket.test.id
+  bucket = aws_s3_bucket_versioning.test.bucket
   key    = %[1]q
   source = "test-fixtures/apigateway-domain-name-truststore-1.pem"
 }
@@ -776,8 +774,6 @@ resource "aws_api_gateway_domain_name" "test" {
     truststore_uri     = "s3://${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
     truststore_version = aws_s3_object.test.version_id
   }
-
-  depends_on = [aws_s3_bucket_versioning.test]
 }
 `, rName, certificate, key))
 }

--- a/internal/service/apigateway/errorcheck_test.go
+++ b/internal/service/apigateway/errorcheck_test.go
@@ -1,0 +1,20 @@
+package apigateway_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(apigateway.EndpointsID, testAccErrorCheckSkip)
+}
+
+// testAccErrorCheckSkipAppStream skips AppStream tests that have error messages indicating unsupported features
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"no matching Route53Zone found",
+	)
+}

--- a/internal/service/apigateway/errorcheck_test.go
+++ b/internal/service/apigateway/errorcheck_test.go
@@ -12,7 +12,7 @@ func init() {
 	acctest.RegisterServiceErrorCheckFunc(apigateway.EndpointsID, testAccErrorCheckSkip)
 }
 
-// testAccErrorCheckSkipAppStream skips AppStream tests that have error messages indicating unsupported features
+// skips tests that have error messages indicating unsupported features
 func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"no matching Route53Zone found",

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -84,7 +84,7 @@ func ResourceDomainName() *schema.Resource {
 						"ownership_verification_certificate_arn": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validateArn,
+							ValidateFunc: verify.ValidARN,
 						},
 					},
 				},

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -84,6 +84,7 @@ func ResourceDomainName() *schema.Resource {
 						"ownership_verification_certificate_arn": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 					},
@@ -123,8 +124,8 @@ func resourceDomainNameCreate(d *schema.ResourceData, meta interface{}) error {
 
 	input := &apigatewayv2.CreateDomainNameInput{
 		DomainName:               aws.String(domainName),
-		DomainNameConfigurations: expandApiGatewayV2DomainNameConfiguration(d.Get("domain_name_configuration").([]interface{})),
-		MutualTlsAuthentication:  expandApiGatewayV2MutualTlsAuthentication(d.Get("mutual_tls_authentication").([]interface{})),
+		DomainNameConfigurations: expandDomainNameConfigurations(d.Get("domain_name_configuration").([]interface{})),
+		MutualTlsAuthentication:  expandMutualTLSAuthentication(d.Get("mutual_tls_authentication").([]interface{})),
 		Tags:                     Tags(tags.IgnoreAWS()),
 	}
 
@@ -170,12 +171,13 @@ func resourceDomainNameRead(d *schema.ResourceData, meta interface{}) error {
 	}.String()
 	d.Set("arn", arn)
 	d.Set("domain_name", output.DomainName)
-	err = d.Set("domain_name_configuration", flattenApiGatewayV2DomainNameConfiguration(output.DomainNameConfigurations[0]))
+
+	err = d.Set("domain_name_configuration", flattenDomainNameConfiguration(output.DomainNameConfigurations[0]))
 	if err != nil {
 		return fmt.Errorf("error setting domain_name_configuration: %w", err)
 	}
-	err = d.Set("mutual_tls_authentication", flattenApiGatewayV2MutualTlsAuthentication(output.MutualTlsAuthentication))
-	if err != nil {
+
+	if err = d.Set("mutual_tls_authentication", flattenMutualTLSAuthentication(output.MutualTlsAuthentication)); err != nil {
 		return fmt.Errorf("error setting mutual_tls_authentication: %w", err)
 	}
 
@@ -199,7 +201,7 @@ func resourceDomainNameUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChanges("domain_name_configuration", "mutual_tls_authentication") {
 		input := &apigatewayv2.UpdateDomainNameInput{
 			DomainName:               aws.String(d.Id()),
-			DomainNameConfigurations: expandApiGatewayV2DomainNameConfiguration(d.Get("domain_name_configuration").([]interface{})),
+			DomainNameConfigurations: expandDomainNameConfigurations(d.Get("domain_name_configuration").([]interface{})),
 		}
 
 		if d.HasChange("mutual_tls_authentication") {
@@ -258,59 +260,126 @@ func resourceDomainNameDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandApiGatewayV2DomainNameConfiguration(vDomainNameConfiguration []interface{}) []*apigatewayv2.DomainNameConfiguration {
-	if len(vDomainNameConfiguration) == 0 || vDomainNameConfiguration[0] == nil {
+func expandDomainNameConfiguration(tfMap map[string]interface{}) *apigatewayv2.DomainNameConfiguration {
+	if tfMap == nil {
 		return nil
 	}
-	mDomainNameConfiguration := vDomainNameConfiguration[0].(map[string]interface{})
 
-	return []*apigatewayv2.DomainNameConfiguration{{
-		CertificateArn:                      aws.String(mDomainNameConfiguration["certificate_arn"].(string)),
-		EndpointType:                        aws.String(mDomainNameConfiguration["endpoint_type"].(string)),
-		SecurityPolicy:                      aws.String(mDomainNameConfiguration["security_policy"].(string)),
-		OwnershipVerificationCertificateArn: aws.String(mDomainNameConfiguration["ownership_verification_certificate_arn"].(string)),
-	}}
-}
+	apiObject := &apigatewayv2.DomainNameConfiguration{}
 
-func flattenApiGatewayV2DomainNameConfiguration(domainNameConfiguration *apigatewayv2.DomainNameConfiguration) []interface{} {
-	if domainNameConfiguration == nil {
-		return []interface{}{}
+	if v, ok := tfMap["certificate_arn"].(string); ok && v != "" {
+		apiObject.CertificateArn = aws.String(v)
 	}
 
-	return []interface{}{map[string]interface{}{
-		"certificate_arn":                        aws.StringValue(domainNameConfiguration.CertificateArn),
-		"endpoint_type":                          aws.StringValue(domainNameConfiguration.EndpointType),
-		"hosted_zone_id":                         aws.StringValue(domainNameConfiguration.HostedZoneId),
-		"security_policy":                        aws.StringValue(domainNameConfiguration.SecurityPolicy),
-		"target_domain_name":                     aws.StringValue(domainNameConfiguration.ApiGatewayDomainName),
-		"ownership_verification_certificate_arn": aws.StringValue(domainNameConfiguration.OwnershipVerificationCertificateArn),
-	}}
+	if v, ok := tfMap["endpoint_type"].(string); ok && v != "" {
+		apiObject.EndpointType = aws.String(v)
+	}
+
+	if v, ok := tfMap["security_policy"].(string); ok && v != "" {
+		apiObject.SecurityPolicy = aws.String(v)
+	}
+
+	if v, ok := tfMap["ownership_verification_certificate_arn"].(string); ok && v != "" {
+		apiObject.OwnershipVerificationCertificateArn = aws.String(v)
+	}
+
+	return apiObject
 }
 
-func expandApiGatewayV2MutualTlsAuthentication(vMutualTlsAuthentication []interface{}) *apigatewayv2.MutualTlsAuthenticationInput {
-	if len(vMutualTlsAuthentication) == 0 || vMutualTlsAuthentication[0] == nil {
+func expandDomainNameConfigurations(tfList []interface{}) []*apigatewayv2.DomainNameConfiguration {
+	if len(tfList) == 0 {
 		return nil
 	}
-	mMutualTlsAuthentication := vMutualTlsAuthentication[0].(map[string]interface{})
 
-	mutualTlsAuthentication := &apigatewayv2.MutualTlsAuthenticationInput{
-		TruststoreUri: aws.String(mMutualTlsAuthentication["truststore_uri"].(string)),
+	var apiObjects []*apigatewayv2.DomainNameConfiguration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandDomainNameConfiguration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
 	}
 
-	if vTruststoreVersion, ok := mMutualTlsAuthentication["truststore_version"].(string); ok && vTruststoreVersion != "" {
-		mutualTlsAuthentication.TruststoreVersion = aws.String(vTruststoreVersion)
-	}
-
-	return mutualTlsAuthentication
+	return apiObjects
 }
 
-func flattenApiGatewayV2MutualTlsAuthentication(mutualTlsAuthentication *apigatewayv2.MutualTlsAuthentication) []interface{} {
-	if mutualTlsAuthentication == nil {
-		return []interface{}{}
+func flattenDomainNameConfiguration(apiObject *apigatewayv2.DomainNameConfiguration) []interface{} {
+	if apiObject == nil {
+		return nil
 	}
 
-	return []interface{}{map[string]interface{}{
-		"truststore_uri":     aws.StringValue(mutualTlsAuthentication.TruststoreUri),
-		"truststore_version": aws.StringValue(mutualTlsAuthentication.TruststoreVersion),
-	}}
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.CertificateArn; v != nil {
+		tfMap["certificate_arn"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.EndpointType; v != nil {
+		tfMap["endpoint_type"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.HostedZoneId; v != nil {
+		tfMap["hosted_zone_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.SecurityPolicy; v != nil {
+		tfMap["security_policy"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.ApiGatewayDomainName; v != nil {
+		tfMap["target_domain_name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.OwnershipVerificationCertificateArn; v != nil {
+		tfMap["ownership_verification_certificate_arn"] = aws.StringValue(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func expandMutualTLSAuthentication(tfList []interface{}) *apigatewayv2.MutualTlsAuthenticationInput {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]interface{})
+
+	apiObject := &apigatewayv2.MutualTlsAuthenticationInput{}
+
+	if v, ok := tfMap["truststore_uri"].(string); ok && v != "" {
+		apiObject.TruststoreUri = aws.String(v)
+	}
+
+	if v, ok := tfMap["truststore_version"].(string); ok && v != "" {
+		apiObject.TruststoreVersion = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenMutualTLSAuthentication(apiObject *apigatewayv2.MutualTlsAuthentication) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.TruststoreUri; v != nil {
+		tfMap["truststore_uri"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.TruststoreVersion; v != nil {
+		tfMap["truststore_version"] = aws.StringValue(v)
+	}
+
+	return []interface{}{tfMap}
 }

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -205,16 +205,16 @@ func resourceDomainNameUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.HasChange("mutual_tls_authentication") {
-			vMutualTlsAuthentication := d.Get("mutual_tls_authentication").([]interface{})
+			mutTLSAuth := d.Get("mutual_tls_authentication").([]interface{})
 
-			if len(vMutualTlsAuthentication) == 0 || vMutualTlsAuthentication[0] == nil {
+			if len(mutTLSAuth) == 0 || mutTLSAuth[0] == nil {
 				// To disable mutual TLS for a custom domain name, remove the truststore from your custom domain name.
 				input.MutualTlsAuthentication = &apigatewayv2.MutualTlsAuthenticationInput{
 					TruststoreUri: aws.String(""),
 				}
 			} else {
 				input.MutualTlsAuthentication = &apigatewayv2.MutualTlsAuthenticationInput{
-					TruststoreVersion: aws.String(vMutualTlsAuthentication[0].(map[string]interface{})["truststore_version"].(string)),
+					TruststoreVersion: aws.String(mutTLSAuth[0].(map[string]interface{})["truststore_version"].(string)),
 				}
 			}
 		}

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -81,6 +81,11 @@ func ResourceDomainName() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"ownership_verification_certificate_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
 					},
 				},
 			},
@@ -260,9 +265,10 @@ func expandApiGatewayV2DomainNameConfiguration(vDomainNameConfiguration []interf
 	mDomainNameConfiguration := vDomainNameConfiguration[0].(map[string]interface{})
 
 	return []*apigatewayv2.DomainNameConfiguration{{
-		CertificateArn: aws.String(mDomainNameConfiguration["certificate_arn"].(string)),
-		EndpointType:   aws.String(mDomainNameConfiguration["endpoint_type"].(string)),
-		SecurityPolicy: aws.String(mDomainNameConfiguration["security_policy"].(string)),
+		CertificateArn:                      aws.String(mDomainNameConfiguration["certificate_arn"].(string)),
+		EndpointType:                        aws.String(mDomainNameConfiguration["endpoint_type"].(string)),
+		SecurityPolicy:                      aws.String(mDomainNameConfiguration["security_policy"].(string)),
+		OwnershipVerificationCertificateArn: aws.String(mDomainNameConfiguration["ownership_verification_certificate_arn"].(string)),
 	}}
 }
 
@@ -272,11 +278,12 @@ func flattenApiGatewayV2DomainNameConfiguration(domainNameConfiguration *apigate
 	}
 
 	return []interface{}{map[string]interface{}{
-		"certificate_arn":    aws.StringValue(domainNameConfiguration.CertificateArn),
-		"endpoint_type":      aws.StringValue(domainNameConfiguration.EndpointType),
-		"hosted_zone_id":     aws.StringValue(domainNameConfiguration.HostedZoneId),
-		"security_policy":    aws.StringValue(domainNameConfiguration.SecurityPolicy),
-		"target_domain_name": aws.StringValue(domainNameConfiguration.ApiGatewayDomainName),
+		"certificate_arn":                        aws.StringValue(domainNameConfiguration.CertificateArn),
+		"endpoint_type":                          aws.StringValue(domainNameConfiguration.EndpointType),
+		"hosted_zone_id":                         aws.StringValue(domainNameConfiguration.HostedZoneId),
+		"security_policy":                        aws.StringValue(domainNameConfiguration.SecurityPolicy),
+		"target_domain_name":                     aws.StringValue(domainNameConfiguration.ApiGatewayDomainName),
+		"ownership_verification_certificate_arn": aws.StringValue(domainNameConfiguration.OwnershipVerificationCertificateArn),
 	}}
 }
 

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/apigateway"
-
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -327,7 +325,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, apigateway.EndpointsID),
+		ErrorCheck:   acctest.ErrorCheck(t, apigatewayv2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckDomainNameDestroy,
 		Steps: []resource.TestStep{

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -312,7 +312,7 @@ func TestAccAPIGatewayV2DomainName_mutualTLSAuthentication(t *testing.T) {
 	})
 }
 
-func TestAccAWSAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.T) {
+func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.T) {
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 
 	var v apigatewayv2.GetDomainNameOutput

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -349,7 +349,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.
 		CheckDestroy: testAccCheckDomainNameDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainNameConfigMututalTlsAuthenticationOwnershipVerificationCert(rName, rootDomain, domain, certificate, key),
+				Config: testAccDomainNameConfigMututalTLSAuthenticationOwnershipVerificationCert(rName, rootDomain, domain, certificate, key),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/domainnames/+.`)),
@@ -613,7 +613,7 @@ resource "aws_apigatewayv2_domain_name" "test" {
 `)
 }
 
-func testAccDomainNameConfigMututalTlsAuthenticationOwnershipVerificationCert(rName, rootDomain, domain, certificate, key string) string {
+func testAccDomainNameConfigMututalTLSAuthenticationOwnershipVerificationCert(rName, rootDomain, domain, certificate, key string) string {
 	return acctest.ConfigCompose(
 		testAccDomainNamePublicCertConfig(rootDomain, domain),
 		fmt.Sprintf(`

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -231,24 +231,6 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDomainNameDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainNameMututalTLSAuthenticationNoObjectVersionConfig(rName, rootDomain, domain),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainNameExists(resourceName, &v),
-					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/domainnames/.+`)),
-					resource.TestCheckResourceAttrPair(resourceName, "domain_name", acmCertificateResourceName, "domain_name"),
-					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.0.endpoint_type", "REGIONAL"),
-					resource.TestCheckResourceAttrSet(resourceName, "domain_name_configuration.0.hosted_zone_id"),
-					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.0.security_policy", "TLS_1_2"),
-					resource.TestCheckResourceAttrSet(resourceName, "domain_name_configuration.0.target_domain_name"),
-					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.0.truststore_uri", fmt.Sprintf("s3://%s/%s", rName, rName)),
-					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.0.truststore_version", ""),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-				),
-			},
-			{
 				Config: testAccDomainNameMututalTLSAuthenticationObjectVersionConfig(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(resourceName, &v),
@@ -303,6 +285,43 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.0.security_policy", "TLS_1_2"),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name_configuration.0.target_domain_name"),
 					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_noVersion(t *testing.T) {
+	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
+	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(), rootDomain)
+
+	var v apigatewayv2.GetDomainNameOutput
+	resourceName := "aws_apigatewayv2_domain_name.test"
+	acmCertificateResourceName := "aws_acm_certificate.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apigatewayv2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainNameDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainNameMututalTLSAuthenticationNoObjectVersionConfig(rName, rootDomain, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainNameExists(resourceName, &v),
+					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/domainnames/.+`)),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name", acmCertificateResourceName, "domain_name"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.0.endpoint_type", "REGIONAL"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_name_configuration.0.hosted_zone_id"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.0.security_policy", "TLS_1_2"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_name_configuration.0.target_domain_name"),
+					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.0.truststore_uri", fmt.Sprintf("s3://%s/%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.0.truststore_version", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -2,9 +2,10 @@ package apigatewayv2_test
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/apigateway"
 	"regexp"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/apigateway"
 
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -331,7 +332,7 @@ func TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership(t *testi
 		CheckDestroy: testAccCheckDomainNameDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAPIGatewayV2DomainNameConfigMututalTlsAuthenticationOwnershipVerificationCert(rootDomain, rName, "apigateway-domain-name-truststore-1.pem", certificate, key),
+				Config: testAccDomainNameConfigMututalTlsAuthenticationOwnershipVerificationCert(rootDomain, rName, "apigateway-domain-name-truststore-1.pem", certificate, key),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/domainnames/+.`)),
@@ -575,6 +576,8 @@ resource "aws_apigatewayv2_domain_name" "test" {
     truststore_uri     = "s3://${aws_s3_object.test.bucket}/${aws_s3_object.test.key}"
     truststore_version = aws_s3_object.test.version_id
   }
+
+  depends_on = [aws_s3_bucket_versioning.test]
 }
 `, rName, pemFileName))
 }
@@ -595,7 +598,7 @@ resource "aws_apigatewayv2_domain_name" "test" {
 `)
 }
 
-func testAccAPIGatewayV2DomainNameConfigMututalTlsAuthenticationOwnershipVerificationCert(rootDomain, rName, pemFileName, certificate, key string) string {
+func testAccDomainNameConfigMututalTlsAuthenticationOwnershipVerificationCert(rootDomain, rName, pemFileName, certificate, key string) string {
 	domain := fmt.Sprintf("%s.%s", rName, rootDomain)
 
 	return acctest.ConfigCompose(

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -312,7 +312,7 @@ func TestAccAPIGatewayV2DomainName_mutualTLSAuthentication(t *testing.T) {
 	})
 }
 
-func TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership(t *testing.T) {
+func TestAccAWSAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.T) {
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 
 	var v apigatewayv2.GetDomainNameOutput

--- a/internal/service/apigatewayv2/errorcheck_test.go
+++ b/internal/service/apigatewayv2/errorcheck_test.go
@@ -12,7 +12,7 @@ func init() {
 	acctest.RegisterServiceErrorCheckFunc(apigatewayv2.EndpointsID, testAccErrorCheckSkip)
 }
 
-// testAccErrorCheckSkipAppStream skips AppStream tests that have error messages indicating unsupported features
+// skips tests that have error messages indicating unsupported features
 func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"no matching Route53Zone found",

--- a/internal/service/apigatewayv2/errorcheck_test.go
+++ b/internal/service/apigatewayv2/errorcheck_test.go
@@ -1,0 +1,20 @@
+package apigatewayv2_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(apigatewayv2.EndpointsID, testAccErrorCheckSkip)
+}
+
+// testAccErrorCheckSkipAppStream skips AppStream tests that have error messages indicating unsupported features
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"no matching Route53Zone found",
+	)
+}

--- a/internal/service/s3/status.go
+++ b/internal/service/s3/status.go
@@ -57,3 +57,34 @@ func lifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket,
 		return output, LifecycleConfigurationRulesStatusReady, nil
 	}
 }
+
+func bucketVersioningStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &s3.GetBucketVersioningInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketVersioningWithContext(ctx, input)
+
+		if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil {
+			return nil, "", &resource.NotFoundError{
+				Message:     "Empty result",
+				LastRequest: input,
+			}
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -49,8 +49,6 @@ func waitForBucketVersioningStatus(ctx context.Context, conn *s3.S3, bucket, exp
 		Delay:                     1 * time.Second,
 	}
 
-	_, err := stateConf.WaitForState()
-
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*s3.GetBucketVersioningOutput); ok {

--- a/website/docs/d/api_gateway_domain_name.html.markdown
+++ b/website/docs/d/api_gateway_domain_name.html.markdown
@@ -20,23 +20,23 @@ data "aws_api_gateway_domain_name" "example" {
 
 ## Argument Reference
 
-* `domain_name` - (Required) The fully-qualified domain name to look up. If no domain name is found, an error will be returned.
+* `domain_name` - (Required) Fully-qualified domain name to look up. If no domain name is found, an error will be returned.
 
 ## Attributes Reference
 
 In addition to the arguments, the following attributes are exported:
 
-* `arn` - The ARN of the found custom domain name.
-* `certificate_arn` - The ARN for an AWS-managed certificate that is used by edge-optimized endpoint for this domain name.
-* `certificate_name` - The name of the certificate that is used by edge-optimized endpoint for this domain name.
-* `certificate_upload_date` - The upload date associated with the domain certificate.
-* `cloudfront_domain_name` - The hostname created by Cloudfront to represent the distribution that implements this domain name mapping.
+* `arn` - ARN of the found custom domain name.
+* `certificate_arn` - ARN for an AWS-managed certificate that is used by edge-optimized endpoint for this domain name.
+* `certificate_name` - Name of the certificate that is used by edge-optimized endpoint for this domain name.
+* `certificate_upload_date` - Upload date associated with the domain certificate.
+* `cloudfront_domain_name` - Hostname created by Cloudfront to represent the distribution that implements this domain name mapping.
 * `cloudfront_zone_id` - For convenience, the hosted zone ID (`Z2FDTNDATAQYW2`) that can be used to create a Route53 alias record for the distribution.
 * `endpoint_configuration` - List of objects with the endpoint configuration of this domain name.
     * `types` - List of endpoint types.
-* `regional_certificate_arn` - The ARN for an AWS-managed certificate that is used for validating the regional domain name.
-* `regional_certificate_name` - The user-friendly name of the certificate that is used by regional endpoint for this domain name.
-* `regional_domain_name` - The hostname for the custom domain's regional endpoint.
-* `regional_zone_id` - The hosted zone ID that can be used to create a Route53 alias record for the regional endpoint.
-* `security_policy` - The security policy for the domain name.
+* `regional_certificate_arn` - ARN for an AWS-managed certificate that is used for validating the regional domain name.
+* `regional_certificate_name` - User-friendly name of the certificate that is used by regional endpoint for this domain name.
+* `regional_domain_name` - Hostname for the custom domain's regional endpoint.
+* `regional_zone_id` - Hosted zone ID that can be used to create a Route53 alias record for the regional endpoint.
+* `security_policy` - Security policy for the domain name.
 * `tags` - Key-value map of tags for the resource.

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -1741,7 +1741,7 @@ your Terraform state and will henceforth be managed by Terraform.
 
 #### Ensure Objects Depend on Versioning
 
-When you create an object whose `version_id` you need and an `aws_s3_bucket_versioning` resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on = [aws_s3_bucket_version.example]`) on the `aws_s3_bucket_versioning` resource.
+When you create an object whose `version_id` you need and an `aws_s3_bucket_versioning` resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on = [aws_s3_bucket_versioning.example]`) on the `aws_s3_bucket_versioning` resource.
 
 ~> **NOTE:** For critical and/or production S3 objects, do not create a bucket, enable versioning, and create an object in the bucket within the same configuration. Doing so will not allow the AWS-recommended 15 minutes between enabling versioning and writing to the bucket.
 

--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -158,6 +158,7 @@ The following arguments are supported:
 * `endpoint_configuration` - (Optional) Configuration block defining API endpoint information including type. Defined below.
 * `mutual_tls_authentication` - (Optional) The mutual TLS authentication configuration for the domain name. Defined below.
 * `security_policy` - (Optional) The Transport Layer Security (TLS) version + cipher suite for this DomainName. The valid values are `TLS_1_0` and `TLS_1_2`. Must be configured to perform drift detection.
+* `ownership_verification_certificate_arn` - (Optional) The ARN of the AWS-issued certificate used to validate custom domain ownership (when `certificate_arn` is issued via an ACM Private CA or `mutual_tls_authentication` is configured with an ACM-imported certificate.)
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 When referencing an AWS-managed certificate, the following arguments are supported:

--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -154,59 +154,47 @@ resource "aws_route53_record" "example" {
 
 The following arguments are supported:
 
-* `domain_name` - (Required) The fully-qualified domain name to register
-* `endpoint_configuration` - (Optional) Configuration block defining API endpoint information including type. Defined below.
-* `mutual_tls_authentication` - (Optional) The mutual TLS authentication configuration for the domain name. Defined below.
-* `security_policy` - (Optional) The Transport Layer Security (TLS) version + cipher suite for this DomainName. The valid values are `TLS_1_0` and `TLS_1_2`. Must be configured to perform drift detection.
-* `ownership_verification_certificate_arn` - (Optional) The ARN of the AWS-issued certificate used to validate custom domain ownership (when `certificate_arn` is issued via an ACM Private CA or `mutual_tls_authentication` is configured with an ACM-imported certificate.)
+* `domain_name` - (Required) Fully-qualified domain name to register.
+* `endpoint_configuration` - (Optional) Configuration block defining API endpoint information including type. See below.
+* `mutual_tls_authentication` - (Optional) Mutual TLS authentication configuration for the domain name. See below.
+* `ownership_verification_certificate_arn` - (Optional) ARN of the AWS-issued certificate used to validate custom domain ownership (when `certificate_arn` is issued via an ACM Private CA or `mutual_tls_authentication` is configured with an ACM-imported certificate.)
+* `security_policy` - (Optional) Transport Layer Security (TLS) version + cipher suite for this DomainName. Valid values are `TLS_1_0` and `TLS_1_2`. Must be configured to perform drift detection.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 When referencing an AWS-managed certificate, the following arguments are supported:
 
-* `certificate_arn` - (Optional) The ARN for an AWS-managed certificate. AWS Certificate Manager is the only supported source. Used when an edge-optimized domain name is desired. Conflicts with `certificate_name`, `certificate_body`, `certificate_chain`, `certificate_private_key`, `regional_certificate_arn`, and `regional_certificate_name`.
-* `regional_certificate_arn` - (Optional) The ARN for an AWS-managed certificate. AWS Certificate Manager is the only supported source. Used when a regional domain name is desired. Conflicts with `certificate_arn`, `certificate_name`, `certificate_body`, `certificate_chain`, and `certificate_private_key`.
+* `certificate_arn` - (Optional) ARN for an AWS-managed certificate. AWS Certificate Manager is the only supported source. Used when an edge-optimized domain name is desired. Conflicts with `certificate_name`, `certificate_body`, `certificate_chain`, `certificate_private_key`, `regional_certificate_arn`, and `regional_certificate_name`.
+* `regional_certificate_arn` - (Optional) ARN for an AWS-managed certificate. AWS Certificate Manager is the only supported source. Used when a regional domain name is desired. Conflicts with `certificate_arn`, `certificate_name`, `certificate_body`, `certificate_chain`, and `certificate_private_key`.
 
 When uploading a certificate, the following arguments are supported:
 
-* `certificate_name` - (Optional) The unique name to use when registering this
-  certificate as an IAM server certificate. Conflicts with `certificate_arn`, `regional_certificate_arn`, and
-  `regional_certificate_name`. Required if `certificate_arn` is not set.
-* `certificate_body` - (Optional) The certificate issued for the domain name
-  being registered, in PEM format. Only valid for `EDGE` endpoint configuration type. Conflicts with `certificate_arn`, `regional_certificate_arn`, and
-  `regional_certificate_name`.
-* `certificate_chain` - (Optional) The certificate for the CA that issued the
-  certificate, along with any intermediate CA certificates required to
-  create an unbroken chain to a certificate trusted by the intended API clients. Only valid for `EDGE` endpoint configuration type. Conflicts with `certificate_arn`,
-  `regional_certificate_arn`, and `regional_certificate_name`.
-* `certificate_private_key` - (Optional) The private key associated with the
-  domain certificate given in `certificate_body`. Only valid for `EDGE` endpoint configuration type. Conflicts with `certificate_arn`, `regional_certificate_arn`, and `regional_certificate_name`.
-* `regional_certificate_name` - (Optional) The user-friendly name of the certificate that will be used by regional endpoint for this domain name. Conflicts with `certificate_arn`, `certificate_name`, `certificate_body`, `certificate_chain`, and
-  `certificate_private_key`.
+* `certificate_body` - (Optional) Certificate issued for the domain name being registered, in PEM format. Only valid for `EDGE` endpoint configuration type. Conflicts with `certificate_arn`, `regional_certificate_arn`, and `regional_certificate_name`.
+* `certificate_chain` - (Optional) Certificate for the CA that issued the certificate, along with any intermediate CA certificates required to create an unbroken chain to a certificate trusted by the intended API clients. Only valid for `EDGE` endpoint configuration type. Conflicts with `certificate_arn`, `regional_certificate_arn`, and `regional_certificate_name`.
+* `certificate_name` - (Optional) Unique name to use when registering this certificate as an IAM server certificate. Conflicts with `certificate_arn`, `regional_certificate_arn`, and `regional_certificate_name`. Required if `certificate_arn` is not set.
+* `certificate_private_key` - (Optional) Private key associated with the domain certificate given in `certificate_body`. Only valid for `EDGE` endpoint configuration type. Conflicts with `certificate_arn`, `regional_certificate_arn`, and `regional_certificate_name`.
+* `regional_certificate_name` - (Optional) User-friendly name of the certificate that will be used by regional endpoint for this domain name. Conflicts with `certificate_arn`, `certificate_name`, `certificate_body`, `certificate_chain`, and `certificate_private_key`.
 
 ### endpoint_configuration
 
-* `types` - (Required) A list of endpoint types. This resource currently only supports managing a single value. Valid values: `EDGE` or `REGIONAL`. If unspecified, defaults to `EDGE`. Must be declared as `REGIONAL` in non-Commercial partitions. Refer to the [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/create-regional-api.html) for more information on the difference between edge-optimized and regional APIs.
+* `types` - (Required) List of endpoint types. This resource currently only supports managing a single value. Valid values: `EDGE` or `REGIONAL`. If unspecified, defaults to `EDGE`. Must be declared as `REGIONAL` in non-Commercial partitions. Refer to the [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/create-regional-api.html) for more information on the difference between edge-optimized and regional APIs.
 
 ### mutual_tls_authentication
 
-* `truststore_uri` - (Required) An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, `s3://bucket-name/key-name`.
-The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version.
-* `truststore_version` - (Optional) The version of the S3 object that contains the truststore. To specify a version, you must have versioning enabled for the S3 bucket.
+* `truststore_uri` - (Required) Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, `s3://bucket-name/key-name`. The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version.
+* `truststore_version` - (Optional) Version of the S3 object that contains the truststore. To specify a version, you must have versioning enabled for the S3 bucket.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The internal id assigned to this domain name by API Gateway.
-* `certificate_upload_date` - The upload date associated with the domain certificate.
-* `cloudfront_domain_name` - The hostname created by Cloudfront to represent
-  the distribution that implements this domain name mapping.
-* `cloudfront_zone_id` - For convenience, the hosted zone ID (`Z2FDTNDATAQYW2`)
-  that can be used to create a Route53 alias record for the distribution.
-* `regional_domain_name` - The hostname for the custom domain's regional endpoint.
-* `regional_zone_id` - The hosted zone ID that can be used to create a Route53 alias record for the regional endpoint.
-* `arn` - Amazon Resource Name (ARN)
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `arn` - ARN of domain name.
+* `certificate_upload_date` - Upload date associated with the domain certificate.
+* `cloudfront_domain_name` - Hostname created by Cloudfront to represent the distribution that implements this domain name mapping.
+* `cloudfront_zone_id` - For convenience, the hosted zone ID (`Z2FDTNDATAQYW2`) that can be used to create a Route53 alias record for the distribution.
+* `id` - Internal identifier assigned to this domain name by API Gateway.
+* `regional_domain_name` - Hostname for the custom domain's regional endpoint.
+* `regional_zone_id` - Hosted zone ID that can be used to create a Route53 alias record for the regional endpoint.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 

--- a/website/docs/r/apigatewayv2_domain_name.html.markdown
+++ b/website/docs/r/apigatewayv2_domain_name.html.markdown
@@ -73,6 +73,7 @@ Use the [`aws_acm_certificate`](/docs/providers/aws/r/acm_certificate.html) reso
 * `security_policy` - (Required) The Transport Layer Security (TLS) version of the [security policy](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html) for the domain name. Valid values: `TLS_1_2`.
 * `hosted_zone_id` - (Computed) The Amazon Route 53 Hosted Zone ID of the endpoint.
 * `target_domain_name` - (Computed) The target domain name.
+* `ownership_verification_certificate_arn` - (Optional) The ARN of the AWS-issued certificate used to validate custom domain ownership (when `certificate_arn` is issued via an ACM Private CA or `mutual_tls_authentication` is configured with an ACM-imported certificate.)
 
 The `mutual_tls_authentication` object supports the following:
 

--- a/website/docs/r/apigatewayv2_domain_name.html.markdown
+++ b/website/docs/r/apigatewayv2_domain_name.html.markdown
@@ -60,35 +60,33 @@ resource "aws_route53_record" "example" {
 
 The following arguments are supported:
 
-* `domain_name` - (Required) The domain name. Must be between 1 and 512 characters in length.
-* `domain_name_configuration` - (Required) The domain name configuration.
-* `mutual_tls_authentication` - (Optional) The mutual TLS authentication configuration for the domain name.
-* `tags` - (Optional) A map of tags to assign to the domain name. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `domain_name` - (Required) Domain name. Must be between 1 and 512 characters in length.
+* `domain_name_configuration` - (Required) Domain name configuration. See below.
+* `mutual_tls_authentication` - (Optional) Mutual TLS authentication configuration for the domain name.
+* `tags` - (Optional) Map of tags to assign to the domain name. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-The `domain_name_configuration` object supports the following:
+### `domain_name_configuration`
 
-* `certificate_arn` - (Required) The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source.
-Use the [`aws_acm_certificate`](/docs/providers/aws/r/acm_certificate.html) resource to configure an ACM certificate.
-* `endpoint_type` - (Required) The endpoint type. Valid values: `REGIONAL`.
-* `security_policy` - (Required) The Transport Layer Security (TLS) version of the [security policy](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html) for the domain name. Valid values: `TLS_1_2`.
-* `hosted_zone_id` - (Computed) The Amazon Route 53 Hosted Zone ID of the endpoint.
-* `target_domain_name` - (Computed) The target domain name.
-* `ownership_verification_certificate_arn` - (Optional) The ARN of the AWS-issued certificate used to validate custom domain ownership (when `certificate_arn` is issued via an ACM Private CA or `mutual_tls_authentication` is configured with an ACM-imported certificate.)
+* `certificate_arn` - (Required) ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source. Use the [`aws_acm_certificate`](/docs/providers/aws/r/acm_certificate.html) resource to configure an ACM certificate.
+* `endpoint_type` - (Required) Endpoint type. Valid values: `REGIONAL`.
+* `hosted_zone_id` - (Computed) Amazon Route 53 Hosted Zone ID of the endpoint.
+* `ownership_verification_certificate_arn` - (Optional) ARN of the AWS-issued certificate used to validate custom domain ownership (when `certificate_arn` is issued via an ACM Private CA or `mutual_tls_authentication` is configured with an ACM-imported certificate.)
+* `security_policy` - (Required) Transport Layer Security (TLS) version of the [security policy](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html) for the domain name. Valid values: `TLS_1_2`.
+* `target_domain_name` - (Computed) Target domain name.
 
-The `mutual_tls_authentication` object supports the following:
+### `mutual_tls_authentication`
 
-* `truststore_uri` - (Required) An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, `s3://bucket-name/key-name`.
-The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version.
-* `truststore_version` - (Optional) The version of the S3 object that contains the truststore. To specify a version, you must have versioning enabled for the S3 bucket.
+* `truststore_uri` - (Required) Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example, `s3://bucket-name/key-name`. The truststore can contain certificates from public or private certificate authorities. To update the truststore, upload a new version to S3, and then update your custom domain name to use the new version.
+* `truststore_version` - (Optional) Version of the S3 object that contains the truststore. To specify a version, you must have versioning enabled for the S3 bucket.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The domain name identifier.
-* `api_mapping_selection_expression` - The [API mapping selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-mapping-selection-expressions) for the domain name.
-* `arn` - The ARN of the domain name.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `api_mapping_selection_expression` - [API mapping selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-mapping-selection-expressions) for the domain name.
+* `arn` - ARN of the domain name.
+* `id` - Domain name identifier.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Timeouts
 

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -36,7 +36,11 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
 
 ### Object Dependency On Versioning
 
-As noted above, AWS recommends waiting 15 minutes after enabling versioning before putting or deleting objects in a bucket. When that wait is not possible and you create an object whose `version_id` you need and a versioning resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on`) on the `aws_s3_bucket_versioning` resource.
+When you create an object whose `version_id` you need and an `aws_s3_bucket_versioning` resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on = [aws_s3_bucket_version.example]`) on the `aws_s3_bucket_versioning` resource.
+
+~> **NOTE:** For critical and/or production S3 objects, do not create a bucket, enable versioning, and create an object in the bucket within the same configuration. Doing so will not allow the AWS-recommended 15 minutes between enabling versioning and writing to the bucket.
+
+This example shows the `aws_s3_object.example` depending implicitly on the versioning resource through the reference to `aws_s3_bucket_versioning.example.bucket` to define `bucket`:
 
 ```terraform
 resource "aws_s3_bucket" "example" {

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -34,6 +34,30 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
 }
 ```
 
+### Object Dependency On Versioning
+
+As noted above, AWS recommends waiting 15 minutes after enabling versioning before putting or deleting objects in a bucket. When that wait is not possible and you create an object whose `version_id` you need and a versioning resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on`) on the `aws_s3_bucket_versioning` resource.
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "yotto"
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "example" {
+  bucket = aws_s3_bucket_versioning.example.bucket
+  key    = "droeloe"
+  source = "example.txt"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -36,7 +36,7 @@ resource "aws_s3_bucket_versioning" "versioning_example" {
 
 ### Object Dependency On Versioning
 
-When you create an object whose `version_id` you need and an `aws_s3_bucket_versioning` resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on = [aws_s3_bucket_version.example]`) on the `aws_s3_bucket_versioning` resource.
+When you create an object whose `version_id` you need and an `aws_s3_bucket_versioning` resource in the same configuration, you are more likely to have success by ensuring the `s3_object` depends either implicitly (see below) or explicitly (i.e., using `depends_on = [aws_s3_bucket_versioning.example]`) on the `aws_s3_bucket_versioning` resource.
 
 ~> **NOTE:** For critical and/or production S3 objects, do not create a bucket, enable versioning, and create an object in the bucket within the same configuration. Doing so will not allow the AWS-recommended 15 minutes between enabling versioning and writing to the bucket.
 


### PR DESCRIPTION
- add `ownership_verification_certificate_arn` to:
  - `aws_apigatewayv2_domain_name.domain_name_configuration`,
  - `aws_api_gateway_domain_name`.
- update documentation to include `ownership_verification_certificate_arn`;
- add separate tests for mTLS with ownership-verification (as it requires both a public cert. for verification plus an imported cert. to trigger the requirement.)
  - the existing test framework provides `testAccAWSAPIGatewayV2DomainNameConfigPublicCert()` and `testAccAWSAPIGatewayV2DomainNameConfigImportedCerts()` for creating certs. However, both create a `aws_acm_certificate.test` resource (i.e. a conflicting name.) As this change effectively requires both (mTLS with an imported ACM cert. but using an ACM-issued cert. for verification), I've opted to use the former and use a separate, explicit config. to do the latter.
  - I've also added entirely separate tests for these rather than adding a `TestStep` to an existing `ParallelTest` as, largely due to the above, this didn't immediately seem to fit the pattern of the existing tests.
- according to AWS' [docs.](https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mutual-tls.html#rest-api-mutual-tls-non-acm-certs), this field is needed for imported certs. or when using ACM PCA—the tests verify the former but due to the potential expense of the latter, I've not implemented tests for this explicitly.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #20582

Output from acceptance testing:

```
$ ACM_CERTIFICATE_ROOT_DOMAIN=${TF_DOMAIN} make testacc TESTARGS='-run=TestAccAWSAPIGatewayDomainName_MutualTlsAuthentication_ownership'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGateway*DomainName_MutualTlsAuthentication_ownership -timeout 180m
=== RUN   TestAccAWSAPIGatewayDomainName_MutualTlsAuthentication_ownership
=== PAUSE TestAccAWSAPIGatewayDomainName_MutualTlsAuthentication_ownership
=== CONT  TestAccAWSAPIGatewayDomainName_MutualTlsAuthentication_ownership
--- PASS: TestAccAWSAPIGatewayDomainName_MutualTlsAuthentication_ownership (145.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	145.497s

ACM_CERTIFICATE_ROOT_DOMAIN=${TF_DOMAIN} make testacc TESTARGS='-run=TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership -timeout 180m
=== RUN   TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership
=== PAUSE TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership
=== CONT  TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership
--- PASS: TestAccAWSAPIGatewayV2DomainName_MutualTlsAuthentication_ownership (132.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	132.156s
```
