### PR TITLE
provider: Add HTTP proxy setting

### DIFF
--- a/.changelog/21077.txt
+++ b/.changelog/21077.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add parameter `http_proxy` to provider configuration
+```

--- a/aws/config.go
+++ b/aws/config.go
@@ -205,6 +205,7 @@ type Config struct {
 	Endpoints         map[string]string
 	IgnoreTagsConfig  *keyvaluetags.IgnoreConfig
 	Insecure          bool
+	HTTPProxy         string
 
 	SkipCredsValidation     bool
 	SkipGetEC2Platforms     bool
@@ -435,6 +436,7 @@ func (c *Config) Client() (interface{}, error) {
 		DebugLogging:                logging.IsDebugOrHigher(),
 		IamEndpoint:                 c.Endpoints["iam"],
 		Insecure:                    c.Insecure,
+		HTTPProxy:                   c.HTTPProxy,
 		MaxRetries:                  c.MaxRetries,
 		Profile:                     c.Profile,
 		Region:                      c.Region,

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -106,6 +106,12 @@ func Provider() *schema.Provider {
 				},
 			},
 
+			"http_proxy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["http_proxy"],
+			},
+
 			"endpoints": endpointsSchema(),
 
 			"ignore_tags": {
@@ -1325,9 +1331,12 @@ func init() {
 			"being executed. If the API request still fails, an error is\n" +
 			"thrown.",
 
+		"http_proxy": "The address of an HTTP proxy to use when accessing the AWS API. " +
+			"Can also be configured using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.",
+
 		"endpoint": "Use this to override the default service endpoint URL",
 
-		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
+		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, " +
 			"default value is `false`",
 
 		"skip_credentials_validation": "Skip the credentials validation via STS API. " +
@@ -1529,6 +1538,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		MaxRetries:              d.Get("max_retries").(int),
 		IgnoreTagsConfig:        expandProviderIgnoreTags(d.Get("ignore_tags").([]interface{})),
 		Insecure:                d.Get("insecure").(bool),
+		HTTPProxy:               d.Get("http_proxy").(string),
 		SkipCredsValidation:     d.Get("skip_credentials_validation").(bool),
 		SkipGetEC2Platforms:     d.Get("skip_get_ec2_platforms").(bool),
 		SkipRegionValidation:    d.Get("skip_region_validation").(bool),

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.50
 	github.com/beevik/etree v1.1.0
 	github.com/fatih/color v1.9.0 // indirect
-	github.com/hashicorp/aws-sdk-go-base v0.7.1
+	github.com/hashicorp/aws-sdk-go-base v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/hashicorp/aws-sdk-go-base v0.7.1 h1:7s/aR3hFn74tYPVihzDyZe7y/+BorN70rr9ZvpV3j3o=
-github.com/hashicorp/aws-sdk-go-base v0.7.1/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
+github.com/hashicorp/aws-sdk-go-base v1.0.0 h1:J7MMLOfSoDWkusy+cSzKYG1/aFyCzYJmdE0mod3/WLw=
+github.com/hashicorp/aws-sdk-go-base v1.0.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -199,6 +199,9 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `assume_role` - (Optional) An `assume_role` block (documented below). Only one
   `assume_role` block may be in the configuration.
 
+* `http_proxy` - (Optional) The address of an HTTP proxy to use when accessing the AWS API.
+  Can also be configured using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
+
 * `endpoints` - (Optional) Configuration block for customizing service endpoints. See the
 [Custom Service Endpoints Guide](/docs/providers/aws/guides/custom-service-endpoints.html)
 for more information about connecting to alternate AWS endpoints or AWS compatible solutions.


### PR DESCRIPTION
The AWS Provider currently supports the environment variables `HTTP_PROXY` or `HTTPS_PROXY` to configure an HTTP proxy. In some cases, only the AWS Provider or a specific instance of the AWS Provider need to traverse the proxy.

This PR allows setting the HTTP proxy at the level of the provider configuration.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14942
