### PR TITLE
fix: use `resource.Test` in serialized connect resource tests 

### DIFF
--- a/aws/resource_aws_connect_contact_flow_test.go
+++ b/aws/resource_aws_connect_contact_flow_test.go
@@ -34,7 +34,7 @@ func testAccAwsConnectContactFlow_basic(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_contact_flow.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, connect.EndpointsID),
 		Providers:    testAccProviders,
@@ -83,7 +83,7 @@ func testAccAwsConnectContactFlow_filename(t *testing.T) {
 	rName2 := acctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_contact_flow.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, connect.EndpointsID),
 		Providers:    testAccProviders,
@@ -137,7 +137,7 @@ func testAccAwsConnectContactFlow_disappears_ConnectInstance(t *testing.T) {
 	resourceName := "aws_connect_contact_flow.test"
 	instanceResourceName := "aws_connect_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, connect.EndpointsID),
 		Providers:    testAccProviders,

--- a/aws/resource_aws_connect_instance_test.go
+++ b/aws/resource_aws_connect_instance_test.go
@@ -98,7 +98,7 @@ func testAccAwsConnectInstance_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, connect.EndpointsID),
 		Providers:    testAccProviders,
@@ -152,7 +152,7 @@ func testAccAwsConnectInstance_directory(t *testing.T) {
 	rName := acctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, connect.EndpointsID),
 		Providers:    testAccProviders,
@@ -181,7 +181,7 @@ func testAccAwsConnectInstance_saml(t *testing.T) {
 	rName := acctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		ErrorCheck:   testAccErrorCheck(t, connect.EndpointsID),
 		Providers:    testAccProviders,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16709, #16854 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsConnectContactFlow_serial (342.35s)
    --- PASS: TestAccAwsConnectContactFlow_serial/basic (143.88s)
    --- PASS: TestAccAwsConnectContactFlow_serial/filename (99.32s)
    --- PASS: TestAccAwsConnectContactFlow_serial/disappears (99.15s)

--- PASS: TestAccAwsConnectInstance_serial (1021.50s)
    --- PASS: TestAccAwsConnectInstance_serial/basic (122.20s)
    --- PASS: TestAccAwsConnectInstance_serial/directory (816.96s)
    --- PASS: TestAccAwsConnectInstance_serial/saml (82.34s)
```
