### PR TITLE
DirectConnect Connection & LAG: `provider_name` -> Computed

### DIFF
--- a/.changelog/21085.txt
+++ b/.changelog/21085.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_dx_connection: Mark `provider_name` as Computed to avoid resource recreation with pre-v3.56.0 configurations
+```
+
+```release-note:bug
+resource/aws_dx_lag: Mark `provider_name` as Computed to avoid resource recreation with pre-v3.56.0 configurations
+```

--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -65,6 +65,7 @@ func resourceAwsDxConnection() *schema.Resource {
 			"provider_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"tags":     tagsSchema(),

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -65,6 +65,7 @@ func resourceAwsDxLag() *schema.Resource {
 			"provider_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"tags":     tagsSchema(),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21068.
Relates #17852.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAwsDxConnection_\|TestAccAwsDxLag_'                                                             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsDxConnection_\|TestAccAwsDxLag_ -timeout 180m
=== RUN   TestAccAwsDxConnection_basic
=== PAUSE TestAccAwsDxConnection_basic
=== RUN   TestAccAwsDxConnection_disappears
=== PAUSE TestAccAwsDxConnection_disappears
=== RUN   TestAccAwsDxConnection_ProviderName
=== PAUSE TestAccAwsDxConnection_ProviderName
=== RUN   TestAccAwsDxConnection_Tags
=== PAUSE TestAccAwsDxConnection_Tags
=== RUN   TestAccAwsDxLag_basic
=== PAUSE TestAccAwsDxLag_basic
=== RUN   TestAccAwsDxLag_ProviderName
=== PAUSE TestAccAwsDxLag_ProviderName
=== RUN   TestAccAwsDxLag_disappears
=== PAUSE TestAccAwsDxLag_disappears
=== RUN   TestAccAwsDxLag_Tags
=== PAUSE TestAccAwsDxLag_Tags
=== CONT  TestAccAwsDxConnection_basic
=== CONT  TestAccAwsDxLag_ProviderName
=== CONT  TestAccAwsDxLag_basic
=== CONT  TestAccAwsDxLag_disappears
=== CONT  TestAccAwsDxConnection_Tags
=== CONT  TestAccAwsDxConnection_disappears
=== CONT  TestAccAwsDxLag_Tags
=== CONT  TestAccAwsDxConnection_ProviderName
--- PASS: TestAccAwsDxConnection_disappears (20.92s)
--- PASS: TestAccAwsDxLag_disappears (22.80s)
--- PASS: TestAccAwsDxConnection_basic (25.56s)
--- PASS: TestAccAwsDxConnection_ProviderName (27.93s)
--- PASS: TestAccAwsDxLag_ProviderName (28.42s)
--- PASS: TestAccAwsDxLag_basic (40.31s)
--- PASS: TestAccAwsDxConnection_Tags (51.05s)
--- PASS: TestAccAwsDxLag_Tags (54.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.220s
```
