### PR TITLE
Fix syntax in example usage

### DIFF
--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -32,23 +32,19 @@ resource "aws_vpc" "mainvpc" {
 resource "aws_default_security_group" "default" {
   vpc_id = aws_vpc.mainvpc.id
 
-  ingress = [
-    {
-      protocol  = -1
-      self      = true
-      from_port = 0
-      to_port   = 0
-    }
-  ]
+  ingress {
+    self      = true
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+  }
 
-  egress = [
-    {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
-    }
-  ]
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 ```
 


### PR DESCRIPTION
Running `terraform apply` (v1.0.5) with this example resulted in:

│ Error: Incorrect attribute value type
│
│   on main.tf line 94, in resource "aws_default_security_group" "default":
│   94:   ingress = [
│   95:     {
│   96:       protocol  = -1
│   97:       self      = true
│   98:       from_port = 0
│   99:       to_port   = 0
│  100:     }
│  101:   ]
│
│ Inappropriate value for attribute "ingress": element 0: attributes "cidr_blocks",
│ "description", "ipv6_cidr_blocks", "prefix_list_ids", and "security_groups" are
│ required.

Is there a parity mismatch between the two ways of defining a collection of blocks?
```
ingress { ... }
ingress { ... }
```

vs.

```
ingress = [{ ... }, { ... }]
```

From what I gather from this error message and the fact that changing the syntax resolved the error, that means there are certain required-present attributes in the `ingress = []` syntax that aren't required in the `ingress {}` syntax?

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
