### PR TITLE
feat: aws_kinesisanalyticsv2_application custom timeouts

### DIFF
--- a/.changelog/21094.txt
+++ b/.changelog/21094.txt
@@ -1,0 +1,7 @@
+release-note:enhancement
+resource/aws_kinesisanalyticsv2_application: Add configurable timeouts
+```
+
+release-note:enhancement
+resource/aws_kinesisanalyticsv2_application_snapshot: Add configurable timeouts
+```

--- a/internal/service/kinesisanalyticsv2/application.go
+++ b/internal/service/kinesisanalyticsv2/application.go
@@ -41,6 +41,12 @@ func ResourceApplication() *schema.Resource {
 			State: resourceApplicationImport,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"application_configuration": {
 				Type:     schema.TypeList,
@@ -957,7 +963,7 @@ func resourceApplicationCreate(d *schema.ResourceData, meta interface{}) error {
 	d.Set("create_timestamp", aws.TimeValue(output.ApplicationDetail.CreateTimestamp).Format(time.RFC3339))
 
 	if _, ok := d.GetOk("start_application"); ok {
-		if err := startApplication(conn, expandStartApplicationInput(d)); err != nil {
+		if err := startApplication(conn, expandStartApplicationInput(d), d.Timeout(schema.TimeoutCreate)); err != nil {
 			return err
 		}
 	}
@@ -1086,7 +1092,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 						output := outputRaw.(*kinesisanalyticsv2.AddApplicationInputOutput)
 
-						if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+						if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 						}
 
@@ -1125,7 +1131,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 								output := outputRaw.(*kinesisanalyticsv2.AddApplicationInputProcessingConfigurationOutput)
 
-								if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+								if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 									return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 								}
 
@@ -1150,7 +1156,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 								output := outputRaw.(*kinesisanalyticsv2.DeleteApplicationInputProcessingConfigurationOutput)
 
-								if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+								if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 									return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 								}
 
@@ -1212,7 +1218,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 						output := outputRaw.(*kinesisanalyticsv2.DeleteApplicationOutputOutput)
 
-						if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+						if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 						}
 
@@ -1239,7 +1245,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 						output := outputRaw.(*kinesisanalyticsv2.AddApplicationOutputOutput)
 
-						if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+						if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 						}
 
@@ -1270,7 +1276,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 						output := outputRaw.(*kinesisanalyticsv2.AddApplicationReferenceDataSourceOutput)
 
-						if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+						if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 						}
 
@@ -1297,7 +1303,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 						output := outputRaw.(*kinesisanalyticsv2.DeleteApplicationReferenceDataSourceOutput)
 
-						if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+						if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 							return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 						}
 
@@ -1338,7 +1344,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 					output := outputRaw.(*kinesisanalyticsv2.AddApplicationVpcConfigurationOutput)
 
-					if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+					if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 						return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 					}
 
@@ -1365,7 +1371,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 					output := outputRaw.(*kinesisanalyticsv2.DeleteApplicationVpcConfigurationOutput)
 
-					if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+					if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 						return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 					}
 
@@ -1424,7 +1430,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 				output := outputRaw.(*kinesisanalyticsv2.AddApplicationCloudWatchLoggingOptionOutput)
 
-				if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+				if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 					return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 				}
 
@@ -1451,7 +1457,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 				output := outputRaw.(*kinesisanalyticsv2.DeleteApplicationCloudWatchLoggingOptionOutput)
 
-				if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+				if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 					return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 				}
 
@@ -1491,7 +1497,7 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error updating Kinesis Analytics v2 Application (%s): %w", d.Id(), err)
 			}
 
-			if _, err := waitApplicationUpdated(conn, applicationName); err != nil {
+			if _, err := waitApplicationUpdated(conn, applicationName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to update: %w", d.Id(), err)
 			}
 		}
@@ -1507,11 +1513,11 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("start_application") {
 		if _, ok := d.GetOk("start_application"); ok {
-			if err := startApplication(conn, expandStartApplicationInput(d)); err != nil {
+			if err := startApplication(conn, expandStartApplicationInput(d), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return err
 			}
 		} else {
-			if err := stopApplication(conn, expandStopApplicationInput(d)); err != nil {
+			if err := stopApplication(conn, expandStopApplicationInput(d), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return err
 			}
 		}
@@ -1544,7 +1550,7 @@ func resourceApplicationDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error deleting Kinesis Analytics v2 Application (%s): %w", d.Id(), err)
 	}
 
-	_, err = waitApplicationDeleted(conn, applicationName)
+	_, err = waitApplicationDeleted(conn, applicationName, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) deletion: %w", d.Id(), err)
@@ -1570,7 +1576,7 @@ func resourceApplicationImport(d *schema.ResourceData, meta interface{}) ([]*sch
 	return []*schema.ResourceData{d}, nil
 }
 
-func startApplication(conn *kinesisanalyticsv2.KinesisAnalyticsV2, input *kinesisanalyticsv2.StartApplicationInput) error {
+func startApplication(conn *kinesisanalyticsv2.KinesisAnalyticsV2, input *kinesisanalyticsv2.StartApplicationInput, timeout time.Duration) error {
 	applicationName := aws.StringValue(input.ApplicationName)
 
 	application, err := FindApplicationDetailByName(conn, applicationName)
@@ -1602,14 +1608,14 @@ func startApplication(conn *kinesisanalyticsv2.KinesisAnalyticsV2, input *kinesi
 		return fmt.Errorf("error starting Kinesis Analytics v2 Application (%s): %w", applicationARN, err)
 	}
 
-	if _, err := waitApplicationStarted(conn, applicationName); err != nil {
+	if _, err := waitApplicationStarted(conn, applicationName, timeout); err != nil {
 		return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to start: %w", applicationARN, err)
 	}
 
 	return nil
 }
 
-func stopApplication(conn *kinesisanalyticsv2.KinesisAnalyticsV2, input *kinesisanalyticsv2.StopApplicationInput) error {
+func stopApplication(conn *kinesisanalyticsv2.KinesisAnalyticsV2, input *kinesisanalyticsv2.StopApplicationInput, timeout time.Duration) error {
 	applicationName := aws.StringValue(input.ApplicationName)
 
 	application, err := FindApplicationDetailByName(conn, applicationName)
@@ -1631,7 +1637,7 @@ func stopApplication(conn *kinesisanalyticsv2.KinesisAnalyticsV2, input *kinesis
 		return fmt.Errorf("error stopping Kinesis Analytics v2 Application (%s): %w", applicationARN, err)
 	}
 
-	if _, err := waitApplicationStopped(conn, applicationName); err != nil {
+	if _, err := waitApplicationStopped(conn, applicationName, timeout); err != nil {
 		return fmt.Errorf("error waiting for Kinesis Analytics v2 Application (%s) to stop: %w", applicationARN, err)
 	}
 

--- a/internal/service/kinesisanalyticsv2/application_snapshot.go
+++ b/internal/service/kinesisanalyticsv2/application_snapshot.go
@@ -25,6 +25,11 @@ func ResourceApplicationSnapshot() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"application_name": {
 				Type:     schema.TypeString,
@@ -79,7 +84,7 @@ func resourceApplicationSnapshotCreate(d *schema.ResourceData, meta interface{})
 
 	d.SetId(applicationSnapshotCreateID(applicationName, snapshotName))
 
-	_, err = waitSnapshotCreated(conn, applicationName, snapshotName)
+	_, err = waitSnapshotCreated(conn, applicationName, snapshotName, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return fmt.Errorf("error waiting for Kinesis Analytics v2 Application Snapshot (%s) creation: %w", d.Id(), err)
@@ -150,7 +155,7 @@ func resourceApplicationSnapshotDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error deleting Kinesis Analytics v2 Application Snapshot (%s): %w", d.Id(), err)
 	}
 
-	_, err = waitSnapshotDeleted(conn, applicationName, snapshotName)
+	_, err = waitSnapshotDeleted(conn, applicationName, snapshotName, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return fmt.Errorf("error waiting for Kinesis Analytics v2 Application Snapshot (%s) deletion: %w", d.Id(), err)

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -1194,7 +1194,7 @@ func TestAccKinesisAnalyticsV2Application_FlinkApplication_restoreFromSnapshot(t
 					resource.TestCheckResourceAttr(resourceName, "start_application", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "version_id", "2"),
+					resource.TestCheckResourceAttr(resourceName, "version_id", "1"),
 				),
 			},
 			{
@@ -1264,7 +1264,7 @@ func TestAccKinesisAnalyticsV2Application_FlinkApplication_restoreFromSnapshot(t
 					resource.TestCheckResourceAttr(resourceName, "start_application", "true"),
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "version_id", "3"),
+					resource.TestCheckResourceAttr(resourceName, "version_id", "1"),
 				),
 			},
 			{
@@ -1323,7 +1323,7 @@ func TestAccKinesisAnalyticsV2Application_FlinkApplication_restoreFromSnapshot(t
 					resource.TestCheckResourceAttr(resourceName, "start_application", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "version_id", "4"),
+					resource.TestCheckResourceAttr(resourceName, "version_id", "1"),
 				),
 			},
 		},

--- a/internal/service/kinesisanalyticsv2/wait.go
+++ b/internal/service/kinesisanalyticsv2/wait.go
@@ -10,23 +10,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-const (
-	applicationDeletedTimeout = 5 * time.Minute
-	applicationStartedTimeout = 5 * time.Minute
-	applicationStoppedTimeout = 5 * time.Minute
-	applicationUpdatedTimeout = 5 * time.Minute
-
-	snapshotCreatedTimeout = 5 * time.Minute
-	snapshotDeletedTimeout = 5 * time.Minute
-)
-
 // waitApplicationDeleted waits for an Application to return Deleted
-func waitApplicationDeleted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string) (*kinesisanalyticsv2.ApplicationDetail, error) {
+func waitApplicationDeleted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string, timeout time.Duration) (*kinesisanalyticsv2.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalyticsv2.ApplicationStatusDeleting},
 		Target:  []string{},
 		Refresh: statusApplication(conn, name),
-		Timeout: applicationDeletedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -39,12 +29,12 @@ func waitApplicationDeleted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name st
 }
 
 // waitApplicationStarted waits for an Application to start
-func waitApplicationStarted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string) (*kinesisanalyticsv2.ApplicationDetail, error) {
+func waitApplicationStarted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string, timeout time.Duration) (*kinesisanalyticsv2.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalyticsv2.ApplicationStatusStarting},
 		Target:  []string{kinesisanalyticsv2.ApplicationStatusRunning},
 		Refresh: statusApplication(conn, name),
-		Timeout: applicationStartedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -57,12 +47,12 @@ func waitApplicationStarted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name st
 }
 
 // waitApplicationStopped waits for an Application to stop
-func waitApplicationStopped(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string) (*kinesisanalyticsv2.ApplicationDetail, error) {
+func waitApplicationStopped(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string, timeout time.Duration) (*kinesisanalyticsv2.ApplicationDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalyticsv2.ApplicationStatusForceStopping, kinesisanalyticsv2.ApplicationStatusStopping},
 		Target:  []string{kinesisanalyticsv2.ApplicationStatusReady},
 		Refresh: statusApplication(conn, name),
-		Timeout: applicationStoppedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -75,12 +65,12 @@ func waitApplicationStopped(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name st
 }
 
 // waitApplicationUpdated waits for an Application to return Deleted
-func waitApplicationUpdated(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string) (*kinesisanalyticsv2.ApplicationDetail, error) { //nolint:unparam
+func waitApplicationUpdated(conn *kinesisanalyticsv2.KinesisAnalyticsV2, name string, timeout time.Duration) (*kinesisanalyticsv2.ApplicationDetail, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalyticsv2.ApplicationStatusUpdating},
 		Target:  []string{kinesisanalyticsv2.ApplicationStatusReady, kinesisanalyticsv2.ApplicationStatusRunning},
 		Refresh: statusApplication(conn, name),
-		Timeout: applicationUpdatedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -141,12 +131,12 @@ func waitIAMPropagation(f func() (interface{}, error)) (interface{}, error) {
 }
 
 // waitSnapshotCreated waits for a Snapshot to return Created
-func waitSnapshotCreated(conn *kinesisanalyticsv2.KinesisAnalyticsV2, applicationName, snapshotName string) (*kinesisanalyticsv2.SnapshotDetails, error) {
+func waitSnapshotCreated(conn *kinesisanalyticsv2.KinesisAnalyticsV2, applicationName, snapshotName string, timeout time.Duration) (*kinesisanalyticsv2.SnapshotDetails, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalyticsv2.SnapshotStatusCreating},
 		Target:  []string{kinesisanalyticsv2.SnapshotStatusReady},
 		Refresh: statusSnapshotDetails(conn, applicationName, snapshotName),
-		Timeout: snapshotCreatedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -159,12 +149,12 @@ func waitSnapshotCreated(conn *kinesisanalyticsv2.KinesisAnalyticsV2, applicatio
 }
 
 // waitSnapshotDeleted waits for a Snapshot to return Deleted
-func waitSnapshotDeleted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, applicationName, snapshotName string) (*kinesisanalyticsv2.SnapshotDetails, error) {
+func waitSnapshotDeleted(conn *kinesisanalyticsv2.KinesisAnalyticsV2, applicationName, snapshotName string, timeout time.Duration) (*kinesisanalyticsv2.SnapshotDetails, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{kinesisanalyticsv2.SnapshotStatusDeleting},
 		Target:  []string{},
 		Refresh: statusSnapshotDetails(conn, applicationName, snapshotName),
-		Timeout: snapshotDeletedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -483,6 +483,16 @@ In addition to all arguments above, the following attributes are exported:
 * `version_id` - The current application version. Kinesis Data Analytics updates the `version_id` each time the application is updated.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
+## Timeouts
+
+`aws_kinesisanalyticsv2_application` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for Application creation
+- `update` - (Default `10 minutes`) Used for Application modifications and snapshotting
+- `delete` - (Default `10 minutes`) Used for destroying Application or snapshot. This includes
+any cleanup task during the destroying process.
+
 ## Import
 
 `aws_kinesisanalyticsv2_application` can be imported by using the application ARN, e.g.,

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -490,8 +490,7 @@ In addition to all arguments above, the following attributes are exported:
 
 - `create` - (Default `10 minutes`) Used for Application creation
 - `update` - (Default `10 minutes`) Used for Application modifications and snapshotting
-- `delete` - (Default `10 minutes`) Used for destroying Application or snapshot. This includes
-any cleanup task during the destroying process.
+- `delete` - (Default `10 minutes`) Used for Application deletion
 
 ## Import
 

--- a/website/docs/r/kinesisanalyticsv2_application_snapshot.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application_snapshot.html.markdown
@@ -35,6 +35,14 @@ In addition to all arguments above, the following attributes are exported:
 * `application_version_id` - The current application version ID when the snapshot was created.
 * `snapshot_creation_timestamp` - The timestamp of the application snapshot.
 
+## Timeouts
+
+`aws_kinesisanalyticsv2_application_snapshot` provides the following
+[Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for Snapshot creation
+- `delete` - (Default `10 minutes`) Used for Snapshot destruction
+
 ## Import
 
 `aws_kinesisanalyticsv2_application` can be imported by using `application_name` together with `snapshot_name`, e.g.,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR adds support for customizable timeouts for Kinesis Data Analytics v2 Applications. We're seeing constant timeouts with the default 5m timeouts, so this raises the default timeout to 10m for the applications and then makes it customizable as well.

According to AWS support this is somewhat expected when dealing with Flink apps that are deployed into a VPC due to the additional hardware provisioning time required. They said "unfortunately AWS cannot guarantee completion of the application UPDATE under the 5 minute window" which is why we are proposing changing the default to 10m and making this customizable.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSKinesisAnalyticsV2Application'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKinesisAnalyticsV2Application -timeout 180m
=== RUN   TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_basic
=== PAUSE TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_basic
=== RUN   TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears
=== PAUSE TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears
=== RUN   TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears_Application
=== PAUSE TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears_Application
=== RUN   TestAccAWSKinesisAnalyticsV2Application_basicFlinkApplication
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_basicFlinkApplication
=== RUN   TestAccAWSKinesisAnalyticsV2Application_basicSQLApplication
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_basicSQLApplication
=== RUN   TestAccAWSKinesisAnalyticsV2Application_disappears
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_disappears
=== RUN   TestAccAWSKinesisAnalyticsV2Application_Tags
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_Tags
=== RUN   TestAccAWSKinesisAnalyticsV2Application_ApplicationCodeConfiguration_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_ApplicationCodeConfiguration_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Add
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Add
=== RUN   TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Delete
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Delete
=== RUN   TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_EnvironmentProperties_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_EnvironmentProperties_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_EnvironmentProperties_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_EnvironmentProperties_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_RestoreFromSnapshot
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_RestoreFromSnapshot
=== RUN   TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnCreate
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnCreate
=== RUN   TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnUpdate
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnUpdate
=== RUN   TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_UpdateRunning
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_UpdateRunning
=== RUN   TestAccAWSKinesisAnalyticsV2Application_ServiceExecutionRole_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_ServiceExecutionRole_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Add
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Add
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Add
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Add
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Delete
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Delete
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Multiple_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Multiple_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Output_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Output_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Add
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Add
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Delete
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Delete
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Update
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnCreate
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnCreate
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnUpdate
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnUpdate
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_UpdateRunning
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_UpdateRunning
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Add
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Add
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Delete
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Delete
=== RUN   TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Update
=== PAUSE TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Update
=== CONT  TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_basic
=== CONT  TestAccAWSKinesisAnalyticsV2Application_ServiceExecutionRole_Update
=== CONT  TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Delete
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Delete
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Add
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Update
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Delete
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Update
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Delete
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Add
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_UpdateRunning
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnUpdate
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnCreate
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Add
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Output_Update
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Update
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Add
=== CONT  TestAccAWSKinesisAnalyticsV2Application_disappears
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Multiple_Update
=== CONT  TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Update
--- PASS: TestAccAWSKinesisAnalyticsV2Application_disappears (98.39s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Add
--- PASS: TestAccAWSKinesisAnalyticsV2Application_ServiceExecutionRole_Update (138.29s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_ApplicationCodeConfiguration_Update
--- PASS: TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Delete (139.42s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_Tags
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Update (206.19s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_basicFlinkApplication
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Delete (206.27s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_basicSQLApplication
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_VPCConfiguration_Add (206.75s)
=== CONT  TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears_Application
--- PASS: TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Add (147.14s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_RestoreFromSnapshot
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Delete (277.28s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_UpdateRunning
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Add (309.44s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnUpdate
--- PASS: TestAccAWSKinesisAnalyticsV2Application_ApplicationCodeConfiguration_Update (182.78s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnCreate
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Add (324.39s)
=== CONT  TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears
--- PASS: TestAccAWSKinesisAnalyticsV2Application_basicSQLApplication (124.02s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_Update
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Update (330.38s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_EnvironmentProperties_Update
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnCreate (349.04s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_EnvironmentProperties_Update
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Delete (366.31s)
=== CONT  TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Update
--- PASS: TestAccAWSKinesisAnalyticsV2Application_Tags (230.30s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Input_Update (370.96s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_InputProcessingConfiguration_Update (386.31s)
--- PASS: TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_basic (388.96s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Multiple_Update (389.30s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_StartApplication_OnUpdate (389.93s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_Output_Update (411.11s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_basicFlinkApplication (208.88s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_ReferenceDataSource_Add (439.98s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_SQLApplicationConfiguration_UpdateRunning (450.77s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_CloudWatchLoggingOptions_Update (92.34s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_Update (135.66s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_EnvironmentProperties_Update (135.76s)
--- PASS: TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears_Application (267.14s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_EnvironmentProperties_Update (182.08s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnCreate (275.25s)
--- PASS: TestAccAWSKinesisAnalyticsV2ApplicationSnapshot_disappears (337.11s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_StartApplication_OnUpdate (377.86s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_UpdateRunning (482.22s)
--- PASS: TestAccAWSKinesisAnalyticsV2Application_FlinkApplicationConfiguration_RestoreFromSnapshot (750.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	998.059s

...
```
