### PR TITLE
Fix depends_on in securityhub_invite_accepter

### DIFF
--- a/website/docs/r/securityhub_invite_accepter.markdown
+++ b/website/docs/r/securityhub_invite_accepter.markdown
@@ -29,7 +29,7 @@ resource "aws_securityhub_account" "invitee" {
 
 resource "aws_securityhub_invite_accepter" "invitee" {
   provider   = "aws.invitee"
-  depends_on = [aws_securityhub_account.accepter]
+  depends_on = [aws_securityhub_account.invitee]
   master_id  = aws_securityhub_member.example.master_id
 }
 ```


### PR DESCRIPTION
This PR fixes a typo in the documentation for [aws_securityhub_invite_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_invite_accepter) where the `depends_on` statement was incorrectly listed as `aws_securityhub_account.accepter` rather than `aws_securityhub_account.invitee`.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #21102

Output from acceptance testing: N/a, documentation fix.
