### PR TITLE
aws_autoscaling_group: add checkpoints to `instance_refresh`

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -539,6 +539,18 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 										Default:      90,
 										ValidateFunc: validation.IntBetween(0, 100),
 									},
+									"checkpoint_delay": {
+										Type:         nullable.TypeNullableInt,
+										Optional:     true,
+										ValidateFunc: nullable.ValidateTypeStringNullableIntAtLeast(0),
+									},
+									"checkpoint_percentages": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeInt,
+										},
+									},
 								},
 							},
 						},
@@ -2207,6 +2219,19 @@ func expandAutoScalingGroupInstanceRefreshPreferences(l []interface{}) *autoscal
 
 	if v, ok := m["min_healthy_percentage"]; ok {
 		refreshPreferences.MinHealthyPercentage = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := m["checkpoint_delay"]; ok {
+		refreshPreferences.CheckpointDelay = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := m["checkpoint_percentages"]; ok {
+		l := v.([]interface{})
+		p := make([]*int64, len(l))
+		for i, v := range l {
+			p[i] = aws.Int64(int64(v.(int)))
+		}
+		refreshPreferences.CheckpointPercentages = p
 	}
 
 	return refreshPreferences


### PR DESCRIPTION
This change adds `checkpoint_delay` and `checkpoint_percentages` to
`resource "aws_autoscaling_group"` to allow rolling autoscaling groups
with checkpoints.

See https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-adding-checkpoints-instance-refresh.html

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAutoScalingGroup_InstanceRefresh_Basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup_InstanceRefresh_Basic -timeout 180m
=== RUN   TestAccAWSAutoScalingGroup_InstanceRefresh_Basic
=== PAUSE TestAccAWSAutoScalingGroup_InstanceRefresh_Basic
=== CONT  TestAccAWSAutoScalingGroup_InstanceRefresh_Basic

--- PASS: TestAccAWSAutoScalingGroup_InstanceRefresh_Basic (271.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	272.598s
```
