### PR TITLE
Docs/add note for ssm association to target all instances

### DIFF
--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -27,7 +27,7 @@ resource "aws_ssm_association" "example" {
 
 ### Create an association for all managed instances in an AWS account
 
-To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`. This example also illustrates how to use an Amazon owned SSM document named `AmazonCloudWatch-ManageAgent`.
+To target all managed instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`. This example also illustrates how to use an Amazon owned SSM document named `AmazonCloudWatch-ManageAgent`.
 
 ```terraform
 resource "aws_ssm_association" "example" {

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -53,6 +53,7 @@ Targets specify what instance IDs or tags to apply the document to and has these
 
 -> **Note:** To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`.
 Example:
+
 ```terraform
 resource "aws_ssm_association" "example" {
   name = "AmazonCloudWatch-ManageAgent"

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -51,6 +51,19 @@ Targets specify what instance IDs or tags to apply the document to and has these
 * `key` - (Required) Either `InstanceIds` or `tag:Tag Name` to specify an EC2 tag.
 * `values` - (Required) A list of instance IDs or tag values. AWS currently limits this list size to one value.
 
+-> **Note:** To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`.
+Example:
+```terraform
+resource "aws_ssm_association" "example" {
+  name = "AmazonCloudWatch-ManageAgent"
+
+  targets {
+    key    = "InstanceIds"
+    values = ["*"]
+  }
+}
+```
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -27,7 +27,7 @@ resource "aws_ssm_association" "example" {
 
 ### Create an association for all managed instances in an AWS account
 
-To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`.
+To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`. This example also illustrates how to use an Amazon owned SSM document named `AmazonCloudWatch-ManageAgent`.
 
 ```terraform
 resource "aws_ssm_association" "example" {

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -12,6 +12,8 @@ Associates an SSM Document to an instance or EC2 tag.
 
 ## Example Usage
 
+### Create an association for a specific instance
+
 ```terraform
 resource "aws_ssm_association" "example" {
   name = aws_ssm_document.example.name
@@ -19,6 +21,21 @@ resource "aws_ssm_association" "example" {
   targets {
     key    = "InstanceIds"
     values = [aws_instance.example.id]
+  }
+}
+```
+
+### Create an association for all managed instances in an AWS account
+
+To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`.
+
+```terraform
+resource "aws_ssm_association" "example" {
+  name = "AmazonCloudWatch-ManageAgent"
+
+  targets {
+    key    = "InstanceIds"
+    values = ["*"]
   }
 }
 ```
@@ -50,20 +67,6 @@ Targets specify what instance IDs or tags to apply the document to and has these
 
 * `key` - (Required) Either `InstanceIds` or `tag:Tag Name` to specify an EC2 tag.
 * `values` - (Required) A list of instance IDs or tag values. AWS currently limits this list size to one value.
-
--> **Note:** To target all instances in an AWS account, set the `key` as `"InstanceIds"` with `values` set as `["*"]`.
-Example:
-
-```terraform
-resource "aws_ssm_association" "example" {
-  name = "AmazonCloudWatch-ManageAgent"
-
-  targets {
-    key    = "InstanceIds"
-    values = ["*"]
-  }
-}
-```
 
 ## Attributes Reference
 

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -40,6 +40,21 @@ resource "aws_ssm_association" "example" {
 }
 ```
 
+### Create an association for a specific tag
+
+This example shows how to target all managed instances that are assigned a tag key of `Environment` and value of `Development`.
+
+```terraform
+resource "aws_ssm_association" "example" {
+  name = "AmazonCloudWatch-ManageAgent"
+
+  targets {
+    key    = "tag:Environment"
+    values = ["Development"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
add note and example code snippet for `aws_ssm_association` to target all instances in an AWS account

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

In the console, one can target all instances for an SSM association as shown below:

![image](https://user-images.githubusercontent.com/31919569/135621906-312b9c58-eb54-4cef-98f9-bbbf3f66f3ed.png)

Doing it from Terraform is slightly confusing as the previous documentation did not specify how one can target all instances in an AWS account for `aws_ssm_association`. This issue was also faced in the CloudFormation documentation. After providing feedback to the CloudFormation team, they have updated their set of docs at [AWS::SSM::Association](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-association.html#aws-resource-ssm-association-properties) to explicitly specify how to use the `targets` attribute to target all instances in an AWS account. Similarly, I felt it would be useful to update the Terraform documentation to help users with the same need and added the note to the Terraform documentation.

### Testing

I've tested it with the following snippet

```terraform
resource "aws_ssm_association" "example" {
  name = "AmazonCloudWatch-ManageAgent"

  targets {
    key    = "InstanceIds"
    values = ["*"]
  }
}
```

which has an output of:

![image](https://user-images.githubusercontent.com/31919569/135622280-5daff28e-344e-476c-86de-5ef345b4750f.png)

Verifying on the console also shows that it now targets all instances

![image](https://user-images.githubusercontent.com/31919569/135622306-421f97b9-d600-4858-8113-65df13d08182.png)
