### PR TITLE
Added proper status and waiter to Lex Bot. Fixed issues with import tests.

### DIFF
--- a/.changelog/20383.txt
+++ b/.changelog/20383.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+aws/resource_aws_lex_bot: Correctly determine `version` attribute
+```
+
+```release-note:bug
+aws/resource_aws_lex_intent: Correctly determine `version` attribute
+```

--- a/.changelog/21122.txt
+++ b/.changelog/21122.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lex_bot: Added waiter support to account for BUILDING state.
+```

--- a/.changelog/21122.txt
+++ b/.changelog/21122.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lex_bot: Added waiter support to account for BUILDING state.
+resource/aws_lex_bot: Added waiter support to account for `BUILDING` status
 ```

--- a/aws/data_source_aws_lex_bot.go
+++ b/aws/data_source_aws_lex_bot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
 )
 
 func dataSourceAwsLexBot() *schema.Resource {
@@ -75,7 +76,7 @@ func dataSourceAwsLexBot() *schema.Resource {
 			"version": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      LexBotVersionLatest,
+				Default:      tflex.LexBotVersionLatest,
 				ValidateFunc: validateLexBotVersion,
 			},
 			"voice_id": {

--- a/aws/data_source_aws_lex_bot.go
+++ b/aws/data_source_aws_lex_bot.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/finder"
 )
 
 func dataSourceAwsLexBot() *schema.Resource {
@@ -90,13 +89,12 @@ func dataSourceAwsLexBot() *schema.Resource {
 func dataSourceAwsLexBotRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).lexmodelconn
 
-	botName := d.Get("name").(string)
-	resp, err := conn.GetBot(&lexmodelbuildingservice.GetBotInput{
-		Name:           aws.String(botName),
-		VersionOrAlias: aws.String(d.Get("version").(string)),
-	})
+	name := d.Get("name").(string)
+	version := d.Get("version").(string)
+	output, err := finder.BotVersionByName(conn, name, version)
+
 	if err != nil {
-		return fmt.Errorf("error reading bot %s: %w", botName, err)
+		return fmt.Errorf("error reading Lex Bot (%s/%s): %w", name, version, err)
 	}
 
 	arn := arn.ARN{
@@ -104,27 +102,26 @@ func dataSourceAwsLexBotRead(d *schema.ResourceData, meta interface{}) error {
 		Region:    meta.(*AWSClient).region,
 		Service:   "lex",
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("bot:%s", d.Get("name").(string)),
+		Resource:  fmt.Sprintf("bot:%s", name),
 	}
 	d.Set("arn", arn.String())
+	d.Set("checksum", output.Checksum)
+	d.Set("child_directed", output.ChildDirected)
+	d.Set("created_date", output.CreatedDate.Format(time.RFC3339))
+	d.Set("description", output.Description)
+	d.Set("detect_sentiment", output.DetectSentiment)
+	d.Set("enable_model_improvements", output.EnableModelImprovements)
+	d.Set("failure_reason", output.FailureReason)
+	d.Set("idle_session_ttl_in_seconds", output.IdleSessionTTLInSeconds)
+	d.Set("last_updated_date", output.LastUpdatedDate.Format(time.RFC3339))
+	d.Set("locale", output.Locale)
+	d.Set("name", output.Name)
+	d.Set("nlu_intent_confidence_threshold", output.NluIntentConfidenceThreshold)
+	d.Set("status", output.Status)
+	d.Set("version", output.Version)
+	d.Set("voice_id", output.VoiceId)
 
-	d.Set("checksum", resp.Checksum)
-	d.Set("child_directed", resp.ChildDirected)
-	d.Set("created_date", resp.CreatedDate.Format(time.RFC3339))
-	d.Set("description", resp.Description)
-	d.Set("detect_sentiment", resp.DetectSentiment)
-	d.Set("enable_model_improvements", resp.EnableModelImprovements)
-	d.Set("failure_reason", resp.FailureReason)
-	d.Set("idle_session_ttl_in_seconds", resp.IdleSessionTTLInSeconds)
-	d.Set("last_updated_date", resp.LastUpdatedDate.Format(time.RFC3339))
-	d.Set("locale", resp.Locale)
-	d.Set("name", resp.Name)
-	d.Set("nlu_intent_confidence_threshold", resp.NluIntentConfidenceThreshold)
-	d.Set("status", resp.Status)
-	d.Set("version", resp.Version)
-	d.Set("voice_id", resp.VoiceId)
-
-	d.SetId(botName)
+	d.SetId(name)
 
 	return nil
 }

--- a/aws/data_source_aws_lex_bot_test.go
+++ b/aws/data_source_aws_lex_bot_test.go
@@ -67,14 +67,14 @@ func testAccDataSourceAwsLexBot_withVersion(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "checksum", resourceName, "checksum"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "child_directed", resourceName, "child_directed"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "created_date", resourceName, "created_date"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "detect_sentiment", resourceName, "detect_sentiment"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "enable_model_improvements", resourceName, "enable_model_improvements"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "failure_reason", resourceName, "failure_reason"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "idle_session_ttl_in_seconds", resourceName, "idle_session_ttl_in_seconds"),
-					//Removed due to race condition when bots build/read/not_rady. Modified the bot status to read true status:
+					//Removed due to race condition when bots build/read/not_ready. Modified the bot status to read true status:
 					//https://github.com/hashicorp/terraform-provider-aws/issues/21107
+					//resource.TestCheckResourceAttrPair(dataSourceName, "created_date", resourceName, "created_date"),
 					//resource.TestCheckResourceAttrPair(dataSourceName, "last_updated_date", resourceName, "last_updated_date"),
 					//resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "locale", resourceName, "locale"),

--- a/aws/data_source_aws_lex_bot_test.go
+++ b/aws/data_source_aws_lex_bot_test.go
@@ -73,11 +73,13 @@ func testAccDataSourceAwsLexBot_withVersion(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "enable_model_improvements", resourceName, "enable_model_improvements"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "failure_reason", resourceName, "failure_reason"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "idle_session_ttl_in_seconds", resourceName, "idle_session_ttl_in_seconds"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "last_updated_date", resourceName, "last_updated_date"),
+					//Removed due to race condition when bots build/read/not_rady. Modified the bot status to read true status:
+					//https://github.com/hashicorp/terraform-provider-aws/issues/21107
+					//resource.TestCheckResourceAttrPair(dataSourceName, "last_updated_date", resourceName, "last_updated_date"),
+					//resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "locale", resourceName, "locale"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "nlu_intent_confidence_threshold", resourceName, "nlu_intent_confidence_threshold"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
 				),
 			},

--- a/aws/data_source_aws_lex_intent.go
+++ b/aws/data_source_aws_lex_intent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
 )
 
 func dataSourceAwsLexIntent() *schema.Resource {
@@ -52,7 +53,7 @@ func dataSourceAwsLexIntent() *schema.Resource {
 			"version": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  LexIntentVersionLatest,
+				Default:  tflex.LexIntentVersionLatest,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 64),
 					validation.StringMatch(regexp.MustCompile(`\$LATEST|[0-9]+`), ""),

--- a/aws/internal/service/lex/enum.go
+++ b/aws/internal/service/lex/enum.go
@@ -1,5 +1,6 @@
 package lex
 
 const (
-	LexBotVersionLatest = "$LATEST"
+	LexBotVersionLatest    = "$LATEST"
+	LexIntentVersionLatest = "$LATEST"
 )

--- a/aws/internal/service/lex/enum.go
+++ b/aws/internal/service/lex/enum.go
@@ -1,0 +1,15 @@
+package lex
+
+import "time"
+
+const (
+	LexBotCreateTimeout      = 5 * time.Minute
+	LexBotDeleteTimeout      = 5 * time.Minute
+	LexBotUpdateTimeout      = 5 * time.Minute
+	LexIntentDeleteTimeout   = 5 * time.Minute
+	LexSlotTypeDeleteTimeout = 5 * time.Minute
+)
+
+const (
+	LexBotVersionLatest = "$LATEST"
+)

--- a/aws/internal/service/lex/enum.go
+++ b/aws/internal/service/lex/enum.go
@@ -1,15 +1,5 @@
 package lex
 
-import "time"
-
-const (
-	LexBotCreateTimeout      = 5 * time.Minute
-	LexBotDeleteTimeout      = 5 * time.Minute
-	LexBotUpdateTimeout      = 5 * time.Minute
-	LexIntentDeleteTimeout   = 5 * time.Minute
-	LexSlotTypeDeleteTimeout = 5 * time.Minute
-)
-
 const (
 	LexBotVersionLatest = "$LATEST"
 )

--- a/aws/internal/service/lex/finder/finder.go
+++ b/aws/internal/service/lex/finder/finder.go
@@ -1,0 +1,79 @@
+package finder
+
+import (
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+func BotVersionByName(conn *lexmodelbuildingservice.LexModelBuildingService, name, version string) (*lexmodelbuildingservice.GetBotOutput, error) {
+	input := &lexmodelbuildingservice.GetBotInput{
+		Name:           aws.String(name),
+		VersionOrAlias: aws.String(version),
+	}
+
+	output, err := conn.GetBot(input)
+
+	if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+// LatestBotVersionByName returns the latest published version of a bot or $LATEST if the bot has never been published.
+// See https://docs.aws.amazon.com/lex/latest/dg/versioning-aliases.html.
+func LatestBotVersionByName(conn *lexmodelbuildingservice.LexModelBuildingService, name string) (string, error) {
+	input := &lexmodelbuildingservice.GetBotVersionsInput{
+		Name: aws.String(name),
+	}
+	var latestVersion int
+
+	err := conn.GetBotVersionsPages(input, func(page *lexmodelbuildingservice.GetBotVersionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, bot := range page.Bots {
+			version := aws.StringValue(bot.Version)
+
+			if version == tflex.LexBotVersionLatest {
+				continue
+			}
+
+			if version, err := strconv.Atoi(version); err != nil {
+				continue
+			} else if version > latestVersion {
+				latestVersion = version
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if latestVersion == 0 {
+		return tflex.LexBotVersionLatest, nil
+	}
+
+	return strconv.Itoa(latestVersion), nil
+}

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -261,6 +261,9 @@ func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.PutBot(input)
+	}
 
 	if _, err = waiter.LexBotCreated(conn, name, tflex.LexBotVersionLatest, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error creating bot %s: %w", name, err)
@@ -415,7 +418,9 @@ func resourceAwsLexBotDelete(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteBot(input)
+	}
 	if _, err = waiter.LexBotDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("error deleting bot %s: %w", d.Id(), err)
 	}

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -441,9 +441,9 @@ func resourceAwsLexBotDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetBotVersionsInput) (string, error) {
-	version := tflex.LexBotVersionLatest
+	version := 0
 
-	var currentVersion, botVersion int
+	var botVersion int
 	for {
 		page, err := conn.GetBotVersions(input)
 		if err != nil {
@@ -460,20 +460,14 @@ func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingServic
 				continue
 			}
 
-			currentVersion, err = strconv.Atoi(version)
-			if err != nil {
-				log.Printf("[DEBUG] invalid version for Lex Bot: %s", version)
-				continue
-			}
-
 			botVersion, err = strconv.Atoi(*bot.Version)
 			if err != nil {
 				log.Printf("[DEBUG] invalid version for Lex Bot: %s", *bot.Version)
 				continue
 			}
 
-			if botVersion > currentVersion {
-				version = strconv.Itoa(botVersion)
+			if botVersion > version {
+				version = botVersion
 			}
 		}
 
@@ -483,7 +477,7 @@ func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingServic
 		input.NextToken = page.NextToken
 	}
 
-	return version, nil
+	return strconv.Itoa(version), nil
 }
 
 func flattenLexIntents(intents []*lexmodelbuildingservice.Intent) (flattenedIntents []map[string]interface{}) {

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -442,6 +443,7 @@ func resourceAwsLexBotDelete(d *schema.ResourceData, meta interface{}) error {
 func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetBotVersionsInput) (string, error) {
 	version := tflex.LexBotVersionLatest
 
+  var currentVersion, botVersion int
 	for {
 		page, err := conn.GetBotVersions(input)
 		if err != nil {
@@ -457,8 +459,21 @@ func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingServic
 			if *bot.Version == tflex.LexBotVersionLatest {
 				continue
 			}
-			if *bot.Version > version {
-				version = *bot.Version
+
+      currentVersion, err = strconv.Atoi(version)
+      if err != nil {
+        log.Printf("[DEBUG] invalid version for Lex Bot: %s", version)
+        continue
+      }
+
+      botVersion, err = strconv.Atoi(*bot.Version)
+      if err != nil {
+        log.Printf("[DEBUG] invalid version for Lex Bot: %s", *bot.Version)
+        continue
+      }
+
+			if botVersion > currentVersion {
+				version = strconv.Itoa(botVersion)
 			}
 		}
 

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -264,6 +264,9 @@ func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 	if isResourceTimeoutError(err) {
 		_, err = conn.PutBot(input)
 	}
+	if err != nil {
+		return fmt.Errorf("error creating bot %s: %w", name, err)
+	}
 
 	if _, err = waiter.LexBotCreated(conn, name, tflex.LexBotVersionLatest, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error creating bot %s: %w", name, err)
@@ -421,6 +424,10 @@ func resourceAwsLexBotDelete(d *schema.ResourceData, meta interface{}) error {
 	if isResourceTimeoutError(err) {
 		_, err = conn.DeleteBot(input)
 	}
+	if err != nil {
+		return fmt.Errorf("error deleting bot %s: %w", d.Id(), err)
+	}
+
 	if _, err = waiter.LexBotDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("error deleting bot %s: %w", d.Id(), err)
 	}

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -443,7 +443,7 @@ func resourceAwsLexBotDelete(d *schema.ResourceData, meta interface{}) error {
 func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetBotVersionsInput) (string, error) {
 	version := tflex.LexBotVersionLatest
 
-  var currentVersion, botVersion int
+	var currentVersion, botVersion int
 	for {
 		page, err := conn.GetBotVersions(input)
 		if err != nil {
@@ -460,17 +460,17 @@ func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingServic
 				continue
 			}
 
-      currentVersion, err = strconv.Atoi(version)
-      if err != nil {
-        log.Printf("[DEBUG] invalid version for Lex Bot: %s", version)
-        continue
-      }
+			currentVersion, err = strconv.Atoi(version)
+			if err != nil {
+				log.Printf("[DEBUG] invalid version for Lex Bot: %s", version)
+				continue
+			}
 
-      botVersion, err = strconv.Atoi(*bot.Version)
-      if err != nil {
-        log.Printf("[DEBUG] invalid version for Lex Bot: %s", *bot.Version)
-        continue
-      }
+			botVersion, err = strconv.Atoi(*bot.Version)
+			if err != nil {
+				log.Printf("[DEBUG] invalid version for Lex Bot: %s", *bot.Version)
+				continue
+			}
 
 			if botVersion > currentVersion {
 				version = strconv.Itoa(botVersion)

--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
@@ -38,9 +37,9 @@ func resourceAwsLexBot() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(tflex.LexBotCreateTimeout),
-			Update: schema.DefaultTimeout(tflex.LexBotUpdateTimeout),
-			Delete: schema.DefaultTimeout(tflex.LexBotDeleteTimeout),
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -220,8 +219,8 @@ var validateLexBotVersion = validation.All(
 
 func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).lexmodelconn
-	name := d.Get("name").(string)
 
+	name := d.Get("name").(string)
 	input := &lexmodelbuildingservice.PutBotInput{
 		AbortStatement:          expandLexStatement(d.Get("abort_statement")),
 		ChildDirected:           aws.Bool(d.Get("child_directed").(bool)),
@@ -249,30 +248,26 @@ func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 		input.VoiceId = aws.String(v.(string))
 	}
 
-	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		output, err := conn.PutBot(input)
+	var output *lexmodelbuildingservice.PutBotOutput
+	_, err := tfresource.RetryWhenAwsErrCodeEquals(d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+		var err error
 
-		if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeConflictException) {
+		if output != nil {
 			input.Checksum = output.Checksum
-			return resource.RetryableError(fmt.Errorf("%q bot still creating, another operation is pending: %s", d.Id(), err))
 		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
+		output, err = conn.PutBot(input)
 
-		return nil
-	})
-	if tfresource.TimedOut(err) { // nosemgrep: helper-schema-TimeoutError-check-doesnt-return-output
-		_, err = conn.PutBot(input)
-	}
+		return output, err
+	}, lexmodelbuildingservice.ErrCodeConflictException)
+
 	if err != nil {
-		return fmt.Errorf("error creating bot %s: %w", name, err)
+		return fmt.Errorf("error creating Lex Bot (%s): %w", name, err)
 	}
 
-	d.SetId(name)
+	d.SetId(aws.StringValue(output.Name))
 
-	if output, err := waiter.LexBotCreated(conn, name, tflex.LexBotVersionLatest, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for bot %s to have valid status. Current status: %s: %w", name, aws.StringValue(output.Status), err)
+	if _, err := waiter.BotVersionCreated(conn, name, tflex.LexBotVersionLatest, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("error waiting for Lex Bot (%s) create: %w", d.Id(), err)
 	}
 
 	return resourceAwsLexBotRead(d, meta)
@@ -281,17 +276,16 @@ func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsLexBotRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).lexmodelconn
 
-	resp, err := conn.GetBot(&lexmodelbuildingservice.GetBotInput{
-		Name:           aws.String(d.Id()),
-		VersionOrAlias: aws.String(tflex.LexBotVersionLatest),
-	})
-	if isAWSErr(err, lexmodelbuildingservice.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] Bot (%s) not found, removing from state", d.Id())
+	output, err := finder.BotVersionByName(conn, d.Id(), tflex.LexBotVersionLatest)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Lex Bot (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+
 	if err != nil {
-		return fmt.Errorf("error getting intent %s: %w", d.Id(), err)
+		return fmt.Errorf("error reading Lex Bot (%s): %w", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -310,40 +304,40 @@ func resourceAwsLexBotRead(d *schema.ResourceData, meta interface{}) error {
 		processBehavior = v.(string)
 	}
 
-	d.Set("checksum", resp.Checksum)
-	d.Set("child_directed", resp.ChildDirected)
-	d.Set("created_date", resp.CreatedDate.Format(time.RFC3339))
-	d.Set("description", resp.Description)
-	d.Set("detect_sentiment", resp.DetectSentiment)
-	d.Set("enable_model_improvements", resp.EnableModelImprovements)
-	d.Set("failure_reason", resp.FailureReason)
-	d.Set("idle_session_ttl_in_seconds", resp.IdleSessionTTLInSeconds)
-	d.Set("intent", flattenLexIntents(resp.Intents))
-	d.Set("last_updated_date", resp.LastUpdatedDate.Format(time.RFC3339))
-	d.Set("locale", resp.Locale)
-	d.Set("name", resp.Name)
-	d.Set("nlu_intent_confidence_threshold", resp.NluIntentConfidenceThreshold)
+	d.Set("checksum", output.Checksum)
+	d.Set("child_directed", output.ChildDirected)
+	d.Set("created_date", output.CreatedDate.Format(time.RFC3339))
+	d.Set("description", output.Description)
+	d.Set("detect_sentiment", output.DetectSentiment)
+	d.Set("enable_model_improvements", output.EnableModelImprovements)
+	d.Set("failure_reason", output.FailureReason)
+	d.Set("idle_session_ttl_in_seconds", output.IdleSessionTTLInSeconds)
+	d.Set("intent", flattenLexIntents(output.Intents))
+	d.Set("last_updated_date", output.LastUpdatedDate.Format(time.RFC3339))
+	d.Set("locale", output.Locale)
+	d.Set("name", output.Name)
+	d.Set("nlu_intent_confidence_threshold", output.NluIntentConfidenceThreshold)
 	d.Set("process_behavior", processBehavior)
-	d.Set("status", resp.Status)
+	d.Set("status", output.Status)
 
-	if resp.AbortStatement != nil {
-		d.Set("abort_statement", flattenLexStatement(resp.AbortStatement))
+	if output.AbortStatement != nil {
+		d.Set("abort_statement", flattenLexStatement(output.AbortStatement))
 	}
 
-	if resp.ClarificationPrompt != nil {
-		d.Set("clarification_prompt", flattenLexPrompt(resp.ClarificationPrompt))
+	if output.ClarificationPrompt != nil {
+		d.Set("clarification_prompt", flattenLexPrompt(output.ClarificationPrompt))
 	}
 
-	version, err := getLatestLexBotVersion(conn, &lexmodelbuildingservice.GetBotVersionsInput{
-		Name: aws.String(d.Id()),
-	})
+	version, err := finder.LatestBotVersionByName(conn, d.Id())
+
 	if err != nil {
-		return fmt.Errorf("error reading Lex Bot (%s) version: %w", d.Id(), err)
+		return fmt.Errorf("error reading Lex Bot (%s) latest version: %w", d.Id(), err)
 	}
+
 	d.Set("version", version)
 
-	if resp.VoiceId != nil {
-		d.Set("voice_id", resp.VoiceId)
+	if output.VoiceId != nil {
+		d.Set("voice_id", output.VoiceId)
 	}
 
 	return nil
@@ -351,7 +345,6 @@ func resourceAwsLexBotRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsLexBotUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).lexmodelconn
-	name := d.Get("name").(string)
 
 	input := &lexmodelbuildingservice.PutBotInput{
 		Checksum:                     aws.String(d.Get("checksum").(string)),
@@ -380,28 +373,16 @@ func resourceAwsLexBotUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.VoiceId = aws.String(v.(string))
 	}
 
-	err := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-		_, err := conn.PutBot(input)
+	_, err := tfresource.RetryWhenAwsErrCodeEquals(d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		return conn.PutBot(input)
+	}, lexmodelbuildingservice.ErrCodeConflictException)
 
-		if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeConflictException) {
-			return resource.RetryableError(fmt.Errorf("%q: bot still updating", d.Id()))
-		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		_, err = conn.PutBot(input)
-	}
 	if err != nil {
-		return fmt.Errorf("error updating bot %s: %w", d.Id(), err)
+		return fmt.Errorf("error updating Lex Bot (%s): %w", d.Id(), err)
 	}
 
-	if output, err := waiter.LexBotCreated(conn, name, tflex.LexBotVersionLatest, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for bot %s to have valid status. Current status: %s: %w", name, aws.StringValue(output.Status), err)
+	if _, err = waiter.BotVersionCreated(conn, d.Id(), tflex.LexBotVersionLatest, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return fmt.Errorf("error waiting for Lex Bot (%s) update: %w", d.Id(), err)
 	}
 
 	return resourceAwsLexBotRead(d, meta)
@@ -414,70 +395,24 @@ func resourceAwsLexBotDelete(d *schema.ResourceData, meta interface{}) error {
 		Name: aws.String(d.Id()),
 	}
 
-	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		_, err := conn.DeleteBot(input)
+	log.Printf("[DEBUG] Deleting Lex Bot: (%s)", d.Id())
+	_, err := tfresource.RetryWhenAwsErrCodeEquals(d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+		return conn.DeleteBot(input)
+	}, lexmodelbuildingservice.ErrCodeConflictException)
 
-		if isAWSErr(err, lexmodelbuildingservice.ErrCodeConflictException, "") {
-			return resource.RetryableError(fmt.Errorf("%q: there is a pending operation, bot still deleting", d.Id()))
-		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
+	if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeNotFoundException) {
 		return nil
-	})
-	if tfresource.TimedOut(err) {
-		_, err = conn.DeleteBot(input)
-	}
-	if err != nil {
-		return fmt.Errorf("error deleting bot %s: %w", d.Id(), err)
 	}
 
-	if _, err = waiter.LexBotDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("error deleting bot %s: %w", d.Id(), err)
+	if err != nil {
+		return fmt.Errorf("error deleting Lex Bot (%s): %w", d.Id(), err)
+	}
+
+	if _, err = waiter.BotDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error waiting for Lex Bot (%s) delete: %w", d.Id(), err)
 	}
 
 	return nil
-}
-
-func getLatestLexBotVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetBotVersionsInput) (string, error) {
-	version := 0
-
-	var botVersion int
-	for {
-		page, err := conn.GetBotVersions(input)
-		if err != nil {
-			return "", err
-		}
-
-		// At least 1 version will always be returned.
-		if len(page.Bots) == 1 {
-			break
-		}
-
-		for _, bot := range page.Bots {
-			if *bot.Version == tflex.LexBotVersionLatest {
-				continue
-			}
-
-			botVersion, err = strconv.Atoi(*bot.Version)
-			if err != nil {
-				log.Printf("[DEBUG] invalid version for Lex Bot: %s", *bot.Version)
-				continue
-			}
-
-			if botVersion > version {
-				version = botVersion
-			}
-		}
-
-		if page.NextToken == nil {
-			break
-		}
-		input.NextToken = page.NextToken
-	}
-
-	return strconv.Itoa(version), nil
 }
 
 func flattenLexIntents(intents []*lexmodelbuildingservice.Intent) (flattenedIntents []map[string]interface{}) {

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -160,9 +160,10 @@ func testAccAwsLexBotAlias_botVersion(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"created_date"},
 			},
 			{
 				Config: composeConfig(
@@ -176,9 +177,10 @@ func testAccAwsLexBotAlias_botVersion(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"created_date"},
 			},
 		},
 	})

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
 )
 
 func init() {
@@ -121,7 +122,7 @@ func TestAccAwsLexBotAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Testing lex bot alias create."),
 					testAccCheckResourceAttrRfc3339(resourceName, "last_updated_date"),
 					resource.TestCheckResourceAttr(resourceName, "bot_name", testBotAliasID),
-					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, "bot_version", tflex.LexBotVersionLatest),
 					resource.TestCheckResourceAttr(resourceName, "name", testBotAliasID),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.#", "0"),
 				),
@@ -155,7 +156,7 @@ func testAccAwsLexBotAlias_botVersion(t *testing.T) {
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexBotAliasExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, "bot_version", tflex.LexBotVersionLatest),
 				),
 			},
 			{
@@ -206,7 +207,7 @@ func TestAccAwsLexBotAlias_conversationLogsText(t *testing.T) {
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexBotAliasExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, "bot_version", tflex.LexBotVersionLatest),
 					resource.TestCheckResourceAttrPair(resourceName, "conversation_logs.0.iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.0.log_settings.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
@@ -216,7 +217,7 @@ func TestAccAwsLexBotAlias_conversationLogsText(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", cloudwatchLogGroupResourceName, "arn"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
-						"resource_prefix": regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, LexBotVersionLatest))),
+						"resource_prefix": regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, tflex.LexBotVersionLatest))),
 					}),
 				),
 			},
@@ -253,7 +254,7 @@ func TestAccAwsLexBotAlias_conversationLogsAudio(t *testing.T) {
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexBotAliasExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, "bot_version", tflex.LexBotVersionLatest),
 					resource.TestCheckResourceAttrPair(resourceName, "conversation_logs.0.iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.0.log_settings.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]string{
@@ -263,7 +264,7 @@ func TestAccAwsLexBotAlias_conversationLogsAudio(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", s3BucketResourceName, "arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.kms_key_arn", kmsKeyResourceName, "arn"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
-						"resource_prefix": regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, LexBotVersionLatest))),
+						"resource_prefix": regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, tflex.LexBotVersionLatest))),
 					}),
 				),
 			},
@@ -301,7 +302,7 @@ func TestAccAwsLexBotAlias_conversationLogsBoth(t *testing.T) {
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexBotAliasExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "bot_version", LexBotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, "bot_version", tflex.LexBotVersionLatest),
 					resource.TestCheckResourceAttrPair(resourceName, "conversation_logs.0.iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.0.log_settings.#", "2"),
 

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func init() {
+	RegisterServiceErrorCheckFunc(lexmodelbuildingservice.EndpointsID, testAccErrorCheckSkipLex)
+
 	resource.AddTestSweepers("aws_lex_bot", &resource.Sweeper{
 		Name:         "aws_lex_bot",
 		F:            testSweepLexBots,
@@ -68,6 +70,12 @@ func testSweepLexBots(region string) error {
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func testAccErrorCheckSkipLex(t *testing.T) resource.ErrorCheckFunc {
+	return testAccErrorCheckSkipMessagesContaining(t,
+		"You can't set the enableModelImprovements field to false",
+	)
 }
 
 func TestAccAwsLexBot_basic(t *testing.T) {

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
 )
 
 func init() {
@@ -107,7 +108,7 @@ func TestAccAwsLexBot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "nlu_intent_confidence_threshold", "0"),
 					resource.TestCheckResourceAttr(rName, "process_behavior", "SAVE"),
 					resource.TestCheckResourceAttr(rName, "status", "NOT_BUILT"),
-					resource.TestCheckResourceAttr(rName, "version", LexBotVersionLatest),
+					resource.TestCheckResourceAttr(rName, "version", tflex.LexBotVersionLatest),
 					resource.TestCheckNoResourceAttr(rName, "voice_id"),
 				),
 			},
@@ -156,19 +157,7 @@ func testAccAwsLexBot_createVersion(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexBotExists(rName, &v1),
 					testAccCheckAwsLexBotNotExists(testBotID, "1"),
-					resource.TestCheckResourceAttr(rName, "version", LexBotVersionLatest),
-					resource.TestCheckResourceAttr(rName, "description", "Bot to order flowers on the behalf of a user"),
-				),
-			},
-			{
-				Config: composeConfig(
-					testAccAwsLexBotConfig_intent(testBotID),
-					testAccAwsLexBotConfig_createVersion(testBotID),
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAwsLexBotExists(rName, &v2),
-					testAccCheckAwsLexBotExistsWithVersion(rName, "1", &v2),
-					resource.TestCheckResourceAttr(rName, "version", "1"),
+					resource.TestCheckResourceAttr(rName, "version", tflex.LexBotVersionLatest),
 					resource.TestCheckResourceAttr(rName, "description", "Bot to order flowers on the behalf of a user"),
 				),
 			},
@@ -176,6 +165,17 @@ func testAccAwsLexBot_createVersion(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: composeConfig(
+					testAccAwsLexBotConfig_intent(testBotID),
+					testAccAwsLexBotConfig_createVersion(testBotID),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsLexBotExistsWithVersion(rName, "1", &v2),
+					resource.TestCheckResourceAttr(rName, "version", "1"),
+					resource.TestCheckResourceAttr(rName, "description", "Bot to order flowers on the behalf of a user"),
+				),
 			},
 		},
 	})
@@ -757,7 +757,7 @@ func testAccCheckAwsLexBotExistsWithVersion(rName, botVersion string, output *le
 }
 
 func testAccCheckAwsLexBotExists(rName string, output *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
-	return testAccCheckAwsLexBotExistsWithVersion(rName, LexBotVersionLatest, output)
+	return testAccCheckAwsLexBotExistsWithVersion(rName, tflex.LexBotVersionLatest, output)
 }
 
 func testAccCheckAwsLexBotNotExists(botName, botVersion string) resource.TestCheckFunc {

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func init() {
@@ -727,7 +728,7 @@ func TestAccAwsLexBot_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckAwsLexBotExistsWithVersion(rName, botVersion string, output *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
+func testAccCheckAwsLexBotExistsWithVersion(rName, botVersion string, v *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rName]
 		if !ok {
@@ -735,22 +736,18 @@ func testAccCheckAwsLexBotExistsWithVersion(rName, botVersion string, output *le
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Lex bot ID is set")
+			return fmt.Errorf("No Lex Bot ID is set")
 		}
 
-		var err error
 		conn := testAccProvider.Meta().(*AWSClient).lexmodelconn
 
-		output, err = conn.GetBot(&lexmodelbuildingservice.GetBotInput{
-			Name:           aws.String(rs.Primary.ID),
-			VersionOrAlias: aws.String(botVersion),
-		})
-		if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeNotFoundException) {
-			return fmt.Errorf("error bot %q version %s not found", rs.Primary.ID, botVersion)
-		}
+		output, err := finder.BotVersionByName(conn, rs.Primary.ID, botVersion)
+
 		if err != nil {
-			return fmt.Errorf("error getting bot %q version %s: %w", rs.Primary.ID, botVersion, err)
+			return err
 		}
+
+		*v = *output
 
 		return nil
 	}
@@ -764,18 +761,17 @@ func testAccCheckAwsLexBotNotExists(botName, botVersion string) resource.TestChe
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).lexmodelconn
 
-		_, err := conn.GetBot(&lexmodelbuildingservice.GetBotInput{
-			Name:           aws.String(botName),
-			VersionOrAlias: aws.String(botVersion),
-		})
-		if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeNotFoundException) {
+		_, err := finder.BotVersionByName(conn, botName, botVersion)
+
+		if tfresource.NotFound(err) {
 			return nil
 		}
+
 		if err != nil {
-			return fmt.Errorf("error getting bot %s version %s: %s", botName, botVersion, err)
+			return err
 		}
 
-		return fmt.Errorf("error bot %s version %s exists", botName, botVersion)
+		return fmt.Errorf("Lex Box %s/%s still exists", botName, botVersion)
 	}
 }
 
@@ -790,9 +786,7 @@ func testAccCheckAwsLexBotDestroy(s *terraform.State) error {
 		output, err := conn.GetBotVersions(&lexmodelbuildingservice.GetBotVersionsInput{
 			Name: aws.String(rs.Primary.ID),
 		})
-		if tfawserr.ErrCodeEquals(err, lexmodelbuildingservice.ErrCodeNotFoundException) {
-			continue
-		}
+
 		if err != nil {
 			return err
 		}
@@ -801,7 +795,7 @@ func testAccCheckAwsLexBotDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		return fmt.Errorf("Lex bot %q still exists", rs.Primary.ID)
+		return fmt.Errorf("Lex Bot %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -612,7 +612,7 @@ var lexStatementResource = &schema.Resource{
 func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetIntentVersionsInput) (string, error) {
 	version := LexIntentVersionLatest
 
-  var currentVersion, intentVersion int
+	var currentVersion, intentVersion int
 	for {
 		page, err := conn.GetIntentVersions(input)
 		if err != nil {
@@ -629,17 +629,17 @@ func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingSer
 				continue
 			}
 
-      currentVersion, err = strconv.Atoi(version)
-      if err != nil {
-        log.Printf("[DEBUG] invalid version for Lex Intent: %s", version)
-        continue
-      }
+			currentVersion, err = strconv.Atoi(version)
+			if err != nil {
+				log.Printf("[DEBUG] invalid version for Lex Intent: %s", version)
+				continue
+			}
 
-      intentVersion, err = strconv.Atoi(*intent.Version)
-      if err != nil {
-        log.Printf("[DEBUG] invalid version for Lex Intent: %s", *intent.Version)
-        continue
-      }
+			intentVersion, err = strconv.Atoi(*intent.Version)
+			if err != nil {
+				log.Printf("[DEBUG] invalid version for Lex Intent: %s", *intent.Version)
+				continue
+			}
 
 			if intentVersion > currentVersion {
 				version = strconv.Itoa(intentVersion)

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -610,9 +610,9 @@ var lexStatementResource = &schema.Resource{
 }
 
 func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetIntentVersionsInput) (string, error) {
-	version := LexIntentVersionLatest
+	version := 0
 
-	var currentVersion, intentVersion int
+	var intentVersion int
 	for {
 		page, err := conn.GetIntentVersions(input)
 		if err != nil {
@@ -629,20 +629,14 @@ func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingSer
 				continue
 			}
 
-			currentVersion, err = strconv.Atoi(version)
-			if err != nil {
-				log.Printf("[DEBUG] invalid version for Lex Intent: %s", version)
-				continue
-			}
-
 			intentVersion, err = strconv.Atoi(*intent.Version)
 			if err != nil {
 				log.Printf("[DEBUG] invalid version for Lex Intent: %s", *intent.Version)
 				continue
 			}
 
-			if intentVersion > currentVersion {
-				version = strconv.Itoa(intentVersion)
+			if intentVersion > version {
+				version = intentVersion
 			}
 		}
 
@@ -652,7 +646,7 @@ func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingSer
 		input.NextToken = page.NextToken
 	}
 
-	return version, nil
+	return strconv.Itoa(version), nil
 }
 
 func flattenLexCodeHook(hook *lexmodelbuildingservice.CodeHook) (flattened []map[string]interface{}) {

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -611,6 +612,7 @@ var lexStatementResource = &schema.Resource{
 func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetIntentVersionsInput) (string, error) {
 	version := LexIntentVersionLatest
 
+  var currentVersion, intentVersion int
 	for {
 		page, err := conn.GetIntentVersions(input)
 		if err != nil {
@@ -626,8 +628,21 @@ func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingSer
 			if *intent.Version == LexIntentVersionLatest {
 				continue
 			}
-			if *intent.Version > version {
-				version = *intent.Version
+
+      currentVersion, err = strconv.Atoi(version)
+      if err != nil {
+        log.Printf("[DEBUG] invalid version for Lex Intent: %s", version)
+        continue
+      }
+
+      intentVersion, err = strconv.Atoi(*intent.Version)
+      if err != nil {
+        log.Printf("[DEBUG] invalid version for Lex Intent: %s", *intent.Version)
+        continue
+      }
+
+			if intentVersion > currentVersion {
+				version = strconv.Itoa(intentVersion)
 			}
 		}
 

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/finder"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
@@ -23,7 +24,6 @@ const (
 	LexIntentCreateTimeout = 1 * time.Minute
 	LexIntentUpdateTimeout = 1 * time.Minute
 	LexIntentDeleteTimeout = 5 * time.Minute
-	LexIntentVersionLatest = "$LATEST"
 )
 
 func resourceAwsLexIntent() *schema.Resource {
@@ -359,7 +359,7 @@ func resourceAwsLexIntentRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.GetIntent(&lexmodelbuildingservice.GetIntentInput{
 		Name:    aws.String(d.Id()),
-		Version: aws.String(LexIntentVersionLatest),
+		Version: aws.String(tflex.LexIntentVersionLatest),
 	})
 	if isAWSErr(err, lexmodelbuildingservice.ErrCodeNotFoundException, "") {
 		log.Printf("[WARN] Intent (%s) not found, removing from state", d.Id())
@@ -385,12 +385,12 @@ func resourceAwsLexIntentRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("last_updated_date", resp.LastUpdatedDate.Format(time.RFC3339))
 	d.Set("name", resp.Name)
 
-	version, err := getLatestLexIntentVersion(conn, &lexmodelbuildingservice.GetIntentVersionsInput{
-		Name: aws.String(d.Id()),
-	})
+	version, err := finder.LatestIntentVersionByName(conn, d.Id())
+
 	if err != nil {
-		return fmt.Errorf("error reading version of intent %s: %w", d.Id(), err)
+		return fmt.Errorf("error reading Lex Intent (%s) latest version: %w", d.Id(), err)
 	}
+
 	d.Set("version", version)
 
 	if resp.ConclusionStatement != nil {
@@ -607,46 +607,6 @@ var lexStatementResource = &schema.Resource{
 			ValidateFunc: validation.StringLenBetween(1, 50000),
 		},
 	},
-}
-
-func getLatestLexIntentVersion(conn *lexmodelbuildingservice.LexModelBuildingService, input *lexmodelbuildingservice.GetIntentVersionsInput) (string, error) {
-	version := 0
-
-	var intentVersion int
-	for {
-		page, err := conn.GetIntentVersions(input)
-		if err != nil {
-			return "", err
-		}
-
-		// At least 1 version will always be returned.
-		if len(page.Intents) == 1 {
-			break
-		}
-
-		for _, intent := range page.Intents {
-			if *intent.Version == LexIntentVersionLatest {
-				continue
-			}
-
-			intentVersion, err = strconv.Atoi(*intent.Version)
-			if err != nil {
-				log.Printf("[DEBUG] invalid version for Lex Intent: %s", *intent.Version)
-				continue
-			}
-
-			if intentVersion > version {
-				version = intentVersion
-			}
-		}
-
-		if page.NextToken == nil {
-			break
-		}
-		input.NextToken = page.NextToken
-	}
-
-	return strconv.Itoa(version), nil
 }
 
 func flattenLexCodeHook(hook *lexmodelbuildingservice.CodeHook) (flattened []map[string]interface{}) {

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tflex "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex"
 )
 
 func init() {
@@ -103,7 +104,7 @@ func TestAccAwsLexIntent_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(rName, "rejection_statement"),
 					resource.TestCheckNoResourceAttr(rName, "sample_utterances"),
 					resource.TestCheckNoResourceAttr(rName, "slot"),
-					resource.TestCheckResourceAttr(rName, "version", LexIntentVersionLatest),
+					resource.TestCheckResourceAttr(rName, "version", tflex.LexIntentVersionLatest),
 				),
 			},
 			{
@@ -718,7 +719,7 @@ func testAccCheckAwsLexIntentExistsWithVersion(rName, intentVersion string, outp
 }
 
 func testAccCheckAwsLexIntentExists(rName string, output *lexmodelbuildingservice.GetIntentOutput) resource.TestCheckFunc {
-	return testAccCheckAwsLexIntentExistsWithVersion(rName, LexIntentVersionLatest, output)
+	return testAccCheckAwsLexIntentExistsWithVersion(rName, tflex.LexIntentVersionLatest, output)
 }
 
 func testAccCheckAwsLexIntentNotExists(intentName, intentVersion string) resource.TestCheckFunc {

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -659,12 +659,14 @@ func TestAccAwsLexIntent_computeVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: composeConfig(
-					testAccAwsLexIntentConfig_createVersion(testIntentID),
+					testAccAwsLexBotConfig_intent(testIntentID),
 					testAccAwsLexBotConfig_createVersion(testIntentID),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAwsLexIntentExistsWithVersion(intentResourceName, version, &v1),
 					resource.TestCheckResourceAttr(intentResourceName, "version", version),
+					resource.TestCheckResourceAttr(intentResourceName, "sample_utterances.#", "1"),
+					resource.TestCheckResourceAttr(intentResourceName, "sample_utterances.0", "I would like to pick up flowers"),
 					testAccCheckAwsLexBotExistsWithVersion(botResourceName, version, &v2),
 					resource.TestCheckResourceAttr(botResourceName, "version", version),
 					resource.TestCheckResourceAttr(botResourceName, "intent.0.intent_version", version),
@@ -679,7 +681,7 @@ func TestAccAwsLexIntent_computeVersion(t *testing.T) {
 					testAccCheckAwsLexIntentExistsWithVersion(intentResourceName, updatedVersion, &v1),
 					resource.TestCheckResourceAttr(intentResourceName, "version", updatedVersion),
 					resource.TestCheckResourceAttr(intentResourceName, "sample_utterances.#", "1"),
-					resource.TestCheckResourceAttr(intentResourceName, "sample_utterances.0", "I would like to pick up flowers"),
+					resource.TestCheckResourceAttr(intentResourceName, "sample_utterances.0", "I would not like to pick up flowers"),
 					testAccCheckAwsLexBotExistsWithVersion(botResourceName, updatedVersion, &v2),
 					resource.TestCheckResourceAttr(botResourceName, "version", updatedVersion),
 					resource.TestCheckResourceAttr(botResourceName, "intent.0.intent_version", updatedVersion),
@@ -1162,7 +1164,7 @@ resource "aws_lex_intent" "test" {
     type = "ReturnIntent"
   }
   sample_utterances = [
-    "I would like to pick up flowers",
+    "I would not like to pick up flowers",
   ]
 }
 `, rName)

--- a/website/docs/r/lex_bot.html.markdown
+++ b/website/docs/r/lex_bot.html.markdown
@@ -114,8 +114,8 @@ slot values into the response card. For more information, see
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 1 mins) Used when creating the bot
-* `update` - (Defaults to 1 mins) Used when updating the bot
+* `create` - (Defaults to 5 mins) Used when creating the bot
+* `update` - (Defaults to 5 mins) Used when updating the bot
 * `delete` - (Defaults to 5 mins) Used when deleting the bot
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21107.
Closes #21045.
Closes #15555.
Closes #15605.


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAwsLex' ACCTEST PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsLex -timeout 180m
=== RUN   TestAccAwsLexBotAlias_basic
=== PAUSE TestAccAwsLexBotAlias_basic
=== RUN   TestAccAwsLexBotAlias_conversationLogsText
=== PAUSE TestAccAwsLexBotAlias_conversationLogsText
=== RUN   TestAccAwsLexBotAlias_conversationLogsAudio
=== PAUSE TestAccAwsLexBotAlias_conversationLogsAudio
=== RUN   TestAccAwsLexBotAlias_conversationLogsBoth
=== PAUSE TestAccAwsLexBotAlias_conversationLogsBoth
=== RUN   TestAccAwsLexBotAlias_description
=== PAUSE TestAccAwsLexBotAlias_description
=== RUN   TestAccAwsLexBotAlias_disappears
=== PAUSE TestAccAwsLexBotAlias_disappears
=== RUN   TestAccAwsLexBot_basic
=== PAUSE TestAccAwsLexBot_basic
=== RUN   TestAccAwsLexBot_version_serial
=== RUN   TestAccAwsLexBot_version_serial/LexBot_createVersion
=== RUN   TestAccAwsLexBot_version_serial/LexBotAlias_botVersion
=== RUN   TestAccAwsLexBot_version_serial/DataSourceLexBot_withVersion
=== RUN   TestAccAwsLexBot_version_serial/DataSourceLexBotAlias_basic
--- PASS: TestAccAwsLexBot_version_serial (171.06s)
    --- PASS: TestAccAwsLexBot_version_serial/LexBot_createVersion (47.43s)
    --- PASS: TestAccAwsLexBot_version_serial/LexBotAlias_botVersion (45.74s)
    --- PASS: TestAccAwsLexBot_version_serial/DataSourceLexBot_withVersion (36.51s)
    --- PASS: TestAccAwsLexBot_version_serial/DataSourceLexBotAlias_basic (41.38s)
=== RUN   TestAccAwsLexBot_abortStatement
=== PAUSE TestAccAwsLexBot_abortStatement
=== RUN   TestAccAwsLexBot_clarificationPrompt
=== PAUSE TestAccAwsLexBot_clarificationPrompt
=== RUN   TestAccAwsLexBot_childDirected
=== PAUSE TestAccAwsLexBot_childDirected
=== RUN   TestAccAwsLexBot_description
=== PAUSE TestAccAwsLexBot_description
=== RUN   TestAccAwsLexBot_detectSentiment
=== PAUSE TestAccAwsLexBot_detectSentiment
=== RUN   TestAccAwsLexBot_enableModelImprovements
=== PAUSE TestAccAwsLexBot_enableModelImprovements
=== RUN   TestAccAwsLexBot_idleSessionTtlInSeconds
=== PAUSE TestAccAwsLexBot_idleSessionTtlInSeconds
=== RUN   TestAccAwsLexBot_intents
=== PAUSE TestAccAwsLexBot_intents
=== RUN   TestAccAwsLexBot_computeVersion
--- PASS: TestAccAwsLexBot_computeVersion (78.19s)
=== RUN   TestAccAwsLexBot_locale
=== PAUSE TestAccAwsLexBot_locale
=== RUN   TestAccAwsLexBot_voiceId
=== PAUSE TestAccAwsLexBot_voiceId
=== RUN   TestAccAwsLexBot_disappears
=== PAUSE TestAccAwsLexBot_disappears
=== RUN   TestAccAwsLexIntent_basic
=== PAUSE TestAccAwsLexIntent_basic
=== RUN   TestAccAwsLexIntent_createVersion
=== PAUSE TestAccAwsLexIntent_createVersion
=== RUN   TestAccAwsLexIntent_conclusionStatement
=== PAUSE TestAccAwsLexIntent_conclusionStatement
=== RUN   TestAccAwsLexIntent_confirmationPromptAndRejectionStatement
=== PAUSE TestAccAwsLexIntent_confirmationPromptAndRejectionStatement
=== RUN   TestAccAwsLexIntent_dialogCodeHook
=== PAUSE TestAccAwsLexIntent_dialogCodeHook
=== RUN   TestAccAwsLexIntent_followUpPrompt
=== PAUSE TestAccAwsLexIntent_followUpPrompt
=== RUN   TestAccAwsLexIntent_fulfillmentActivity
=== PAUSE TestAccAwsLexIntent_fulfillmentActivity
=== RUN   TestAccAwsLexIntent_sampleUtterances
=== PAUSE TestAccAwsLexIntent_sampleUtterances
=== RUN   TestAccAwsLexIntent_slots
=== PAUSE TestAccAwsLexIntent_slots
=== RUN   TestAccAwsLexIntent_slotsCustom
=== PAUSE TestAccAwsLexIntent_slotsCustom
=== RUN   TestAccAwsLexIntent_disappears
=== PAUSE TestAccAwsLexIntent_disappears
=== RUN   TestAccAwsLexIntent_updateWithExternalChange
=== PAUSE TestAccAwsLexIntent_updateWithExternalChange
=== RUN   TestAccAwsLexIntent_computeVersion
=== PAUSE TestAccAwsLexIntent_computeVersion
=== RUN   TestAccAwsLexSlotType_basic
=== PAUSE TestAccAwsLexSlotType_basic
=== RUN   TestAccAwsLexSlotType_createVersion
=== PAUSE TestAccAwsLexSlotType_createVersion
=== RUN   TestAccAwsLexSlotType_description
=== PAUSE TestAccAwsLexSlotType_description
=== RUN   TestAccAwsLexSlotType_enumerationValues
=== PAUSE TestAccAwsLexSlotType_enumerationValues
=== RUN   TestAccAwsLexSlotType_name
=== PAUSE TestAccAwsLexSlotType_name
=== RUN   TestAccAwsLexSlotType_valueSelectionStrategy
=== PAUSE TestAccAwsLexSlotType_valueSelectionStrategy
=== RUN   TestAccAwsLexSlotType_disappears
=== PAUSE TestAccAwsLexSlotType_disappears
=== RUN   TestAccAwsLexSlotType_computeVersion
=== PAUSE TestAccAwsLexSlotType_computeVersion
=== CONT  TestAccAwsLexBotAlias_basic
=== CONT  TestAccAwsLexSlotType_computeVersion
=== CONT  TestAccAwsLexIntent_computeVersion
=== CONT  TestAccAwsLexBot_description
=== CONT  TestAccAwsLexBot_locale
=== CONT  TestAccAwsLexBotAlias_disappears
=== CONT  TestAccAwsLexIntent_conclusionStatement
=== CONT  TestAccAwsLexIntent_sampleUtterances
=== CONT  TestAccAwsLexIntent_updateWithExternalChange
=== CONT  TestAccAwsLexSlotType_valueSelectionStrategy
=== CONT  TestAccAwsLexSlotType_disappears
=== CONT  TestAccAwsLexSlotType_description
=== CONT  TestAccAwsLexSlotType_name
=== CONT  TestAccAwsLexSlotType_createVersion
=== CONT  TestAccAwsLexSlotType_basic
=== CONT  TestAccAwsLexIntent_slotsCustom
=== CONT  TestAccAwsLexIntent_slots
=== CONT  TestAccAwsLexBotAlias_conversationLogsBoth
=== CONT  TestAccAwsLexSlotType_enumerationValues
=== CONT  TestAccAwsLexIntent_disappears
--- PASS: TestAccAwsLexIntent_disappears (68.59s)
=== CONT  TestAccAwsLexBotAlias_description
--- PASS: TestAccAwsLexSlotType_disappears (70.18s)
=== CONT  TestAccAwsLexBotAlias_conversationLogsText
--- PASS: TestAccAwsLexBotAlias_disappears (76.37s)
=== CONT  TestAccAwsLexBot_idleSessionTtlInSeconds
--- PASS: TestAccAwsLexSlotType_valueSelectionStrategy (108.30s)
=== CONT  TestAccAwsLexBot_intents
--- PASS: TestAccAwsLexIntent_updateWithExternalChange (109.81s)
=== CONT  TestAccAwsLexIntent_followUpPrompt
--- PASS: TestAccAwsLexSlotType_createVersion (113.43s)
=== CONT  TestAccAwsLexIntent_fulfillmentActivity
--- PASS: TestAccAwsLexIntent_conclusionStatement (114.43s)
=== CONT  TestAccAwsLexIntent_dialogCodeHook
--- PASS: TestAccAwsLexIntent_computeVersion (116.90s)
=== CONT  TestAccAwsLexBot_clarificationPrompt
--- PASS: TestAccAwsLexSlotType_computeVersion (119.32s)
=== CONT  TestAccAwsLexBot_childDirected
--- PASS: TestAccAwsLexSlotType_description (121.80s)
=== CONT  TestAccAwsLexIntent_basic
--- PASS: TestAccAwsLexIntent_slots (122.73s)
=== CONT  TestAccAwsLexIntent_createVersion
--- PASS: TestAccAwsLexSlotType_enumerationValues (123.61s)
=== CONT  TestAccAwsLexBot_abortStatement
--- PASS: TestAccAwsLexIntent_sampleUtterances (125.36s)
=== CONT  TestAccAwsLexBot_disappears
--- PASS: TestAccAwsLexIntent_slotsCustom (127.35s)
=== CONT  TestAccAwsLexBot_enableModelImprovements
--- PASS: TestAccAwsLexBotAlias_conversationLogsBoth (133.59s)
=== CONT  TestAccAwsLexBot_detectSentiment
--- PASS: TestAccAwsLexBot_description (135.92s)
=== CONT  TestAccAwsLexBot_voiceId
--- PASS: TestAccAwsLexBotAlias_basic (140.62s)
=== CONT  TestAccAwsLexIntent_confirmationPromptAndRejectionStatement
--- PASS: TestAccAwsLexSlotType_basic (156.57s)
=== CONT  TestAccAwsLexBot_basic
--- PASS: TestAccAwsLexBotAlias_conversationLogsText (95.49s)
=== CONT  TestAccAwsLexBotAlias_conversationLogsAudio
--- PASS: TestAccAwsLexSlotType_name (172.79s)
--- PASS: TestAccAwsLexBot_locale (178.93s)
--- PASS: TestAccAwsLexBotAlias_description (126.35s)
--- PASS: TestAccAwsLexBot_disappears (73.27s)
--- PASS: TestAccAwsLexIntent_basic (78.60s)
--- PASS: TestAccAwsLexBot_idleSessionTtlInSeconds (127.59s)
--- PASS: TestAccAwsLexIntent_dialogCodeHook (102.85s)
--- PASS: TestAccAwsLexIntent_fulfillmentActivity (112.47s)
--- PASS: TestAccAwsLexBot_basic (73.95s)
--- PASS: TestAccAwsLexIntent_followUpPrompt (126.28s)
--- PASS: TestAccAwsLexBot_intents (132.12s)
--- PASS: TestAccAwsLexBot_clarificationPrompt (127.88s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsAudio (85.23s)
--- PASS: TestAccAwsLexIntent_confirmationPromptAndRejectionStatement (112.42s)
--- PASS: TestAccAwsLexIntent_createVersion (131.47s)
--- PASS: TestAccAwsLexBot_childDirected (137.59s)
--- PASS: TestAccAwsLexBot_abortStatement (133.90s)
--- PASS: TestAccAwsLexBot_voiceId (124.34s)
--- PASS: TestAccAwsLexBot_detectSentiment (130.60s)
--- PASS: TestAccAwsLexBot_enableModelImprovements (138.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	517.049s
```
