### PR TITLE
Add option to stop an instance before trying to remove an attached volume

### DIFF
--- a/.changelog/21144.txt
+++ b/.changelog/21144.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_volume_attachment: Add `stop_instance_before_detaching` argument
+```

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -19,6 +19,8 @@ const (
 	// Maximum amount of time to wait for EC2 Instance attribute modifications to propagate
 	InstanceAttributePropagationTimeout = 2 * time.Minute
 
+	InstanceStopTimeout = 10 * time.Minute
+
 	// General timeout for EC2 resource creations to propagate
 	PropagationTimeout = 2 * time.Minute
 )

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -65,6 +65,10 @@ func resourceAwsVolumeAttachment() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"stop_instance_before_detaching": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -186,6 +190,43 @@ func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, name, volumeID, instanceID 
 	}
 }
 
+// InstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// an EC2 instance.
+func instanceStateRefreshFunc(conn *ec2.EC2, instanceID string, failStates []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+		if err != nil {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
+				// Set this to nil as if we didn't find anything.
+				resp = nil
+			} else {
+				log.Printf("Error on InstanceStateRefresh: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if resp == nil || len(resp.Reservations) == 0 || len(resp.Reservations[0].Instances) == 0 {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		i := resp.Reservations[0].Instances[0]
+		state := *i.State.Name
+
+		for _, failState := range failStates {
+			if state == failState {
+				return i, state, fmt.Errorf("Failed to reach target state. Reason: %s",
+					stringifyStateReason(i.StateReason))
+			}
+		}
+
+		return i, state, nil
+	}
+}
+
 func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
@@ -235,6 +276,29 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 	name := d.Get("device_name").(string)
 	vID := d.Get("volume_id").(string)
 	iID := d.Get("instance_id").(string)
+
+	if _, ok := d.GetOk("stop_instance_before_detaching"); ok {
+		opts := &ec2.StopInstancesInput{
+			InstanceIds: []*string{aws.String(iID)},
+		}
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"pending", "running", "shutting-down", "stopping"},
+			Target:     []string{"stopped"},
+			Refresh:    instanceStateRefreshFunc(conn, iID, []string{}),
+			Timeout:    5 * time.Minute,
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+		log.Printf("[Debug] Stopping target instance (%s) before detaching Volume (%s)", iID, vID)
+		_, err := conn.StopInstances(opts)
+		if err != nil {
+			return fmt.Errorf("Error stopping Instance (%s)", iID)
+		}
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf("Error waiting Instance (%s) to stop", iID)
+		}
+	}
 
 	opts := &ec2.DetachVolumeInput{
 		Device:     aws.String(name),

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
 )
 
 func resourceAwsVolumeAttachment() *schema.Resource {
@@ -211,7 +212,7 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("error stopping instance (%s): %s", iID, err)
 		}
 
-		if err := waitForInstanceStopping(conn, iID, 10*time.Minute); err != nil {
+		if err := waitForInstanceStopping(conn, iID, waiter.InstanceStopTimeout); err != nil {
 			return err
 		}
 	}

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -55,6 +55,8 @@ to detach the volume from the instance to which it is attached at destroy
 time, and instead just remove the attachment from Terraform state. This is
 useful when destroying an instance which has volumes created by some other
 means attached.
+* `stop_instance_before_detaching` - (Optional, Boolean) Set this to true to ensure that the target instance is stopped
+before trying to detach the volume. Stops the instance, if it is not already stopped.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8602 
This is a cherry-picked continuation of #8602 (unable to make edits to it).

Fixes #6673
Fixes #2084
Fixes #2957
Fixes #4770
Fixes #288
Fixes #1017
Relates #4293
Relates #1991

Output from acceptance testing (`us-west-2`):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSVolumeAttachment_disappears (114.38s)
--- PASS: TestAccAWSVolumeAttachment_stopInstance (117.35s)
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (126.91s)
--- PASS: TestAccAWSVolumeAttachment_basic (130.15s)
--- PASS: TestAccAWSVolumeAttachment_update (164.19s)
--- PASS: TestAccAWSVolumeAttachment_attachStopped (377.79s)
```

Output from acceptance testing (`GovCloud`):
```
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (117.02s)
--- PASS: TestAccAWSVolumeAttachment_basic (117.57s)
--- PASS: TestAccAWSVolumeAttachment_attachStopped (123.17s)
--- PASS: TestAccAWSVolumeAttachment_disappears (135.32s)
--- PASS: TestAccAWSVolumeAttachment_stopInstance (139.20s)
--- PASS: TestAccAWSVolumeAttachment_update (141.49s)
```
