### PR TITLE
Update workflow name

### DIFF
--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -1,3 +1,4 @@
+name: Autoremove Labels
 on:
   issues:
     types: [closed]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Information

Pretty straightforward; when I wrote the GitHub automation to automatically remove `waiting-response` and `needs-triage` labels from closed issues and PRs, I forgot to give it a name, so it's sad to look at in the GitHub UI. This PR fixes that.
