### PR TITLE
Add exclusions list to issue-comment-created

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   issue_comment_triage:
+    if: github.event_name = 'issue_comment' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "dependabot[bot]", "DrFaust92", "ewbankkit", "gdavison", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding"]'), github.actor)
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Information

The `issue-comment-created` workflow automatically removes the `waiting-response` label when a comment is left on an issue. Lately, I've noticed that if I leave a comment just before adding the `waiting-response` label, this automation will be triggered and the label I've just applied will be removed.

It's possible to work around this by waiting "a bit" before adding the `waiting-response` label, but I figured it was worth adding a similar exclusions list as we use elsewhere.