### PR TITLE
wafv2_web_acl doc: Update rate based example

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -77,15 +77,16 @@ resource "aws_wafv2_web_acl" "example" {
 ```
 
 ### Rate Based
+Rate-limit US and NL-based clients to 10,000 requests for every 5 minutes.
 
 ```terraform
 resource "aws_wafv2_web_acl" "example" {
   name        = "rate-based-example"
-  description = "Example of a rate based statement."
-  scope       = "REGIONAL"
+  description = "Example of a Cloudfront rate based statement."
+  scope       = "CLOUDFRONT"
 
   default_action {
-    block {}
+    allow {}
   }
 
   rule {
@@ -93,7 +94,7 @@ resource "aws_wafv2_web_acl" "example" {
     priority = 1
 
     action {
-      count {}
+      block {}
     }
 
     statement {


### PR DESCRIPTION
- If we rate-limit clients, we should **Allow by default, block when rule is matching**
- Add a comment so geographical restriction is explicit
- Use `CLOUDFRONT` for scope to have at least one Cloudfront example for the `scope` parameter

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
