### PR TITLE
tests: Standardize test variables, config

### DIFF
--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -10,13 +10,11 @@ import (
 )
 
 func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
-	rString := acctest.RandString(7)
-	prefix := "tf-acc-test-d-mq-broker"
-	brokerName := fmt.Sprintf("%s-%s", prefix, rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_mq_broker.test"
 
 	dataSourceByIdName := "data.aws_mq_broker.by_id"
 	dataSourceByNameName := "data.aws_mq_broker.by_name"
-	resourceName := "aws_mq_broker.acctest"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(mq.EndpointsID, t) },
@@ -24,7 +22,7 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSMqBrokerConfig_byId(brokerName, prefix),
+				Config: testAccDataSourceAWSMqBrokerConfig_byId(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceByIdName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceByIdName, "broker_name", resourceName, "broker_name"),
@@ -49,7 +47,7 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceAWSMqBrokerConfig_byName(brokerName, prefix),
+				Config: testAccDataSourceAWSMqBrokerConfig_byName(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceByNameName, "broker_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceByNameName, "broker_name", resourceName, "broker_name"),
@@ -59,12 +57,8 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAWSMqBrokerConfig_base(brokerName, prefix string) string {
+func testAccDataSourceAWSMqBrokerConfig_base(rName string) string {
 	return fmt.Sprintf(`
-variable "prefix" {
-  default = "%s"
-}
-
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -74,52 +68,56 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_vpc" "acctest" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = var.prefix
+    Name = %[1]q
   }
 }
 
-resource "aws_internet_gateway" "acctest" {
-  vpc_id = aws_vpc.acctest.id
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
 }
 
-resource "aws_route_table" "acctest" {
-  vpc_id = aws_vpc.acctest.id
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.acctest.id
+    gateway_id = aws_internet_gateway.test.id
   }
 }
 
-resource "aws_subnet" "acctest" {
+resource "aws_subnet" "test" {
   count             = 2
   cidr_block        = "10.0.${count.index}.0/24"
   availability_zone = data.aws_availability_zones.available.names[count.index]
-  vpc_id            = aws_vpc.acctest.id
+  vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = var.prefix
+    Name = %[1]q
   }
 }
 
-resource "aws_route_table_association" "acctest" {
+resource "aws_route_table_association" "test" {
   count          = 2
-  subnet_id      = aws_subnet.acctest.*.id[count.index]
-  route_table_id = aws_route_table.acctest.id
+  subnet_id      = aws_subnet.test.*.id[count.index]
+  route_table_id = aws_route_table.test.id
 }
 
-resource "aws_security_group" "acctest" {
-  count  = 2
-  name   = "${var.prefix}-${count.index}"
-  vpc_id = aws_vpc.acctest.id
+resource "aws_security_group" "test" {
+  count = 2
+
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_mq_configuration" "acctest" {
-  name           = var.prefix
+resource "aws_mq_configuration" "test" {
+  name           = %[1]q
   engine_type    = "ActiveMQ"
   engine_version = "5.15.0"
 
@@ -130,14 +128,14 @@ resource "aws_mq_configuration" "acctest" {
 DATA
 }
 
-resource "aws_mq_broker" "acctest" {
+resource "aws_mq_broker" "test" {
   auto_minor_version_upgrade = true
   apply_immediately          = true
-  broker_name                = "%s"
+  broker_name                = %[1]q
 
   configuration {
-    id       = aws_mq_configuration.acctest.id
-    revision = aws_mq_configuration.acctest.latest_revision
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
   }
 
   deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
@@ -152,8 +150,8 @@ resource "aws_mq_broker" "acctest" {
   }
 
   publicly_accessible = true
-  security_groups     = aws_security_group.acctest[*].id
-  subnet_ids          = aws_subnet.acctest[*].id
+  security_groups     = aws_security_group.test.*.id
+  subnet_ids          = aws_subnet.test.*.id
 
   user {
     username = "Ender"
@@ -167,23 +165,23 @@ resource "aws_mq_broker" "acctest" {
     groups         = ["dragon", "salamander", "leopard"]
   }
 
-  depends_on = [aws_internet_gateway.acctest]
+  depends_on = [aws_internet_gateway.test]
 }
-`, prefix, brokerName)
+`, rName)
 }
 
-func testAccDataSourceAWSMqBrokerConfig_byId(brokerName, prefix string) string {
-	return testAccDataSourceAWSMqBrokerConfig_base(brokerName, prefix) + `
+func testAccDataSourceAWSMqBrokerConfig_byId(rName string) string {
+	return composeConfig(testAccDataSourceAWSMqBrokerConfig_base(rName), `
 data "aws_mq_broker" "by_id" {
-  broker_id = aws_mq_broker.acctest.id
+  broker_id = aws_mq_broker.test.id
 }
-`
+`)
 }
 
-func testAccDataSourceAWSMqBrokerConfig_byName(brokerName, prefix string) string {
-	return testAccDataSourceAWSMqBrokerConfig_base(brokerName, prefix) + `
+func testAccDataSourceAWSMqBrokerConfig_byName(rName string) string {
+	return composeConfig(testAccDataSourceAWSMqBrokerConfig_base(rName), `
 data "aws_mq_broker" "by_name" {
-  broker_name = aws_mq_broker.acctest.broker_name
+  broker_name = aws_mq_broker.test.broker_name
 }
-`
+`)
 }

--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -119,7 +119,7 @@ resource "aws_security_group" "test" {
 resource "aws_mq_configuration" "test" {
   name           = %[1]q
   engine_type    = "ActiveMQ"
-  engine_version = "5.15.0"
+  engine_version = "5.15.12"
 
   data = <<DATA
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -140,7 +140,7 @@ resource "aws_mq_broker" "test" {
 
   deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
   engine_type        = "ActiveMQ"
-  engine_version     = "5.15.0"
+  engine_version     = "5.15.12"
   host_instance_type = "mq.t2.micro"
 
   maintenance_window_start_time {

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDataSourceAWSRDSCluster_basic(t *testing.T) {
-	clusterName := fmt.Sprintf("testaccawsrdscluster-basic-%s", acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_rds_cluster.test"
 	resourceName := "aws_rds_cluster.test"
 
@@ -20,7 +20,7 @@ func TestAccDataSourceAWSRDSCluster_basic(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRdsClusterConfigBasic(clusterName),
+				Config: testAccDataSourceAwsRdsClusterConfigBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "backtrack_window", resourceName, "backtrack_window"),
@@ -38,10 +38,10 @@ func TestAccDataSourceAWSRDSCluster_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAwsRdsClusterConfigBasic(clusterName string) string {
+func testAccDataSourceAwsRdsClusterConfigBasic(rName string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier              = "%[1]s"
+  cluster_identifier              = %[1]q
   database_name                   = "mydb"
   db_cluster_parameter_group_name = "default.aurora5.6"
   db_subnet_group_name            = aws_db_subnet_group.test.name
@@ -58,7 +58,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-rds-cluster-data-source-basic"
+    Name = %[1]q
   }
 }
 
@@ -68,7 +68,7 @@ resource "aws_subnet" "a" {
   availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "tf-acc-rds-cluster-data-source-basic"
+    Name = %[1]q
   }
 }
 
@@ -78,17 +78,17 @@ resource "aws_subnet" "b" {
   availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
-    Name = "tf-acc-rds-cluster-data-source-basic"
+    Name = %[1]q
   }
 }
 
 resource "aws_db_subnet_group" "test" {
-  name       = "%[1]s"
+  name       = %[1]q
   subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
 }
 
 data "aws_rds_cluster" "test" {
   cluster_identifier = aws_rds_cluster.test.cluster_identifier
 }
-`, clusterName))
+`, rName))
 }

--- a/aws/resource_aws_shield_protection_test.go
+++ b/aws/resource_aws_shield_protection_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccAWSShieldProtection_GlobalAccelerator(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,7 +45,7 @@ func TestAccAWSShieldProtection_GlobalAccelerator(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_ElasticIPAddress(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -76,7 +76,7 @@ func TestAccAWSShieldProtection_ElasticIPAddress(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_disappears(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -102,7 +102,7 @@ func TestAccAWSShieldProtection_disappears(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_Alb(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +133,7 @@ func TestAccAWSShieldProtection_Alb(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_Elb(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -164,7 +164,7 @@ func TestAccAWSShieldProtection_Elb(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_Cloudfront(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -196,7 +196,7 @@ func TestAccAWSShieldProtection_Cloudfront(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_Cloudfront_Tags(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -248,7 +248,7 @@ func TestAccAWSShieldProtection_Cloudfront_Tags(t *testing.T) {
 }
 
 func TestAccAWSShieldProtection_Route53(t *testing.T) {
-	resourceName := "aws_shield_protection.acctest"
+	resourceName := "aws_shield_protection.test"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -357,25 +357,21 @@ func testAccShieldProtectionCloudfrontRetainConfig() string {
 
 func testAccShieldProtectionRoute53HostedZoneConfig(rName string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
-
-resource "aws_route53_zone" "acctest" {
-  name    = "${var.name}.com."
+resource "aws_route53_zone" "test" {
+  name    = "%[1]s.com."
   comment = "Terraform Acceptance Tests"
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
 data "aws_partition" "current" {}
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = "arn:${data.aws_partition.current.partition}:route53:::hostedzone/${aws_route53_zone.acctest.zone_id}"
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = "arn:${data.aws_partition.current.partition}:route53:::hostedzone/${aws_route53_zone.test.zone_id}"
 }
 `, rName)
 }
@@ -396,36 +392,32 @@ variable "subnets" {
   type    = list(string)
 }
 
-variable "name" {
-  default = "%s"
-}
-
-resource "aws_vpc" "acctest" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "acctest" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.acctest.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_elb" "acctest" {
-  name = var.name
+resource "aws_elb" "test" {
+  name = %[1]q
 
-  subnets  = aws_subnet.acctest[*].id
+  subnets  = aws_subnet.test[*].id
   internal = true
 
   listener {
@@ -437,15 +429,15 @@ resource "aws_elb" "acctest" {
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 
   cross_zone_load_balancing = true
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = aws_elb.acctest.arn
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = aws_elb.test.arn
 }
 `, rName)
 }
@@ -466,51 +458,47 @@ variable "subnets" {
   type    = list(string)
 }
 
-variable "name" {
-  default = "%s"
-}
-
-resource "aws_lb" "acctest" {
-  name            = var.name
+resource "aws_lb" "test" {
+  name            = %[1]q
   internal        = true
-  security_groups = [aws_security_group.acctest.id]
-  subnets         = aws_subnet.acctest[*].id
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "acctest" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "acctest" {
+resource "aws_subnet" "test" {
   count                   = 2
-  vpc_id                  = aws_vpc.acctest.id
+  vpc_id                  = aws_vpc.test.id
   cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = true
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_security_group" "acctest" {
-  name        = var.name
-  description = "acctest"
-  vpc_id      = aws_vpc.acctest.id
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = "test"
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     from_port   = 0
@@ -528,24 +516,20 @@ resource "aws_security_group" "acctest" {
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = aws_lb.acctest.arn
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = aws_lb.test.arn
 }
 `, rName)
 }
 
 func testAccShieldProtectionCloudfrontConfig(rName, retainOnDelete string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
-
-resource "aws_cloudfront_distribution" "acctest" {
+resource "aws_cloudfront_distribution" "test" {
   origin {
     custom_origin_config {
       http_port              = 80
@@ -560,8 +544,8 @@ resource "aws_cloudfront_distribution" "acctest" {
     }
 
     # This is a fake origin and it's set to this name to indicate that.
-    domain_name = "${var.name}.com"
-    origin_id   = "acctest"
+    domain_name = "%[1]s.com"
+    origin_id   = %[1]q
   }
 
   enabled             = false
@@ -570,7 +554,7 @@ resource "aws_cloudfront_distribution" "acctest" {
   default_cache_behavior {
     allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "acctest"
+    target_origin_id = %[1]q
 
     forwarded_values {
       query_string = false
@@ -595,19 +579,19 @@ resource "aws_cloudfront_distribution" "acctest" {
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 
   viewer_certificate {
     cloudfront_default_certificate = true
   }
 
-  %s
+  %[2]s
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = aws_cloudfront_distribution.acctest.arn
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = aws_cloudfront_distribution.test.arn
 
 }
 `, rName, retainOnDelete)
@@ -615,11 +599,7 @@ resource "aws_shield_protection" "acctest" {
 
 func testAccShieldProtectionCloudfrontConfigTags1(rName, retainOnDelete, tagKey string, tagValue string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
-
-resource "aws_cloudfront_distribution" "acctest" {
+resource "aws_cloudfront_distribution" "test" {
   origin {
     custom_origin_config {
       http_port              = 80
@@ -634,8 +614,8 @@ resource "aws_cloudfront_distribution" "acctest" {
     }
 
     # This is a fake origin and it's set to this name to indicate that.
-    domain_name = "${var.name}.com"
-    origin_id   = "acctest"
+    domain_name = "%[1]s.com"
+    origin_id   = %[1]q
   }
 
   enabled             = false
@@ -644,7 +624,7 @@ resource "aws_cloudfront_distribution" "acctest" {
   default_cache_behavior {
     allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "acctest"
+    target_origin_id = %[1]q
 
     forwarded_values {
       query_string = false
@@ -669,19 +649,19 @@ resource "aws_cloudfront_distribution" "acctest" {
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 
   viewer_certificate {
     cloudfront_default_certificate = true
   }
 
-  %s
+  %[2]s
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = aws_cloudfront_distribution.acctest.arn
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = aws_cloudfront_distribution.test.arn
 
   tags = {
     %[3]q = %[4]q
@@ -692,11 +672,7 @@ resource "aws_shield_protection" "acctest" {
 
 func testAccShieldProtectionCloudfrontConfigTags2(rName, retainOnDelete, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
-
-resource "aws_cloudfront_distribution" "acctest" {
+resource "aws_cloudfront_distribution" "test" {
   origin {
     custom_origin_config {
       http_port              = 80
@@ -711,8 +687,8 @@ resource "aws_cloudfront_distribution" "acctest" {
     }
 
     # This is a fake origin and it's set to this name to indicate that.
-    domain_name = "${var.name}.com"
-    origin_id   = "acctest"
+    domain_name = "%[1]s.com"
+    origin_id   = %[1]q
   }
 
   enabled             = false
@@ -721,7 +697,7 @@ resource "aws_cloudfront_distribution" "acctest" {
   default_cache_behavior {
     allowed_methods  = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "acctest"
+    target_origin_id = %[1]q
 
     forwarded_values {
       query_string = false
@@ -746,19 +722,19 @@ resource "aws_cloudfront_distribution" "acctest" {
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 
   viewer_certificate {
     cloudfront_default_certificate = true
   }
 
-  %s
+  %[2]s
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = aws_cloudfront_distribution.acctest.arn
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = aws_cloudfront_distribution.test.arn
 
   tags = {
     %[3]q = %[4]q
@@ -770,10 +746,6 @@ resource "aws_shield_protection" "acctest" {
 
 func testAccShieldProtectionElasticIPAddressConfig(rName string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
-
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -789,35 +761,31 @@ data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
 
-resource "aws_eip" "acctest" {
+resource "aws_eip" "test" {
   vpc = true
 
   tags = {
     foo  = "bar"
-    Name = var.name
+    Name = %[1]q
   }
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.acctest.id}"
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"
 }
 `, rName)
 }
 
 func testAccShieldProtectionGlobalAcceleratorConfig(rName string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
+resource "aws_shield_protection" "test" {
+  name         = %[1]q
+  resource_arn = aws_globalaccelerator_accelerator.test.id
 }
 
-resource "aws_shield_protection" "acctest" {
-  name         = var.name
-  resource_arn = aws_globalaccelerator_accelerator.acctest.id
-}
-
-resource "aws_globalaccelerator_accelerator" "acctest" {
-  name            = var.name
+resource "aws_globalaccelerator_accelerator" "test" {
+  name            = %[1]q
   ip_address_type = "IPV4"
   enabled         = true
 }


### PR DESCRIPTION
- tests/shield_protection: Standardize name
- tests/ds/mq_broker: Standardize naming

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing (`us-west-2`):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSShieldProtection_disappears (16.04s)
--- PASS: TestAccAWSShieldProtection_ElasticIPAddress (18.02s)
--- PASS: TestAccAWSShieldProtection_Elb (47.30s)
--- PASS: TestAccAWSShieldProtection_Route53 (69.97s)
--- PASS: TestAccAWSShieldProtection_GlobalAccelerator (71.05s)
--- PASS: TestAccAWSShieldProtection_Cloudfront (162.71s)
--- PASS: TestAccAWSShieldProtection_Cloudfront_Tags (218.78s)
--- PASS: TestAccAWSShieldProtection_Alb (242.27s)

--- PASS: TestAccDataSourceAWSMqBroker_basic (1233.93s)

--- PASS: TestAccDataSourceAWSRDSCluster_basic (149.64s)
```

Output from acceptance testing (`GovCloud`):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- SKIP: TestAccAWSShieldProtection_Elb (1.30s)
--- SKIP: TestAccAWSShieldProtection_GlobalAccelerator (1.30s)
--- SKIP: TestAccAWSShieldProtection_Cloudfront_Tags (1.30s)
--- SKIP: TestAccAWSShieldProtection_Alb (1.30s)
--- SKIP: TestAccAWSShieldProtection_Cloudfront (1.30s)
--- SKIP: TestAccAWSShieldProtection_disappears (1.30s)
--- SKIP: TestAccAWSShieldProtection_Route53 (1.30s)
--- SKIP: TestAccAWSShieldProtection_ElasticIPAddress (1.30s)

--- PASS: TestAccDataSourceAWSMqBroker_basic (1153.35s)

--- PASS: TestAccDataSourceAWSRDSCluster_basic (147.76s)
```