### PR TITLE
resource/aws_elasticache_replication_group: Fix updating tags

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -512,6 +511,23 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 	d.Set("replication_group_id", rgp.ReplicationGroupId)
 	d.Set("arn", rgp.ARN)
 
+	tags, err := keyvaluetags.ElasticacheListTags(conn, aws.StringValue(rgp.ARN))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for resource (%s): %w", aws.StringValue(rgp.ARN), err)
+	}
+
+	tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
 	if rgp.NodeGroups != nil {
 		if len(rgp.NodeGroups[0].NodeGroupMembers) == 0 {
 			return nil
@@ -555,31 +571,6 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 
 		if c.AuthTokenEnabled != nil && !aws.BoolValue(c.AuthTokenEnabled) {
 			d.Set("auth_token", nil)
-		}
-
-		arn := arn.ARN{
-			Partition: meta.(*AWSClient).partition,
-			Service:   "elasticache",
-			Region:    meta.(*AWSClient).region,
-			AccountID: meta.(*AWSClient).accountid,
-			Resource:  fmt.Sprintf("cluster:%s", aws.StringValue(c.CacheClusterId)),
-		}.String()
-
-		tags, err := keyvaluetags.ElasticacheListTags(conn, arn)
-
-		if err != nil {
-			return fmt.Errorf("error listing tags for resource (%s): %w", arn, err)
-		}
-
-		tags = tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig)
-
-		//lintignore:AWSR002
-		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-			return fmt.Errorf("error setting tags: %w", err)
-		}
-
-		if err := d.Set("tags_all", tags.Map()); err != nil {
-			return fmt.Errorf("error setting tags_all: %w", err)
 		}
 	}
 
@@ -683,30 +674,22 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 	}
 
 	if requestUpdate {
-		err := resourceAwsElasticacheReplicationGroupModify(conn, d.Timeout(schema.TimeoutUpdate), params)
+		_, err := conn.ModifyReplicationGroup(params)
 		if err != nil {
 			return fmt.Errorf("error updating ElastiCache Replication Group (%s): %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("tags_all") {
-		clusters := d.Get("member_clusters").(*schema.Set).List()
-
-		for _, cluster := range clusters {
-
-			arn := arn.ARN{
-				Partition: meta.(*AWSClient).partition,
-				Service:   "elasticache",
-				Region:    meta.(*AWSClient).region,
-				AccountID: meta.(*AWSClient).accountid,
-				Resource:  fmt.Sprintf("cluster:%s", cluster),
-			}.String()
-
-			o, n := d.GetChange("tags_all")
-			if err := keyvaluetags.ElasticacheUpdateTags(conn, arn, o, n); err != nil {
-				return fmt.Errorf("error updating tags: %w", err)
-			}
+		o, n := d.GetChange("tags_all")
+		if err := keyvaluetags.ElasticacheUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %w", err)
 		}
+	}
+
+	_, err := waiter.ReplicationGroupAvailable(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return fmt.Errorf("error waiting for modification: %w", err)
 	}
 
 	return resourceAwsElasticacheReplicationGroupRead(d, meta)
@@ -970,19 +953,6 @@ func elasticacheReplicationGroupDecreaseNumCacheClusters(conn *elasticache.Elast
 		return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) replica removal: %w", replicationGroupID, err)
 	}
 
-	return nil
-}
-
-func resourceAwsElasticacheReplicationGroupModify(conn *elasticache.ElastiCache, timeout time.Duration, input *elasticache.ModifyReplicationGroupInput) error {
-	_, err := conn.ModifyReplicationGroup(input)
-	if err != nil {
-		return fmt.Errorf("error requesting modification: %w", err)
-	}
-
-	_, err = waiter.ReplicationGroupAvailable(conn, aws.StringValue(input.ReplicationGroupId), timeout)
-	if err != nil {
-		return fmt.Errorf("error waiting for modification: %w", err)
-	}
 	return nil
 }
 

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1016,6 +1016,7 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Basic(t *testing.
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
+	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1025,12 +1026,15 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Basic(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
+					testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
+						{"key", "value"},
+					}),
 				),
 			},
 			{
@@ -1041,22 +1045,28 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Basic(t *testing.
 			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 4),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
+					testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 4, []kvp{
+						{"key", "value"},
+					}),
 				),
 			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
+					testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
+						{"key", "value"},
+					}),
 				),
 			},
 		},
@@ -1420,8 +1430,7 @@ func TestAccAWSElasticacheReplicationGroup_tags(t *testing.T) {
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
-	clusterDataSourceName0 :="data.aws_elasticache_cluster.test.0"
-	clusterDataSourceName1 :="data.aws_elasticache_cluster.test.1"
+	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1433,12 +1442,9 @@ func TestAccAWSElasticacheReplicationGroup_tags(t *testing.T) {
 				Config: testAccAWSElasticacheReplicationGroupConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.%", "1"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.key1", "value1"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.%", "1"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.key1", "value1"),
+					testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
+						{"key1", "value1"},
+					}),
 				),
 			},
 			{
@@ -1451,27 +1457,19 @@ func TestAccAWSElasticacheReplicationGroup_tags(t *testing.T) {
 				Config: testAccAWSElasticacheReplicationGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.%", "2"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.key1", "value1updated"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.key2", "value2"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.%", "2"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.key1", "value1updated"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.key2", "value2"),
+					testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
+						{"key1", "value1updated"},
+						{"key2", "value2"},
+					}),
 				),
 			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.%", "1"),
-					resource.TestCheckResourceAttr(clusterDataSourceName0, "tags.key2", "value2"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.%", "1"),
-					resource.TestCheckResourceAttr(clusterDataSourceName1, "tags.key2", "value2"),
+					testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
+						{"key2", "value2"},
+					}),
 				),
 			},
 		},
@@ -1845,6 +1843,31 @@ func testAccCheckAWSElastiCacheReplicationGroupNotRecreated(i, j *map[string]*el
 
 		return nil
 	}
+}
+
+type kvp struct {
+	key   string
+	value string
+}
+
+func testAccAWSElasticacheReplicationGroupCheckMemberClusterTags(resourceName, dataSourceNamePrefix string, memberCount int, kvs []kvp) resource.TestCheckFunc {
+	checks := testAccCheckResourceTags(resourceName, kvs)
+	checks = append(checks, resource.TestCheckResourceAttr(resourceName, "member_clusters.#", strconv.Itoa(memberCount))) // sanity check
+
+	for i := 0; i < memberCount; i++ {
+		dataSourceName := fmt.Sprintf("%s.%d", dataSourceNamePrefix, i)
+		checks = append(checks, testAccCheckResourceTags(dataSourceName, kvs)...)
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func testAccCheckResourceTags(resourceName string, kvs []kvp) []resource.TestCheckFunc {
+	checks := make([]resource.TestCheckFunc, 1, 1+len(kvs))
+	checks[0] = resource.TestCheckResourceAttr(resourceName, "tags.%", strconv.Itoa(len(kvs)))
+	for _, kv := range kvs {
+		checks = append(checks, resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("tags.%s", kv.key), kv.value))
+	}
+	return checks
 }
 
 func testAccAWSElasticacheReplicationGroupConfig(rName string) string {
@@ -2683,7 +2706,9 @@ resource "aws_elasticache_replication_group" "test" {
 }
 
 func testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName string, numberCacheClusters int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSElasticacheReplicationGroupClusterData(numberCacheClusters),
+		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -2724,8 +2749,13 @@ resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "Terraform Acceptance Testing - number_cache_clusters"
   subnet_group_name             = aws_elasticache_subnet_group.test.name
+
+  tags = {
+	key = "value"
 }
-`, rName, numberCacheClusters)
+}
+`, rName, numberCacheClusters),
+	)
 }
 
 func testAccAWSElasticacheReplicationGroupConfig_FailoverMultiAZ(rName string, numberCacheClusters int, autoFailover, multiAZ bool) string {


### PR DESCRIPTION
The resource `aws_elasticache_replication_group` was not correctly updating the tags on the replication group, and was only updating tags on the member clusters. This also fixes tagging member clusters when scaling up.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20695
Closes #18449
Closes #18116

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
