### PR TITLE
Correct endpoint type documentation for data.aws_iot_endpoint.

### DIFF
--- a/website/docs/d/iot_endpoint.html.markdown
+++ b/website/docs/d/iot_endpoint.html.markdown
@@ -36,7 +36,7 @@ resource "kubernetes_pod" "agent" {
 
 ## Argument Reference
 
-* `endpoint_type` - (Optional) Endpoint type. Valid values: `iot:CredentialProvider`, `iot:Data`, `iot:Data-ATS`, `iot:Job`.
+* `endpoint_type` - (Optional) Endpoint type. Valid values: `iot:CredentialProvider`, `iot:Data`, `iot:Data-ATS`, `iot:Jobs`.
 
 ## Attributes Reference
 
@@ -45,4 +45,4 @@ resource "kubernetes_pod" "agent" {
     * `iot:CredentialsProvider`: `IDENTIFIER.credentials.iot.REGION.amazonaws.com`
     * `iot:Data`: `IDENTIFIER.iot.REGION.amazonaws.com`
     * `iot:Data-ATS`: `IDENTIFIER-ats.iot.REGION.amazonaws.com`
-    * `iot:Job`: `IDENTIFIER.jobs.iot.REGION.amazonaws.com`
+    * `iot:Jobs`: `IDENTIFIER.jobs.iot.REGION.amazonaws.com`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

This PR makes a very small correction to the documentation for the `aws_iot_endpoint` data source detailed here: [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iot_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iot_endpoint) to update the `endpoint_type` argument documentation to refer to the correct endpoint type for IoT Jobs. Currently this is documented as `iot:Job` but the correct value is `iot:Jobs`. This is confirmed by the provider giving this error if `iot:Job` is entered for the `endpoint_type` parameter:

```
Error: expected endpoint_type to be one of [iot:CredentialProvider iot:Data iot:Data-ATS iot:Jobs], got iot:Job
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

