### PR TITLE
r/ses_email_identity - move to sesv2

### DIFF
--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -153,6 +153,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/sesv2"
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/aws/aws-sdk-go/service/shield"
 	"github.com/aws/aws-sdk-go/service/signer"
@@ -373,6 +374,7 @@ type AWSClient struct {
 	ServerlessAppRepoConn            *serverlessapplicationrepository.ServerlessApplicationRepository
 	ServiceQuotasConn                *servicequotas.ServiceQuotas
 	SESConn                          *ses.SES
+	SESV2Conn                        *sesv2.SESV2
 	SFNConn                          *sfn.SFN
 	ShieldConn                       *shield.Shield
 	SignerConn                       *signer.Signer
@@ -624,6 +626,7 @@ func (c *Config) Client() (interface{}, error) {
 		ServerlessAppRepoConn:            serverlessapplicationrepository.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["serverlessrepo"])})),
 		ServiceQuotasConn:                servicequotas.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["servicequotas"])})),
 		SESConn:                          ses.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["ses"])})),
+		SESV2Conn:                        sesv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["sesv2"])})),
 		SFNConn:                          sfn.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["stepfunctions"])})),
 		SignerConn:                       signer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["signer"])})),
 		SimpleDBConn:                     simpledb.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["sdb"])})),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21129. In order to support new attributes, it is required to use `sesv2` package from AWS SDK. I'm going to add these attributes in the next PR.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccSESEmailIdentity" PKG_NAME="internal/service/ses"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ses -v -count 1 -parallel 20 -run=TestAccSESEmailIdentity -timeout 180m
=== RUN   TestAccSESEmailIdentity_basic
=== PAUSE TestAccSESEmailIdentity_basic
=== RUN   TestAccSESEmailIdentity_trailingPeriod
=== PAUSE TestAccSESEmailIdentity_trailingPeriod
=== CONT  TestAccSESEmailIdentity_basic
=== CONT  TestAccSESEmailIdentity_trailingPeriod
--- PASS: TestAccSESEmailIdentity_trailingPeriod (29.60s)
--- PASS: TestAccSESEmailIdentity_basic (29.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	36.585s
```
