### PR TITLE
Fix broken CHANGELOG link, remove branch dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2425,4 +2425,4 @@ BUG FIXES
 
 For information on prior major releases, see their changelogs:
 
-* [2.x and earlier](https://github.com/hashicorp/terraform-provider-aws/blob/release/2.x/CHANGELOG.md)
+* [2.70.0 and earlier](https://github.com/hashicorp/terraform-provider-aws/blob/v2.70.0/CHANGELOG.md)

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -14,7 +14,6 @@
             - [yaml.v2 Updates](#yaml-v2-updates)
     - [Pull Request Merge Process](#pull-request-merge-process)
 - [Breaking Changes](#breaking-changes)
-- [Branch Dictionary](#branch-dictionary)
 - [Environment Variable Dictionary](#environment-variable-dictionary)
 - [Release Process](#release-process)
 
@@ -317,17 +316,6 @@ When breaking changes to the provider are necessary we release them in a major v
 - Add the `breaking-change` label.
 - Add the issue/PR to the next major version milestone.
 - Leave a comment why this is a breaking change or otherwise only being considered for a major version update. If possible, detail any changes that might be made for the contributor to accomplish the task without a breaking change.
-
-## Branch Dictionary
-
-The following branch conventions are used:
-
-| Branch | Example | Description |
-|--------|---------|-------------|
-| `main` | `main` | Main, unreleased code branch. |
-| `release/*` | `release/2.x` | Backport branches for previous major releases. |
-
-Additional branch naming recommendations can be found in the [Pull Request Submission and Lifecycle documentation](contributing/pullrequest-submission-and-lifecycle.md#branch-prefixes).
 
 ## Environment Variable Dictionary
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #21214

### Information

The link to the `2.x` changelog link is currently broken. In looking into it, it seems that this is due to a move away from the `releases/*` branch naming convention.

This PR updates the link to point directly at the `v2.7.0` tag. Since it was the last release in the `2.x` series. It also removes the branch dictionary since that seems to be unused at this point.