### PR TITLE
Convert list to a set in aws_subnets data source examples

### DIFF
--- a/website/docs/d/subnets.html.markdown
+++ b/website/docs/d/subnets.html.markdown
@@ -23,7 +23,7 @@ data "aws_subnets" "example" {
 }
 
 data "aws_subnet" "example" {
-  for_each = data.aws_subnets.example.ids
+  for_each = toset(data.aws_subnets.example.ids)
   id       = each.value
 }
 
@@ -49,7 +49,7 @@ data "aws_subnets" "private" {
 }
 
 resource "aws_instance" "app" {
-  for_each      = data.aws_subnets.example.ids
+  for_each      = toset(data.aws_subnets.example.ids)
   ami           = var.ami
   instance_type = "t2.micro"
   subnet_id     = each.value


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #21220

### Information

This PR updates the examples for the `aws_subnets` data source to fix an issue where a list was incorrectly being passed to `for_each`. Previously, `ids` was a `TypeSet`, so this example was correct, however, that has [since changed](https://github.com/hashicorp/terraform-provider-aws/pull/18803).