### PR TITLE
Added support for repository filter to ecr replications

### DIFF
--- a/.changelog/21231.txt
+++ b/.changelog/21231.txt
@@ -1,0 +1,4 @@
+
+```release-note:enhancement
+resource/aws_ecr_replication_configuration: Added support for repository filters
+```

--- a/internal/service/ecr/replication_configuration.go
+++ b/internal/service/ecr/replication_configuration.go
@@ -55,6 +55,22 @@ func ResourceReplicationConfiguration() *schema.Resource {
 											},
 										},
 									},
+									"repository_filter": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"filter": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"filter_type": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -153,7 +169,8 @@ func expandEcrReplicationConfigurationReplicationConfigurationRules(data []inter
 	for _, rule := range data {
 		ec := rule.(map[string]interface{})
 		config := &ecr.ReplicationRule{
-			Destinations: expandEcrReplicationConfigurationReplicationConfigurationRulesDestinations(ec["destination"].([]interface{})),
+			Destinations:      expandEcrReplicationConfigurationReplicationConfigurationRulesDestinations(ec["destination"].([]interface{})),
+			RepositoryFilters: expandEcrReplicationConfigurationReplicationConfigurationRulesRepositoryFilters(ec["repository_filter"].([]interface{})),
 		}
 
 		rules = append(rules, config)
@@ -171,7 +188,8 @@ func flattenEcrReplicationConfigurationReplicationConfigurationRules(ec []*ecr.R
 
 	for _, apiObject := range ec {
 		tfMap := map[string]interface{}{
-			"destination": flattenEcrReplicationConfigurationReplicationConfigurationRulesDestinations(apiObject.Destinations),
+			"destination":       flattenEcrReplicationConfigurationReplicationConfigurationRulesDestinations(apiObject.Destinations),
+			"repository_filter": flattenEcrReplicationConfigurationReplicationConfigurationRulesRepositoryFilters(apiObject.RepositoryFilters),
 		}
 
 		tfList = append(tfList, tfMap)
@@ -199,6 +217,25 @@ func expandEcrReplicationConfigurationReplicationConfigurationRulesDestinations(
 	return dests
 }
 
+func expandEcrReplicationConfigurationReplicationConfigurationRulesRepositoryFilters(data []interface{}) []*ecr.RepositoryFilter {
+	if len(data) == 0 || data[0] == nil {
+		return nil
+	}
+
+	var dests []*ecr.RepositoryFilter
+
+	for _, dest := range data {
+		ec := dest.(map[string]interface{})
+		config := &ecr.RepositoryFilter{
+			Filter:     aws.String(ec["filter"].(string)),
+			FilterType: aws.String(ec["filter_type"].(string)),
+		}
+
+		dests = append(dests, config)
+	}
+	return dests
+}
+
 func flattenEcrReplicationConfigurationReplicationConfigurationRulesDestinations(ec []*ecr.ReplicationDestination) []interface{} {
 	if len(ec) == 0 {
 		return nil
@@ -210,6 +247,25 @@ func flattenEcrReplicationConfigurationReplicationConfigurationRulesDestinations
 		tfMap := map[string]interface{}{
 			"region":      aws.StringValue(apiObject.Region),
 			"registry_id": aws.StringValue(apiObject.RegistryId),
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
+}
+
+func flattenEcrReplicationConfigurationReplicationConfigurationRulesRepositoryFilters(ec []*ecr.RepositoryFilter) []interface{} {
+	if len(ec) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range ec {
+		tfMap := map[string]interface{}{
+			"filter":      aws.StringValue(apiObject.Filter),
+			"filter_type": aws.StringValue(apiObject.FilterType),
 		}
 
 		tfList = append(tfList, tfMap)

--- a/website/docs/r/ecr_replication_configuration.html.markdown
+++ b/website/docs/r/ecr_replication_configuration.html.markdown
@@ -53,6 +53,31 @@ resource "aws_ecr_replication_configuration" "example" {
 }
 ```
 
+## Repository Filter Usage
+
+```terraform
+data "aws_caller_identity" "current" {}
+
+data "aws_regions" "example" {}
+
+resource "aws_ecr_replication_configuration" "example" {
+  replication_configuration {
+    rule {
+      destination {
+        region      = data.aws_regions.example.names[0]
+        registry_id = data.aws_caller_identity.current.account_id
+      }
+      repository_filter {
+        filter      = "a-prefix"
+        filter_type = "PREFIX_MATCH"
+      }
+    }
+  }
+}
+```
+
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -66,11 +91,17 @@ The following arguments are supported:
 ### Rule
 
 * `destination` - (Required) the details of a replication destination. See [Destination](#destination).
+* `repository_filter` - (Optional) the details of a replication repository filter. See [Repository Filter](#repository-filter).
 
 ### Destination
 
 * `region` - (Required) A Region to replicate to.
 * `registry_id` - (Required) The account ID of the destination registry to replicate to.
+
+### Repository Filter
+
+* `filter` - (Required) The repository name prefixe to configure the replication for.
+* `registry_id` - (Required) The repository filter type, only support value is `PREFIX_MATCH`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21230

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc PKG_NAME=internal/service/ecr TESTARGS='-run=TestAccECRReplicationConfiguration_repositoryFilter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run=TestAccECRReplicationConfiguration_repositoryFilter -timeout 180m
=== RUN   TestAccECRReplicationConfiguration_repositoryFilter
=== PAUSE TestAccECRReplicationConfiguration_repositoryFilter
=== CONT  TestAccECRReplicationConfiguration_repositoryFilter
--- PASS: TestAccECRReplicationConfiguration_repositoryFilter (82.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        82.334s
```
