### PR TITLE
Add data aws_iot_registration_code

### DIFF
--- a/aws/data_source_aws_iot_registration_code.go
+++ b/aws/data_source_aws_iot_registration_code.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsIotRegistrationCode() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIotRegistrationCodeRead,
+		Schema: map[string]*schema.Schema{
+			"code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIotRegistrationCodeRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+	input := &iot.GetRegistrationCodeInput{}
+
+	output, err := conn.GetRegistrationCode(input)
+	if err != nil {
+		return fmt.Errorf("error reading registration code: %v", err)
+	}
+	code := aws.StringValue(output.RegistrationCode)
+	d.SetId(code)
+	if err := d.Set("code", code); err != nil {
+		return fmt.Errorf("error setting code: %s", err)
+	}
+	return nil
+}

--- a/aws/data_source_aws_iot_registration_code_test.go
+++ b/aws/data_source_aws_iot_registration_code_test.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSIotRegistrationCodeDataSource_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTRegistrationCode,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_iot_registration_code.test", "code"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAWSIoTRegistrationCode = `
+data "aws_iot_registration_code" "test" {}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -342,6 +342,7 @@ func Provider() *schema.Provider {
 			"aws_internet_gateway":                           dataSourceAwsInternetGateway(),
 			"aws_iot_endpoint":                               dataSourceAwsIotEndpoint(),
 			"aws_ip_ranges":                                  dataSourceAwsIPRanges(),
+			"aws_iot_registration_code":                      dataSourceAwsIotRegistrationCode(),
 			"aws_kinesis_firehose_delivery_stream":           dataSourceAwsKinesisFirehoseDeliveryStream(),
 			"aws_kinesis_stream":                             dataSourceAwsKinesisStream(),
 			"aws_kinesis_stream_consumer":                    dataSourceAwsKinesisStreamConsumer(),

--- a/website/docs/d/iot_registration_code.html.markdown
+++ b/website/docs/d/iot_registration_code.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "IoT"
+layout: "aws"
+page_title: "AWS: aws_iot_registration_code"
+description: |-
+  Get the unique IoT registration code
+---
+
+# Data Source: aws_iot_registration_code
+
+Returns a unique registration code specific to the AWS account making the call.
+
+## Example Usage
+
+```hcl
+data "aws_iot_registration_code" "example" {}
+resource "tls_private_key" "verification" {
+  algorithm = "RSA"
+}
+resource "tls_cert_request" "verification" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.verification.private_key_pem
+  subject {
+    common_name = data.aws_iot_registration_code.example.id
+  }
+}
+```
+
+## Attributes Reference
+
+* `code` - The code required to be set in a verification common name.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes Pull Request #15098 [here](https://github.com/hashicorp/terraform-provider-aws/pull/15098)

### Description
I saw that the other PR isn't accepted so I've decided to fix it and get it merged. Unfortunately I didn't have enough time to get the acceptance tests working for the resource. To break the work down, I've added only the data object for the registration code and fixed the relevant accaptance tests.

Output from acceptance testing:

`make testacc TESTARGS='-run=TestAccAWSIotRegistrationCodeDataSource'`

```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIotRegistrationCodeDataSource -timeout 180m
=== RUN   TestAccAWSIotRegistrationCodeDataSource_basic
=== PAUSE TestAccAWSIotRegistrationCodeDataSource_basic
=== CONT  TestAccAWSIotRegistrationCodeDataSource_basic

--- PASS: TestAccAWSIotRegistrationCodeDataSource_basic (180.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	182.027s
```
