### PR TITLE
feat: add triggers for r/iam_access_key

### DIFF
--- a/.changelog/21244.txt
+++ b/.changelog/21244.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_access_key: Add `triggers` argument
+```

--- a/internal/service/iam/access_key.go
+++ b/internal/service/iam/access_key.go
@@ -87,6 +87,12 @@ func ResourceAccessKey() *schema.Resource {
 				Default:      iam.StatusTypeActive,
 				ValidateFunc: validation.StringInSlice(iam.StatusType_Values(), false),
 			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"user": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -69,6 +69,7 @@ The following arguments are supported:
 
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:some_person_that_exists`, for use in the `encrypted_secret` output attribute.
 * `status` - (Optional) Access key status to apply. Defaults to `Active`. Valid values are `Active` and `Inactive`.
+* `triggers` - (Optional) Arbitrary map of values that, when changed, will trigger recreation of this resource. To force a redeployment without changing these keys/values, use the [`terraform taint` command](/docs/commands/taint.html).
 * `user` - (Required) IAM user to associate with this access key.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Adds a new argument `triggers` to resource `aws_iam_access_key`.  Concept and code from [terraform-provider-random](https://github.com/hashicorp/terraform-provider-random/blob/2223e50b3b24a071e5f523ddf0a6d3367a3b18df/internal/provider/string.go#L23).

Closes #23180.

The use case for this change is to enable simple rotation of access keys simply by updating a value that is passed to the resource definition. This could be a simple string representing the date that the key was last rotated. Enabling this allows history of the resource rotation to be maintained in version control, instead of relying entirely on `terraform taint`.

Output from acceptance testing (updated after renaming from `keepers` to `triggers`):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
[~/git/terraform-provider-aws]% make testacc TESTARGS='-run=TestAccAWSAccessKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAccessKey -timeout 180m
=== RUN   TestAccAWSAccessKey_basic
=== PAUSE TestAccAWSAccessKey_basic
=== RUN   TestAccAWSAccessKey_encrypted
=== PAUSE TestAccAWSAccessKey_encrypted
=== RUN   TestAccAWSAccessKey_status
=== PAUSE TestAccAWSAccessKey_status
=== CONT  TestAccAWSAccessKey_basic
=== CONT  TestAccAWSAccessKey_status
=== CONT  TestAccAWSAccessKey_encrypted
--- PASS: TestAccAWSAccessKey_encrypted (34.71s)
--- PASS: TestAccAWSAccessKey_basic (37.57s)
--- PASS: TestAccAWSAccessKey_status (61.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       64.481s
```
