### PR TITLE
DRAFT: Datasource IAM Policy Document - verify JSON

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -46,8 +46,9 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 				Optional: true,
 			},
 			"source_json": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
 			},
 			"source_policy_documents": {
 				Type:     schema.TypeList,

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -296,6 +296,20 @@ func TestAccAWSDataSourceIAMPolicyDocument_version20081017(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		ErrorCheck: testAccErrorCheck(t, iam.EndpointsID),
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSIAMPolicyDocumentSourceJsonInvalid,
+				ExpectError: regexp.MustCompile(`invalid character ']' looking for beginning of value`),
+			},
+		},
+	})
+}
+
 var testAccAWSIAMPolicyDocumentConfig = `
 data "aws_partition" "current" {}
 
@@ -1258,3 +1272,26 @@ func testAccAWSIAMPolicyDocumentExpectedJSONStatementPrincipalIdentifiersMultipl
   ]
 }`, testAccGetPartition())
 }
+
+var testAccAWSIAMPolicyDocumentSourceJsonInvalid = `
+data "aws_iam_policy_document" "test" {
+
+source_json = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ContainExtraComma",
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*",
+      ]
+    }
+  ]
+}
+EOF
+}
+`


### PR DESCRIPTION
Validate source JSON is valid during validation step.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
```
make testacc TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid -timeout 180m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_SourceJSONInvalid (2.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       5.382s

```
