### PR TITLE
r/aws_ecrpublic_repository: Skip sweeper outside of `us-east-1`

### DIFF
--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -187,6 +187,10 @@ func testSweepSkipSweepError(err error) bool {
 	if isAWSErr(err, "KeySigningKeyInParentDSRecord", "Due to DNS lookup failure") {
 		return true
 	}
+	// For example from us-west-2 ECR public repository
+	if isAWSErr(err, "UnsupportedCommandException", "command is only supported in") {
+		return true
+	}
 	return false
 }
 

--- a/aws/resource_aws_ecrpublic_repository.go
+++ b/aws/resource_aws_ecrpublic_repository.go
@@ -228,6 +228,7 @@ func resourceAwsEcrPublicRepositoryDelete(d *schema.ResourceData, meta interface
 		deleteInput.Force = aws.Bool(v.(bool))
 	}
 
+	log.Printf("[DEBUG] Deleting ECR Public Repository: (%s)", d.Id())
 	_, err := conn.DeleteRepository(deleteInput)
 
 	if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21277.

##### Before

```console
% TEST=./aws SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_ecrpublic_repository make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_ecrpublic_repository -timeout 60m
2021/10/13 13:04:33 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/13 13:04:33 [DEBUG] Running Sweeper (aws_ecrpublic_repository) in region (us-west-2)
2021/10/13 13:04:33 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/13 13:04:33 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 13:04:33 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 13:04:35 [DEBUG] Completed Sweeper (aws_ecrpublic_repository) in region (us-west-2) in 2.315848202s
2021/10/13 13:04:35 [ERROR] Error running Sweeper (aws_ecrpublic_repository) in region (us-west-2): 1 error occurred:
	* error describing ECR Public Repositories for us-west-2: UnsupportedCommandException: DescribeRepositories command is only supported in us-east-1.

FAIL	github.com/terraform-providers/terraform-provider-aws/aws	5.480s
FAIL
make: *** [sweep] Error 1
```

##### After

```console
% TEST=./aws SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_ecrpublic_repository make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_ecrpublic_repository -timeout 60m
2021/10/13 13:16:57 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/13 13:16:57 [DEBUG] Running Sweeper (aws_ecrpublic_repository) in region (us-west-2)
2021/10/13 13:16:57 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/13 13:16:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 13:16:58 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 13:16:59 [WARN] Skipping ECR Public Repository sweep for us-west-2: UnsupportedCommandException: DescribeRepositories command is only supported in us-east-1.
2021/10/13 13:16:59 [DEBUG] Completed Sweeper (aws_ecrpublic_repository) in region (us-west-2) in 1.371665821s
2021/10/13 13:16:59 Completed Sweepers for region (us-west-2) in 1.371875178s
2021/10/13 13:16:59 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_ecrpublic_repository
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.045s
% TEST=./aws SWEEP=us-east-1 SWEEPARGS=-sweep-run=aws_ecrpublic_repository make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-east-1 -sweep-run=aws_ecrpublic_repository -timeout 60m
2021/10/13 13:18:14 [DEBUG] Running Sweepers for region (us-east-1):
2021/10/13 13:18:14 [DEBUG] Running Sweeper (aws_ecrpublic_repository) in region (us-east-1)
2021/10/13 13:18:14 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/13 13:18:14 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 13:18:14 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 13:18:15 [DEBUG] Completed Sweeper (aws_ecrpublic_repository) in region (us-east-1) in 1.063027608s
2021/10/13 13:18:15 Completed Sweepers for region (us-east-1) in 1.063261961s
2021/10/13 13:18:15 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_ecrpublic_repository
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.290s
```