### PR TITLE
sweeper/aws_route53_resolver_firewall_rule_group_association: add update condition

### DIFF
--- a/aws/resource_aws_route53_resolver_firewall_rule_test.go
+++ b/aws/resource_aws_route53_resolver_firewall_rule_test.go
@@ -19,7 +19,7 @@ func init() {
 		Name: "aws_route53_resolver_firewall_rule",
 		F:    testSweepRoute53ResolverFirewallRules,
 		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule_association",
+			"aws_route53_resolver_firewall_rule_group_association",
 		},
 	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21278 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_route53_resolver_firewall_rule_group_association make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_route53_resolver_firewall_rule_group_association -timeout 60m
2021/10/13 14:23:50 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/13 14:23:50 [DEBUG] Running Sweeper (aws_route53_resolver_firewall_rule_group_association) in region (us-west-2)
2021/10/13 14:23:50 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/13 14:23:50 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 14:23:51 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 14:23:52 [DEBUG] Completed Sweeper (aws_route53_resolver_firewall_rule_group_association) in region (us-west-2) in 1.253550617s
2021/10/13 14:23:52 Completed Sweepers for region (us-west-2) in 1.253740969s
2021/10/13 14:23:52 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_route53_resolver_firewall_rule_group_association
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.135s
```
