### PR TITLE
sweeper/aws_route53_resolver_query_log_config_association: set required arguments

### DIFF
--- a/aws/resource_aws_route53_resolver_query_log_config_association_test.go
+++ b/aws/resource_aws_route53_resolver_query_log_config_association_test.go
@@ -41,6 +41,9 @@ func testSweepRoute53ResolverQueryLogConfigAssociations(region string) error {
 			r := resourceAwsRoute53ResolverQueryLogConfigAssociation()
 			d := r.Data(nil)
 			d.SetId(id)
+			// The following additional arguments are required during the resource's Delete operation
+			d.Set("resolver_query_log_config_id", queryLogConfigAssociation.ResolverQueryLogConfigId)
+			d.Set("resource_id", queryLogConfigAssociation.ResourceId)
 			err := r.Delete(d, client)
 
 			if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21258

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_route53_resolver_query_log_config_association make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_route53_resolver_query_log_config_association -timeout 60m
2021/10/13 15:16:50 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/13 15:16:50 [DEBUG] Running Sweeper (aws_route53_resolver_query_log_config_association) in region (us-west-2)
2021/10/13 15:16:50 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/13 15:16:50 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 15:16:50 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/13 15:16:51 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-26cc6f8a129347c4
2021/10/13 15:16:51 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-26cc6f8a129347c4)
2021/10/13 15:16:52 [DEBUG] Waiting for state to become: []
2021/10/13 15:16:52 [TRACE] Waiting 200ms before next try
2021/10/13 15:16:53 [TRACE] Waiting 400ms before next try
2021/10/13 15:16:54 [TRACE] Waiting 800ms before next try
2021/10/13 15:16:55 [TRACE] Waiting 1.6s before next try
2021/10/13 15:16:57 [TRACE] Waiting 3.2s before next try
2021/10/13 15:17:00 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-5b16027ef3eb4082
2021/10/13 15:17:00 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-5b16027ef3eb4082)
2021/10/13 15:17:01 [DEBUG] Waiting for state to become: []
2021/10/13 15:17:01 [TRACE] Waiting 200ms before next try
2021/10/13 15:17:02 [TRACE] Waiting 400ms before next try
2021/10/13 15:17:03 [TRACE] Waiting 800ms before next try
2021/10/13 15:17:04 [TRACE] Waiting 1.6s before next try
2021/10/13 15:17:06 [TRACE] Waiting 3.2s before next try
2021/10/13 15:17:09 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-61999a620b454cd5
2021/10/13 15:17:09 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-61999a620b454cd5)
2021/10/13 15:17:10 [DEBUG] Waiting for state to become: []
2021/10/13 15:17:10 [TRACE] Waiting 200ms before next try
2021/10/13 15:17:11 [TRACE] Waiting 400ms before next try
2021/10/13 15:17:12 [TRACE] Waiting 800ms before next try
2021/10/13 15:17:13 [TRACE] Waiting 1.6s before next try
2021/10/13 15:17:15 [TRACE] Waiting 3.2s before next try
2021/10/13 15:17:18 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-6b4906461c454326
2021/10/13 15:17:18 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-6b4906461c454326)
2021/10/13 15:17:19 [DEBUG] Waiting for state to become: []
2021/10/13 15:17:19 [TRACE] Waiting 200ms before next try
2021/10/13 15:17:20 [TRACE] Waiting 400ms before next try
2021/10/13 15:17:21 [TRACE] Waiting 800ms before next try
2021/10/13 15:17:22 [TRACE] Waiting 1.6s before next try
2021/10/13 15:17:24 [TRACE] Waiting 3.2s before next try
2021/10/13 15:17:27 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-7c1f44d51f29401b
2021/10/13 15:17:27 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-7c1f44d51f29401b)
2021/10/13 15:17:28 [DEBUG] Waiting for state to become: []
2021/10/13 15:17:28 [TRACE] Waiting 200ms before next try
2021/10/13 15:17:29 [TRACE] Waiting 400ms before next try
2021/10/13 15:17:30 [TRACE] Waiting 800ms before next try
2021/10/13 15:17:31 [TRACE] Waiting 1.6s before next try
2021/10/13 15:17:33 [TRACE] Waiting 3.2s before next try
2021/10/13 15:17:36 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-d9c4114d4d2f4a57
2021/10/13 15:17:36 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-d9c4114d4d2f4a57)
2021/10/13 15:17:37 [DEBUG] Waiting for state to become: []
2021/10/13 15:17:38 [TRACE] Waiting 200ms before next try
2021/10/13 15:17:39 [TRACE] Waiting 400ms before next try
2021/10/13 15:17:40 [TRACE] Waiting 800ms before next try
2021/10/13 15:17:41 [TRACE] Waiting 1.6s before next try
2021/10/13 15:17:43 [INFO] Deleting Route53 Resolver Query Log Config Association: rqlca-ec66ae02a2c74d53
2021/10/13 15:17:43 [DEBUG] Deleting Route53 Resolver Query Log Config Association (rqlca-ec66ae02a2c74d53)
2021/10/13 15:17:44 [DEBUG] Waiting for state to become: []
2021/10/13 15:17:44 [TRACE] Waiting 200ms before next try
2021/10/13 15:17:45 [TRACE] Waiting 400ms before next try
2021/10/13 15:17:45 [TRACE] Waiting 800ms before next try
2021/10/13 15:17:47 [TRACE] Waiting 1.6s before next try
2021/10/13 15:17:48 [TRACE] Waiting 3.2s before next try
2021/10/13 15:17:52 [DEBUG] Completed Sweeper (aws_route53_resolver_query_log_config_association) in region (us-west-2) in 1m1.895730971s
2021/10/13 15:17:52 Completed Sweepers for region (us-west-2) in 1m1.89595209s
2021/10/13 15:17:52 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_route53_resolver_query_log_config_association
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.115s
```
