### PR TITLE
sweeper/aws_dx_gateway_association: update sweeper to set required argument

### DIFF
--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -137,6 +137,7 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 					r := resourceAwsDxGatewayAssociation()
 					d := r.Data(nil)
 					d.SetId(tfdirectconnect.GatewayAssociationCreateResourceID(directConnectGatewayID, transitGatewayID))
+					d.Set("dx_gateway_association_id", association.AssociationId)
 
 					sweepResources = append(sweepResources, NewTestSweepResource(r, d, client))
 				}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21257

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
...
2021/10/13 16:55:36 [DEBUG] [aws-sdk-go] {"directConnectGatewayAssociations":[]}
2021/10/13 16:55:36 [DEBUG] Completed Sweeper (aws_dx_gateway_association) in region (us-west-2) in 7m13.961621981s
2021/10/13 16:55:36 Completed Sweepers for region (us-west-2) in 7m15.213461198s
2021/10/13 16:55:36 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_dx_gateway_association_proposal
	- aws_dx_gateway_association
ok  	github.com/terraform-providers/terraform-provider-aws/aws	437.879s
```
