### PR TITLE
Don't retry on `InsufficientInstanceCapacity` error

### DIFF
--- a/.changelog/21293.txt
+++ b/.changelog/21293.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: When encountering `InsufficientInstanceCapacity` errors, do not retry in order to fail faster, as this error is typically not resolvable in the near future
+```

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -394,6 +394,12 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 			if tfawserr.ErrMessageContains(err, "VpnGatewayLimitExceeded", "maximum number of mutating objects has been reached") {
 				r.Retryable = aws.Bool(true)
 			}
+
+		case "RunInstances":
+			// `InsufficientInstanceCapacity` error has status code 500 and AWS SDK try retry this error by default.
+			if tfawserr.ErrCodeEquals(err, "InsufficientInstanceCapacity") {
+				r.Retryable = aws.Bool(false)
+			}
 		}
 	})
 

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -110,7 +110,7 @@ func TestAccEC2AMIDataSource_windowsInstance(t *testing.T) {
 }
 
 func TestAccEC2AMIDataSource_instanceStore(t *testing.T) {
-	datasourceName := "data.aws_ami.test"
+	datasourceName := "data.aws_ami.amzn-ami-minimal-hvm-instance-store"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -205,7 +205,7 @@ func TestAccEC2AMIDataSource_gp3BlockDevice(t *testing.T) {
 // The data source is named 'amzn-ami-minimal-hvm-instance-store'.
 func testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore() string {
 	return `
-data "aws_ami" "test" {
+data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
   most_recent = true
 
   filter {

--- a/internal/service/ec2/ec2_spot_fleet_request_test.go
+++ b/internal/service/ec2/ec2_spot_fleet_request_test.go
@@ -1665,7 +1665,7 @@ func TestAccEC2SpotFleetRequest_capacityRebalance(t *testing.T) {
 	})
 }
 
-func TestAccEC2SpotFleetRequest_withInstanceStoreAMI(t *testing.T) {
+func TestAccEC2SpotFleetRequest_instanceStoreAMI(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config ec2.SpotFleetRequestConfig
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)


### PR DESCRIPTION
What actually happends:
 - terrafrom call RunInstances (https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/aws/resource_aws_instance.go#L771)
 - AWS SDK run `Request.Send` inside `EC2.RunInstances` (https://github.com/aws/aws-sdk-go/blob/v1.40.9/service/ec2/api.go#L41652)
 - inside Request.Send loop (https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/request/request.go#L537-L560):
   - client send request to AWS service for running instance (https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/request/request.go#L546) and got response with **HTTP status code 500** and error code **InsufficientInstanceCapacity**
   - there are no **Retry** handles in terraform for this error code and line https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/request/request.go#L549 do nothing
   - **AfterRetry** handler at https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/request/request.go#L550 executes default AWS SDK request handler https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go#L187-L219:
     - in this time `Retryable` request flag is `nil` and executes default retry logic at https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go#L192-L194
     - inside `DefaultRetryer.ShouldRetry` method runs `Request.IsErrorRetryable` (https://github.com/aws/aws-sdk-go/blob/v1.40.9/aws/client/default_retryer.go#L143)
     - `Request.IsErrorRetryable` has special case for **HTTP status code 500** (https://github.com/hashicorp/terraform-provider-aws/blob/v3.62.0/awsproviderlint/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go#L261-L263) and `InsufficientInstanceCapacity` error became retryable
   - Request.Send try retry query as retryable

As result `Request.Send` retries query until 25 times with exponential delay. It takes around 50 minutes.

This PR breaks this loop by adding `Retry` handler for mark `InsufficientInstanceCapacity` error as non-retryable.

Fixes #15183, fixes #14403, fixes #1496, fixes #23928