### PR TITLE
b-aws_dynamodb_table

### DIFF
--- a/.changelog/21334.txt
+++ b/.changelog/21334.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: remove extra kms_key_arn from ttl
+```

--- a/.changelog/21334.txt
+++ b/.changelog/21334.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dynamodb_table: remove extra kms_key_arn from ttl
+resource/aws_dynamodb_table: Remove extraneous `kms_key_arn` attribute from the `ttl` configuration block
 ```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -304,12 +304,6 @@ func ResourceTable() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
-						"kms_key_arn": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: verify.ValidARN,
-						},
 					},
 				},
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19344

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ./internal/service/dynamodb -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_TTL' -timeout=180m

=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== CONT  TestAccDynamoDBTable_TTL_enabled
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_TTL_enabled (54.04s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (88.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   94.710s
```
