### PR TITLE
Update bucket_prefix during terraform import of s3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ aws/testdata/service/cloudformation/examplecompany-exampleservice-exampleresourc
 *.winfile eol=crlf
 /.vs
 node_modules
+
+.talismanrc

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3,6 +3,7 @@ package s3_test
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"log"
 	"reflect"
 	"regexp"
@@ -319,14 +320,15 @@ func TestAccS3Bucket_Basic_namePrefix(t *testing.T) {
 				Config: testAccBucketConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "bucket", regexp.MustCompile("^tf-test-")),
+					create.TestCheckResourceAttrNameFromPrefix(resourceName, "bucket", "tf-test-prefix-"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_prefix", "tf-test-prefix-"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
 			},
 		},
 	})
@@ -345,13 +347,15 @@ func TestAccS3Bucket_Basic_generatedName(t *testing.T) {
 				Config: testAccBucketConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
+					create.TestCheckResourceAttrNameGenerated(resourceName, "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_prefix", "terraform-"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
 			},
 		},
 	})
@@ -4724,12 +4728,14 @@ resource "aws_s3_bucket" "test" {
 
 const testAccBucketConfig_namePrefix = `
 resource "aws_s3_bucket" "test" {
-  bucket_prefix = "tf-test-"
+  bucket_prefix = "tf-test-prefix-"
 }
 `
 
 const testAccBucketConfig_generatedName = `
 resource "aws_s3_bucket" "test" {
-  bucket_prefix = "tf-test-"
+  tags = {
+    Name = "tf-test"
+  }
 }
 `

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -337,7 +337,7 @@ resource "aws_s3_bucket" "bucket" {
 
 The following arguments are supported:
 
-* `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+* `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. Conflicts with `bucket_prefix`. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 * `grant` - (Optional) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.


### PR DESCRIPTION
Signed-off-by: Prabhu Jayakumar <j.prabhu91@gmail.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9574 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_Basic_'

--- PASS: TestAccAWSS3Bucket_Basic_shouldFailNotFound (68.00s)
--- PASS: TestAccAWSS3Bucket_Basic_forceDestroy (97.14s)
--- PASS: TestAccAWSS3Bucket_Basic_forceDestroyWithEmptyPrefixes (104.67s)
--- PASS: TestAccAWSS3Bucket_Basic_forceDestroyWithObjectLockEnabled (107.70s)
--- PASS: TestAccAWSS3Bucket_Basic_emptyString (109.08s)
--- PASS: TestAccAWSS3Bucket_Basic_basic (117.78s)
--- PASS: TestAccAWSS3Bucket_Basic_namePrefix (121.32s)
--- PASS: TestAccAWSS3Bucket_Basic_keyEnabled (122.96s)
--- PASS: TestAccAWSS3Bucket_Basic_generatedName (124.56s)
--- PASS: TestAccAWSS3Bucket_Basic_acceleration (201.94s)
--- PASS: TestAccAWSS3Bucket_Basic_requestPayer (216.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	218.652s
```
