### PR TITLE
tests/appmesh_virtual_gateway: update configuration's listener protocol type

### DIFF
--- a/internal/service/appmesh/virtual_gateway_test.go
+++ b/internal/service/appmesh/virtual_gateway_test.go
@@ -381,7 +381,7 @@ func testAccVirtualGateway_ListenerHealthChecks(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.listener.0.health_check.0.unhealthy_threshold", "9"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.listener.0.port_mapping.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.listener.0.port_mapping.0.port", "8081"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.listener.0.port_mapping.0.protocol", "http"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.listener.0.port_mapping.0.protocol", "http2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.listener.0.tls.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.logging.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
@@ -1020,7 +1020,7 @@ resource "aws_appmesh_virtual_gateway" "test" {
     listener {
       port_mapping {
         port     = 8081
-        protocol = "http"
+        protocol = "http2"
       }
 
       health_check {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21359 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAppMesh_serial (314.52s)
    --- PASS: TestAccAppMesh_serial/VirtualGateway (314.52s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/basic (16.92s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/disappears (13.04s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/backendDefaults (27.71s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/backendDefaultsCertificate (16.06s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/listenerConnectionPool (28.20s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/listenerHealthChecks (27.07s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/listenerTls (80.51s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/listenerValidation (34.04s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/logging (27.54s)
        --- PASS: TestAccAppMesh_serial/VirtualGateway/tags (43.42s)
PASS
```
