### PR TITLE
generator/tags: include `PropagateAtLaunch` key in TagData for `autoscaling`

### DIFF
--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -517,7 +517,7 @@ func KeyValueTags(tags interface{}{{ if .TagTypeIDElem }}, identifier string{{ i
 
 			tagData.AdditionalBoolFields = make(map[string]*bool)
 			{{- if .TagTypeAddBoolElem }}
-			tagData.AdditionalBoolFields["{{ .TagTypeAddBoolElemSnake }}"] = tag.{{ .TagTypeAddBoolElem }}
+			tagData.AdditionalBoolFields["{{ .TagTypeAddBoolElem }}"] = tag.{{ .TagTypeAddBoolElem }}
 			{{- end }}
 
 			{{- if .TagTypeIDElem }}
@@ -550,7 +550,7 @@ func KeyValueTags(tags interface{}{{ if .TagTypeIDElem }}, identifier string{{ i
 
 			{{- if .TagTypeAddBoolElem }}
 			tagData.AdditionalBoolFields = make(map[string]*bool)
-			tagData.AdditionalBoolFields["{{ .TagTypeAddBoolElemSnake }}"] = tag.{{ .TagTypeAddBoolElem }}
+			tagData.AdditionalBoolFields["{{ .TagTypeAddBoolElem }}"] = tag.{{ .TagTypeAddBoolElem }}
 			{{- end }}
 
 			{{- if .TagTypeIDElem }}

--- a/internal/service/autoscaling/tags_gen.go
+++ b/internal/service/autoscaling/tags_gen.go
@@ -152,7 +152,7 @@ func KeyValueTags(tags interface{}, identifier string, resourceType string) tfta
 			}
 
 			tagData.AdditionalBoolFields = make(map[string]*bool)
-			tagData.AdditionalBoolFields["propagate_at_launch"] = tag.PropagateAtLaunch
+			tagData.AdditionalBoolFields["PropagateAtLaunch"] = tag.PropagateAtLaunch
 			tagData.AdditionalStringFields = make(map[string]*string)
 			tagData.AdditionalStringFields["ResourceId"] = &identifier
 			tagData.AdditionalStringFields["ResourceType"] = &resourceType
@@ -169,7 +169,7 @@ func KeyValueTags(tags interface{}, identifier string, resourceType string) tfta
 				Value: tag.Value,
 			}
 			tagData.AdditionalBoolFields = make(map[string]*bool)
-			tagData.AdditionalBoolFields["propagate_at_launch"] = tag.PropagateAtLaunch
+			tagData.AdditionalBoolFields["PropagateAtLaunch"] = tag.PropagateAtLaunch
 			tagData.AdditionalStringFields = make(map[string]*string)
 			tagData.AdditionalStringFields["ResourceId"] = &identifier
 			tagData.AdditionalStringFields["ResourceType"] = &resourceType


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21306 

Output from acceptance testing (previously failing in CI):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAutoScalingGroupTag_value (87.85s)
--- PASS: TestAccAutoScalingGroupTag_basic (61.49s)
--- PASS: TestAccAutoScalingGroupTag_disappears (67.51s)

--- PASS: TestAccAutoScalingAttachment_albTargetGroup (162.91s)

--- PASS: TestAccAutoScalingGroup_tags (286.11s)
```
