### PR TITLE
sweep/servicatalog_provisioned_product: set `accessLevelFilter.value` with `self`

### DIFF
--- a/internal/service/servicecatalog/sweep.go
+++ b/internal/service/servicecatalog/sweep.go
@@ -490,7 +490,7 @@ func sweepProvisionedProducts(region string) error {
 	input := &servicecatalog.SearchProvisionedProductsInput{
 		AccessLevelFilter: &servicecatalog.AccessLevelFilter{
 			Key:   aws.String(servicecatalog.AccessLevelFilterKeyAccount),
-			Value: aws.String(client.(*conns.AWSClient).AccountID),
+			Value: aws.String("self"), // only supported value
 		},
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21370 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_servicecatalog_provisioned_product make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_servicecatalog_provisioned_product -timeout 60m
2021/10/19 11:04:40 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/19 11:04:40 [DEBUG] Running Sweeper (aws_servicecatalog_provisioned_product) in region (us-west-2)
2021/10/19 11:04:40 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/19 11:04:40 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/19 11:04:41 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/19 11:04:42 [DEBUG] Completed Sweeper (aws_servicecatalog_provisioned_product) in region (us-west-2) in 1.096087403s
2021/10/19 11:04:42 Completed Sweepers for region (us-west-2) in 1.096276406s
2021/10/19 11:04:42 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_servicecatalog_provisioned_product
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	3.342s
```
