### PR TITLE
tests/appconfig_deployment: ignore `state` value during import step of `TestAccAppConfigDeployment_predefinedStrategy`

### DIFF
--- a/internal/service/appconfig/deployment_test.go
+++ b/internal/service/appconfig/deployment_test.go
@@ -81,6 +81,11 @@ func TestAccAppConfigDeployment_predefinedStrategy(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				// Since AppConfig Deployments can vary in completion times
+				// depending on the predefined deployment strategy,
+				// a waiter is not implemented for the resource;
+				// thus, we cannot guarantee the "state" value during import.
+				ImportStateVerifyIgnore: []string{"state"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/pull/20288
Closes #21386 
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAppConfigDeployment_predefinedStrategy (26.12s)
```
