### PR TITLE
Revert "change arg back to a TypeSet since it supports multiple values and order doesn't matter"

### DIFF
--- a/.changelog/21404.txt
+++ b/.changelog/21404.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_node_group: Respect order of configured `instance_types`
+```

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -313,8 +313,8 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.DiskSize = aws.Int64(int64(v.(int)))
 	}
 
-	if v := d.Get("instance_types").([]interface{}); len(v) > 0 {
-		input.InstanceTypes = flex.ExpandStringList(v)
+	if v, ok := d.GetOk("instance_types"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.InstanceTypes = flex.ExpandStringList(v.([]interface{}))
 	}
 
 	if v := d.Get("labels").(map[string]interface{}); len(v) > 0 {

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -75,7 +75,7 @@ func ResourceNodeGroup() *schema.Resource {
 				Optional: true,
 			},
 			"instance_types": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -313,8 +313,8 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.DiskSize = aws.Int64(int64(v.(int)))
 	}
 
-	if v := d.Get("instance_types").(*schema.Set); v.Len() > 0 {
-		input.InstanceTypes = flex.ExpandStringSet(v)
+	if v := d.Get("instance_types").([]interface{}); len(v) > 0 {
+		input.InstanceTypes = flex.ExpandStringList(v)
 	}
 
 	if v := d.Get("labels").(map[string]interface{}); len(v) > 0 {

--- a/internal/service/eks/node_group_test.go
+++ b/internal/service/eks/node_group_test.go
@@ -279,8 +279,8 @@ func TestAccEKSNodeGroup_forceUpdateVersion(t *testing.T) {
 func TestAccEKSNodeGroup_InstanceTypes_multiple(t *testing.T) {
 	var nodeGroup1 eks.Nodegroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	ec2InstanceTypeOfferingsDataSourceName := "data.aws_ec2_instance_type_offerings.available"
 	resourceName := "aws_eks_node_group.test"
+	instanceTypes := fmt.Sprintf("%q, %q, %q, %q", "t2.medium", "t3.medium", "t2.large", "t3.large")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -289,10 +289,14 @@ func TestAccEKSNodeGroup_InstanceTypes_multiple(t *testing.T) {
 		CheckDestroy: testAccCheckNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodeGroupInstanceTypesMultipleConfig(rName),
+				Config: testAccNodeGroupInstanceTypesMultipleConfig(rName, instanceTypes),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttrPair(resourceName, "instance_types.#", ec2InstanceTypeOfferingsDataSourceName, "instance_types.#"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.0", "t2.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.1", "t3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.2", "t2.large"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.3", "t3.large"),
 				),
 			},
 			{
@@ -1386,21 +1390,16 @@ resource "aws_eks_node_group" "test" {
 `, rName))
 }
 
-func testAccNodeGroupInstanceTypesMultipleConfig(rName string) string {
+func testAccNodeGroupInstanceTypesMultipleConfig(rName, instanceTypes string) string {
 	return acctest.ConfigCompose(
 		testAccNodeGroupBaseConfig(rName),
 		fmt.Sprintf(`
-data "aws_ec2_instance_type_offerings" "available" {
-  filter {
-    name   = "instance-type"
-    values = ["t3.medium", "t3.large", "t2.medium", "t2.large"]
-  }
-}
-
 resource "aws_eks_node_group" "test" {
-  cluster_name    = aws_eks_cluster.test.name
-  instance_types  = data.aws_ec2_instance_type_offerings.available.instance_types
-  node_group_name = %[1]q
+  cluster_name = aws_eks_cluster.test.name
+  # use a predetermined string instead of aws_ec2_instance_type_offerings data source for the instance_types (TypeList)
+  # as the apply-time values of the data source's instance_types can change in order
+  instance_types  = [%[1]s]
+  node_group_name = %[2]q
   node_role_arn   = aws_iam_role.node.arn
   subnet_ids      = aws_subnet.test[*].id
 
@@ -1416,7 +1415,7 @@ resource "aws_eks_node_group" "test" {
     aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly,
   ]
 }
-`, rName))
+`, instanceTypes, rName))
 }
 
 func testAccNodeGroupInstanceTypesSingleConfig(rName string) string {

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -130,7 +130,7 @@ The following arguments are optional:
 * `capacity_type` - (Optional) Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. Terraform will only perform drift detection if a configuration value is provided.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
-* `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
+* `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 * `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
 * `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name. Conflicts with `node_group_name_prefix`.


### PR DESCRIPTION
This reverts commit eff27751df66602298bc1e73352f188f8d1f3982.

Fixes #21203.
Relates #20532.

Original PR stated that the order of instance types did not matter but it absolutely does.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
