### PR TITLE
tests/backup_global_settings: add organization management account pre-check

### DIFF
--- a/internal/service/backup/global_settings_test.go
+++ b/internal/service/backup/global_settings_test.go
@@ -18,6 +18,7 @@ func TestAccBackupGlobalSettings_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckOrganizationManagementAccount(t)
 			testAccPreCheck(t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21407 

Output from acceptance testing (organizations):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccBackupGlobalSettings_basic (33.75s)
```

Output from acceptance testing (commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- SKIP: TestAccBackupGlobalSettings_basic (1.63s)
```

Output from acceptance testing (us-gov-west-1):
```
--- PASS: TestAccBackupGlobalSettings_basic (43.65s)
```