### PR TITLE
appstream/sweep: add skip condition for `no such host` in gov cloud

### DIFF
--- a/internal/service/appstream/sweep.go
+++ b/internal/service/appstream/sweep.go
@@ -76,6 +76,11 @@ func sweepFleet(region string) error {
 		return !lastPage
 	})
 
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Appstream Fleets sweep for %s: %s", region, err)
+		return nil
+	}
+
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Fleets: %w", err))
 	}
@@ -125,6 +130,11 @@ func sweepImageBuilder(region string) error {
 
 		return !lastPage
 	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Appstream Image Builders sweep for %s: %s", region, err)
+		return nil
+	}
 
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Image Builders: %w", err))
@@ -176,6 +186,11 @@ func sweepStack(region string) error {
 
 		return !lastPage
 	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Appstream Stacks sweep for %s: %s", region, err)
+		return nil
+	}
 
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Stacks: %w", err))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21417 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 make sweep SWEEP=us-gov-east-1 SWEEPARGS='-sweep-run=aws_appstream_stack'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-gov-east-1 -sweep-run=aws_appstream_stack -timeout 60m
2021/10/20 20:17:06 [DEBUG] Running Sweepers for region (us-gov-east-1):
2021/10/20 20:17:06 [DEBUG] Running Sweeper (aws_appstream_stack) in region (us-gov-east-1)
2021/10/20 20:17:06 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/20 20:17:06 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/20 20:17:06 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/20 20:17:08 [WARN] Skipping Appstream Stacks sweep for us-gov-east-1: RequestError: send request failed
caused by: Post "https://appstream2.us-gov-east-1.amazonaws.com/": dial tcp: lookup appstream2.us-gov-east-1.amazonaws.com: no such host
2021/10/20 20:17:08 [DEBUG] Completed Sweeper (aws_appstream_stack) in region (us-gov-east-1) in 1.897066098s
2021/10/20 20:17:08 Completed Sweepers for region (us-gov-east-1) in 1.89717696s
2021/10/20 20:17:08 Sweeper Tests for region (us-gov-east-1) ran successfully:
	- aws_appstream_stack
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	3.900s
```
