### PR TITLE
apprunner/sweep: add skip condition for `no such host` error in gov cloud

### DIFF
--- a/internal/service/apprunner/sweep.go
+++ b/internal/service/apprunner/sweep.go
@@ -79,6 +79,11 @@ func sweepAutoScalingConfigurationVersions(region string) error {
 		return !lastPage
 	})
 
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping App Runner AutoScaling Configuration Versions sweep for %s: %s", region, err)
+		return nil
+	}
+
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error listing App Runner AutoScaling Configuration Versions: %w", err))
 	}
@@ -135,6 +140,11 @@ func sweepConnections(region string) error {
 		return !lastPage
 	})
 
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping App Runner Connections sweep for %s: %s", region, err)
+		return nil
+	}
+
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error listing App Runner Connections: %w", err))
 	}
@@ -188,6 +198,11 @@ func sweepServices(region string) error {
 
 		return !lastPage
 	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping App Runner Services sweep for %s: %s", region, err)
+		return nil
+	}
 
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error listing App Runner Services: %w", err))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21419

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make sweep SWEEP=us-gov-east-1 SWEEPARGS='-sweep-run=aws_apprunner_connection'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-gov-east-1 -sweep-run=aws_apprunner_connection -timeout 60m
2021/10/20 20:33:47 [DEBUG] Running Sweepers for region (us-gov-east-1):
2021/10/20 20:33:47 [DEBUG] Sweeper (aws_apprunner_connection) has dependency (aws_apprunner_service), running..
2021/10/20 20:33:47 [DEBUG] Running Sweeper (aws_apprunner_service) in region (us-gov-east-1)
2021/10/20 20:33:47 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/20 20:33:47 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/20 20:33:47 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/20 20:33:48 [WARN] Skipping App Runner Services sweep for us-gov-east-1: RequestError: send request failed
caused by: Post "https://apprunner.us-gov-east-1.amazonaws.com/": dial tcp: lookup apprunner.us-gov-east-1.amazonaws.com: no such host
2021/10/20 20:33:48 [DEBUG] Completed Sweeper (aws_apprunner_service) in region (us-gov-east-1) in 1.949723532s
2021/10/20 20:33:48 [DEBUG] Running Sweeper (aws_apprunner_connection) in region (us-gov-east-1)
2021/10/20 20:33:50 [WARN] Skipping App Runner Connections sweep for us-gov-east-1: RequestError: send request failed
caused by: Post "https://apprunner.us-gov-east-1.amazonaws.com/": dial tcp: lookup apprunner.us-gov-east-1.amazonaws.com: no such host
2021/10/20 20:33:50 [DEBUG] Completed Sweeper (aws_apprunner_connection) in region (us-gov-east-1) in 1.576354039s
2021/10/20 20:33:50 [DEBUG] Sweeper (aws_apprunner_service) already ran in region (us-gov-east-1)
2021/10/20 20:33:50 Completed Sweepers for region (us-gov-east-1) in 3.526228244s
2021/10/20 20:33:50 Sweeper Tests for region (us-gov-east-1) ran successfully:
	- aws_apprunner_service
	- aws_apprunner_connection
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	5.602s

make sweep SWEEP=us-gov-east-1 SWEEPARGS='-sweep-run=aws_apprunner_auto_scaling_configuration_version'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-gov-east-1 -sweep-run=aws_apprunner_auto_scaling_configuration_version -timeout 60m
2021/10/20 20:33:13 [DEBUG] Running Sweepers for region (us-gov-east-1):
2021/10/20 20:33:13 [DEBUG] Sweeper (aws_apprunner_auto_scaling_configuration_version) has dependency (aws_apprunner_service), running..
2021/10/20 20:33:13 [DEBUG] Running Sweeper (aws_apprunner_service) in region (us-gov-east-1)
2021/10/20 20:33:13 [INFO] AWS Auth provider used: "EnvProvider"
2021/10/20 20:33:13 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/20 20:33:13 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/20 20:33:15 [WARN] Skipping App Runner Services sweep for us-gov-east-1: RequestError: send request failed
caused by: Post "https://apprunner.us-gov-east-1.amazonaws.com/": dial tcp: lookup apprunner.us-gov-east-1.amazonaws.com: no such host
2021/10/20 20:33:15 [DEBUG] Completed Sweeper (aws_apprunner_service) in region (us-gov-east-1) in 1.972275057s
2021/10/20 20:33:15 [DEBUG] Running Sweeper (aws_apprunner_auto_scaling_configuration_version) in region (us-gov-east-1)
2021/10/20 20:33:16 [WARN] Skipping App Runner AutoScaling Configuration Versions sweep for us-gov-east-1: RequestError: send request failed
caused by: Post "https://apprunner.us-gov-east-1.amazonaws.com/": dial tcp: lookup apprunner.us-gov-east-1.amazonaws.com: no such host
2021/10/20 20:33:16 [DEBUG] Completed Sweeper (aws_apprunner_auto_scaling_configuration_version) in region (us-gov-east-1) in 1.259759177s
2021/10/20 20:33:16 [DEBUG] Sweeper (aws_apprunner_service) already ran in region (us-gov-east-1)
2021/10/20 20:33:16 Completed Sweepers for region (us-gov-east-1) in 3.232205505s
2021/10/20 20:33:16 Sweeper Tests for region (us-gov-east-1) ran successfully:
	- aws_apprunner_service
	- aws_apprunner_auto_scaling_configuration_version
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	5.373s
```
