### PR TITLE
d/aws_iam_user_ssh_key: Fix `terrafmt` error

### DIFF
--- a/internal/service/iam/user_ssh_key_data_source_test.go
+++ b/internal/service/iam/user_ssh_key_data_source_test.go
@@ -43,21 +43,21 @@ func TestAccIAMUserSSHKeyDataSource_basic(t *testing.T) {
 func testAccSSHKeyDataSourceConfig(username, publicKey string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
-	name = %[1]q
-	path = "/"
+  name = %[1]q
+  path = "/"
 }
 
 resource "aws_iam_user_ssh_key" "test" {
-	username   = aws_iam_user.test.name
-	encoding   = "SSH"
-	public_key = %[2]q
-	status     = "Inactive"
+  username   = aws_iam_user.test.name
+  encoding   = "SSH"
+  public_key = %[2]q
+  status     = "Inactive"
 }
 
 data "aws_iam_user_ssh_key" "test" {
-	username          = aws_iam_user.test.name
-	encoding          = "SSH"
-	ssh_public_key_id = aws_iam_user_ssh_key.test.ssh_public_key_id
+  username          = aws_iam_user.test.name
+  encoding          = "SSH"
+  ssh_public_key_id = aws_iam_user_ssh_key.test.ssh_public_key_id
 }
 `, username, publicKey)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21335.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
