### PR TITLE
r/aws_prometheus_alert_manager_definition: Fix `terrafmt` error

### DIFF
--- a/internal/service/prometheus/alert_manager_definition_test.go
+++ b/internal/service/prometheus/alert_manager_definition_test.go
@@ -146,8 +146,7 @@ resource "aws_prometheus_workspace" "test" {
 }
 resource "aws_prometheus_alert_manager_definition" "test" {
   workspace_id = aws_prometheus_workspace.test.id
-  definition   = <<EOF
-%[1]sEOF
+  definition   = %[1]q
 }
 `, definition)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21431.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/prometheus TESTARGS='-run=TestAccPrometheusAlertManagerDefinition_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/prometheus/... -v -count 1 -parallel 20 -run=TestAccPrometheusAlertManagerDefinition_basic -timeout 180m
=== RUN   TestAccPrometheusAlertManagerDefinition_basic
=== PAUSE TestAccPrometheusAlertManagerDefinition_basic
=== CONT  TestAccPrometheusAlertManagerDefinition_basic
--- PASS: TestAccPrometheusAlertManagerDefinition_basic (274.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/prometheus	279.022s
```
