### PR TITLE
linting: Restores Semgrep checks

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer naming acceptance tests with _disappears_Parent suffix
     paths:
       include:
-        - 'aws/*_test.go'
+        - 'internal/**/*_test.go'
     patterns:
       - pattern: func $FUNCNAME(t *testing.T) { ... }
       - metavariable-regex:

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer naming acceptance tests with _disappears_Parent suffix
     paths:
       include:
-        - 'internal/**/*_test.go'
+        - "internal/**/*_test.go"
     patterns:
       - pattern: func $FUNCNAME(t *testing.T) { ... }
       - metavariable-regex:
@@ -17,28 +17,12 @@ rules:
     message: Resources should not implement multiple AWS service functionality
     paths:
       exclude:
-        - aws/config.go
-        - aws/structure.go
-        - aws/validators.go
-        - aws/*wafregional*.go
-        - aws/resource_aws_serverlessapplicationrepository_cloudformation_stack.go
-        - aws/resource_aws_transfer_server.go
-        - aws/*_test.go
-        - aws/internal/keyvaluetags/
-        - aws/internal/namevaluesfilters/
-        - aws/internal/service/wafregional/
-        # Legacy resource handling
-        - aws/resource_aws_autoscaling_group.go
-        - aws/resource_aws_efs_mount_target.go
-        - aws/resource_aws_elastic_beanstalk_environment.go
-        - aws/resource_aws_elb.go
-        - aws/resource_aws_iam_server_certificate.go
-        - aws/resource_aws_lambda_event_source_mapping.go
-        - aws/resource_aws_launch_configuration.go
-        - aws/resource_aws_lb.go
-        - aws/resource_aws_s3_bucket_object.go
+        - "internal/service/**/*_test.go"
+        - "internal/service/**/sweep.go"
+        - "internal/acctest/acctest.go"
+        - "internal/conns/conns.go"
       include:
-        - aws/
+        - internal/
     patterns:
       - pattern: |
           import ("$X")
@@ -49,6 +33,10 @@ rules:
       - metavariable-regex:
           metavariable: '$Y'
           regex: '^"github.com/aws/aws-sdk-go/service/[^/]+"$'
+      # wafregional uses a number of resources from waf
+      - pattern-not: |
+          import ("github.com/aws/aws-sdk-go/service/waf")
+          import ("github.com/aws/aws-sdk-go/service/wafregional")
     severity: WARNING
 
   - id: prefer-aws-go-sdk-pointer-conversion-assignment

--- a/internal/generate/namevaluesfilters/generators/servicefilters/main.go
+++ b/internal/generate/namevaluesfilters/generators/servicefilters/main.go
@@ -92,7 +92,7 @@ var templateBody = `
 
 package namevaluesfilters
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"github.com/aws/aws-sdk-go/aws"
 {{- range .SliceServiceNames }}
 {{- if eq . (. | FilterPackage) }}

--- a/internal/generate/namevaluesfilters/service_filters_gen.go
+++ b/internal/generate/namevaluesfilters/service_filters_gen.go
@@ -2,7 +2,7 @@
 
 package namevaluesfilters
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice"

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1,6 +1,6 @@
 package autoscaling
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"bytes"
 	"context"
 	"fmt"

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -1,6 +1,6 @@
 package autoscaling
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"bytes"
 	"crypto/sha1"
 	"encoding/base64"

--- a/internal/service/backup/vault_notifications_test.go
+++ b/internal/service/backup/vault_notifications_test.go
@@ -14,7 +14,7 @@ import (
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 )
 
-func TestAccBackupVaultNotifications_Notification_basic(t *testing.T) {
+func TestAccBackupVaultNotification_basic(t *testing.T) {
 	var vault backup.GetBackupVaultNotificationsOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -41,7 +41,7 @@ func TestAccBackupVaultNotifications_Notification_basic(t *testing.T) {
 	})
 }
 
-func TestAccBackupVaultNotifications_Notification_disappears(t *testing.T) {
+func TestAccBackupVaultNotification_disappears(t *testing.T) {
 	var vault backup.GetBackupVaultNotificationsOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/cognitoidp/user_pool_ui_customization_test.go
+++ b/internal/service/cognitoidp/user_pool_ui_customization_test.go
@@ -15,7 +15,7 @@ import (
 	tfcognitoidp "github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp"
 )
 
-func TestAccCognitoIDPUserPoolUICustomization_AllClients_cSS(t *testing.T) {
+func TestAccCognitoIDPUserPoolUICustomization_AllClients_CSS(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool_ui_customization.test"
 	userPoolResourceName := "aws_cognito_user_pool.test"
@@ -67,7 +67,7 @@ func TestAccCognitoIDPUserPoolUICustomization_AllClients_cSS(t *testing.T) {
 	})
 }
 
-func TestAccCognitoIDPUserPoolUICustomization_AllClients_disappears(t *testing.T) {
+func TestAccCognitoIDPUserPoolUICustomization_AllClients_disappears(t *testing.T) { // nosemgrep: acceptance-test-naming-parent-disappears
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool_ui_customization.test"
 
@@ -143,7 +143,7 @@ func TestAccCognitoIDPUserPoolUICustomization_AllClients_imageFile(t *testing.T)
 	})
 }
 
-func TestAccCognitoIDPUserPoolUICustomization_AllClients_cSSAndImageFile(t *testing.T) {
+func TestAccCognitoIDPUserPoolUICustomization_AllClients_CSSAndImageFile(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool_ui_customization.test"
 	userPoolResourceName := "aws_cognito_user_pool.test"
@@ -210,7 +210,7 @@ func TestAccCognitoIDPUserPoolUICustomization_AllClients_cSSAndImageFile(t *test
 	})
 }
 
-func TestAccCognitoIDPUserPoolUICustomization_Client_cSS(t *testing.T) {
+func TestAccCognitoIDPUserPoolUICustomization_Client_CSS(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool_ui_customization.test"
 	clientResourceName := "aws_cognito_user_pool_client.test"
@@ -263,7 +263,7 @@ func TestAccCognitoIDPUserPoolUICustomization_Client_cSS(t *testing.T) {
 	})
 }
 
-func TestAccCognitoIDPUserPoolUICustomization_Client_disappears(t *testing.T) {
+func TestAccCognitoIDPUserPoolUICustomization_Client_disappears(t *testing.T) { // nosemgrep: acceptance-test-naming-parent-disappears
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cognito_user_pool_ui_customization.test"
 

--- a/internal/service/ec2/network_interface_sg_attachment_test.go
+++ b/internal/service/ec2/network_interface_sg_attachment_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkInterfaceSgAttachment_SG_basic(t *testing.T) {
+func TestAccEC2NetworkInterfaceSgAttachment_basic(t *testing.T) {
 	networkInterfaceResourceName := "aws_network_interface.test"
 	securityGroupResourceName := "aws_security_group.test"
 	resourceName := "aws_network_interface_sg_attachment.test"
@@ -38,7 +38,7 @@ func TestAccEC2NetworkInterfaceSgAttachment_SG_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceSgAttachment_SG_disappears(t *testing.T) {
+func TestAccEC2NetworkInterfaceSgAttachment_disappears(t *testing.T) {
 	resourceName := "aws_network_interface_sg_attachment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -60,7 +60,7 @@ func TestAccEC2NetworkInterfaceSgAttachment_SG_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceSgAttachment_SG_instance(t *testing.T) {
+func TestAccEC2NetworkInterfaceSgAttachment_instance(t *testing.T) {
 	instanceResourceName := "aws_instance.test"
 	securityGroupResourceName := "aws_security_group.test"
 	resourceName := "aws_network_interface_sg_attachment.test"
@@ -84,7 +84,7 @@ func TestAccEC2NetworkInterfaceSgAttachment_SG_instance(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterfaceSgAttachment_SG_multiple(t *testing.T) {
+func TestAccEC2NetworkInterfaceSgAttachment_multiple(t *testing.T) {
 	networkInterfaceResourceName := "aws_network_interface.test"
 	securityGroupResourceName1 := "aws_security_group.test.0"
 	securityGroupResourceName2 := "aws_security_group.test.1"

--- a/internal/service/ec2/network_interface_test.go
+++ b/internal/service/ec2/network_interface_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccEC2NetworkInterface_ENI_basic(t *testing.T) {
+func TestAccEC2NetworkInterface_basic(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	subnetResourceName := "aws_subnet.test"
@@ -61,7 +61,7 @@ func TestAccEC2NetworkInterface_ENI_basic(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ipv6(t *testing.T) {
+func TestAccEC2NetworkInterface_ipv6(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -105,7 +105,7 @@ func TestAccEC2NetworkInterface_ENI_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_tags(t *testing.T) {
+func TestAccEC2NetworkInterface_tags(t *testing.T) {
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var conf ec2.NetworkInterface
@@ -150,7 +150,7 @@ func TestAccEC2NetworkInterface_ENI_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ipv6Count(t *testing.T) {
+func TestAccEC2NetworkInterface_ipv6Count(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -198,7 +198,7 @@ func TestAccEC2NetworkInterface_ENI_ipv6Count(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_disappears(t *testing.T) {
+func TestAccEC2NetworkInterface_disappears(t *testing.T) {
 	var networkInterface ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -221,7 +221,7 @@ func TestAccEC2NetworkInterface_ENI_disappears(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_description(t *testing.T) {
+func TestAccEC2NetworkInterface_description(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	subnetResourceName := "aws_subnet.test"
@@ -289,7 +289,7 @@ func TestAccEC2NetworkInterface_ENI_description(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_attachment(t *testing.T) {
+func TestAccEC2NetworkInterface_attachment(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -322,7 +322,7 @@ func TestAccEC2NetworkInterface_ENI_attachment(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_ignoreExternalAttachment(t *testing.T) {
+func TestAccEC2NetworkInterface_ignoreExternalAttachment(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -349,7 +349,7 @@ func TestAccEC2NetworkInterface_ENI_ignoreExternalAttachment(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_sourceDestCheck(t *testing.T) {
+func TestAccEC2NetworkInterface_sourceDestCheck(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -390,7 +390,7 @@ func TestAccEC2NetworkInterface_ENI_sourceDestCheck(t *testing.T) {
 	})
 }
 
-func TestAccEC2NetworkInterface_ENI_privateIPsCount(t *testing.T) {
+func TestAccEC2NetworkInterface_privateIPsCount(t *testing.T) {
 	var conf ec2.NetworkInterface
 	resourceName := "aws_network_interface.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -1,6 +1,6 @@
 package elasticbeanstalk
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"fmt"
 	"log"
 	"regexp"

--- a/internal/service/elasticsearch/domain_saml_options_test.go
+++ b/internal/service/elasticsearch/domain_saml_options_test.go
@@ -15,7 +15,7 @@ import (
 	tfelasticsearch "github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch"
 )
 
-func TestAccElasticsearchDomainSamlOptions_SAML_basic(t *testing.T) {
+func TestAccElasticSearchDomainSamlOptions_basic(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 
 	rName := sdkacctest.RandomWithPrefix("acc-test")
@@ -49,7 +49,7 @@ func TestAccElasticsearchDomainSamlOptions_SAML_basic(t *testing.T) {
 	})
 }
 
-func TestAccElasticsearchDomainSamlOptions_SAML_disappears(t *testing.T) {
+func TestAccElasticSearchDomainSamlOptions_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("acc-test")
 	rUserName := sdkacctest.RandomWithPrefix("es-master-user")
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
@@ -72,7 +72,7 @@ func TestAccElasticsearchDomainSamlOptions_SAML_disappears(t *testing.T) {
 	})
 }
 
-func TestAccElasticsearchDomainSamlOptions_SAMLDisappears_domain(t *testing.T) {
+func TestAccElasticSearchDomainSamlOptions_disappears_domain(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("acc-test")
 	rUserName := sdkacctest.RandomWithPrefix("es-master-user")
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
@@ -96,7 +96,7 @@ func TestAccElasticsearchDomainSamlOptions_SAMLDisappears_domain(t *testing.T) {
 	})
 }
 
-func TestAccElasticsearchDomainSamlOptions_SAML_update(t *testing.T) {
+func TestAccElasticSearchDomainSamlOptions_update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("acc-test")
 	rUserName := sdkacctest.RandomWithPrefix("es-master-user")
 	resourceName := "aws_elasticsearch_domain_saml_options.main"
@@ -128,7 +128,7 @@ func TestAccElasticsearchDomainSamlOptions_SAML_update(t *testing.T) {
 	})
 }
 
-func TestAccElasticsearchDomainSamlOptions_SAML_disabled(t *testing.T) {
+func TestAccElasticSearchDomainSamlOptions_disabled(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix("acc-test")
 	rUserName := sdkacctest.RandomWithPrefix("es-master-user")
 	resourceName := "aws_elasticsearch_domain_saml_options.main"

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -1,6 +1,6 @@
 package elb
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"bytes"
 	"fmt"
 	"log"

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -1,6 +1,6 @@
 package elb_test
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"fmt"
 	"math/rand"
 	"reflect"

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -1,6 +1,6 @@
 package elbv2
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"bytes"
 	"context"
 	"fmt"
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -359,7 +358,7 @@ func resourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
 
 	lb, err := FindLoadBalancerByARN(conn, d.Id())
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, elb.ErrCodeAccessPointNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, elbv2.ErrCodeLoadBalancerNotFoundException) {
 		// The ALB is gone now, so just remove it from the state
 		log.Printf("[WARN] ALB %s not found in AWS, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/glue/ml_transform_test.go
+++ b/internal/service/glue/ml_transform_test.go
@@ -16,7 +16,7 @@ import (
 	tfglue "github.com/hashicorp/terraform-provider-aws/internal/service/glue"
 )
 
-func TestAccGlueMlTransform_ML_basic(t *testing.T) {
+func TestAccGlueMlTransform_basic(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -66,7 +66,7 @@ func TestAccGlueMlTransform_ML_basic(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_typeFindMatchesFull(t *testing.T) {
+func TestAccGlueMlTransform_typeFindMatchesFull(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -126,7 +126,7 @@ func TestAccGlueMlTransform_ML_typeFindMatchesFull(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_description(t *testing.T) {
+func TestAccGlueMlTransform_description(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -161,7 +161,7 @@ func TestAccGlueMlTransform_ML_description(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_glueVersion(t *testing.T) {
+func TestAccGlueMlTransform_glueVersion(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -196,7 +196,7 @@ func TestAccGlueMlTransform_ML_glueVersion(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_maxRetries(t *testing.T) {
+func TestAccGlueMlTransform_maxRetries(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -235,7 +235,7 @@ func TestAccGlueMlTransform_ML_maxRetries(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_tags(t *testing.T) {
+func TestAccGlueMlTransform_tags(t *testing.T) {
 	var transform1, transform2, transform3 glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -281,7 +281,7 @@ func TestAccGlueMlTransform_ML_tags(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_timeout(t *testing.T) {
+func TestAccGlueMlTransform_timeout(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -316,7 +316,7 @@ func TestAccGlueMlTransform_ML_timeout(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_workerType(t *testing.T) {
+func TestAccGlueMlTransform_workerType(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -353,7 +353,7 @@ func TestAccGlueMlTransform_ML_workerType(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_maxCapacity(t *testing.T) {
+func TestAccGlueMlTransform_maxCapacity(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -388,7 +388,7 @@ func TestAccGlueMlTransform_ML_maxCapacity(t *testing.T) {
 	})
 }
 
-func TestAccGlueMlTransform_ML_disappears(t *testing.T) {
+func TestAccGlueMlTransform_disappears(t *testing.T) {
 	var transform glue.GetMLTransformOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -15,7 +15,7 @@ import (
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 )
 
-func TestAccIAMOpenidConnectProvider_OpenID_basic(t *testing.T) {
+func TestAccIAMOpenidConnectProvider_basic(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	url := "accounts.testle.com/" + rString
 	resourceName := "aws_iam_openid_connect_provider.test"
@@ -62,7 +62,7 @@ func TestAccIAMOpenidConnectProvider_OpenID_basic(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenidConnectProvider_OpenID_tags(t *testing.T) {
+func TestAccIAMOpenidConnectProvider_tags(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 
@@ -107,7 +107,7 @@ func TestAccIAMOpenidConnectProvider_OpenID_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMOpenidConnectProvider_OpenID_disappears(t *testing.T) {
+func TestAccIAMOpenidConnectProvider_disappears(t *testing.T) {
 	rString := sdkacctest.RandString(5)
 	resourceName := "aws_iam_openid_connect_provider.test"
 

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -1,6 +1,6 @@
 package iam
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"

--- a/internal/service/prometheus/workspace_test.go
+++ b/internal/service/prometheus/workspace_test.go
@@ -15,7 +15,7 @@ import (
 	tfprometheus "github.com/hashicorp/terraform-provider-aws/internal/service/prometheus"
 )
 
-func TestAccPrometheusWorkspace_AMP_basic(t *testing.T) {
+func TestAccPrometheusWorkspace_basic(t *testing.T) {
 	workspaceAlias := sdkacctest.RandomWithPrefix("tf_amp_workspace")
 	resourceName := "aws_prometheus_workspace.test"
 
@@ -54,7 +54,7 @@ func TestAccPrometheusWorkspace_AMP_basic(t *testing.T) {
 	})
 }
 
-func TestAccPrometheusWorkspace_AMP_disappears(t *testing.T) {
+func TestAccPrometheusWorkspace_disappears(t *testing.T) {
 	resourceName := "aws_prometheus_workspace.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -23,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/kms"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -565,15 +565,13 @@ func resourceBucketObjectSetKMS(d *schema.ResourceData, meta interface{}, sseKMS
 	if sseKMSKeyId != nil {
 		// retrieve S3 KMS Default Master Key
 		conn := meta.(*conns.AWSClient).KMSConn
-		kmsresp, err := conn.DescribeKey(&kms.DescribeKeyInput{
-			KeyId: aws.String("alias/aws/s3"),
-		})
+		keyMetadata, err := kms.FindKeyByID(conn, DefaultKmsKeyAlias)
 		if err != nil {
-			return fmt.Errorf("Failed to describe default S3 KMS key (alias/aws/s3): %s", err)
+			return fmt.Errorf("Failed to describe default S3 KMS key (%s): %s", DefaultKmsKeyAlias, err)
 		}
 
-		if *sseKMSKeyId != *kmsresp.KeyMetadata.Arn {
-			log.Printf("[DEBUG] S3 object is encrypted using a non-default KMS Key ID: %s", *sseKMSKeyId)
+		if aws.StringValue(sseKMSKeyId) != aws.StringValue(keyMetadata.Arn) {
+			log.Printf("[DEBUG] S3 object is encrypted using a non-default KMS Key ID: %s", aws.StringValue(sseKMSKeyId))
 			d.Set("kms_key_id", sseKMSKeyId)
 		}
 	}

--- a/internal/service/s3/enum.go
+++ b/internal/service/s3/enum.go
@@ -4,6 +4,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+const DefaultKmsKeyAlias = "alias/aws/s3"
+
 // These should be defined in the AWS SDK for Go. There is an open issue https://github.com/aws/aws-sdk-go/issues/2683
 const (
 	BucketCannedACLExecRead         = "aws-exec-read"

--- a/internal/service/serverlessapprepo/cloudformation_stack.go
+++ b/internal/service/serverlessapprepo/cloudformation_stack.go
@@ -1,6 +1,6 @@
 package serverlessapprepo
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"fmt"
 	"log"
 	"strings"

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -1,6 +1,6 @@
 package transfer
 
-import (
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"context"
 	"fmt"
 	"log"

--- a/internal/service/worklink/website_certificate_authority_association_test.go
+++ b/internal/service/worklink/website_certificate_authority_association_test.go
@@ -17,7 +17,7 @@ import (
 	tfworklink "github.com/hashicorp/terraform-provider-aws/internal/service/worklink"
 )
 
-func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_WorkLink_basic(t *testing.T) {
+func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
@@ -46,7 +46,7 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_WorkLink_basic(t *tes
 	})
 }
 
-func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_WorkLink_displayName(t *testing.T) {
+func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName(t *testing.T) {
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 	displayName1 := fmt.Sprintf("tf-website-certificate-%s", sdkacctest.RandStringFromCharSet(5, sdkacctest.CharSetAlpha))
@@ -80,7 +80,7 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_WorkLink_displayName(
 	})
 }
 
-func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_WorkLink_disappears(t *testing.T) {
+func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears(t *testing.T) {
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 


### PR DESCRIPTION
With the code reorganization for Service Packages, Semgrep checks were no longer able to run. This PR restores them.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20000

Acceptance test results

```console
$ $ make testacc TESTARGS='-run=TestAccEC2NetworkInterface\|TestAccGlueMlTransform\|TestAccElasticSearchDomainSamlOptions\|TestAccIAMOpenidConnectProvider\|TestAccPrometheusWorkspace\|TestAccELBLoadBalancer\|TestAccEC2NetworkInterfaceSgAttachment\|TestAccBackupVaultNotification\|TestAccCognitoIDPUserPoolUICustomization\|TestAccWorkLinkWebsiteCertificateAuthorityAssociation'

--- PASS: TestAccBackupVaultNotification_disappears (18.83s)
--- PASS: TestAccBackupVaultNotification_basic (21.32s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_Client_disappears (44.29s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_AllClients_disappears (47.44s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_UpdateAllToClient_cSS (83.34s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_UpdateClientToAll_cSS (83.53s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_AllClients_CSS (84.17s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_Client_image (85.03s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_AllClients_imageFile (87.26s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_Client_CSS (87.29s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_ClientAndAll_cSS (90.93s)
--- PASS: TestAccCognitoIDPUserPoolUICustomization_AllClients_CSSAndImageFile (98.33s)
--- SKIP: TestAccEC2NetworkInterfaceDataSource_carrierIPAssociation (0.94s)
--- PASS: TestAccEC2NetworkInterfaceDataSource_filters (50.69s)
--- PASS: TestAccEC2NetworkInterfaceSgAttachment_basic (63.42s)
--- PASS: TestAccEC2NetworkInterfaceDataSource_publicIPAssociation (64.63s)
--- PASS: TestAccEC2NetworkInterfaceSgAttachment_disappears (72.22s)
--- PASS: TestAccEC2NetworkInterfaceDataSource_basic (77.04s)
--- PASS: TestAccEC2NetworkInterfaceSgAttachment_multiple (81.92s)
--- PASS: TestAccEC2NetworkInterface_disappears (100.90s)
--- PASS: TestAccEC2NetworkInterface_ENIInterfaceType_efa (118.41s)
--- PASS: TestAccEC2NetworkInterface_basic (119.29s)
--- PASS: TestAccEC2NetworkInterfaceSgAttachment_instance (139.42s)
--- PASS: TestAccEC2NetworkInterfacesDataSource_filter (70.55s)
--- PASS: TestAccEC2NetworkInterfacesDataSource_tags (69.81s)
--- PASS: TestAccEC2NetworkInterface_description (148.25s)
--- PASS: TestAccEC2NetworkInterface_tags (188.17s)
--- PASS: TestAccEC2NetworkInterface_ENI_ipv4Prefix (188.65s)
--- PASS: TestAccEC2NetworkInterface_ipv6 (191.59s)
--- PASS: TestAccEC2NetworkInterface_sourceDestCheck (193.47s)
--- PASS: TestAccEC2NetworkInterface_ipv6Count (208.02s)
--- PASS: TestAccEC2NetworkInterface_ENI_ipv6Prefix (147.26s)
--- PASS: TestAccEC2NetworkInterface_privateIPsCount (219.52s)
--- PASS: TestAccEC2NetworkInterface_ENI_ipv4PrefixCount (170.85s)
--- PASS: TestAccEC2NetworkInterface_ENI_ipv6PrefixCount (160.43s)
--- PASS: TestAccEC2NetworkInterfaceAttachment_basic (343.44s)
--- PASS: TestAccEC2NetworkInterface_attachment (363.96s)
--- PASS: TestAccEC2NetworkInterface_ignoreExternalAttachment (374.54s)
--- PASS: TestAccELBLoadBalancer_fullCharacterRange (45.14s)
--- PASS: TestAccELBLoadBalancer_timeout (106.01s)
--- PASS: TestAccELBLoadBalancer_generatedName (111.12s)
--- PASS: TestAccELBLoadBalancer_generatesNameForZeroValue (125.10s)
--- PASS: TestAccELBLoadBalancer_connectionDraining (133.26s)
--- PASS: TestAccELBLoadBalancer_namePrefix (134.51s)
--- PASS: TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate (153.75s)
--- PASS: TestAccELBLoadBalancer_availabilityZones (157.22s)
--- PASS: TestAccELBLoadBalancer_Swap_subnets (174.70s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_disabled (189.60s)
--- PASS: TestAccELBLoadBalancer_instanceAttaching (192.48s)
--- PASS: TestAccELBLoadBalancer_listener (217.54s)
--- PASS: TestAccELBLoadBalancer_disappears (242.52s)
--- PASS: TestAccELBLoadBalancerDataSource_basic (246.41s)
--- PASS: TestAccELBLoadBalancer_healthCheck (256.21s)
--- PASS: TestAccELBLoadBalancer_basic (259.32s)
--- PASS: TestAccELBLoadBalancer_tags (300.51s)
--- PASS: TestAccGlueMlTransform_disappears (65.67s)
--- PASS: TestAccELBLoadBalancer_securityGroups (316.97s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_enabled (326.06s)
--- PASS: TestAccGlueMlTransform_basic (81.27s)
--- PASS: TestAccGlueMlTransform_workerType (125.59s)
--- PASS: TestAccGlueMlTransform_description (131.89s)
--- PASS: TestAccGlueMlTransform_maxCapacity (134.53s)
--- PASS: TestAccGlueMlTransform_glueVersion (136.09s)
--- PASS: TestAccGlueMlTransform_maxRetries (141.85s)
--- PASS: TestAccGlueMlTransform_timeout (142.16s)
--- PASS: TestAccGlueMlTransform_typeFindMatchesFull (174.43s)
--- PASS: TestAccGlueMlTransform_tags (182.77s)
--- PASS: TestAccIAMOpenidConnectProvider_disappears (19.08s)
--- PASS: TestAccIAMOpenidConnectProvider_basic (36.84s)
--- PASS: TestAccIAMOpenidConnectProvider_tags (49.85s)
--- PASS: TestAccPrometheusWorkspace_disappears (16.42s)
--- PASS: TestAccPrometheusWorkspace_basic (43.65s)
--- PASS: TestAccElasticSearchDomainSamlOptions_disappears (1180.06s)
--- PASS: TestAccElasticSearchDomainSamlOptions_basic (1212.03s)
--- PASS: TestAccElasticSearchDomainSamlOptions_disabled (1257.03s)
--- PASS: TestAccElasticSearchDomainSamlOptions_update (1448.94s)
--- PASS: TestAccElasticSearchDomainSamlOptions_disappears_domain (1500.37s)
--- PASS: TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears (91.05s)
--- PASS: TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic (96.35s)
--- PASS: TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName (110.93s)
```