### PR TITLE
tests/macie2/finding_filter: update configurations with a boolean string value

### DIFF
--- a/internal/service/macie2/findings_filter_test.go
+++ b/internal/service/macie2/findings_filter_test.go
@@ -225,8 +225,7 @@ func testAccFindingsFilter_WithDate(t *testing.T) {
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
-					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
-					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "finding_criteria.0.criterion.*.eq.*", dataSourceRegion, "name"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
 						"field": "region",
 						"eq.#":  "1",
@@ -247,8 +246,7 @@ func testAccFindingsFilter_WithDate(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
 					resource.TestCheckResourceAttr(resourceName, "position", "1"),
-					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.0.field", "region"),
-					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "finding_criteria.0.criterion.*.eq.*", dataSourceRegion, "name"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
 						"field": "region",
 						"eq.#":  "1",
@@ -259,13 +257,16 @@ func testAccFindingsFilter_WithDate(t *testing.T) {
 						"gte":   startDate,
 						"lt":    endDate,
 					}),
-					acctest.CheckResourceAttrRFC3339(resourceName, "finding_criteria.0.criterion.2.gte"),
-					acctest.CheckResourceAttrRFC3339(resourceName, "finding_criteria.0.criterion.2.lt"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]*regexp.Regexp{
+						"gte": regexp.MustCompile(acctest.RFC3339RegexPattern),
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]*regexp.Regexp{
+						"lt": regexp.MustCompile(acctest.RFC3339RegexPattern),
+					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
 						"field": "sample",
-						"neq.#": "2",
-						"neq.0": "another-sample",
-						"neq.1": "some-sample",
+						"eq.#":  "1",
+						"eq.0":  "true",
 					}),
 				),
 			},
@@ -300,7 +301,7 @@ func testAccFindingsFilter_WithNumber(t *testing.T) {
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "action", macie2.FindingsFilterActionArchive),
-					resource.TestCheckResourceAttrPair(resourceName, "finding_criteria.0.criterion.0.eq.0", dataSourceRegion, "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "finding_criteria.0.criterion.*.eq.*", dataSourceRegion, "name"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "macie2", regexp.MustCompile(`findings-filter/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "position", "1"),
@@ -335,9 +336,8 @@ func testAccFindingsFilter_WithNumber(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "finding_criteria.0.criterion.*", map[string]string{
 						"field": "sample",
-						"neq.#": "2",
-						"neq.0": "another-sample",
-						"neq.1": "some-sample",
+						"eq.#":  "1",
+						"eq.0":  "true",
 					}),
 				),
 			},
@@ -517,7 +517,7 @@ resource "aws_macie2_findings_filter" "test" {
     }
     criterion {
       field = "sample"
-      neq   = ["some-sample", "another-sample"]
+      eq    = ["true"]
     }
     criterion {
       field = "updatedAt"
@@ -547,7 +547,7 @@ resource "aws_macie2_findings_filter" "test" {
     }
     criterion {
       field = "sample"
-      neq   = ["some-sample", "another-sample"]
+      eq    = ["true"]
     }
     criterion {
       field = "count"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21441

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccMacie2_serial (26.41s)
    --- PASS: TestAccMacie2_serial/FindingsFilter (26.41s)
        --- PASS: TestAccMacie2_serial/FindingsFilter/date (26.41s)
PASS

--- PASS: TestAccMacie2_serial (26.29s)
    --- PASS: TestAccMacie2_serial/FindingsFilter (26.29s)
        --- PASS: TestAccMacie2_serial/FindingsFilter/number (26.29s)
```
