### PR TITLE
tests/rds/option_group: update `oracle-ee` major version

### DIFF
--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -675,7 +675,7 @@ resource "aws_db_option_group" "bar" {
   name                     = "%s"
   option_group_description = "Test option group for terraform"
   engine_name              = "oracle-ee"
-  major_engine_version     = "11.2"
+  major_engine_version     = "12.2"
 
   option {
     option_name = "Timezone"
@@ -733,7 +733,7 @@ resource "aws_db_option_group" "bar" {
   name                     = "%s"
   option_group_description = "Test option group for terraform"
   engine_name              = "oracle-ee"
-  major_engine_version     = "11.2"
+  major_engine_version     = "12.2"
 
   option {
     option_name = "Timezone"
@@ -783,7 +783,7 @@ resource "aws_db_option_group" "bar" {
   name                     = "%[1]s"
   option_group_description = "Test option group for terraform issue 748"
   engine_name              = "oracle-ee"
-  major_engine_version     = "12.1"
+  major_engine_version     = "12.2"
 
   option {
     option_name = "OEM_AGENT"
@@ -816,15 +816,15 @@ func testAccOptionGroupMultipleOptions(r string) string {
 resource "aws_db_option_group" "bar" {
   name                     = "%s"
   option_group_description = "Test option group for terraform"
-  engine_name              = "oracle-se"
-  major_engine_version     = "11.2"
+  engine_name              = "oracle-ee"
+  major_engine_version     = "12.2"
 
   option {
-    option_name = "STATSPACK"
+    option_name = "SPATIAL"
   }
 
   option {
-    option_name = "XMLDB"
+    option_name = "STATSPACK"
   }
 }
 `, r)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21449 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccRDSOptionGroup_multipleOptions (138.61s)
--- PASS: TestAccRDSOptionGroup_Option_optionSettings (271.42s)

--- PASS: TestAccRDSOptionGroup_timeoutBlock (138.75s)
--- PASS: TestAccRDSOptionGroup_basic (139.05s)
--- PASS: TestAccRDSOptionGroup_namePrefix (139.24s)
--- PASS: TestAccRDSOptionGroup_generatedName (184.79s)
--- PASS: TestAccRDSOptionGroup_optionGroupDescription (184.80s)
--- PASS: TestAccRDSOptionGroup_OptionOptionSettings_iamRole (185.28s)
--- PASS: TestAccRDSOptionGroup_sqlServerOptionsUpdate (226.78s)
--- PASS: TestAccRDSOptionGroup_OptionOptionSettings_multipleNonDefault (262.13s)
--- PASS: TestAccRDSOptionGroup_oracleOptionsUpdate (262.36s)
--- PASS: TestAccRDSOptionGroup_tags (274.45s)
--- PASS: TestAccRDSOptionGroup_Tags_withOptions (300.68s)
 --- PASS: TestAccRDSOptionGroup_basicDestroyWithInstance (602.47s)
```
