### PR TITLE
tests/codeartifact: serialize tests

### DIFF
--- a/internal/service/codeartifact/authorization_token_data_source_test.go
+++ b/internal/service/codeartifact/authorization_token_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccCodeArtifactAuthorizationTokenDataSource_basic(t *testing.T) {
+func testAccCodeArtifactAuthorizationTokenDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_codeartifact_authorization_token.test"
 
@@ -31,7 +31,7 @@ func TestAccCodeArtifactAuthorizationTokenDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactAuthorizationTokenDataSource_owner(t *testing.T) {
+func testAccCodeArtifactAuthorizationTokenDataSource_owner(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_codeartifact_authorization_token.test"
 
@@ -52,7 +52,7 @@ func TestAccCodeArtifactAuthorizationTokenDataSource_owner(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactAuthorizationTokenDataSource_duration(t *testing.T) {
+func testAccCodeArtifactAuthorizationTokenDataSource_duration(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_codeartifact_authorization_token.test"
 

--- a/internal/service/codeartifact/codeartifact_test.go
+++ b/internal/service/codeartifact/codeartifact_test.go
@@ -1,0 +1,56 @@
+package codeartifact_test
+
+import "testing"
+
+func TestAccCodeArtifact_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"AuthorizationTokenDataSource": {
+			"basic":    testAccCodeArtifactAuthorizationTokenDataSource_basic,
+			"duration": testAccCodeArtifactAuthorizationTokenDataSource_duration,
+			"owner":    testAccCodeArtifactAuthorizationTokenDataSource_owner,
+		},
+		"Domain": {
+			"basic":                testAccCodeArtifactDomain_basic,
+			"defaultEncryptionKey": testAccCodeArtifactDomain_defaultEncryptionKey,
+			"disappears":           testAccCodeArtifactDomain_disappears,
+			"tags":                 testAccCodeArtifactDomain_tags,
+		},
+		"DomainPermissionsPolicy": {
+			"basic":             testAccCodeArtifactDomainPermissionsPolicy_basic,
+			"disappears":        testAccCodeArtifactDomainPermissionsPolicy_disappears,
+			"owner":             testAccCodeArtifactDomainPermissionsPolicy_owner,
+			"Disappears_domain": testAccCodeArtifactDomainPermissionsPolicy_Disappears_domain,
+		},
+		"Repository": {
+			"basic":              testAccCodeArtifactRepository_basic,
+			"description":        testAccCodeArtifactRepository_description,
+			"disappears":         testAccCodeArtifactRepository_disappears,
+			"externalConnection": testAccCodeArtifactRepository_externalConnection,
+			"owner":              testAccCodeArtifactRepository_owner,
+			"tags":               testAccCodeArtifactRepository_tags,
+			"upstreams":          testAccCodeArtifactRepository_upstreams,
+		},
+		"RepositoryEndpointDataSource": {
+			"basic": testAccCodeArtifactRepositoryEndpointDataSource_basic,
+			"owner": testAccCodeArtifactRepositoryEndpointDataSource_owner,
+		},
+		"RepositoryPermissionsPolicy": {
+			"basic":             testAccCodeArtifactRepositoryPermissionsPolicy_basic,
+			"disappears":        testAccCodeArtifactRepositoryPermissionsPolicy_disappears,
+			"owner":             testAccCodeArtifactRepositoryPermissionsPolicy_owner,
+			"Disappears_domain": testAccCodeArtifactRepositoryPermissionsPolicy_Disappears_domain,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/internal/service/codeartifact/domain_permissions_policy_test.go
+++ b/internal/service/codeartifact/domain_permissions_policy_test.go
@@ -16,11 +16,11 @@ import (
 	tfcodeartifact "github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact"
 )
 
-func TestAccCodeArtifactDomainPermissionsPolicy_basic(t *testing.T) {
+func testAccCodeArtifactDomainPermissionsPolicy_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -56,11 +56,11 @@ func TestAccCodeArtifactDomainPermissionsPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactDomainPermissionsPolicy_owner(t *testing.T) {
+func testAccCodeArtifactDomainPermissionsPolicy_owner(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -85,11 +85,11 @@ func TestAccCodeArtifactDomainPermissionsPolicy_owner(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactDomainPermissionsPolicy_disappears(t *testing.T) {
+func testAccCodeArtifactDomainPermissionsPolicy_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -107,11 +107,11 @@ func TestAccCodeArtifactDomainPermissionsPolicy_disappears(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactDomainPermissionsPolicy_Disappears_domain(t *testing.T) {
+func testAccCodeArtifactDomainPermissionsPolicy_Disappears_domain(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/codeartifact/domain_test.go
+++ b/internal/service/codeartifact/domain_test.go
@@ -16,11 +16,11 @@ import (
 	tfcodeartifact "github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact"
 )
 
-func TestAccCodeArtifactDomain_basic(t *testing.T) {
+func testAccCodeArtifactDomain_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -49,11 +49,11 @@ func TestAccCodeArtifactDomain_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactDomain_defaultEncryptionKey(t *testing.T) {
+func testAccCodeArtifactDomain_defaultEncryptionKey(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService("codeartifact", t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -81,11 +81,11 @@ func TestAccCodeArtifactDomain_defaultEncryptionKey(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactDomain_tags(t *testing.T) {
+func testAccCodeArtifactDomain_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService("codeartifact", t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -124,11 +124,11 @@ func TestAccCodeArtifactDomain_tags(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactDomain_disappears(t *testing.T) {
+func testAccCodeArtifactDomain_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_domain.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/codeartifact/repository_endpoint_data_source_test.go
+++ b/internal/service/codeartifact/repository_endpoint_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccCodeArtifactRepositoryEndpointDataSource_basic(t *testing.T) {
+func testAccCodeArtifactRepositoryEndpointDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_codeartifact_repository_endpoint.test"
 
@@ -51,7 +51,7 @@ func TestAccCodeArtifactRepositoryEndpointDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepositoryEndpointDataSource_owner(t *testing.T) {
+func testAccCodeArtifactRepositoryEndpointDataSource_owner(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_codeartifact_repository_endpoint.test"
 

--- a/internal/service/codeartifact/repository_permissions_policy_test.go
+++ b/internal/service/codeartifact/repository_permissions_policy_test.go
@@ -16,11 +16,11 @@ import (
 	tfcodeartifact "github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact"
 )
 
-func TestAccCodeArtifactRepositoryPermissionsPolicy_basic(t *testing.T) {
+func testAccCodeArtifactRepositoryPermissionsPolicy_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -56,11 +56,11 @@ func TestAccCodeArtifactRepositoryPermissionsPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepositoryPermissionsPolicy_owner(t *testing.T) {
+func testAccCodeArtifactRepositoryPermissionsPolicy_owner(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -85,11 +85,11 @@ func TestAccCodeArtifactRepositoryPermissionsPolicy_owner(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepositoryPermissionsPolicy_disappears(t *testing.T) {
+func testAccCodeArtifactRepositoryPermissionsPolicy_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -107,11 +107,11 @@ func TestAccCodeArtifactRepositoryPermissionsPolicy_disappears(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepositoryPermissionsPolicy_Disappears_domain(t *testing.T) {
+func testAccCodeArtifactRepositoryPermissionsPolicy_Disappears_domain(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository_permissions_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/codeartifact/repository_test.go
+++ b/internal/service/codeartifact/repository_test.go
@@ -15,11 +15,11 @@ import (
 	tfcodeartifact "github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact"
 )
 
-func TestAccCodeArtifactRepository_basic(t *testing.T) {
+func testAccCodeArtifactRepository_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -49,11 +49,11 @@ func TestAccCodeArtifactRepository_basic(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepository_tags(t *testing.T) {
+func testAccCodeArtifactRepository_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService("codeartifact", t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -93,11 +93,11 @@ func TestAccCodeArtifactRepository_tags(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepository_owner(t *testing.T) {
+func testAccCodeArtifactRepository_owner(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -126,11 +126,11 @@ func TestAccCodeArtifactRepository_owner(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepository_description(t *testing.T) {
+func testAccCodeArtifactRepository_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -159,11 +159,11 @@ func TestAccCodeArtifactRepository_description(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepository_upstreams(t *testing.T) {
+func testAccCodeArtifactRepository_upstreams(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -203,11 +203,11 @@ func TestAccCodeArtifactRepository_upstreams(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepository_externalConnection(t *testing.T) {
+func testAccCodeArtifactRepository_externalConnection(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,
@@ -249,11 +249,11 @@ func TestAccCodeArtifactRepository_externalConnection(t *testing.T) {
 	})
 }
 
-func TestAccCodeArtifactRepository_disappears(t *testing.T) {
+func testAccCodeArtifactRepository_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeartifact_repository.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(codeartifact.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, codeartifact.EndpointsID),
 		Providers:    acctest.Providers,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21421 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCodeArtifact_serial (671.70s)
    --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource (55.69s)
        --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource/basic (19.26s)
        --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource/duration (18.93s)
        --- PASS: TestAccCodeArtifact_serial/AuthorizationTokenDataSource/owner (17.50s)
    --- PASS: TestAccCodeArtifact_serial/Domain (77.76s)
        --- PASS: TestAccCodeArtifact_serial/Domain/tags (35.04s)
        --- PASS: TestAccCodeArtifact_serial/Domain/basic (18.52s)
        --- PASS: TestAccCodeArtifact_serial/Domain/defaultEncryptionKey (14.42s)
        --- PASS: TestAccCodeArtifact_serial/Domain/disappears (9.79s)
    --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy (87.24s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/owner (19.70s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/Disappears_domain (16.76s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/basic (33.06s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappears (17.71s)
    --- PASS: TestAccCodeArtifact_serial/Repository (264.71s)
        --- PASS: TestAccCodeArtifact_serial/Repository/basic (21.33s)
        --- PASS: TestAccCodeArtifact_serial/Repository/description (36.22s)
        --- PASS: TestAccCodeArtifact_serial/Repository/disappears (18.15s)
        --- PASS: TestAccCodeArtifact_serial/Repository/externalConnection (56.53s)
        --- PASS: TestAccCodeArtifact_serial/Repository/owner (21.30s)
        --- PASS: TestAccCodeArtifact_serial/Repository/tags (51.46s)
        --- PASS: TestAccCodeArtifact_serial/Repository/upstreams (59.72s)
    --- PASS: TestAccCodeArtifact_serial/RepositoryEndpointDataSource (83.20s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryEndpointDataSource/basic (63.72s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryEndpointDataSource/owner (19.48s)
    --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy (103.10s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/basic (37.82s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/disappears (21.70s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/owner (23.21s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/Disappears_domain (20.37s)
PASS
```
