### PR TITLE
r/aws_storagegateway_file_system_association: Correct resource not found error handling

### DIFF
--- a/internal/service/storagegateway/enum.go
+++ b/internal/service/storagegateway/enum.go
@@ -53,19 +53,3 @@ const (
 	fileSystemAssociationStatusUpdating      = "UPDATING"
 	fileSystemAssociationStatusError         = "ERROR"
 )
-
-func fileSystemAssociationStatusAvailableStatusPending() []string {
-	return []string{fileSystemAssociationStatusCreating, fileSystemAssociationStatusUpdating}
-}
-
-func fileSystemAssociationStatusAvailableStatusTarget() []string {
-	return []string{fileSystemAssociationStatusAvailable}
-}
-
-func fileSystemAssociationStatusDeletedStatusPending() []string {
-	return []string{fileSystemAssociationStatusAvailable, fileSystemAssociationStatusDeleting, fileSystemAssociationStatusForceDeleting}
-}
-
-func fileSystemAssociationStatusDeletedStatusTarget() []string {
-	return []string{}
-}

--- a/internal/service/storagegateway/errors.go
+++ b/internal/service/storagegateway/errors.go
@@ -7,9 +7,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 )
 
+// Error code constants missing from AWS Go SDK:
+// https://docs.aws.amazon.com/sdk-for-go/api/service/storagegateway/#pkg-constants
 const (
-	operationErrCodeFileShareNotFound = "FileShareNotFound"
-	fileSystemAssociationNotFound     = "fileSystemAssociationNotFound"
+	operationErrCodeFileShareNotFound             = "FileShareNotFound"
+	operationErrCodeFileSystemAssociationNotFound = "FileSystemAssociationNotFound"
 )
 
 // operationErrorCode returns the operation error code from the specified error:
@@ -26,17 +28,4 @@ func operationErrorCode(err error) string {
 	}
 
 	return ""
-}
-
-// Error code constants missing from AWS Go SDK:
-// https://docs.aws.amazon.com/sdk-for-go/api/service/storagegateway/#pkg-constants
-
-func invalidGatewayRequestErrCodeEquals(err error, errCode string) bool {
-	var igrex *storagegateway.InvalidGatewayRequestException
-	if errors.As(err, &igrex) {
-		if err := igrex.Error_; err != nil {
-			return aws.StringValue(err.ErrorCode) == errCode
-		}
-	}
-	return false
 }

--- a/internal/service/storagegateway/file_system_association.go
+++ b/internal/service/storagegateway/file_system_association.go
@@ -97,9 +97,10 @@ func resourceFileSystemAssociationCreate(d *schema.ResourceData, meta interface{
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
+	gatewayARN := d.Get("gateway_arn").(string)
 	input := &storagegateway.AssociateFileSystemInput{
 		ClientToken: aws.String(resource.UniqueId()),
-		GatewayARN:  aws.String(d.Get("gateway_arn").(string)),
+		GatewayARN:  aws.String(gatewayARN),
 		LocationARN: aws.String(d.Get("location_arn").(string)),
 		Password:    aws.String(d.Get("password").(string)),
 		Tags:        Tags(tags.IgnoreAWS()),
@@ -114,17 +115,17 @@ func resourceFileSystemAssociationCreate(d *schema.ResourceData, meta interface{
 		input.CacheAttributes = expandStorageGatewayFileSystemAssociationCacheAttributes(v.([]interface{}))
 	}
 
-	log.Printf("[DEBUG] Associating File System to Storage Gateway: %s", input)
+	log.Printf("[DEBUG] Creating Storage Gateway File System Association: %s", input)
 	output, err := conn.AssociateFileSystem(input)
+
 	if err != nil {
-		return fmt.Errorf("Error associating file system to storage gateway (%s): %w", d.Get("gateway_arn").(string), err)
+		return fmt.Errorf("error creating Storage Gateway (%s) File System Association: %w", gatewayARN, err)
 	}
 
 	d.SetId(aws.StringValue(output.FileSystemAssociationARN))
-	log.Printf("[INFO] Storage Gateway File System Association ID: %s", d.Id())
 
 	if _, err = waitFileSystemAssociationAvailable(conn, d.Id(), fileSystemAssociationCreateTimeout); err != nil {
-		return fmt.Errorf("error waiting for Storage Gateway File System Association (%s) to be Available: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for Storage Gateway File System Association (%s) create: %w", d.Id(), err)
 	}
 
 	return resourceFileSystemAssociationRead(d, meta)
@@ -137,18 +138,17 @@ func resourceFileSystemAssociationRead(d *schema.ResourceData, meta interface{})
 
 	filesystem, err := FindFileSystemAssociationByARN(conn, d.Id())
 
-	if err != nil {
-		return err
-	}
-
-	if !d.IsNewResource() && filesystem == nil {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Storage Gateway File System Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("arn", filesystem.FileSystemAssociationARN)
+	if err != nil {
+		return fmt.Errorf("error reading Storage Gateway File System Association (%s): %w", d.Id(), err)
+	}
 
+	d.Set("arn", filesystem.FileSystemAssociationARN)
 	d.Set("audit_destination_arn", filesystem.AuditDestinationARN)
 	d.Set("gateway_arn", filesystem.GatewayARN)
 	d.Set("location_arn", filesystem.LocationARN)
@@ -182,7 +182,6 @@ func resourceFileSystemAssociationUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChangesExcept("tags_all") {
-
 		input := &storagegateway.UpdateFileSystemAssociationInput{
 			AuditDestinationARN:      aws.String(d.Get("audit_destination_arn").(string)),
 			Password:                 aws.String(d.Get("password").(string)),
@@ -196,12 +195,13 @@ func resourceFileSystemAssociationUpdate(d *schema.ResourceData, meta interface{
 
 		log.Printf("[DEBUG] Updating Storage Gateway File System Association: %s", input)
 		_, err := conn.UpdateFileSystemAssociation(input)
+
 		if err != nil {
 			return fmt.Errorf("error updating Storage Gateway File System Association (%s): %w", d.Id(), err)
 		}
 
 		if _, err = waitFileSystemAssociationAvailable(conn, d.Id(), fileSystemAssociationUpdateTimeout); err != nil {
-			return fmt.Errorf("error waiting for Storage Gateway File System Association (%s) to be Available: %w", d.Id(), err)
+			return fmt.Errorf("error waiting for Storage Gateway File System Association (%s) update: %w", d.Id(), err)
 		}
 	}
 
@@ -217,17 +217,17 @@ func resourceFileSystemAssociationDelete(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] Deleting Storage Gateway File System Association: %s", input)
 	_, err := conn.DisassociateFileSystem(input)
+
+	if operationErrorCode(err) == operationErrCodeFileSystemAssociationNotFound {
+		return nil
+	}
+
 	if err != nil {
-		if invalidGatewayRequestErrCodeEquals(err, fileSystemAssociationNotFound) {
-			return nil
-		}
+		return fmt.Errorf("error deleting Storage Gateway File System Association (%s): %w", d.Id(), err)
 	}
 
 	if _, err = waitFileSystemAssociationDeleted(conn, d.Id(), fileSystemAssociationDeleteTimeout); err != nil {
-		if tfresource.NotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("error waiting for Storage Gateway File System Association (%s) to be deleted: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for Storage Gateway File System Association (%s) delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/storagegateway/status.go
+++ b/internal/service/storagegateway/status.go
@@ -15,7 +15,6 @@ const (
 	storageGatewayGatewayStatusConnected = "GatewayConnected"
 	storediSCSIVolumeStatusNotFound      = "NotFound"
 	nfsFileShareStatusNotFound           = "NotFound"
-	fileSystemAssociationStatusNotFound  = "NotFound"
 )
 
 func statusStorageGatewayGateway(conn *storagegateway.StorageGateway, gatewayARN string) resource.StateRefreshFunc {
@@ -125,19 +124,16 @@ func statussmBFileShare(conn *storagegateway.StorageGateway, arn string) resourc
 	}
 }
 
-func statusFileSystemAssociation(conn *storagegateway.StorageGateway, fileSystemArn string) resource.StateRefreshFunc {
+func statusFileSystemAssociation(conn *storagegateway.StorageGateway, arn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
+		output, err := FindFileSystemAssociationByARN(conn, arn)
 
-		output, err := FindFileSystemAssociationByARN(conn, fileSystemArn)
-
-		// there was an unhandled error in the Finder
-		if err != nil {
-			return nil, "", err
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
-		// no error, and no File System Association found
-		if output == nil {
-			return nil, fileSystemAssociationStatusNotFound, nil
+		if err != nil {
+			return nil, "", err
 		}
 
 		return output, aws.StringValue(output.FileSystemAssociationStatus), nil

--- a/internal/service/storagegateway/wait.go
+++ b/internal/service/storagegateway/wait.go
@@ -168,11 +168,10 @@ func waitSMBFileShareUpdated(conn *storagegateway.StorageGateway, arn string, ti
 	return nil, err
 }
 
-// waitFileSystemAssociationAvailable waits for a File System Association to return Available
 func waitFileSystemAssociationAvailable(conn *storagegateway.StorageGateway, fileSystemArn string, timeout time.Duration) (*storagegateway.FileSystemAssociationInfo, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending: fileSystemAssociationStatusAvailableStatusPending(),
-		Target:  fileSystemAssociationStatusAvailableStatusTarget(),
+		Pending: []string{fileSystemAssociationStatusCreating, fileSystemAssociationStatusUpdating},
+		Target:  []string{fileSystemAssociationStatusAvailable},
 		Refresh: statusFileSystemAssociation(conn, fileSystemArn),
 		Timeout: timeout,
 		Delay:   fileSystemAssociationAvailableDelay,
@@ -189,8 +188,8 @@ func waitFileSystemAssociationAvailable(conn *storagegateway.StorageGateway, fil
 
 func waitFileSystemAssociationDeleted(conn *storagegateway.StorageGateway, fileSystemArn string, timeout time.Duration) (*storagegateway.FileSystemAssociationInfo, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:        fileSystemAssociationStatusDeletedStatusPending(),
-		Target:         fileSystemAssociationStatusDeletedStatusTarget(),
+		Pending:        []string{fileSystemAssociationStatusAvailable, fileSystemAssociationStatusDeleting, fileSystemAssociationStatusForceDeleting},
+		Target:         []string{},
 		Refresh:        statusFileSystemAssociation(conn, fileSystemArn),
 		Timeout:        timeout,
 		Delay:          fileSystemAssociationDeletedDelay,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21472.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Commercial

```console
% make testacc PKG_NAME=internal/service/storagegateway TESTARGS='-run=TestAccStorageGatewayFileSystemAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/storagegateway/... -v -count 1 -parallel 20 -run=TestAccStorageGatewayFileSystemAssociation_ -timeout 180m
=== RUN   TestAccStorageGatewayFileSystemAssociation_basic
=== PAUSE TestAccStorageGatewayFileSystemAssociation_basic
=== RUN   TestAccStorageGatewayFileSystemAssociation_tags
=== PAUSE TestAccStorageGatewayFileSystemAssociation_tags
=== RUN   TestAccStorageGatewayFileSystemAssociation_cacheAttributes
=== PAUSE TestAccStorageGatewayFileSystemAssociation_cacheAttributes
=== RUN   TestAccStorageGatewayFileSystemAssociation_auditDestination
=== PAUSE TestAccStorageGatewayFileSystemAssociation_auditDestination
=== RUN   TestAccStorageGatewayFileSystemAssociation_disappears
=== PAUSE TestAccStorageGatewayFileSystemAssociation_disappears
=== RUN   TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway
=== PAUSE TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway
=== RUN   TestAccStorageGatewayFileSystemAssociation_Disappears_fsxFileSystem
    file_system_association_test.go:241: A bug in the service API has been reported. Deleting the FSx file system before the association prevents association from being deleted.
--- SKIP: TestAccStorageGatewayFileSystemAssociation_Disappears_fsxFileSystem (0.00s)
=== CONT  TestAccStorageGatewayFileSystemAssociation_basic
=== CONT  TestAccStorageGatewayFileSystemAssociation_disappears
=== CONT  TestAccStorageGatewayFileSystemAssociation_auditDestination
=== CONT  TestAccStorageGatewayFileSystemAssociation_cacheAttributes
=== CONT  TestAccStorageGatewayFileSystemAssociation_tags
=== CONT  TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway
=== CONT  TestAccStorageGatewayFileSystemAssociation_basic
    file_system_association_test.go:28: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating Storage Gateway (arn:aws:storagegateway:us-west-2:123456789012:gateway/sgw-9433D8FD) File System Association: InvalidGatewayRequestException: Service role name AWSServiceRoleForStorageGateway has been taken in this account, please try a different suffix. (Service: AmazonIdentityManagement; Status Code: 400; Error Code: InvalidInput; Request ID: 50cb0139-15d9-47b8-a0c4-999ff304fc4f; Proxy: null)
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "3df27962-f7e8-457e-b8d7-f27e7e26bb01"
          },
          Error_: {
            ErrorCode: "InvalidParameters"
          },
          Message_: "Service role name AWSServiceRoleForStorageGateway has been taken in this account, please try a different suffix. (Service: AmazonIdentityManagement; Status Code: 400; Error Code: InvalidInput; Request ID: 50cb0139-15d9-47b8-a0c4-999ff304fc4f; Proxy: null)"
        }
        
          with aws_storagegateway_file_system_association.test,
          on terraform_plugin_test.tf line 164, in resource "aws_storagegateway_file_system_association" "test":
         164: resource "aws_storagegateway_file_system_association" "test" {
        
--- PASS: TestAccStorageGatewayFileSystemAssociation_cacheAttributes (3276.08s)
--- FAIL: TestAccStorageGatewayFileSystemAssociation_basic (3308.68s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_auditDestination (3339.21s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_tags (3360.18s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_disappears (3397.11s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway (3460.71s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	3466.311s
```

#### GovCloud

```console
% make testacc PKG_NAME=internal/service/storagegateway TESTARGS='-run=TestAccStorageGatewayFileSystemAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/storagegateway/... -v -count 1 -parallel 20 -run=TestAccStorageGatewayFileSystemAssociation_ -timeout 180m
=== RUN   TestAccStorageGatewayFileSystemAssociation_basic
=== PAUSE TestAccStorageGatewayFileSystemAssociation_basic
=== RUN   TestAccStorageGatewayFileSystemAssociation_tags
=== PAUSE TestAccStorageGatewayFileSystemAssociation_tags
=== RUN   TestAccStorageGatewayFileSystemAssociation_cacheAttributes
=== PAUSE TestAccStorageGatewayFileSystemAssociation_cacheAttributes
=== RUN   TestAccStorageGatewayFileSystemAssociation_auditDestination
=== PAUSE TestAccStorageGatewayFileSystemAssociation_auditDestination
=== RUN   TestAccStorageGatewayFileSystemAssociation_disappears
=== PAUSE TestAccStorageGatewayFileSystemAssociation_disappears
=== RUN   TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway
=== PAUSE TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway
=== RUN   TestAccStorageGatewayFileSystemAssociation_Disappears_fsxFileSystem
    file_system_association_test.go:241: A bug in the service API has been reported. Deleting the FSx file system before the association prevents association from being deleted.
--- SKIP: TestAccStorageGatewayFileSystemAssociation_Disappears_fsxFileSystem (0.00s)
=== CONT  TestAccStorageGatewayFileSystemAssociation_basic
=== CONT  TestAccStorageGatewayFileSystemAssociation_disappears
=== CONT  TestAccStorageGatewayFileSystemAssociation_auditDestination
=== CONT  TestAccStorageGatewayFileSystemAssociation_cacheAttributes
=== CONT  TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway
=== CONT  TestAccStorageGatewayFileSystemAssociation_tags
--- PASS: TestAccStorageGatewayFileSystemAssociation_disappears (2937.88s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_basic (2951.53s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_tags (3130.66s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_Disappears_storageGateway (3164.16s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_cacheAttributes (3239.12s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_auditDestination (3493.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	3496.331s
```

Failure is unrelated to this fix.