### PR TITLE
tests/macie: Skip Macie class acceptance tests if not enabled

### DIFF
--- a/internal/service/macie/s3_bucket_association_test.go
+++ b/internal/service/macie/s3_bucket_association_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/macie"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -153,6 +154,10 @@ func testAccPreCheck(t *testing.T) {
 	_, err := conn.ListS3Resources(input)
 
 	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if tfawserr.ErrMessageContains(err, macie.ErrCodeInvalidInputException, "Macie is not enabled for this AWS account") {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Previously

```
=== RUN   TestAccMacieS3BucketAssociation_basic
=== PAUSE TestAccMacieS3BucketAssociation_basic
=== CONT  TestAccMacieS3BucketAssociation_basic
s3_bucket_association_test.go:160: unexpected PreCheck error: InvalidInputException: The request was rejected. Macie is not enabled for this AWS account *******.
{
RespMetadata: {
StatusCode: 400,
RequestID: "6e31e249-5419-4680-b5f8-5e4bc63fb878"
},
ErrorCode: "AWS.Macie.Error.MacieNotEnabled",
Message_: "The request was rejected. Macie is not enabled for this AWS account *******."
}
--- FAIL: TestAccMacieS3BucketAssociation_basic (0.89s)
FAIL
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/macie TESTARGS='-run=TestAccMacieMemberAccountAssociation_\|TestAccMacieS3BucketAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/macie/... -v -count 1 -parallel 20 -run=TestAccMacieMemberAccountAssociation_\|TestAccMacieS3BucketAssociation_ -timeout 180m
=== RUN   TestAccMacieMemberAccountAssociation_basic
    member_account_association_test.go:20: Environment variable MACIE_MEMBER_ACCOUNT_ID is not set
--- SKIP: TestAccMacieMemberAccountAssociation_basic (0.00s)
=== RUN   TestAccMacieMemberAccountAssociation_self
=== PAUSE TestAccMacieMemberAccountAssociation_self
=== RUN   TestAccMacieS3BucketAssociation_basic
=== PAUSE TestAccMacieS3BucketAssociation_basic
=== RUN   TestAccMacieS3BucketAssociation_accountIdAndPrefix
=== PAUSE TestAccMacieS3BucketAssociation_accountIdAndPrefix
=== CONT  TestAccMacieMemberAccountAssociation_self
=== CONT  TestAccMacieS3BucketAssociation_accountIdAndPrefix
=== CONT  TestAccMacieS3BucketAssociation_basic
=== CONT  TestAccMacieS3BucketAssociation_accountIdAndPrefix
    s3_bucket_association_test.go:161: skipping acceptance testing: InvalidInputException: The request was rejected. Macie is not enabled for this AWS account 429228330992.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "c6d92b56-6488-49b3-9273-dcc2b735dc45"
          },
          ErrorCode: "AWS.Macie.Error.MacieNotEnabled",
          Message_: "The request was rejected. Macie is not enabled for this AWS account 429228330992."
        }
--- SKIP: TestAccMacieS3BucketAssociation_accountIdAndPrefix (1.37s)
=== CONT  TestAccMacieS3BucketAssociation_basic
    s3_bucket_association_test.go:161: skipping acceptance testing: InvalidInputException: The request was rejected. Macie is not enabled for this AWS account 429228330992.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "7fda9349-8762-48d5-a3f2-d1e7ab28ca8c"
          },
          ErrorCode: "AWS.Macie.Error.MacieNotEnabled",
          Message_: "The request was rejected. Macie is not enabled for this AWS account 429228330992."
        }
--- SKIP: TestAccMacieS3BucketAssociation_basic (1.37s)
=== CONT  TestAccMacieMemberAccountAssociation_self
    s3_bucket_association_test.go:161: skipping acceptance testing: InvalidInputException: The request was rejected. Macie is not enabled for this AWS account 429228330992.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "f4839ba0-4369-4aa9-8f72-0b9e9aea046f"
          },
          ErrorCode: "AWS.Macie.Error.MacieNotEnabled",
          Message_: "The request was rejected. Macie is not enabled for this AWS account 429228330992."
        }
--- SKIP: TestAccMacieMemberAccountAssociation_self (1.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie	4.287s
```
