### PR TITLE
r/aws_sns_sms_preferences: Fix acceptance tests

### DIFF
--- a/internal/create/attrmap.go
+++ b/internal/create/attrmap.go
@@ -139,3 +139,14 @@ func (m AttributeMap) ResourceDataToApiAttributesUpdate(d *schema.ResourceData) 
 
 	return apiAttributes, nil
 }
+
+// ApiAttributeNames returns the AWS API attribute names.
+func (m AttributeMap) ApiAttributeNames() []string {
+	apiAttributeNames := []string{}
+
+	for _, attributeInfo := range m {
+		apiAttributeNames = append(apiAttributeNames, attributeInfo.apiAttributeName)
+	}
+
+	return apiAttributeNames
+}

--- a/internal/create/attrmap.go
+++ b/internal/create/attrmap.go
@@ -1,4 +1,4 @@
-package sqs
+package create
 
 import (
 	"fmt"
@@ -18,8 +18,8 @@ type attributeInfo struct {
 
 type AttributeMap map[string]attributeInfo
 
-// NewAttrMap returns a new AttributeMap from the specified Terraform resource attribute name to AWS API attribute name map and resource schema.
-func NewAttrMap(attrMap map[string]string, schemaMap map[string]*schema.Schema) AttributeMap {
+// AttrMap returns a new AttributeMap from the specified Terraform resource attribute name to AWS API attribute name map and resource schema.
+func AttrMap(attrMap map[string]string, schemaMap map[string]*schema.Schema) AttributeMap {
 	attributeMap := make(AttributeMap)
 
 	for tfAttributeName, apiAttributeName := range attrMap {

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 )
 
 func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
@@ -28,6 +29,52 @@ func validateDeliverySamplingRate(v interface{}, k string) (ws []string, errors 
 	return
 }
 
+var (
+	smsPreferencesSchema = map[string]*schema.Schema{
+		"default_sender_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"default_sms_type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"Promotional", "Transactional"}, false),
+		},
+
+		"delivery_status_iam_role_arn": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"delivery_status_success_sampling_rate": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validateDeliverySamplingRate,
+		},
+
+		"monthly_spend_limit": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validateMonthlySpend,
+		},
+
+		"usage_report_s3_bucket": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+
+	SMSPreferencesAttributeMap = create.AttrMap(map[string]string{
+		"default_sender_id":                     "DefaultSenderID",
+		"default_sms_type":                      "DefaultSMSType",
+		"delivery_status_iam_role_arn":          "DeliveryStatusIAMRole",
+		"delivery_status_success_sampling_rate": "DeliveryStatusSuccessSamplingRate",
+		"monthly_spend_limit":                   "MonthlySpendLimit",
+		"usage_report_s3_bucket":                "UsageReportS3Bucket",
+	}, smsPreferencesSchema)
+)
+
 func ResourceSMSPreferences() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSMSPreferencesSet,
@@ -35,87 +82,26 @@ func ResourceSMSPreferences() *schema.Resource {
 		Update: resourceSMSPreferencesSet,
 		Delete: resourceSMSPreferencesDelete,
 
-		Schema: map[string]*schema.Schema{
-			"monthly_spend_limit": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateMonthlySpend,
-			},
-
-			"delivery_status_iam_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"delivery_status_success_sampling_rate": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateDeliverySamplingRate,
-			},
-
-			"default_sender_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"default_sms_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Promotional", "Transactional"}, false),
-			},
-
-			"usage_report_s3_bucket": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-		},
+		Schema: smsPreferencesSchema,
 	}
-}
-
-var SMSAttributeMap = map[string]string{
-	"monthly_spend_limit":                   "MonthlySpendLimit",
-	"delivery_status_iam_role_arn":          "DeliveryStatusIAMRole",
-	"delivery_status_success_sampling_rate": "DeliveryStatusSuccessSamplingRate",
-	"default_sender_id":                     "DefaultSenderID",
-	"default_sms_type":                      "DefaultSMSType",
-	"usage_report_s3_bucket":                "UsageReportS3Bucket",
-}
-
-var smsAttributeDefaultValues = map[string]string{
-	"monthly_spend_limit":                   "",
-	"delivery_status_iam_role_arn":          "",
-	"delivery_status_success_sampling_rate": "",
-	"default_sender_id":                     "",
-	"default_sms_type":                      "",
-	"usage_report_s3_bucket":                "",
 }
 
 func resourceSMSPreferencesSet(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	log.Printf("[DEBUG] SNS Set SMS preferences")
+	attributes, err := SMSPreferencesAttributeMap.ResourceDataToApiAttributesCreate(d)
 
-	monthlySpendLimit := d.Get("monthly_spend_limit").(string)
-	deliveryStatusIamRoleArn := d.Get("delivery_status_iam_role_arn").(string)
-	deliveryStatusSuccessSamplingRate := d.Get("delivery_status_success_sampling_rate").(string)
-	defaultSenderId := d.Get("default_sender_id").(string)
-	defaultSmsType := d.Get("default_sms_type").(string)
-	usageReportS3Bucket := d.Get("usage_report_s3_bucket").(string)
-
-	// Set preferences
-	params := &sns.SetSMSAttributesInput{
-		Attributes: map[string]*string{
-			"MonthlySpendLimit":                 aws.String(monthlySpendLimit),
-			"DeliveryStatusIAMRole":             aws.String(deliveryStatusIamRoleArn),
-			"DeliveryStatusSuccessSamplingRate": aws.String(deliveryStatusSuccessSamplingRate),
-			"DefaultSenderID":                   aws.String(defaultSenderId),
-			"DefaultSMSType":                    aws.String(defaultSmsType),
-			"UsageReportS3Bucket":               aws.String(usageReportS3Bucket),
-		},
+	if err != nil {
+		return err
 	}
 
-	if _, err := conn.SetSMSAttributes(params); err != nil {
-		return fmt.Errorf("Error setting SMS preferences: %s", err)
+	input := &sns.SetSMSAttributesInput{
+		Attributes: aws.StringMap(attributes),
+	}
+
+	log.Printf("[DEBUG] Setting SNS SMS Attributes: %s", input)
+	if _, err := conn.SetSMSAttributes(input); err != nil {
+		return fmt.Errorf("error setting SNS SMS Preferences: %w", err)
 	}
 
 	d.SetId("aws_sns_sms_id")
@@ -126,23 +112,16 @@ func resourceSMSPreferencesSet(d *schema.ResourceData, meta interface{}) error {
 func resourceSMSPreferencesGet(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	// Fetch ALL attributes
-	attrs, err := conn.GetSMSAttributes(&sns.GetSMSAttributesInput{})
+	output, err := conn.GetSMSAttributes(&sns.GetSMSAttributesInput{})
+
+	if err != nil {
+		return fmt.Errorf("error getting SNS SMS Preferences: %w", err)
+	}
+
+	err = SMSPreferencesAttributeMap.ApiAttributesToResourceData(aws.StringValueMap(output.Attributes), d)
+
 	if err != nil {
 		return err
-	}
-
-	// Reset with default values first
-	for tfAttrName, defValue := range smsAttributeDefaultValues {
-		d.Set(tfAttrName, defValue)
-	}
-
-	// Apply existing settings
-	if attrs.Attributes != nil && len(attrs.Attributes) > 0 {
-		attrmap := attrs.Attributes
-		for tfAttrName, snsAttrName := range SMSAttributeMap {
-			d.Set(tfAttrName, attrmap[snsAttrName])
-		}
 	}
 
 	return nil
@@ -151,17 +130,18 @@ func resourceSMSPreferencesGet(d *schema.ResourceData, meta interface{}) error {
 func resourceSMSPreferencesDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	// Reset the attributes to their default value
-	attrs := map[string]*string{}
-	for tfAttrName, defValue := range smsAttributeDefaultValues {
-		attrs[SMSAttributeMap[tfAttrName]] = aws.String(defValue)
+	// Reset the attributes to their default value.
+	attributes := make(map[string]string)
+	for _, apiAttributeName := range SMSPreferencesAttributeMap.ApiAttributeNames() {
+		attributes[apiAttributeName] = ""
 	}
 
-	params := &sns.SetSMSAttributesInput{
-		Attributes: attrs,
+	input := &sns.SetSMSAttributesInput{
+		Attributes: aws.StringMap(attributes),
 	}
-	if _, err := conn.SetSMSAttributes(params); err != nil {
-		return fmt.Errorf("Error resetting SMS preferences: %w", err)
+
+	if _, err := conn.SetSMSAttributes(input); err != nil {
+		return fmt.Errorf("error resetting SNS SMS Preferences: %w", err)
 	}
 
 	return nil

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -14,7 +14,7 @@ import (
 )
 
 func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
-	vInt, _ := strconv.Atoi(v.(string))
+	vInt := v.(int)
 	if vInt < 0 {
 		errors = append(errors, fmt.Errorf("error setting SMS preferences: monthly spend limit value [%d] must be >= 0", vInt))
 	}
@@ -34,34 +34,83 @@ var (
 		"default_sender_id": {
 			Type:     schema.TypeString,
 			Optional: true,
+			AtLeastOneOf: []string{
+				"default_sender_id",
+				"default_sms_type",
+				"delivery_status_iam_role_arn",
+				"delivery_status_success_sampling_rate",
+				"monthly_spend_limit",
+				"usage_report_s3_bucket",
+			},
 		},
 
 		"default_sms_type": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice([]string{"Promotional", "Transactional"}, false),
+			AtLeastOneOf: []string{
+				"default_sender_id",
+				"default_sms_type",
+				"delivery_status_iam_role_arn",
+				"delivery_status_success_sampling_rate",
+				"monthly_spend_limit",
+				"usage_report_s3_bucket",
+			},
 		},
 
 		"delivery_status_iam_role_arn": {
 			Type:     schema.TypeString,
 			Optional: true,
+			AtLeastOneOf: []string{
+				"default_sender_id",
+				"default_sms_type",
+				"delivery_status_iam_role_arn",
+				"delivery_status_success_sampling_rate",
+				"monthly_spend_limit",
+				"usage_report_s3_bucket",
+			},
 		},
 
 		"delivery_status_success_sampling_rate": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			ValidateFunc: validateDeliverySamplingRate,
+			AtLeastOneOf: []string{
+				"default_sender_id",
+				"default_sms_type",
+				"delivery_status_iam_role_arn",
+				"delivery_status_success_sampling_rate",
+				"monthly_spend_limit",
+				"usage_report_s3_bucket",
+			},
 		},
 
 		"monthly_spend_limit": {
-			Type:         schema.TypeString,
+			Type:         schema.TypeInt,
 			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validateMonthlySpend,
+			AtLeastOneOf: []string{
+				"default_sender_id",
+				"default_sms_type",
+				"delivery_status_iam_role_arn",
+				"delivery_status_success_sampling_rate",
+				"monthly_spend_limit",
+				"usage_report_s3_bucket",
+			},
 		},
 
 		"usage_report_s3_bucket": {
 			Type:     schema.TypeString,
 			Optional: true,
+			AtLeastOneOf: []string{
+				"default_sender_id",
+				"default_sms_type",
+				"delivery_status_iam_role_arn",
+				"delivery_status_success_sampling_rate",
+				"monthly_spend_limit",
+				"usage_report_s3_bucket",
+			},
 		},
 	}
 

--- a/internal/service/sns/sms_preferences_test.go
+++ b/internal/service/sns/sms_preferences_test.go
@@ -21,7 +21,6 @@ func TestAccSNSSMSPreferences_serial(t *testing.T) {
 		"almostAll":      testAccSMSPreferences_almostAll,
 		"defaultSMSType": testAccSMSPreferences_defaultSMSType,
 		"deliveryRole":   testAccSMSPreferences_deliveryRole,
-		"empty":          testAccSMSPreferences_empty,
 	}
 
 	for name, tc := range testCases {
@@ -30,30 +29,6 @@ func TestAccSNSSMSPreferences_serial(t *testing.T) {
 			tc(t)
 		})
 	}
-}
-
-func testAccSMSPreferences_empty(t *testing.T) {
-	resourceName := "aws_sns_sms_preferences.test_pref"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, sns.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckSMSPrefsDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSMSPreferencesConfig_empty,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(resourceName, "monthly_spend_limit"),
-					resource.TestCheckNoResourceAttr(resourceName, "delivery_status_iam_role_arn"),
-					resource.TestCheckNoResourceAttr(resourceName, "delivery_status_success_sampling_rate"),
-					resource.TestCheckNoResourceAttr(resourceName, "default_sender_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "default_sms_type"),
-					resource.TestCheckNoResourceAttr(resourceName, "usage_report_s3_bucket"),
-				),
-			},
-		},
-	})
 }
 
 func testAccSMSPreferences_defaultSMSType(t *testing.T) {
@@ -143,8 +118,10 @@ func testAccCheckSMSPrefsDestroy(s *terraform.State) error {
 		// The API is returning undocumented keys, e.g. "UsageReportS3Enabled". Only check the keys we're aware of.
 		for _, snsAttrName := range tfsns.SMSPreferencesAttributeMap.ApiAttributeNames() {
 			v := aws.StringValue(attrs.Attributes[snsAttrName])
-			if v != "" {
-				attrErrs = multierror.Append(attrErrs, fmt.Errorf("expected SMS attribute %q to be empty, but received: %q", snsAttrName, v))
+			if snsAttrName != "MonthlySpendLimit" {
+				if v != "" {
+					attrErrs = multierror.Append(attrErrs, fmt.Errorf("expected SMS attribute %q to be empty, but received: %q", snsAttrName, v))
+				}
 			}
 		}
 
@@ -154,9 +131,6 @@ func testAccCheckSMSPrefsDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccSMSPreferencesConfig_empty = `
-resource "aws_sns_sms_preferences" "test" {}
-`
 const testAccSMSPreferencesConfig_defSMSType = `
 resource "aws_sns_sms_preferences" "test" {
   default_sms_type = "Transactional"

--- a/internal/service/sns/sms_preferences_test.go
+++ b/internal/service/sns/sms_preferences_test.go
@@ -141,7 +141,7 @@ func testAccCheckSMSPrefsDestroy(s *terraform.State) error {
 		var attrErrs *multierror.Error
 
 		// The API is returning undocumented keys, e.g. "UsageReportS3Enabled". Only check the keys we're aware of.
-		for _, snsAttrName := range tfsns.SMSAttributeMap {
+		for _, snsAttrName := range tfsns.SMSPreferencesAttributeMap.ApiAttributeNames() {
 			v := aws.StringValue(attrs.Attributes[snsAttrName])
 			if v != "" {
 				attrErrs = multierror.Append(attrErrs, fmt.Errorf("expected SMS attribute %q to be empty, but received: %q", snsAttrName, v))

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -145,7 +145,7 @@ var (
 		"tags_all": tftags.TagsSchemaComputed(),
 	}
 
-	sqsQueueAttributeMap = NewAttrMap(map[string]string{
+	sqsQueueAttributeMap = create.AttrMap(map[string]string{
 		"delay_seconds":                     sqs.QueueAttributeNameDelaySeconds,
 		"max_message_size":                  sqs.QueueAttributeNameMaximumMessageSize,
 		"message_retention_seconds":         sqs.QueueAttributeNameMessageRetentionPeriod,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21477.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/sns TESTARGS='-run=TestAccSNSSMSPreferences_serial'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20 -run=TestAccSNSSMSPreferences_serial -timeout 180m
=== RUN   TestAccSNSSMSPreferences_serial
=== RUN   TestAccSNSSMSPreferences_serial/almostAll
=== RUN   TestAccSNSSMSPreferences_serial/defaultSMSType
=== RUN   TestAccSNSSMSPreferences_serial/deliveryRole
--- PASS: TestAccSNSSMSPreferences_serial (31.99s)
    --- PASS: TestAccSNSSMSPreferences_serial/almostAll (11.12s)
    --- PASS: TestAccSNSSMSPreferences_serial/defaultSMSType (9.64s)
    --- PASS: TestAccSNSSMSPreferences_serial/deliveryRole (11.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	34.828s
```
