### PR TITLE
Fix incorrect inputs for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,8 +12,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 720
         days-before-close: 30
-        exempt-issue-label: 'needs-triage'
-        exempt-pr-label: 'needs-triage'
+        exempt-issue-labels: 'needs-triage'
+        exempt-pr-labels: 'needs-triage'
         operations-per-run: 100
         stale-issue-label: 'stale'
         stale-issue-message: |


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Notes

I noticed there were some issues labeled as `needs-triage`, but were being closed by the stale workflow, which should not be happening.

Looking at a [recent run](https://github.com/hashicorp/terraform-provider-aws/actions/runs/1382255163), I noticed two inputs had typos:

> Unexpected input(s) 'exempt-issue-label', 'exempt-pr-label', valid inputs are...

The appropriate values are [`exempt-issue-labels`](https://github.com/actions/stale#exempt-issue-labels) and [`exempt-pr-labels`](https://github.com/actions/stale#exempt-pr-labels), which this PR addresses.