### PR TITLE
service/cloudwatch: tech debt: replace custom validation funcs

### DIFF
--- a/internal/service/cloudwatch/validate.go
+++ b/internal/service/cloudwatch/validate.go
@@ -1,38 +1,14 @@
 package cloudwatch
 
 import (
-	"fmt"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func validDashboardName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 255 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 255 characters: %q", k, value))
-	}
+var validDashboardName = validation.All(
+	validation.StringLenBetween(1, 255),
+	validation.StringMatch(regexp.MustCompile(`^[\-_A-Za-z0-9]+$`), "must contain only alphanumeric characters, underscores and hyphens"),
+)
 
-	// http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutDashboard.html
-	pattern := `^[\-_A-Za-z0-9]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
-	return
-}
-
-func validEC2AutomateARN(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html
-	pattern := `^arn:[\w-]+:automate:[\w-]+:ec2:(reboot|recover|stop|terminate)$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q does not match EC2 automation ARN (%q): %q",
-			k, pattern, value))
-	}
-
-	return
-}
+var validEC2AutomateARN = validation.StringMatch(regexp.MustCompile(`^arn:[\w-]+:automate:[\w-]+:ec2:(reboot|recover|stop|terminate)$`), "must match EC2 automation ARN")

--- a/internal/service/cloudwatchevents/permission.go
+++ b/internal/service/cloudwatchevents/permission.go
@@ -259,39 +259,19 @@ func resourcePermissionDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 // https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html#API_PutPermission_RequestParameters
-func validateCloudWatchEventPermissionAction(v interface{}, k string) (ws []string, es []error) {
-	value := v.(string)
-	if (len(value) < 1) || (len(value) > 64) {
-		es = append(es, fmt.Errorf("%q must be between 1 and 64 characters", k))
-	}
-
-	if !regexp.MustCompile(`^events:[a-zA-Z]+$`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must be: events: followed by one or more alphabetic characters", k))
-	}
-	return
-}
+var validateCloudWatchEventPermissionAction = validation.All(
+	validation.StringLenBetween(1, 64),
+	validation.StringMatch(regexp.MustCompile(`^events:[a-zA-Z]+$`), "must be events: followed by one or more alphanumeric, hyphen, or underscore characters"),
+)
 
 // https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html#API_PutPermission_RequestParameters
-func validateCloudWatchEventPermissionPrincipal(v interface{}, k string) (ws []string, es []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^(\d{12}|\*)$`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must be * or a 12 digit AWS account ID", k))
-	}
-	return
-}
+var validateCloudWatchEventPermissionPrincipal = validation.StringMatch(regexp.MustCompile(`^(\d{12}|\*)$`), "must be * or a 12 digit AWS account ID")
 
 // https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html#API_PutPermission_RequestParameters
-func validateCloudWatchEventPermissionStatementID(v interface{}, k string) (ws []string, es []error) {
-	value := v.(string)
-	if (len(value) < 1) || (len(value) > 64) {
-		es = append(es, fmt.Errorf("%q must be between 1 and 64 characters", k))
-	}
-
-	if !regexp.MustCompile(`^[a-zA-Z0-9-_]+$`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must be one or more alphanumeric, hyphen, or underscore characters", k))
-	}
-	return
-}
+var validateCloudWatchEventPermissionStatementID = validation.All(
+	validation.StringLenBetween(1, 64),
+	validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-_]+$`), "must be one or more alphanumeric, hyphen, or underscore characters"),
+)
 
 // PermissionPolicyDoc represents the Policy attribute of DescribeEventBus
 // See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html

--- a/internal/service/cloudwatchevents/rule.go
+++ b/internal/service/cloudwatchevents/rule.go
@@ -42,7 +42,7 @@ func ResourceRule() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validateCloudWatchEventRuleName,
+				ValidateFunc:  validCloudWatchEventRuleName,
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
@@ -50,7 +50,7 @@ func ResourceRule() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validateCloudWatchEventRuleName,
+				ValidateFunc:  validCloudWatchEventRuleName,
 			},
 			"schedule_expression": {
 				Type:         schema.TypeString,

--- a/internal/service/cloudwatchevents/target.go
+++ b/internal/service/cloudwatchevents/target.go
@@ -51,7 +51,7 @@ func ResourceTarget() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventRuleName,
+				ValidateFunc: validCloudWatchEventRuleName,
 			},
 
 			"target_id": {
@@ -59,7 +59,7 @@ func ResourceTarget() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validateCloudWatchEventTargetId,
+				ValidateFunc: validCloudWatchEventTargetId,
 			},
 
 			"arn": {

--- a/internal/service/cloudwatchevents/validate.go
+++ b/internal/service/cloudwatchevents/validate.go
@@ -9,42 +9,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-func validateCloudWatchEventRuleName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 64 characters: %q", k, value))
-	}
-
-	// http://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutRule.html
-	pattern := `^[\.\-_A-Za-z0-9]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
-	return
-}
-
-func validateCloudWatchEventTargetId(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 64 characters: %q", k, value))
-	}
-
-	// http://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_Target.html
-	pattern := `^[\.\-_A-Za-z0-9]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
-	return
-}
-
 func mapKeysDoNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		m, ok := i.(map[string]interface{})
@@ -90,6 +54,16 @@ var validBusNameOrARN = validation.Any(
 		validation.StringLenBetween(1, 256),
 		validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._\-/]+$`), ""),
 	),
+)
+
+var validCloudWatchEventTargetId = validation.All(
+	validation.StringLenBetween(1, 64),
+	validation.StringMatch(regexp.MustCompile(`^[\.\-_A-Za-z0-9]+$`), "must contain only alphanumeric characters, underscores, periods and hyphens"),
+)
+
+var validCloudWatchEventRuleName = validation.All(
+	validation.StringLenBetween(1, 64),
+	validation.StringMatch(regexp.MustCompile(`^[\.\-_A-Za-z0-9]+$`), "must contain only alphanumeric characters, underscores, periods and hyphens"),
 )
 
 var validCustomEventBusEventSourceName = validation.All(

--- a/internal/service/cloudwatchevents/validate_test.go
+++ b/internal/service/cloudwatchevents/validate_test.go
@@ -130,7 +130,7 @@ func TestValidRuleName(t *testing.T) {
 		"hello.World0125",
 	}
 	for _, v := range validNames {
-		_, errors := validateCloudWatchEventRuleName(v, "name")
+		_, errors := validCloudWatchEventRuleName(v, "name")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid CW event rule name: %q", v, errors)
 		}
@@ -143,7 +143,7 @@ func TestValidRuleName(t *testing.T) {
 		"TooLooooooooooooooooooooooooooooooooooooooooooooooooooooooongName",
 	}
 	for _, v := range invalidNames {
-		_, errors := validateCloudWatchEventRuleName(v, "name")
+		_, errors := validCloudWatchEventRuleName(v, "name")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid CW event rule name", v)
 		}

--- a/internal/service/cloudwatchlogs/validate.go
+++ b/internal/service/cloudwatchlogs/validate.go
@@ -32,6 +32,6 @@ var validLogMetricFilterName = validation.All(
 
 // http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_MetricTransformation.html
 var validLogMetricFilterTransformationName = validation.All(
-	validation.StringLenBetween(1, 255),
-	validation.StringMatch(regexp.MustCompile(`^[^:*]+$`), "must not contain a colon, an asterisk or a dollar sign"),
+	validation.StringLenBetween(0, 255),
+	validation.StringMatch(regexp.MustCompile(`^[^:*$]*$`), "must not contain a colon, an asterisk or a dollar sign"),
 )

--- a/internal/service/cloudwatchlogs/validate.go
+++ b/internal/service/cloudwatchlogs/validate.go
@@ -1,99 +1,37 @@
 package cloudwatchlogs
 
 import (
-	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func validResourcePolicyDocument(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutResourcePolicy.html
-	if len(value) > 5120 || (len(value) == 0) {
-		errors = append(errors, fmt.Errorf("CloudWatch log resource policy document must be between 1 and 5120 characters."))
-	}
-	if _, err := structure.NormalizeJsonString(v); err != nil {
-		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
-	}
-	return
-}
+// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutResourcePolicy.html
+var validResourcePolicyDocument = validation.All(
+	validation.StringLenBetween(1, 5120),
+	validation.StringIsJSON,
+)
 
-func validLogGroupName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
+// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
+var validLogGroupName = validation.All(
+	validation.StringLenBetween(1, 512),
+	validation.StringMatch(regexp.MustCompile(`^[\.\-_/#A-Za-z0-9]+$`), "must contain only alphanumeric characters, underscores, hyphens, slashes, hash signs and periods"),
+)
 
-	if len(value) > 512 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 512 characters: %q", k, value))
-	}
+// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
+var validLogGroupNamePrefix = validation.All(
+	validation.StringLenBetween(1, 483),
+	validation.StringMatch(regexp.MustCompile(`^[\.\-_/#A-Za-z0-9]+$`), "must contain only alphanumeric characters, underscores, hyphens, slashes, hash signs and periods"),
+)
 
-	// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
-	pattern := `^[\.\-_/#A-Za-z0-9]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q isn't a valid log group name (alphanumeric characters, underscores,"+
-				" hyphens, slashes, hash signs and dots are allowed): %q",
-			k, value))
-	}
+// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutMetricFilter.html
+var validLogMetricFilterName = validation.All(
+	validation.StringLenBetween(1, 512),
+	validation.StringMatch(regexp.MustCompile(`^[^:*]+$`), "must not contain a colon or an asterisk"),
+)
 
-	return
-}
-
-func validLogGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if len(value) > 483 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 483 characters: %q", k, value))
-	}
-
-	// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
-	pattern := `^[\.\-_/#A-Za-z0-9]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q isn't a valid log group name (alphanumeric characters, underscores,"+
-				" hyphens, slashes, hash signs and dots are allowed): %q",
-			k, value))
-	}
-
-	return
-}
-
-func validLogMetricFilterName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if len(value) > 512 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 512 characters: %q", k, value))
-	}
-
-	// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutMetricFilter.html
-	pattern := `^[^:*]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q isn't a valid log metric name (must not contain colon nor asterisk): %q",
-			k, value))
-	}
-
-	return
-}
-
-func validLogMetricFilterTransformationName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if len(value) > 255 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 255 characters: %q", k, value))
-	}
-
-	// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_MetricTransformation.html
-	pattern := `^[^:*$]*$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q isn't a valid log metric transformation name (must not contain"+
-				" colon, asterisk nor dollar sign): %q",
-			k, value))
-	}
-
-	return
-}
+// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_MetricTransformation.html
+var validLogMetricFilterTransformationName = validation.All(
+	validation.StringLenBetween(1, 255),
+	validation.StringMatch(regexp.MustCompile(`^[^:*]+$`), "must not contain a colon, an asterisk or a dollar sign"),
+)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11872

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccCloudWatch' PKG_NAME=internal/services/cloudwatch
--- PASS: TestAccCloudWatchMetricAlarm_missingStatistic (42.47s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (66.72s)
--- PASS: TestAccCloudWatchCompositeAlarm_basic (75.11s)
--- PASS: TestAccCloudWatchMetricAlarm_extendedStatistic (31.84s)
--- PASS: TestAccCloudWatchMetricAlarm_basic (135.34s)
--- PASS: TestAccCloudWatchMetricAlarm_disappears (135.95s)
--- PASS: TestAccCloudWatchMetricAlarm_dataPointsToAlarm (139.50s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_swfAction (147.34s)
--- PASS: TestAccCloudWatchMetricStream_tags (148.08s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (148.21s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic (148.26s)
--- PASS: TestAccCloudWatchMetricStream_noName (148.51s)
--- PASS: TestAccCloudWatchMetricStream_includeFilters (155.81s)
--- PASS: TestAccCloudWatchDashboard_updateName (125.90s)
--- PASS: TestAccCloudWatchCompositeAlarm_updateAlarmRule (171.08s)
--- PASS: TestAccCloudWatchDashboard_basic (36.58s)
--- PASS: TestAccCloudWatchCompositeAlarm_description (172.65s)
--- PASS: TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (99.24s)
--- PASS: TestAccCloudWatchMetricAlarm_tags (189.71s)
--- PASS: TestAccCloudWatchMetricAlarm_treatMissingData (97.24s)
--- PASS: TestAccCloudWatchCompositeAlarm_disappears (57.65s)
--- PASS: TestAccCloudWatchMetricStream_update (211.86s)
--- PASS: TestAccCloudWatchDashboard_update (73.96s)
--- PASS: TestAccCloudWatchCompositeAlarm_actionsEnabled (87.83s)
--- PASS: TestAccCloudWatchCompositeAlarm_allActions (87.93s)
--- PASS: TestAccCloudWatchCompositeAlarm_okActions (89.85s)
--- PASS: TestAccCloudWatchMetricStream_basic (247.50s)
--- PASS: TestAccCloudWatchCompositeAlarm_alarmActions (111.85s)
--- PASS: TestAccCloudWatchMetricAlarm_expression (252.90s)
--- PASS: TestAccCloudWatchCompositeAlarm_insufficientDataActions (110.60s)
--- PASS: TestAccCloudWatchMetricStream_updateName (302.91s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate (397.74s)
```

Nice to be back working on some of the linter technical debt again - no doubt more might need doing than last time I looked, so using the output of `make providerlint` to track down changes for future PRs.