### PR TITLE
r/aws_athena_database: remove ForceNew from bucket field

### DIFF
--- a/.changelog/21491.txt
+++ b/.changelog/21491.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_athena_database: Remove ForceNew from bucket field.
+```

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -31,7 +31,6 @@ func ResourceDatabase() *schema.Resource {
 			"bucket": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"force_destroy": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Why?

The `ForceNew: true` is specified in the bucket field of `aws_athena_database`. But there is no need for the resource to be recreated when the bucket field is changed, since the bucket field is only used to store the query results during database creation & deletion.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAthenaDatabase_' PKG_NAME=internal/service/athena
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/athena/... -v -count 1 -parallel 20 -run=TestAccAthenaDatabase_ -timeout 180m
=== RUN   TestAccAthenaDatabase_basic
=== PAUSE TestAccAthenaDatabase_basic
=== RUN   TestAccAthenaDatabase_encryption
=== PAUSE TestAccAthenaDatabase_encryption
=== RUN   TestAccAthenaDatabase_nameStartsWithUnderscore
=== PAUSE TestAccAthenaDatabase_nameStartsWithUnderscore
=== RUN   TestAccAthenaDatabase_nameCantHaveUppercase
=== PAUSE TestAccAthenaDatabase_nameCantHaveUppercase
=== RUN   TestAccAthenaDatabase_destroyFailsIfTablesExist
=== PAUSE TestAccAthenaDatabase_destroyFailsIfTablesExist
=== RUN   TestAccAthenaDatabase_forceDestroyAlwaysSucceeds
=== PAUSE TestAccAthenaDatabase_forceDestroyAlwaysSucceeds
=== CONT  TestAccAthenaDatabase_basic
=== CONT  TestAccAthenaDatabase_destroyFailsIfTablesExist
=== CONT  TestAccAthenaDatabase_nameCantHaveUppercase
=== CONT  TestAccAthenaDatabase_nameStartsWithUnderscore
=== CONT  TestAccAthenaDatabase_encryption
=== CONT  TestAccAthenaDatabase_forceDestroyAlwaysSucceeds
--- PASS: TestAccAthenaDatabase_nameCantHaveUppercase (3.94s)
--- PASS: TestAccAthenaDatabase_nameStartsWithUnderscore (57.61s)
--- PASS: TestAccAthenaDatabase_basic (57.64s)
--- PASS: TestAccAthenaDatabase_forceDestroyAlwaysSucceeds (62.24s)
--- PASS: TestAccAthenaDatabase_encryption (63.03s)
--- PASS: TestAccAthenaDatabase_destroyFailsIfTablesExist (71.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena    73.794s
```
