### PR TITLE
r/aws_synthetics_canary: Increase IAM role propagation wait time on Create

### DIFF
--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -283,10 +283,12 @@ func resourceCanaryCreate(d *schema.ResourceData, meta interface{}) error {
 	// operation. The goal is only retry these types of errors up to the IAM
 	// timeout. Since the creation process is asynchronous and can take up to
 	// its own timeout, we store a stop time upfront for checking.
-	iamwaiterStopTime := time.Now().Add(tfiam.PropagationTimeout)
+	// Real-life experience shows that double the standard IAM propagation time is required.
+	iamPropagationTimeout := tfiam.PropagationTimeout * 2
+	iamwaiterStopTime := time.Now().Add(iamPropagationTimeout)
 
 	_, err = tfresource.RetryWhen(
-		tfiam.PropagationTimeout+canaryCreatedTimeout,
+		iamPropagationTimeout+canaryCreatedTimeout,
 		func() (interface{}, error) {
 			return waitCanaryReady(conn, d.Id())
 		},

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -674,6 +674,17 @@ resource "aws_iam_role_policy" "test" {
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": [
+        "*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21394.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSyntheticsCanary_' PKG_NAME=internal/service/synthetics
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/synthetics/... -v -count 1 -parallel 20 -run=TestAccSyntheticsCanary_ -timeout 180m
=== RUN   TestAccSyntheticsCanary_basic
=== PAUSE TestAccSyntheticsCanary_basic
=== RUN   TestAccSyntheticsCanary_runtimeVersion
=== PAUSE TestAccSyntheticsCanary_runtimeVersion
=== RUN   TestAccSyntheticsCanary_startCanary
=== PAUSE TestAccSyntheticsCanary_startCanary
=== RUN   TestAccSyntheticsCanary_StartCanary_codeChanges
=== PAUSE TestAccSyntheticsCanary_StartCanary_codeChanges
=== RUN   TestAccSyntheticsCanary_s3
=== PAUSE TestAccSyntheticsCanary_s3
=== RUN   TestAccSyntheticsCanary_run
=== PAUSE TestAccSyntheticsCanary_run
=== RUN   TestAccSyntheticsCanary_runTracing
=== PAUSE TestAccSyntheticsCanary_runTracing
=== RUN   TestAccSyntheticsCanary_vpc
=== PAUSE TestAccSyntheticsCanary_vpc
=== RUN   TestAccSyntheticsCanary_tags
=== PAUSE TestAccSyntheticsCanary_tags
=== RUN   TestAccSyntheticsCanary_disappears
=== PAUSE TestAccSyntheticsCanary_disappears
=== CONT  TestAccSyntheticsCanary_basic
=== CONT  TestAccSyntheticsCanary_runTracing
=== CONT  TestAccSyntheticsCanary_s3
=== CONT  TestAccSyntheticsCanary_disappears
=== CONT  TestAccSyntheticsCanary_StartCanary_codeChanges
=== CONT  TestAccSyntheticsCanary_tags
=== CONT  TestAccSyntheticsCanary_run
=== CONT  TestAccSyntheticsCanary_vpc
=== CONT  TestAccSyntheticsCanary_startCanary
=== CONT  TestAccSyntheticsCanary_runtimeVersion
=== CONT  TestAccSyntheticsCanary_vpc
--- PASS: TestAccSyntheticsCanary_disappears (61.67s)
--- PASS: TestAccSyntheticsCanary_s3 (67.47s)
--- PASS: TestAccSyntheticsCanary_runtimeVersion (108.96s)
--- PASS: TestAccSyntheticsCanary_basic (114.07s)
--- PASS: TestAccSyntheticsCanary_startCanary (116.67s)
--- PASS: TestAccSyntheticsCanary_tags (122.47s)
--- PASS: TestAccSyntheticsCanary_run (136.06s)
--- PASS: TestAccSyntheticsCanary_StartCanary_codeChanges (154.18s)
--- PASS: TestAccSyntheticsCanary_runTracing (160.41s)
--- PASS: TestAccSyntheticsCanary_vpc (2144.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	2147.246s
```
