### PR TITLE
Added index check for parsing record ID to avoid panic

### DIFF
--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -983,7 +983,9 @@ func ParseRecordID(id string) [4]string {
 		if firstUnderscore == 0 {
 			firstUnderscore = strings.Index(parts[1][1:], "_") + 1
 		}
-		recName, recType = parts[1][0:firstUnderscore], parts[1][firstUnderscore+1:]
+		if firstUnderscore != -1 {
+			recName, recType = parts[1][0:firstUnderscore], parts[1][firstUnderscore+1:]
+		}
 		if !r53ValidRecordTypes.MatchString(recType) {
 			firstUnderscore = strings.Index(recType, "_")
 			if firstUnderscore != -1 {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -87,6 +87,8 @@ func TestParseRecordId(t *testing.T) {
 	cases := []struct {
 		Input, Zone, Name, Type, Set string
 	}{
+		{"ABCDEF", "", "", "", ""},
+		{"ABCDEF_test.example.com", "ABCDEF", "", "", ""},
 		{"ABCDEF_test.example.com_A", "ABCDEF", "test.example.com", "A", ""},
 		{"ABCDEF_test.example.com._A", "ABCDEF", "test.example.com", "A", ""},
 		{"ABCDEF_test.example.com_A_set1", "ABCDEF", "test.example.com", "A", "set1"},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
### Why

When specifying wrong format for the recordID, the panic occurs. The index check is not enough. This fix avoids panic, and instead return the empty string value, so that caller can handle error properly.

I encountered the panic as follows, so I added the if condition to avoid the panic to fix this.
```
Stack trace from the terraform-provider-aws_v3.63.0_x5 plugin:

✗ terraform import aws_route53_record.example ZONEID_example.com

panic: runtime error: slice bounds out of range [:-1]

goroutine 90 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.parseRecordId(0xc000336ab0, 0x24, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/hashicorp/terraform-provider-aws/aws/resource_aws_route53_record.go:976 +0x4d2
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsRoute53RecordRead(0xc00014fd80, 0x74553e0, 0xc001766000, 0xca078f0, 0xc0006d4000)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/hashicorp/terraform-provider-aws/aws/resource_aws_route53_record.go:515 +0x1b57
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000c4db20, 0x8f161a8, 0xc002303100, 0xc00014fd80, 0x74553e0, 0xc001766000, 0x0, 0x0, 0x0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/resource.go:335 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000c4db20, 0x8f161a8, 0xc002303100, 0xc0022da850, 0x74553e0, 0xc001766000, 0xc000114880, 0x0, 0x0, 0x0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/resource.go:624 +0x1cb
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc00000c870, 0x8f161a8, 0xc002303100, 0xc002303140, 0xc002303100, 0x100b665, 0x7ddaba0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/grpc_provider.go:575 +0x43b
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadResource(0xc0020e5600, 0x8f16250, 0xc002303100, 0xc001262c00, 0xc0020e5600, 0xc0016098c0, 0xc0006ecba0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:298 +0x105
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0x80d3a00, 0xc0020e5600, 0x8f16250, 0xc0016098c0, 0xc001262b40, 0x0, 0x8f16250, 0xc0016098c0, 0xc0001b8b00, 0x14e)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002b5a40, 0x8f3a098, 0xc0006d6300, 0xc0022faa00, 0xc000d80810, 0xc9c6190, 0x0, 0x0, 0x0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc0002b5a40, 0x8f3a098, 0xc0006d6300, 0xc0022faa00, 0x0)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc000864260, 0xc0002b5a40, 0x8f3a098, 0xc0006d6300, 0xc0022faa00)
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
    /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd

Error: The terraform-provider-aws_v3.63.0_x5 plugin crashed!
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccRoute53Record_basic' PKG_NAME=internal/service/route53
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run=TestAccRoute53Record_basic -timeout 180m
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== CONT  TestAccRoute53Record_basic
--- PASS: TestAccRoute53Record_basic (169.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	171.549s
```
