### PR TITLE
New resource for Appstream Directory Config

### DIFF
--- a/.changelog/21505.txt
+++ b/.changelog/21505.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_appstream_directory_config
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -782,9 +782,10 @@ func Provider() *schema.Provider {
 			"aws_apprunner_custom_domain_association":          apprunner.ResourceCustomDomainAssociation(),
 			"aws_apprunner_service":                            apprunner.ResourceService(),
 
-			"aws_appstream_fleet":         appstream.ResourceFleet(),
-			"aws_appstream_image_builder": appstream.ResourceImageBuilder(),
-			"aws_appstream_stack":         appstream.ResourceStack(),
+			"aws_appstream_directory_config": appstream.ResourceDirectoryConfig(),
+			"aws_appstream_fleet":            appstream.ResourceFleet(),
+			"aws_appstream_image_builder":    appstream.ResourceImageBuilder(),
+			"aws_appstream_stack":            appstream.ResourceStack(),
 
 			"aws_appsync_api_key":     appsync.ResourceAPIKey(),
 			"aws_appsync_datasource":  appsync.ResourceDataSource(),

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -76,10 +76,9 @@ func resourceDirectoryConfigCreate(ctx context.Context, d *schema.ResourceData, 
 		ServiceAccountCredentials:            expandServiceAccountCredentials(d.Get("service_account_credentials").([]interface{})),
 	}
 
-	var err error
 	var output *appstream.CreateDirectoryConfigOutput
-	err = resource.RetryContext(ctx, directoryConfigTimeout, func() *resource.RetryError {
-		output, err = conn.CreateDirectoryConfigWithContext(ctx, input)
+	err := resource.RetryContext(ctx, directoryConfigTimeout, func() *resource.RetryError {
+		out, err := conn.CreateDirectoryConfigWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
 				return resource.RetryableError(err)
@@ -87,6 +86,7 @@ func resourceDirectoryConfigCreate(ctx context.Context, d *schema.ResourceData, 
 
 			return resource.NonRetryableError(err)
 		}
+		output = out
 
 		return nil
 	})

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -78,11 +78,11 @@ func resourceDirectoryConfigCreate(ctx context.Context, d *schema.ResourceData, 
 
 	output, err := conn.CreateDirectoryConfigWithContext(ctx, input)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating Appstream DirectoryConfig (%s): %w", directoryName, err))
+		return diag.FromErr(fmt.Errorf("error creating AppStream Directory Config (%s): %w", directoryName, err))
 	}
 
 	if output == nil || output.DirectoryConfig == nil {
-		return diag.Errorf("error creating AppStream DirectoryConfig (%s): empty response", directoryName)
+		return diag.Errorf("error creating AppStream Directory Config (%s): empty response", directoryName)
 	}
 
 	d.SetId(aws.StringValue(output.DirectoryConfig.DirectoryName))
@@ -96,21 +96,21 @@ func resourceDirectoryConfigRead(ctx context.Context, d *schema.ResourceData, me
 	resp, err := conn.DescribeDirectoryConfigsWithContext(ctx, &appstream.DescribeDirectoryConfigsInput{DirectoryNames: []*string{aws.String(d.Id())}})
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
-		log.Printf("[WARN] Appstream DirectoryConfig (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] AppStream Directory Config (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error reading Appstream DirectoryConfig (%s): %w", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error reading AppStream Directory Config (%s): %w", d.Id(), err))
 	}
 
 	if len(resp.DirectoryConfigs) == 0 {
-		return diag.FromErr(fmt.Errorf("error reading Appstream DirectoryConfig (%s): %s", d.Id(), "empty response"))
+		return diag.FromErr(fmt.Errorf("error reading AppStream Directory Config (%s): %s", d.Id(), "empty response"))
 	}
 
 	if len(resp.DirectoryConfigs) > 1 {
-		return diag.FromErr(fmt.Errorf("error reading Appstream DirectoryConfig (%s): %s", d.Id(), "multiple directories config found"))
+		return diag.FromErr(fmt.Errorf("error reading AppStream Directory Config (%s): %s", d.Id(), "multiple Directory Configs found"))
 	}
 
 	directoryConfig := resp.DirectoryConfigs[0]
@@ -120,7 +120,7 @@ func resourceDirectoryConfigRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("organizational_unit_distinguished_names", flex.FlattenStringSet(directoryConfig.OrganizationalUnitDistinguishedNames))
 
 	if err = d.Set("service_account_credentials", flattenServiceAccountCredentials(directoryConfig.ServiceAccountCredentials, d)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream DirectoryConfig (%s): %w", "service_account_credentials", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream Directory Config (%s): %w", "service_account_credentials", d.Id(), err))
 	}
 
 	return nil
@@ -142,7 +142,7 @@ func resourceDirectoryConfigUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	_, err := conn.UpdateDirectoryConfigWithContext(ctx, input)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error updating Appstream DirectoryConfig (%s): %w", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error updating AppStream Directory Config (%s): %w", d.Id(), err))
 	}
 
 	return resourceDirectoryConfigRead(ctx, d, meta)
@@ -159,7 +159,7 @@ func resourceDirectoryConfigDelete(ctx context.Context, d *schema.ResourceData, 
 		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.FromErr(fmt.Errorf("error deleting Appstream DirectoryConfig (%s): %w", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("error deleting AppStream Directory Config (%s): %w", d.Id(), err))
 	}
 	return nil
 }

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -1,0 +1,205 @@
+package appstream
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appstream"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceDirectoryConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceDirectoryConfigCreate,
+		ReadWithoutTimeout:   resourceDirectoryConfigRead,
+		UpdateWithoutTimeout: resourceDirectoryConfigUpdate,
+		DeleteWithoutTimeout: resourceDirectoryConfigDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"directory_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"organizational_unit_distinguished_names": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(0, 2000),
+				},
+				Set: schema.HashString,
+			},
+			"service_account_credentials": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"account_password": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceDirectoryConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppStreamConn
+	input := &appstream.CreateDirectoryConfigInput{
+		DirectoryName:                        aws.String(d.Get("directory_name").(string)),
+		OrganizationalUnitDistinguishedNames: flex.ExpandStringSet(d.Get("organizational_unit_distinguished_names").(*schema.Set)),
+		ServiceAccountCredentials:            expandServiceAccountCredentials(d.Get("service_account_credentials").([]interface{})),
+	}
+
+	var err error
+	var output *appstream.CreateDirectoryConfigOutput
+	err = resource.RetryContext(ctx, directoryConfigTimeout, func() *resource.RetryError {
+		output, err = conn.CreateDirectoryConfigWithContext(ctx, input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateDirectoryConfigWithContext(ctx, input)
+	}
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating Appstream DirectoryConfig (%s): %w", d.Id(), err))
+	}
+
+	d.SetId(aws.StringValue(output.DirectoryConfig.DirectoryName))
+
+	return resourceDirectoryConfigRead(ctx, d, meta)
+}
+
+func resourceDirectoryConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppStreamConn
+
+	resp, err := conn.DescribeDirectoryConfigsWithContext(ctx, &appstream.DescribeDirectoryConfigsInput{DirectoryNames: []*string{aws.String(d.Id())}})
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Appstream DirectoryConfig (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error reading Appstream DirectoryConfig (%s): %w", d.Id(), err))
+	}
+
+	if len(resp.DirectoryConfigs) == 0 {
+		return diag.FromErr(fmt.Errorf("error reading Appstream DirectoryConfig (%s): %s", d.Id(), "empty response"))
+	}
+
+	if len(resp.DirectoryConfigs) > 1 {
+		return diag.FromErr(fmt.Errorf("error reading Appstream DirectoryConfig (%s): %s", d.Id(), "multiple directories config found"))
+	}
+
+	directoryConfig := resp.DirectoryConfigs[0]
+
+	d.Set("created_time", aws.TimeValue(directoryConfig.CreatedTime).Format(time.RFC3339))
+	d.Set("directory_name", directoryConfig.DirectoryName)
+	d.Set("organizational_unit_distinguished_names", flex.FlattenStringSet(directoryConfig.OrganizationalUnitDistinguishedNames))
+
+	if err = d.Set("service_account_credentials", flattenServiceAccountCredentials(directoryConfig.ServiceAccountCredentials, d)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream DirectoryConfig (%s): %w", "service_account_credentials", d.Id(), err))
+	}
+
+	return nil
+}
+
+func resourceDirectoryConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppStreamConn
+	input := &appstream.UpdateDirectoryConfigInput{
+		DirectoryName: aws.String(d.Id()),
+	}
+
+	if d.HasChange("organizational_unit_distinguished_names") {
+		input.OrganizationalUnitDistinguishedNames = flex.ExpandStringSet(d.Get("organizational_unit_distinguished_names").(*schema.Set))
+	}
+
+	if d.HasChange("service_account_credentials") {
+		input.ServiceAccountCredentials = expandServiceAccountCredentials(d.Get("service_account_credentials").([]interface{}))
+	}
+
+	_, err := conn.UpdateDirectoryConfigWithContext(ctx, input)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating Appstream DirectoryConfig (%s): %w", d.Id(), err))
+	}
+
+	return resourceDirectoryConfigRead(ctx, d, meta)
+}
+
+func resourceDirectoryConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppStreamConn
+
+	_, err := conn.DeleteDirectoryConfigWithContext(ctx, &appstream.DeleteDirectoryConfigInput{
+		DirectoryName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("error deleting Appstream DirectoryConfig (%s): %w", d.Id(), err))
+	}
+	return nil
+}
+
+func expandServiceAccountCredentials(tfList []interface{}) *appstream.ServiceAccountCredentials {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	attr := tfList[0].(map[string]interface{})
+
+	apiObject := &appstream.ServiceAccountCredentials{
+		AccountName:     aws.String(attr["account_name"].(string)),
+		AccountPassword: aws.String(attr["account_password"].(string)),
+	}
+
+	return apiObject
+}
+
+func flattenServiceAccountCredentials(apiObject *appstream.ServiceAccountCredentials, d *schema.ResourceData) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfList := map[string]interface{}{}
+	tfList["account_name"] = aws.StringValue(apiObject.AccountName)
+	tfList["account_password"] = d.Get("service_account_credentials.0.account_password").(string)
+
+	return []interface{}{tfList}
+}

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -102,7 +102,7 @@ func testAccCheckDirectoryConfigExists(resourceName string, appStreamDirectoryCo
 		}
 
 		if resp == nil && len(resp.DirectoryConfigs) == 0 {
-			return fmt.Errorf("appstream directory config %q does not exist", rs.Primary.ID)
+			return fmt.Errorf("AppStream Directory Config %q does not exist", rs.Primary.ID)
 		}
 
 		*appStreamDirectoryConfig = *resp.DirectoryConfigs[0]
@@ -130,7 +130,7 @@ func testAccCheckDirectoryConfigDestroy(s *terraform.State) error {
 		}
 
 		if resp != nil && len(resp.DirectoryConfigs) > 0 {
-			return fmt.Errorf("appstream directory config %q still exists", rs.Primary.ID)
+			return fmt.Errorf("AppStream Directory Config %q still exists", rs.Primary.ID)
 		}
 	}
 

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -25,10 +25,7 @@ func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
 	rPasswordUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckHasIAMRole(t, "AmazonAppStreamServiceAccess")
-		},
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDirectoryConfigDestroy,
 		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
@@ -49,11 +46,10 @@ func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
 					resource.TestCheckResourceAttr(resourceName, "directory_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.0.account_name", rUserNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.0.account_password", rPasswordUpdated),
-
-					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 				),
 			},
 			{
@@ -74,10 +70,7 @@ func TestAccAppStreamDirectoryConfig_disappears(t *testing.T) {
 	rPassword := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckHasIAMRole(t, "AmazonAppStreamServiceAccess")
-		},
+		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDirectoryConfigDestroy,
 		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -174,8 +174,8 @@ resource "aws_directory_service_directory" "test" {
 resource "aws_appstream_directory_config" "test" {
   directory_name                          = %[1]q
   organizational_unit_distinguished_names = [aws_directory_service_directory.test.id]
-  
-  service_account_credentials{
+
+  service_account_credentials {
     account_name     = %[2]q
     account_password = %[3]q
   }

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -225,7 +225,7 @@ resource "aws_appstream_directory_config" "test" {
   }
 
   depends_on = [
-	aws_directory_service_directory.test
+    aws_directory_service_directory.test
   ]
 }
 
@@ -257,7 +257,7 @@ resource "aws_appstream_directory_config" "test" {
   }
 
   depends_on = [
-	aws_directory_service_directory.test
+    aws_directory_service_directory.test
   ]
 }
 

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -86,6 +86,7 @@ func TestAccAppStreamDirectoryConfig_disappears(t *testing.T) {
 		},
 	})
 }
+
 func testAccCheckDirectoryConfigExists(resourceName string, appStreamDirectoryConfig *appstream.DirectoryConfig) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -147,6 +148,7 @@ data "aws_organizations_organizational_units" "test" {
 resource "aws_appstream_directory_config" "test" {
   directory_name                          = %[1]q
   organizational_unit_distinguished_names = data.aws_organizations_organizational_units.test.children.*.id
+  
   service_account_credentials{
     account_name     = %[2]q
     account_password = %[3]q

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -1,0 +1,156 @@
+package appstream_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appstream"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfappstream "github.com/hashicorp/terraform-provider-aws/internal/service/appstream"
+)
+
+func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
+	var directoryOutput appstream.DirectoryConfig
+	resourceName := "aws_appstream_directory_config.test"
+	rName := acctest.RandomDomainName()
+	rUserName := fmt.Sprintf("%s\\%s", rName, sdkacctest.RandString(10))
+	rPassword := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rUserNameUpdated := fmt.Sprintf("%s\\%s", rName, sdkacctest.RandString(10))
+	rPasswordUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckHasIAMRole(t, "AmazonAppStreamServiceAccess")
+		},
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDirectoryConfigDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryConfigConfig(rName, rUserName, rPassword),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+				),
+			},
+			{
+				Config: testAccDirectoryConfigConfig(rName, rUserNameUpdated, rPasswordUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", rName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_account_credentials.0.account_password"},
+			},
+		},
+	})
+}
+
+func TestAccAppStreamDirectoryConfig_disappears(t *testing.T) {
+	var directoryOutput appstream.DirectoryConfig
+	resourceName := "aws_appstream_directory_config.test"
+	rName := acctest.RandomDomainName()
+	rUserName := fmt.Sprintf("%s\\%s", rName, sdkacctest.RandString(10))
+	rPassword := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckHasIAMRole(t, "AmazonAppStreamServiceAccess")
+		},
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDirectoryConfigDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryConfigConfig(rName, rUserName, rPassword),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
+					acctest.CheckResourceDisappears(acctest.Provider, tfappstream.ResourceDirectoryConfig(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+func testAccCheckDirectoryConfigExists(resourceName string, appStreamDirectoryConfig *appstream.DirectoryConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppStreamConn
+		resp, err := conn.DescribeDirectoryConfigs(&appstream.DescribeDirectoryConfigsInput{DirectoryNames: []*string{aws.String(rs.Primary.ID)}})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil && len(resp.DirectoryConfigs) == 0 {
+			return fmt.Errorf("appstream directory config %q does not exist", rs.Primary.ID)
+		}
+
+		*appStreamDirectoryConfig = *resp.DirectoryConfigs[0]
+
+		return nil
+	}
+}
+
+func testAccCheckDirectoryConfigDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AppStreamConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_appstream_directory_config" {
+			continue
+		}
+
+		resp, err := conn.DescribeDirectoryConfigs(&appstream.DescribeDirectoryConfigsInput{DirectoryNames: []*string{aws.String(rs.Primary.ID)}})
+
+		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if resp != nil && len(resp.DirectoryConfigs) > 0 {
+			return fmt.Errorf("appstream directory config %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccDirectoryConfigConfig(name, userName, password string) string {
+	return fmt.Sprintf(`
+data "aws_organizations_organization" "test" {}
+
+data "aws_organizations_organizational_units" "test" {
+  parent_id = data.aws_organizations_organization.test.roots[0].id
+}
+
+resource "aws_appstream_directory_config" "test" {
+  directory_name                          = %[1]q
+  organizational_unit_distinguished_names = data.aws_organizations_organizational_units.test.children.*.id
+  service_account_credentials{
+    account_name     = %[2]q
+    account_password = %[3]q
+  }
+}
+`, name, userName, password)
+}

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -167,7 +167,7 @@ resource "aws_directory_service_directory" "test" {
 
   vpc_settings {
     vpc_id     = aws_vpc.test.id
-    subnet_ids = aws_subnet.test.*.id
+    subnet_ids = aws_subnet.test[*].id
   }
 }
 

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -2,6 +2,7 @@ package appstream_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -16,13 +17,14 @@ import (
 )
 
 func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
-	var directoryOutput appstream.DirectoryConfig
+	var v1, v2 appstream.DirectoryConfig
 	resourceName := "aws_appstream_directory_config.test"
-	rName := acctest.RandomDomainName()
-	rUserName := fmt.Sprintf("%s\\%s", rName, sdkacctest.RandString(10))
+	domain := acctest.RandomDomainName()
+	rUserName := fmt.Sprintf("%s\\%s", domain, sdkacctest.RandString(10))
 	rPassword := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rUserNameUpdated := fmt.Sprintf("%s\\%s", rName, sdkacctest.RandString(10))
+	rUserNameUpdated := fmt.Sprintf("%s\\%s", domain, sdkacctest.RandString(10))
 	rPasswordUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	orgUnitDN := orgUnitFromDomain("Test", domain)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -31,23 +33,28 @@ func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDirectoryConfigConfig(rName, rUserName, rPassword),
+				Config: testAccDirectoryConfigConfig(domain, rUserName, rPassword, orgUnitDN),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
-					resource.TestCheckResourceAttr(resourceName, "directory_name", rName),
+					testAccCheckDirectoryConfigExists(resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", domain),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.0", orgUnitDN),
+					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.0.account_name", rUserName),
 					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.0.account_password", rPassword),
 				),
 			},
 			{
-				Config: testAccDirectoryConfigConfig(rName, rUserNameUpdated, rPasswordUpdated),
+				Config: testAccDirectoryConfigConfig(domain, rUserNameUpdated, rPasswordUpdated, orgUnitDN),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
-					resource.TestCheckResourceAttr(resourceName, "directory_name", rName),
+					testAccCheckDirectoryConfigExists(resourceName, &v2),
+					testAccCheckDirectoryConfigNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", domain),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.0", orgUnitDN),
+					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.0.account_name", rUserNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "service_account_credentials.0.account_password", rPasswordUpdated),
 				),
@@ -63,11 +70,12 @@ func TestAccAppStreamDirectoryConfig_basic(t *testing.T) {
 }
 
 func TestAccAppStreamDirectoryConfig_disappears(t *testing.T) {
-	var directoryOutput appstream.DirectoryConfig
+	var v appstream.DirectoryConfig
 	resourceName := "aws_appstream_directory_config.test"
-	rName := acctest.RandomDomainName()
-	rUserName := fmt.Sprintf("%s\\%s", rName, sdkacctest.RandString(10))
+	domain := acctest.RandomDomainName()
+	rUserName := fmt.Sprintf("%s\\%s", domain, sdkacctest.RandString(10))
 	rPassword := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	orgUnitDN := orgUnitFromDomain("Test", domain)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -76,12 +84,59 @@ func TestAccAppStreamDirectoryConfig_disappears(t *testing.T) {
 		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDirectoryConfigConfig(rName, rUserName, rPassword),
+				Config: testAccDirectoryConfigConfig(domain, rUserName, rPassword, orgUnitDN),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDirectoryConfigExists(resourceName, &directoryOutput),
+					testAccCheckDirectoryConfigExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappstream.ResourceDirectoryConfig(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAppStreamDirectoryConfig_OrganizationalUnitDistinguishedNames(t *testing.T) {
+	var v1, v2, v3 appstream.DirectoryConfig
+	resourceName := "aws_appstream_directory_config.test"
+	domain := acctest.RandomDomainName()
+	rUserName := fmt.Sprintf("%s\\%s", domain, sdkacctest.RandString(10))
+	rPassword := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	orgUnitDN1 := orgUnitFromDomain("One", domain)
+	orgUnitDN2 := orgUnitFromDomain("Two", domain)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDirectoryConfigDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryConfigConfig(domain, rUserName, rPassword, orgUnitDN1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectoryConfigExists(resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", domain),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.0", orgUnitDN1),
+				),
+			},
+			{
+				Config: testAccDirectoryConfig_OrganizationalUnitDistinguishedNamesConfig(domain, rUserName, rPassword, orgUnitDN1, orgUnitDN2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectoryConfigExists(resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", domain),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.0", orgUnitDN1),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.1", orgUnitDN2),
+				),
+			},
+			{
+				Config: testAccDirectoryConfigConfig(domain, rUserName, rPassword, orgUnitDN2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectoryConfigExists(resourceName, &v3),
+					resource.TestCheckResourceAttr(resourceName, "directory_name", domain),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "organizational_unit_distinguished_names.0", orgUnitDN2),
+				),
 			},
 		},
 	})
@@ -137,18 +192,41 @@ func testAccCheckDirectoryConfigDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccDirectoryConfigConfig(name, userName, password string) string {
+func testAccCheckDirectoryConfigNotRecreated(i, j *appstream.DirectoryConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !aws.TimeValue(i.CreatedTime).Equal(aws.TimeValue(j.CreatedTime)) {
+			return fmt.Errorf("AppStream Directory Config recreated")
+		}
+
+		return nil
+	}
+}
+
+func orgUnitFromDomain(orgUnit, domainName string) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("OU=%s", orgUnit))
+	for _, dc := range strings.Split(domainName, ".") {
+		sb.WriteString(fmt.Sprintf(" DC=%s", dc))
+	}
+	return sb.String()
+}
+
+func testAccDirectoryConfigConfig(domain, userName, password, orgUnitDN string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVpcWithSubnets(2),
 		fmt.Sprintf(`
 resource "aws_appstream_directory_config" "test" {
   directory_name                          = %[1]q
-  organizational_unit_distinguished_names = [aws_directory_service_directory.test.id]
+  organizational_unit_distinguished_names = [%[4]q]
 
   service_account_credentials {
     account_name     = %[2]q
     account_password = %[3]q
   }
+
+  depends_on = [
+	aws_directory_service_directory.test
+  ]
 }
 
 resource "aws_directory_service_directory" "test" {
@@ -162,5 +240,37 @@ resource "aws_directory_service_directory" "test" {
     subnet_ids = aws_subnet.test[*].id
   }
 }
-`, name, userName, password))
+`, domain, userName, password, orgUnitDN))
+}
+
+func testAccDirectoryConfig_OrganizationalUnitDistinguishedNamesConfig(domain, userName, password, orgUnitDN1, orgUnitDN2 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVpcWithSubnets(2),
+		fmt.Sprintf(`
+resource "aws_appstream_directory_config" "test" {
+  directory_name                          = %[1]q
+  organizational_unit_distinguished_names = [%[4]q, %[5]q]
+
+  service_account_credentials {
+    account_name     = %[2]q
+    account_password = %[3]q
+  }
+
+  depends_on = [
+	aws_directory_service_directory.test
+  ]
+}
+
+resource "aws_directory_service_directory" "test" {
+  name     = %[1]q
+  password = %[3]q
+  edition  = "Standard"
+  type     = "MicrosoftAD"
+
+  vpc_settings {
+    vpc_id     = aws_vpc.test.id
+    subnet_ids = aws_subnet.test[*].id
+  }
+}
+`, domain, userName, password, orgUnitDN1, orgUnitDN2))
 }

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -333,7 +333,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_appstream_fleet" "test" {
-  name       = %[1]q
+  name      = %[1]q
   image_arn = "arn:${data.aws_partition.current.partition}:appstream:${data.aws_region.current.name}::image/Amazon-AppStream2-Sample-Image-02-04-2019"
 
   compute_capacity {

--- a/internal/service/appstream/wait.go
+++ b/internal/service/appstream/wait.go
@@ -23,8 +23,6 @@ const (
 	// imageBuilderStateTimeout Maximum amount of time to wait for the statusImageBuilderState to be RUNNING
 	// or for the ImageBuilder to be deleted
 	imageBuilderStateTimeout = 60 * time.Minute
-	// directoryConfigTimeout Maximum amount of time to wait for DirectoryConfig operation eventual consistency
-	directoryConfigTimeout = 4 * time.Minute
 )
 
 // waitStackStateDeleted waits for a deleted stack

--- a/internal/service/appstream/wait.go
+++ b/internal/service/appstream/wait.go
@@ -23,6 +23,8 @@ const (
 	// imageBuilderStateTimeout Maximum amount of time to wait for the statusImageBuilderState to be RUNNING
 	// or for the ImageBuilder to be deleted
 	imageBuilderStateTimeout = 60 * time.Minute
+	// directoryConfigTimeout Maximum amount of time to wait for DirectoryConfig operation eventual consistency
+	directoryConfigTimeout = 4 * time.Minute
 )
 
 // waitStackStateDeleted waits for a deleted stack

--- a/website/docs/r/appstream_directory_config.html.markdown
+++ b/website/docs/r/appstream_directory_config.html.markdown
@@ -16,7 +16,7 @@ Provides an AppStream Directory Config.
 resource "aws_appstream_directory_config" "example" {
   directory_name                          = "NAME OF DIRECTORY CONFIG"
   organizational_unit_distinguished_names = ["DISTINGUISHED NAME"]
-  
+
   service_account_credentials {
     account_name     = "NAME OF ACCOUNT"
     account_password = "PASSWORD OF ACCOUNT"

--- a/website/docs/r/appstream_directory_config.html.markdown
+++ b/website/docs/r/appstream_directory_config.html.markdown
@@ -30,7 +30,7 @@ The following arguments are required:
 
 * `directory_name` - (Required) Fully qualified name of the directory.
 * `organizational_unit_distinguished_names` - (Required) Distinguished names of the organizational units for computer accounts.
-* `service_account_credentials` - (Required) Configuration block for the name of the directory and organizational unit (OU) to use to join the directory config to a Microsoft Active Directory domain. See below.
+* `service_account_credentials` - (Required) Configuration block for the name of the directory and organizational unit (OU) to use to join the directory config to a Microsoft Active Directory domain. See [`service_account_credentials`](#service_account_credentials) below.
 
 ### `service_account_credentials`
 

--- a/website/docs/r/appstream_directory_config.html.markdown
+++ b/website/docs/r/appstream_directory_config.html.markdown
@@ -14,7 +14,7 @@ Provides an AppStream Directory Config.
 
 ```terraform
 resource "aws_appstream_directory_config" "example" {
-  directory_name                          = "NAME OF DIRECTORY CONFIG"
+  directory_name                          = "NAME OF DIRECTORY"
   organizational_unit_distinguished_names = ["DISTINGUISHED NAME"]
 
   service_account_credentials {

--- a/website/docs/r/appstream_directory_config.html.markdown
+++ b/website/docs/r/appstream_directory_config.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "AppStream"
+layout: "aws"
+page_title: "AWS: aws_appstream_directory_config"
+description: |-
+  Provides an AppStream Directory Config
+---
+
+# Resource: aws_appstream_directory_config
+
+Provides an AppStream Directory Config.
+
+## Example Usage
+
+```terraform
+resource "aws_appstream_directory_config" "example" {
+  directory_name                          = "NAME OF DIRECTORY CONFIG"
+  organizational_unit_distinguished_names = ["DISTINGUISHED NAME"]
+  service_account_credentials {
+    account_name     = "NAME OF ACCOUNT"
+    account_password = "PASSWORD OF ACCOUNT"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `directory_name` - (Required) Fully qualified name of the directory.
+* `organizational_unit_distinguished_names` - (Required) Distinguished names of the organizational units for computer accounts.
+* `service_account_credentials` - (Required) Configuration block for the name of the directory and organizational unit (OU) to use to join the directory config to a Microsoft Active Directory domain. See below.
+
+### `service_account_credentials`
+
+* `account_name` - (Required) User name of the account. This account must have the following privileges: create computer objects, join computers to the domain, and change/reset the password on descendant computer objects for the organizational units specified.
+* `account_password` - (Required) Password for the account.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Unique identifier (ID) of the appstream directory config.
+* `created_time` -  Date and time, in UTC and extended RFC 3339 format, when the directory config was created.
+
+## Import
+
+`aws_appstream_directory_config` can be imported using the id, e.g.,
+
+```
+$ terraform import aws_appstream_directory_config.example directoryNameExample
+```

--- a/website/docs/r/appstream_directory_config.html.markdown
+++ b/website/docs/r/appstream_directory_config.html.markdown
@@ -16,6 +16,7 @@ Provides an AppStream Directory Config.
 resource "aws_appstream_directory_config" "example" {
   directory_name                          = "NAME OF DIRECTORY CONFIG"
   organizational_unit_distinguished_names = ["DISTINGUISHED NAME"]
+  
   service_account_credentials {
     account_name     = "NAME OF ACCOUNT"
     account_password = "PASSWORD OF ACCOUNT"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->
 Added a new resource, doc and tests for [AppStream Directory Config](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateDirectoryConfig.html) called `aws_appstream_directory_config`
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6508

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAppStreamDirectoryConfig' PKG_NAME=internal/service/appstream
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run=TestAccAppStreamDirectoryConfig -timeout 180m
=== RUN   TestAccAppStreamDirectoryConfig_basic
=== PAUSE TestAccAppStreamDirectoryConfig_basic
=== RUN   TestAccAppStreamDirectoryConfig_disappears
=== PAUSE TestAccAppStreamDirectoryConfig_disappears
=== CONT  TestAccAppStreamDirectoryConfig_basic
=== CONT  TestAccAppStreamDirectoryConfig_disappears
--- PASS: TestAccAppStreamDirectoryConfig_disappears (40.98s)
--- PASS: TestAccAppStreamDirectoryConfig_basic (64.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  64.308s

```
