### PR TITLE
elastic_beanstalk_environment data source

### DIFF
--- a/.changelog/21520.txt
+++ b/.changelog/21520.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_elastic_beanstalk_environment
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -497,6 +497,7 @@ func Provider() *schema.Provider {
 			"aws_elasticache_user":              elasticache.DataSourceUser(),
 
 			"aws_elastic_beanstalk_application":    elasticbeanstalk.DataSourceApplication(),
+			"aws_elastic_beanstalk_environment":    elasticbeanstalk.DataSourceEnvironment(),
 			"aws_elastic_beanstalk_hosted_zone":    elasticbeanstalk.DataSourceHostedZone(),
 			"aws_elastic_beanstalk_solution_stack": elasticbeanstalk.DataSourceSolutionStack(),
 

--- a/internal/service/elasticbeanstalk/environment_data_source.go
+++ b/internal/service/elasticbeanstalk/environment_data_source.go
@@ -1,0 +1,104 @@
+package elasticbeanstalk
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceEnvironmentRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"application": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version_label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"solution_stack_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"template_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn
+
+	// Get the name and description
+	name := d.Get("name").(string)
+
+	resp, err := conn.DescribeEnvironments(&elasticbeanstalk.DescribeEnvironmentsInput{
+		EnvironmentNames: []*string{aws.String(name)},
+	})
+	if err != nil {
+		return fmt.Errorf("Error describing Environments (%s): %w", name, err)
+	}
+
+	if len(resp.Environments) > 1 || len(resp.Environments) < 1 {
+		return fmt.Errorf("Error %d Environments matched, expected 1", len(resp.Environments))
+	}
+
+	app := resp.Environments[0]
+
+	d.SetId(name)
+	d.Set("arn", app.EnvironmentArn)
+	d.Set("name", app.EnvironmentName)
+	d.Set("application", app.ApplicationName)
+	d.Set("version_label", app.VersionLabel)
+	d.Set("solution_stack_name", app.SolutionStackName)
+	d.Set("platform_arn", app.PlatformArn)
+	d.Set("template_name", app.TemplateName)
+	d.Set("description", app.Description)
+	d.Set("endpoint_url", app.EndpointURL)
+	d.Set("cname", app.CNAME)
+	d.Set("resources", app.Resources)
+	d.Set("tier", app.Tier)
+
+	return nil
+}

--- a/internal/service/elasticbeanstalk/environment_data_source_test.go
+++ b/internal/service/elasticbeanstalk/environment_data_source_test.go
@@ -1,0 +1,36 @@
+package elasticbeanstalk_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccElasticBeanstalkEnvironmentDataSource_basic(t *testing.T) {
+	dataSourceResourceName := "data.aws_elastic_beanstalk_environment.test"
+	resourceName := "aws_elastic_beanstalk_environment.tftest"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, elasticbeanstalk.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentDataSourceConfig_Basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceResourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+const testAccEnvironmentDataSourceConfig_Basic = `
+data "aws_elastic_beanstalk_environment" "test" {
+	name = aws_elastic_beanstalk_environment.tftest.name
+  }
+`

--- a/website/docs/d/elastic_beanstalk_environment.html.markdown
+++ b/website/docs/d/elastic_beanstalk_environment.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "Elastic Beanstalk"
+layout: "aws"
+page_title: "AWS: aws_elastic_beanstalk_environment"
+description: |-
+  Retrieve information about an Elastic Beanstalk Environment
+---
+
+# Data Source: aws_elastic_beanstalk_environment
+
+Retrieve information about an Elastic Beanstalk Environment.
+
+## Example Usage
+
+```terraform
+data "aws_elastic_beanstalk_environment" "example" {
+  name = "my-app"
+}
+output "endpoint_url" {
+  value = data.aws_elastic_beanstalk_environment.example.endpoint_url
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the environment.
+
+## Attributes Reference
+
+* `arn` -  The Amazon Resource Name (ARN) of the environment.
+* `application` - The application to which the environment belongs.
+* `version_label` - The version of the environment.
+* `solution_stack_name` - The name of the SolutionStack deployed with the environment.
+* `platform_arn` - The ARN of the platform version.
+* `template_name` - The name of the configuration template used to originally launch the environment.
+* `description` - The description of the environment.
+* `endpoint_url` - For load-balanced, autoscaling environments, the URL to the LoadBalancer. For single-instance environments, the IP address of the instance.
+* `cname` - The URL to the CNAME for the environment.
+* `resources` - The description of the AWS resources used by this environment.
+* `tier` - The tier of the environment.


### PR DESCRIPTION
Adds an elastic_beanstalk_environment data source.

Includes all beanstalk attributes supported by `describe-environments`, documentation, and initial test framework.

This improves on #15635.

I need help with determining whether additional testing is required for this feature.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

