### PR TITLE
Change authentication update to not be a destructive operation

### DIFF
--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -106,26 +106,26 @@ func ResourceCluster() *schema.Resource {
 			"client_authentication": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"sasl": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
+							ForceNew: false,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"scram": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										ForceNew: true,
+										ForceNew: false,
 									},
 									"iam": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										ForceNew: true,
+										ForceNew: false,
 									},
 								},
 							},
@@ -640,6 +640,25 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error waiting for MSK Cluster (%s) operation (%s): %w", d.Id(), clusterOperationARN, err)
 		}
+	}
+	if d.HasChange("client_authentication") {
+		input := &kafka.UpdateSecurityInput{
+			ClusterArn:           aws.String(d.Id()),
+			CurrentVersion:       aws.String(d.Get("current_version").(string)),
+			ClientAuthentication: expandMskClusterClientAuthentication(d.Get("client_authentication").([]interface{})),
+		}
+		output, err := conn.UpdateSecurity(input)
+		if err != nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) security settings: %w", d.Id(), err)
+		}
+		clusterOperationARN := aws.StringValue(output.ClusterOperationArn)
+
+		_, err = waitClusterOperationCompleted(conn, clusterOperationARN, d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return fmt.Errorf("error waiting for MSK Cluster (%s) operation (%s): %w", d.Id(), clusterOperationARN, err)
+		}
+
 	}
 
 	if d.HasChange("tags_all") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
This PR Closes #21535, changing the Kafka client authentication updates to be non-destructive.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWS MskCluster'

...
```
