### PR TITLE
Correct argument in `aws_cloudwatch_log_groups` data source example

### DIFF
--- a/website/docs/d/cloudwatch_log_groups.html.markdown
+++ b/website/docs/d/cloudwatch_log_groups.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get a list of AWS Cloudwatch Log Groups
 
 ```terraform
 data "aws_cloudwatch_log_groups" "example" {
-  log_group_prefix = "/MyImportantLogs"
+  log_group_name_prefix = "/MyImportantLogs"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21529

Output from acceptance testing:

N/A - docs fix.

## Info

This PR corrects the argument in the example for the `aws_cloudwatch_log_groups` data source; from `log_group_prefix` to `log_group_name_prefix`.

Useful links:
- [Argument in the registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_groups#log_group_name_prefix)
- [Link to data source code](https://github.com/hashicorp/terraform-provider-aws/blob/83448eb85d92828e1488b87b4ff71b03cb770f9f/internal/service/cloudwatchlogs/groups_data_source.go#L22-L25)
