### PR TITLE
tech_debt: functions for detaching and deleting network interfaces

### DIFF
--- a/.changelog/21542.txt
+++ b/.changelog/21542.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_network_interface: Correctly set `attachment` attribute
+```

--- a/.changelog/21542.txt
+++ b/.changelog/21542.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 data-source/aws_network_interface: Correctly set `attachment` attribute
 ```
+
+```release-note:bug
+resource/aws_internet_gateway: Retry resource read after creation to deal with EC2 API eventual consistency
+```

--- a/internal/service/ec2/enum.go
+++ b/internal/service/ec2/enum.go
@@ -36,7 +36,12 @@ const (
 	EBSSnapshotImportStateCompleted  = "completed"
 )
 
-// See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html#API_CreateNetworkInterface_Example_2_Response
+// See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkInterface.html#API_CreateNetworkInterface_Example_2_Response.
 const (
 	NetworkInterfaceStatusPending = "pending"
+)
+
+// See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html#API_DescribeInternetGateways_Example_1_Response.
+const (
+	InternetGatewayAttachmentStateAvailable = "available"
 )

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -28,6 +28,10 @@ const (
 )
 
 const (
+	ErrCodeInvalidInternetGatewayIDNotFound = "InvalidInternetGatewayID.NotFound"
+)
+
+const (
 	ErrCodeInvalidNetworkInterfaceIDNotFound = "InvalidNetworkInterfaceID.NotFound"
 )
 

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	ErrCodeDependencyViolation          = "DependencyViolation"
 	ErrCodeGatewayNotAttached           = "Gateway.NotAttached"
 	ErrCodeInvalidAssociationIDNotFound = "InvalidAssociationID.NotFound"
 	ErrCodeInvalidAttachmentIDNotFound  = "InvalidAttachmentID.NotFound"

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -306,6 +306,17 @@ func FindNetworkInterfaceByID(conn *ec2.EC2, id string) (*ec2.NetworkInterface, 
 	return networkInterface, nil
 }
 
+func FindNetworkInterfacesByAttachmentInstanceOwnerIDAndDescription(conn *ec2.EC2, attachmentInstanceOwnerID, description string) ([]*ec2.NetworkInterface, error) {
+	input := &ec2.DescribeNetworkInterfacesInput{
+		Filters: BuildAttributeFilterList(map[string]string{
+			"attachment.instance-owner-id": attachmentInstanceOwnerID,
+			"description":                  description,
+		}),
+	}
+
+	return FindNetworkInterfaces(conn, input)
+}
+
 func FindNetworkInterfaceAttachmentByID(conn *ec2.EC2, id string) (*ec2.NetworkInterfaceAttachment, error) {
 	input := &ec2.DescribeNetworkInterfacesInput{
 		Filters: BuildAttributeFilterList(map[string]string{

--- a/internal/service/ec2/internet_gateway.go
+++ b/internal/service/ec2/internet_gateway.go
@@ -3,14 +3,11 @@ package ec2
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -67,18 +64,8 @@ func resourceInternetGatewayCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(aws.StringValue(output.InternetGateway.InternetGatewayId))
 
-	_, err = tfresource.RetryWhenNotFound(PropagationTimeout, func() (interface{}, error) {
-		return FindInternetGatewayByID(conn, d.Id())
-	})
-
-	if err != nil {
-		return fmt.Errorf("error reading EC2 Internet Gateway (%s): %w", d.Id(), err)
-	}
-
 	if v, ok := d.GetOk("vpc_id"); ok {
-		err = attachInternetGateway(conn, d.Id(), v.(string), internetGatewayAttachedTimeout)
-
-		if err != nil {
+		if err := attachInternetGateway(conn, d.Id(), v.(string)); err != nil {
 			return err
 		}
 	}
@@ -91,19 +78,34 @@ func resourceInternetGatewayRead(d *schema.ResourceData, meta interface{}) error
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	igRaw, _, err := IGStateRefreshFunc(conn, d.Id())()
-	if err != nil {
-		return err
-	}
-	if igRaw == nil {
-		log.Printf("[WARN] Internet Gateway (%s) not found, removing from state", d.Id())
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(PropagationTimeout, func() (interface{}, error) {
+		return FindInternetGatewayByID(conn, d.Id())
+	}, d.IsNewResource())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] EC2 Internet Gateway %s not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	ig := igRaw.(*ec2.InternetGateway)
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Internet Gateway (%s): %w", d.Id(), err)
+	}
+
+	ig := outputRaw.(*ec2.InternetGateway)
+
+	ownerID := aws.StringValue(ig.OwnerId)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   ec2.ServiceName,
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: ownerID,
+		Resource:  fmt.Sprintf("internet-gateway/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+	d.Set("owner_id", ownerID)
 	if len(ig.Attachments) == 0 {
-		// Gateway exists but not attached to the VPC
+		// Gateway exists but not attached to the VPC.
 		d.Set("vpc_id", "")
 	} else {
 		d.Set("vpc_id", ig.Attachments[0].VpcId)
@@ -120,41 +122,33 @@ func resourceInternetGatewayRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
-	d.Set("owner_id", ig.OwnerId)
-
-	arn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Service:   ec2.ServiceName,
-		Region:    meta.(*conns.AWSClient).Region,
-		AccountID: aws.StringValue(ig.OwnerId),
-		Resource:  fmt.Sprintf("internet-gateway/%s", d.Id()),
-	}.String()
-
-	d.Set("arn", arn)
-
 	return nil
 }
 
 func resourceInternetGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
 	if d.HasChange("vpc_id") {
-		// If we're already attached, detach it first
-		if err := resourceInternetGatewayDetach(d, meta); err != nil {
-			return err
+		o, n := d.GetChange("vpc_id")
+
+		if v := o.(string); v != "" {
+			if err := detachInternetGateway(conn, d.Id(), v); err != nil {
+				return err
+			}
 		}
 
-		// Attach the gateway to the new vpc
-		if err := resourceInternetGatewayAttach(d, meta); err != nil {
-			return err
+		if v := n.(string); v != "" {
+			if err := attachInternetGateway(conn, d.Id(), v); err != nil {
+				return err
+			}
 		}
 	}
-
-	conn := meta.(*conns.AWSClient).EC2Conn
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating EC2 Internet Gateway (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating EC2 Internet Gateway (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -164,262 +158,32 @@ func resourceInternetGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceInternetGatewayDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	// Detach if it is attached
-	if err := resourceInternetGatewayDetach(d, meta); err != nil {
-		return err
+	// Detach if it is attached.
+	if v, ok := d.GetOk("vpc_id"); ok {
+		if err := detachInternetGateway(conn, d.Id(), v.(string)); err != nil {
+			return err
+		}
 	}
 
 	log.Printf("[INFO] Deleting Internet Gateway: %s", d.Id())
-	input := &ec2.DeleteInternetGatewayInput{
-		InternetGatewayId: aws.String(d.Id()),
-	}
-	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteInternetGateway(input)
-		if err == nil {
-			return nil
-		}
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(internetGatewayDeletedTimeout, func() (interface{}, error) {
+		return conn.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: aws.String(d.Id()),
+		})
+	}, ErrCodeDependencyViolation)
 
-		if tfawserr.ErrMessageContains(err, "InvalidInternetGatewayID.NotFound", "") {
-			return nil
-		}
-
-		if tfawserr.ErrMessageContains(err, "DependencyViolation", "") {
-			return resource.RetryableError(err)
-		}
-
-		return resource.NonRetryableError(err)
-	})
-	if tfresource.TimedOut(err) {
-		_, err = conn.DeleteInternetGateway(input)
-	}
-	if err != nil {
-		return fmt.Errorf("Error deleting internet gateway: %s", err)
-	}
-	return nil
-}
-
-func resourceInternetGatewayAttach(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).EC2Conn
-
-	if d.Get("vpc_id").(string) == "" {
-		log.Printf(
-			"[DEBUG] Not attaching Internet Gateway '%s' as no VPC ID is set",
-			d.Id())
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidInternetGatewayIDNotFound) {
 		return nil
 	}
 
-	log.Printf(
-		"[INFO] Attaching Internet Gateway '%s' to VPC '%s'",
-		d.Id(),
-		d.Get("vpc_id").(string))
-	input := &ec2.AttachInternetGatewayInput{
-		InternetGatewayId: aws.String(d.Id()),
-		VpcId:             aws.String(d.Get("vpc_id").(string)),
-	}
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		_, err := conn.AttachInternetGateway(input)
-		if err == nil {
-			return nil
-		}
-		if tfawserr.ErrMessageContains(err, "InvalidInternetGatewayID.NotFound", "") {
-			return resource.RetryableError(err)
-		}
-
-		return resource.NonRetryableError(err)
-	})
-	if tfresource.TimedOut(err) {
-		_, err = conn.AttachInternetGateway(input)
-	}
 	if err != nil {
-		return fmt.Errorf("Error attaching internet gateway: %s", err)
-	}
-
-	// A note on the states below: the AWS docs (as of July, 2014) say
-	// that the states would be: attached, attaching, detached, detaching,
-	// but when running, I noticed that the state is usually "available" when
-	// it is attached.
-
-	// Wait for it to be fully attached before continuing
-	log.Printf("[DEBUG] Waiting for internet gateway (%s) to attach", d.Id())
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.AttachmentStatusDetached, ec2.AttachmentStatusAttaching},
-		Target:  []string{"available"},
-		Refresh: IGAttachStateRefreshFunc(conn, d.Id(), "available"),
-		Timeout: 4 * time.Minute,
-	}
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf(
-			"Error waiting for internet gateway (%s) to attach: %s",
-			d.Id(), err)
+		return fmt.Errorf("error deleting EC2 Internet Gateway (%s): %w", d.Id(), err)
 	}
 
 	return nil
 }
 
-func resourceInternetGatewayDetach(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).EC2Conn
-
-	// Get the old VPC ID to detach from
-	vpcID, _ := d.GetChange("vpc_id")
-
-	if vpcID.(string) == "" {
-		log.Printf(
-			"[DEBUG] Not detaching Internet Gateway '%s' as no VPC ID is set",
-			d.Id())
-		return nil
-	}
-
-	log.Printf(
-		"[INFO] Detaching Internet Gateway '%s' from VPC '%s'",
-		d.Id(),
-		vpcID.(string))
-
-	// Wait for it to be fully detached before continuing
-	log.Printf("[DEBUG] Waiting for internet gateway (%s) to detach", d.Id())
-	stateConf := &resource.StateChangeConf{
-		Pending:        []string{ec2.AttachmentStatusDetaching},
-		Target:         []string{ec2.AttachmentStatusDetached},
-		Refresh:        DetachIGStateRefreshFunc(conn, d.Id(), vpcID.(string)),
-		Timeout:        15 * time.Minute,
-		Delay:          10 * time.Second,
-		NotFoundChecks: 30,
-	}
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf(
-			"Error waiting for internet gateway (%s) to detach: %s",
-			d.Id(), err)
-	}
-
-	return nil
-}
-
-// InstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
-// an EC2 instance.
-func DetachIGStateRefreshFunc(conn *ec2.EC2, gatewayID, vpcID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		_, err := conn.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
-			InternetGatewayId: aws.String(gatewayID),
-			VpcId:             aws.String(vpcID),
-		})
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok {
-				switch ec2err.Code() {
-				case "InvalidInternetGatewayID.NotFound":
-					log.Printf("[TRACE] Error detaching Internet Gateway '%s' from VPC '%s': %s", gatewayID, vpcID, err)
-					return nil, "", nil
-
-				case "Gateway.NotAttached":
-					return 42, ec2.AttachmentStatusDetached, nil
-
-				case "DependencyViolation":
-					// This can be caused by associated public IPs left (e.g. by ELBs)
-					// and here we find and log which ones are to blame
-					out, err := findPublicNetworkInterfacesForVpcID(conn, vpcID)
-					if err != nil {
-						return 42, "detaching", err
-					}
-					if len(out.NetworkInterfaces) > 0 {
-						log.Printf("[DEBUG] Waiting for the following %d ENIs to be gone: %s",
-							len(out.NetworkInterfaces), out.NetworkInterfaces)
-					}
-
-					return 42, ec2.AttachmentStatusDetaching, nil
-				}
-			}
-			return 42, "", err
-		}
-
-		// DetachInternetGateway only returns an error, so if it's nil, assume we're
-		// detached
-		return 42, ec2.AttachmentStatusDetached, nil
-	}
-}
-
-func findPublicNetworkInterfacesForVpcID(conn *ec2.EC2, vpcID string) (*ec2.DescribeNetworkInterfacesOutput, error) {
-	return conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("vpc-id"),
-				Values: []*string{aws.String(vpcID)},
-			},
-			{
-				Name:   aws.String("association.public-ip"),
-				Values: []*string{aws.String("*")},
-			},
-		},
-	})
-}
-
-// IGStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
-// an internet gateway.
-func IGStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
-			InternetGatewayIds: []*string{aws.String(id)},
-		})
-		if err != nil {
-			if tfawserr.ErrMessageContains(err, "InvalidInternetGatewayID.NotFound", "") {
-				resp = nil
-			} else {
-				log.Printf("[ERROR] Error on IGStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
-
-		if resp == nil {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		ig := resp.InternetGateways[0]
-		return ig, "available", nil
-	}
-}
-
-// IGAttachStateRefreshFunc returns a resource.StateRefreshFunc that is used
-// watch the state of an internet gateway's attachment.
-func IGAttachStateRefreshFunc(conn *ec2.EC2, id string, expected string) resource.StateRefreshFunc {
-	var start time.Time
-	return func() (interface{}, string, error) {
-		if start.IsZero() {
-			start = time.Now()
-		}
-
-		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
-			InternetGatewayIds: []*string{aws.String(id)},
-		})
-		if err != nil {
-			if tfawserr.ErrMessageContains(err, "InvalidInternetGatewayID.NotFound", "") {
-				resp = nil
-			} else {
-				log.Printf("[ERROR] Error on IGStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
-
-		if resp == nil {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		ig := resp.InternetGateways[0]
-
-		if time.Since(start) > 10*time.Second {
-			return ig, expected, nil
-		}
-
-		if len(ig.Attachments) == 0 {
-			// No attachments, we're detached
-			return ig, ec2.AttachmentStatusDetached, nil
-		}
-
-		return ig, *ig.Attachments[0].State, nil
-	}
-}
-
-func attachInternetGateway(conn *ec2.EC2, internetGatewayID, vpcID string, timeout time.Duration) error {
+func attachInternetGateway(conn *ec2.EC2, internetGatewayID, vpcID string) error {
 	input := &ec2.AttachInternetGatewayInput{
 		InternetGatewayId: aws.String(internetGatewayID),
 		VpcId:             aws.String(vpcID),
@@ -434,10 +198,36 @@ func attachInternetGateway(conn *ec2.EC2, internetGatewayID, vpcID string, timeo
 		return fmt.Errorf("error attaching EC2 Internet Gateway (%s) to VPC (%s): %w", internetGatewayID, vpcID, err)
 	}
 
-	_, err = WaitInternetGatewayAttached(conn, internetGatewayID, vpcID, timeout)
+	_, err = WaitInternetGatewayAttached(conn, internetGatewayID, vpcID, internetGatewayAttachedTimeout)
 
 	if err != nil {
 		return fmt.Errorf("error waiting for EC2 Internet Gateway (%s) to attach to VPC (%s): %w", internetGatewayID, vpcID, err)
+	}
+
+	return nil
+}
+
+func detachInternetGateway(conn *ec2.EC2, internetGatewayID, vpcID string) error {
+	input := &ec2.DetachInternetGatewayInput{
+		InternetGatewayId: aws.String(internetGatewayID),
+		VpcId:             aws.String(vpcID),
+	}
+
+	log.Printf("[INFO] Detaching EC2 Internet Gateway: %s", input)
+	_, err := conn.DetachInternetGateway(input)
+
+	if tfawserr.ErrCodeEquals(err, ErrCodeGatewayNotAttached) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error detaching EC2 Internet Gateway (%s) from VPC (%s): %w", internetGatewayID, vpcID, err)
+	}
+
+	_, err = WaitInternetGatewayDetached(conn, internetGatewayID, vpcID, internetGatewayDetachedTimeout)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for EC2 Internet Gateway (%s) to detach from VPC (%s): %w", internetGatewayID, vpcID, err)
 	}
 
 	return nil

--- a/internal/service/ec2/internet_gateway_data_source_test.go
+++ b/internal/service/ec2/internet_gateway_data_source_test.go
@@ -1,19 +1,22 @@
 package ec2_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccEC2InternetGatewayDataSource_typical(t *testing.T) {
+func TestAccEC2InternetGatewayDataSource_basic(t *testing.T) {
 	igwResourceName := "aws_internet_gateway.test"
 	vpcResourceName := "aws_vpc.test"
 	ds1ResourceName := "data.aws_internet_gateway.by_id"
 	ds2ResourceName := "data.aws_internet_gateway.by_filter"
 	ds3ResourceName := "data.aws_internet_gateway.by_tags"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -21,7 +24,7 @@ func TestAccEC2InternetGatewayDataSource_typical(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInternetGatewayDataSourceConfig,
+				Config: testAccInternetGatewayDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "internet_gateway_id", igwResourceName, "id"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", igwResourceName, "owner_id"),
@@ -41,12 +44,13 @@ func TestAccEC2InternetGatewayDataSource_typical(t *testing.T) {
 	})
 }
 
-const testAccInternetGatewayDataSourceConfig = `
+func testAccInternetGatewayDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-igw-data-source"
+    Name = %[1]q
   }
 }
 
@@ -54,7 +58,7 @@ resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-data-source-igw"
+    Name = %[1]q
   }
 }
 
@@ -74,4 +78,5 @@ data "aws_internet_gateway" "by_filter" {
     values = [aws_internet_gateway.test.id]
   }
 }
-`
+`, rName)
+}

--- a/internal/service/ec2/network_interface.go
+++ b/internal/service/ec2/network_interface.go
@@ -382,7 +382,7 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 		if oa != nil && oa.(*schema.Set).Len() > 0 {
 			attachment := oa.(*schema.Set).List()[0].(map[string]interface{})
 
-			err := DetachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout)
+			err := DetachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), NetworkInterfaceDetachedTimeout)
 
 			if err != nil {
 				return err
@@ -779,7 +779,7 @@ func resourceNetworkInterfaceDelete(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("attachment"); ok && v.(*schema.Set).Len() > 0 {
 		attachment := v.(*schema.Set).List()[0].(map[string]interface{})
 
-		err := DetachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout)
+		err := DetachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), NetworkInterfaceDetachedTimeout)
 
 		if err != nil {
 			return err

--- a/internal/service/ec2/network_interface.go
+++ b/internal/service/ec2/network_interface.go
@@ -382,7 +382,7 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 		if oa != nil && oa.(*schema.Set).Len() > 0 {
 			attachment := oa.(*schema.Set).List()[0].(map[string]interface{})
 
-			err := detachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout)
+			err := DetachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout)
 
 			if err != nil {
 				return err
@@ -779,14 +779,14 @@ func resourceNetworkInterfaceDelete(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("attachment"); ok && v.(*schema.Set).Len() > 0 {
 		attachment := v.(*schema.Set).List()[0].(map[string]interface{})
 
-		err := detachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout)
+		err := DetachNetworkInterface(conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout)
 
 		if err != nil {
 			return err
 		}
 	}
 
-	return deleteNetworkInterface(conn, d.Id())
+	return DeleteNetworkInterface(conn, d.Id())
 }
 
 func attachNetworkInterface(conn *ec2.EC2, networkInterfaceID, instanceID string, deviceIndex int, timeout time.Duration) (string, error) {
@@ -814,7 +814,7 @@ func attachNetworkInterface(conn *ec2.EC2, networkInterfaceID, instanceID string
 	return attachmentID, nil
 }
 
-func deleteNetworkInterface(conn *ec2.EC2, networkInterfaceID string) error {
+func DeleteNetworkInterface(conn *ec2.EC2, networkInterfaceID string) error {
 	log.Printf("[INFO] Deleting EC2 Network Interface: %s", networkInterfaceID)
 	_, err := conn.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
 		NetworkInterfaceId: aws.String(networkInterfaceID),
@@ -831,7 +831,7 @@ func deleteNetworkInterface(conn *ec2.EC2, networkInterfaceID string) error {
 	return nil
 }
 
-func detachNetworkInterface(conn *ec2.EC2, networkInterfaceID, attachmentID string, timeout time.Duration) error {
+func DetachNetworkInterface(conn *ec2.EC2, networkInterfaceID, attachmentID string, timeout time.Duration) error {
 	input := &ec2.DetachNetworkInterfaceInput{
 		AttachmentId: aws.String(attachmentID),
 		Force:        aws.Bool(true),

--- a/internal/service/ec2/network_interface.go
+++ b/internal/service/ec2/network_interface.go
@@ -285,7 +285,7 @@ func resourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) erro
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(1*time.Minute, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(PropagationTimeout, func() (interface{}, error) {
 		return FindNetworkInterfaceByID(conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/network_interface_attachment.go
+++ b/internal/service/ec2/network_interface_attachment.go
@@ -91,5 +91,5 @@ func resourceNetworkInterfaceAttachmentRead(d *schema.ResourceData, meta interfa
 func resourceNetworkInterfaceAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	return DetachNetworkInterface(conn, d.Get("network_interface_id").(string), d.Id(), networkInterfaceDetachedTimeout)
+	return DetachNetworkInterface(conn, d.Get("network_interface_id").(string), d.Id(), NetworkInterfaceDetachedTimeout)
 }

--- a/internal/service/ec2/network_interface_attachment.go
+++ b/internal/service/ec2/network_interface_attachment.go
@@ -91,5 +91,5 @@ func resourceNetworkInterfaceAttachmentRead(d *schema.ResourceData, meta interfa
 func resourceNetworkInterfaceAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	return detachNetworkInterface(conn, d.Get("network_interface_id").(string), d.Id(), networkInterfaceDetachedTimeout)
+	return DetachNetworkInterface(conn, d.Get("network_interface_id").(string), d.Id(), networkInterfaceDetachedTimeout)
 }

--- a/internal/service/ec2/network_interface_data_source.go
+++ b/internal/service/ec2/network_interface_data_source.go
@@ -187,7 +187,7 @@ func dataSourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("association", nil)
 	}
 	if eni.Attachment != nil {
-		if err := d.Set("attachment", []interface{}{flattenNetworkInterfaceAttachment(eni.Attachment)}); err != nil {
+		if err := d.Set("attachment", []interface{}{flattenNetworkInterfaceAttachmentForDataSource(eni.Attachment)}); err != nil {
 			return fmt.Errorf("error setting attachment: %w", err)
 		}
 	} else {
@@ -213,4 +213,30 @@ func dataSourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return nil
+}
+
+func flattenNetworkInterfaceAttachmentForDataSource(apiObject *ec2.NetworkInterfaceAttachment) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.AttachmentId; v != nil {
+		tfMap["attachment_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.DeviceIndex; v != nil {
+		tfMap["device_index"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.InstanceId; v != nil {
+		tfMap["instance_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.InstanceOwnerId; v != nil {
+		tfMap["instance_owner_id"] = aws.StringValue(v)
+	}
+
+	return tfMap
 }

--- a/internal/service/ec2/network_interface_data_source_test.go
+++ b/internal/service/ec2/network_interface_data_source_test.go
@@ -158,6 +158,45 @@ func TestAccEC2NetworkInterfaceDataSource_publicIPAssociation(t *testing.T) {
 	})
 }
 
+func TestAccEC2NetworkInterfaceDataSource_attachment(t *testing.T) {
+	datasourceName := "data.aws_network_interface.test"
+	resourceName := "aws_network_interface.test"
+	instanceResourceName := "aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkInterfaceAttachmentDataSourceConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "association.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "attachment.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "attachment.0.device_index", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "attachment.0.instance_id", instanceResourceName, "id"),
+					acctest.CheckResourceAttrAccountID(datasourceName, "attachment.0.instance_owner_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttr(datasourceName, "interface_type", "interface"),
+					resource.TestCheckResourceAttr(datasourceName, "ipv6_addresses.#", "0"),
+					resource.TestCheckResourceAttrSet(datasourceName, "mac_address"),
+					resource.TestCheckResourceAttr(datasourceName, "outpost_arn", ""),
+					acctest.CheckResourceAttrAccountID(datasourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "private_dns_name", resourceName, "private_dns_name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "private_ip", resourceName, "private_ip"),
+					resource.TestCheckResourceAttrPair(datasourceName, "private_ips.#", resourceName, "private_ips.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "private_ips.0", resourceName, "private_ip"),
+					resource.TestCheckResourceAttrPair(datasourceName, "security_groups.#", resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "subnet_id", resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNetworkInterfaceBaseDataSourceConfig(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
@@ -326,4 +365,32 @@ data "aws_network_interface" "test" {
   }
 }
 `)
+}
+
+func testAccNetworkInterfaceAttachmentDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccNetworkInterfaceBaseDataSourceConfig(rName),
+		acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
+		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface_attachment" "test" {
+  device_index         = 1
+  instance_id          = aws_instance.test.id
+  network_interface_id = aws_network_interface.test.id
+}
+
+data "aws_network_interface" "test" {
+  id = aws_network_interface_attachment.test.network_interface_id
+}
+`, rName))
 }

--- a/internal/service/ec2/network_interfaces_data_source.go
+++ b/internal/service/ec2/network_interfaces_data_source.go
@@ -49,24 +49,19 @@ func dataSourceNetworkInterfacesRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	networkInterfaceIDs := []string{}
-	err := conn.DescribeNetworkInterfacesPages(input, func(page *ec2.DescribeNetworkInterfacesOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
 
-		for _, networkInterface := range page.NetworkInterfaces {
-			networkInterfaceIDs = append(networkInterfaceIDs, aws.StringValue(networkInterface.NetworkInterfaceId))
-		}
-
-		return !lastPage
-	})
+	output, err := FindNetworkInterfaces(conn, input)
 
 	if err != nil {
 		return fmt.Errorf("error reading EC2 Network Interfaces: %w", err)
 	}
 
-	if len(networkInterfaceIDs) == 0 {
+	if len(output) == 0 {
 		return errors.New("no matching network interfaces found")
+	}
+
+	for _, v := range output {
+		networkInterfaceIDs = append(networkInterfaceIDs, aws.StringValue(v.NetworkInterfaceId))
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)

--- a/internal/service/ec2/security_group.go
+++ b/internal/service/ec2/security_group.go
@@ -1381,14 +1381,14 @@ func deleteLingeringLambdaENIs(conn *ec2.EC2, filterName, resourceId string, tim
 		}
 
 		if eni.Attachment != nil {
-			err = detachNetworkInterface(conn, eniId, aws.StringValue(eni.Attachment.AttachmentId), timeout)
+			err = DetachNetworkInterface(conn, eniId, aws.StringValue(eni.Attachment.AttachmentId), timeout)
 
 			if err != nil {
 				return fmt.Errorf("error detaching Lambda ENI (%s): %w", eniId, err)
 			}
 		}
 
-		err = deleteNetworkInterface(conn, eniId)
+		err = DeleteNetworkInterface(conn, eniId)
 
 		if err != nil {
 			return fmt.Errorf("error deleting Lambda ENI (%s): %w", eniId, err)

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -495,6 +495,22 @@ func StatusHostState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	}
 }
 
+func StatusInternetGatewayAttachmentState(conn *ec2.EC2, internetGatewayID, vpcID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindInternetGatewayAttachment(conn, internetGatewayID, vpcID)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.State), nil
+	}
+}
+
 func StatusManagedPrefixListState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindManagedPrefixListByID(conn, id)

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -813,6 +813,9 @@ func sweepInternetGateways(region string) error {
 			r := ResourceInternetGateway()
 			d := r.Data(nil)
 			d.SetId(internetGatewayID)
+			if len(internetGateway.Attachments) > 0 {
+				d.Set("vpc_id", internetGateway.Attachments[0].VpcId)
+			}
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -690,6 +690,27 @@ func WaitHostDeleted(conn *ec2.EC2, id string) (*ec2.Host, error) {
 }
 
 const (
+	internetGatewayAttachedTimeout = 4 * time.Minute
+)
+
+func WaitInternetGatewayAttached(conn *ec2.EC2, internetGatewayID, vpcID string, timeout time.Duration) (*ec2.InternetGatewayAttachment, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.AttachmentStatusAttaching},
+		Target:  []string{InternetGatewayAttachmentStateAvailable},
+		Timeout: timeout,
+		Refresh: StatusInternetGatewayAttachmentState(conn, internetGatewayID, vpcID),
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.InternetGatewayAttachment); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+const (
 	ManagedPrefixListTimeout = 15 * time.Minute
 )
 

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -691,12 +691,31 @@ func WaitHostDeleted(conn *ec2.EC2, id string) (*ec2.Host, error) {
 
 const (
 	internetGatewayAttachedTimeout = 4 * time.Minute
+	internetGatewayDeletedTimeout  = 10 * time.Minute
+	internetGatewayDetachedTimeout = 15 * time.Minute
 )
 
 func WaitInternetGatewayAttached(conn *ec2.EC2, internetGatewayID, vpcID string, timeout time.Duration) (*ec2.InternetGatewayAttachment, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.AttachmentStatusAttaching},
 		Target:  []string{InternetGatewayAttachmentStateAvailable},
+		Timeout: timeout,
+		Refresh: StatusInternetGatewayAttachmentState(conn, internetGatewayID, vpcID),
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.InternetGatewayAttachment); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func WaitInternetGatewayDetached(conn *ec2.EC2, internetGatewayID, vpcID string, timeout time.Duration) (*ec2.InternetGatewayAttachment, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.AttachmentStatusDetaching},
+		Target:  []string{},
 		Timeout: timeout,
 		Refresh: StatusInternetGatewayAttachmentState(conn, internetGatewayID, vpcID),
 	}

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -758,7 +758,7 @@ func WaitManagedPrefixListDeleted(conn *ec2.EC2, id string) (*ec2.ManagedPrefixL
 
 const (
 	networkInterfaceAttachedTimeout = 5 * time.Minute
-	networkInterfaceDetachedTimeout = 10 * time.Minute
+	NetworkInterfaceDetachedTimeout = 10 * time.Minute
 )
 
 func WaitNetworkInterfaceAttached(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.NetworkInterfaceAttachment, error) {

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -801,7 +802,7 @@ func resourceLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error 
 
 	name := d.Get("name").(string)
 
-	err := CleanupNetworkInterfaces(meta.(*conns.AWSClient).EC2Conn, name)
+	err := cleanupNetworkInterfaces(meta.(*conns.AWSClient).EC2Conn, name)
 	if err != nil {
 		log.Printf("[WARN] Failed to cleanup ENIs for ELB %q: %#v", name, err)
 	}
@@ -941,114 +942,40 @@ func validateListenerProtocol() schema.SchemaValidateFunc {
 // but the cleanup is asynchronous and may take time
 // which then blocks IGW, SG or VPC on deletion
 // So we make the cleanup "synchronous" here
-func CleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
-	out, err := conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("attachment.instance-owner-id"),
-				Values: []*string{aws.String("amazon-elb")},
-			},
-			{
-				Name:   aws.String("description"),
-				Values: []*string{aws.String("ELB " + name)},
-			},
-		},
-	})
+func cleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
+	// https://aws.amazon.com/premiumsupport/knowledge-center/elb-find-load-balancer-IP/.
+	networkInterfaces, err := tfec2.FindNetworkInterfacesByAttachmentInstanceOwnerIDAndDescription(conn, "amazon-elb", "ELB "+name)
+
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] Found %d ENIs to cleanup for ELB %q",
-		len(out.NetworkInterfaces), name)
+	var errs *multierror.Error
 
-	if len(out.NetworkInterfaces) == 0 {
-		// Nothing to cleanup
-		return nil
-	}
-
-	err = detachNetworkInterfaces(conn, out.NetworkInterfaces)
-	if err != nil {
-		return err
-	}
-
-	err = deleteNetworkInterfaces(conn, out.NetworkInterfaces)
-	return err
-}
-
-func detachNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
-	log.Printf("[DEBUG] Trying to detach %d leftover ENIs", len(nis))
-	for _, ni := range nis {
-		if ni.Attachment == nil {
-			log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
+	for _, networkInterface := range networkInterfaces {
+		if networkInterface.Attachment == nil {
 			continue
 		}
-		_, err := conn.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
-			AttachmentId: ni.Attachment.AttachmentId,
-			Force:        aws.Bool(true),
-		})
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidAttachmentID.NotFound" {
-				log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
-				continue
-			}
-			return err
-		}
 
-		log.Printf("[DEBUG] Waiting for ENI (%s) to become detached", *ni.NetworkInterfaceId)
-		stateConf := &resource.StateChangeConf{
-			Pending: []string{"true"},
-			Target:  []string{"false"},
-			Refresh: networkInterfaceAttachmentRefreshFunc(conn, *ni.NetworkInterfaceId),
-			Timeout: 10 * time.Minute,
-		}
+		attachmentID := aws.StringValue(networkInterface.Attachment.AttachmentId)
+		networkInterfaceID := aws.StringValue(networkInterface.NetworkInterfaceId)
 
-		if _, err := stateConf.WaitForState(); err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				continue
-			}
-			return fmt.Errorf(
-				"Error waiting for ENI (%s) to become detached: %s", *ni.NetworkInterfaceId, err)
-		}
-	}
-	return nil
-}
-
-func deleteNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
-	log.Printf("[DEBUG] Trying to delete %d leftover ENIs", len(nis))
-	for _, ni := range nis {
-		_, err := conn.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-			NetworkInterfaceId: ni.NetworkInterfaceId,
-		})
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				log.Printf("[DEBUG] ENI %s is already deleted", *ni.NetworkInterfaceId)
-				continue
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-func networkInterfaceAttachmentRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-
-		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIds: []*string{aws.String(id)},
-		}
-		describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
+		err = tfec2.DetachNetworkInterface(conn, networkInterfaceID, attachmentID, tfec2.NetworkInterfaceDetachedTimeout)
 
 		if err != nil {
-			log.Printf("[ERROR] Could not find network interface %s. %s", id, err)
-			return nil, "", err
+			errs = multierror.Append(errs, err)
+
+			continue
 		}
 
-		eni := describeResp.NetworkInterfaces[0]
-		hasAttachment := strconv.FormatBool(eni.Attachment != nil)
-		log.Printf("[DEBUG] ENI %s has attachment state %s", id, hasAttachment)
-		return eni, hasAttachment, nil
+		err = tfec2.DeleteNetworkInterface(conn, networkInterfaceID)
+
+		if err != nil {
+			errs = multierror.Append(errs, err)
+
+			continue
+		}
 	}
+
+	return errs.ErrorOrNil()
 }

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -27,8 +27,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-const detachNetworkInterfaceTimeout = 10 * time.Minute
-
 func ResourceLoadBalancer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceLoadBalancerCreate,
@@ -968,11 +966,89 @@ func CleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
 		return nil
 	}
 
-	err = tfec2.DetachNetworkInterfaces(conn, out.NetworkInterfaces, detachNetworkInterfaceTimeout)
+	err = detachNetworkInterfaces(conn, out.NetworkInterfaces)
 	if err != nil {
 		return err
 	}
 
-	err = tfec2.DeleteNetworkInterfaces(conn, out.NetworkInterfaces)
+	err = deleteNetworkInterfaces(conn, out.NetworkInterfaces)
 	return err
+}
+
+func detachNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
+	log.Printf("[DEBUG] Trying to detach %d leftover ENIs", len(nis))
+	for _, ni := range nis {
+		if ni.Attachment == nil {
+			log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
+			continue
+		}
+		_, err := conn.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
+			AttachmentId: ni.Attachment.AttachmentId,
+			Force:        aws.Bool(true),
+		})
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "InvalidAttachmentID.NotFound" {
+				log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
+				continue
+			}
+			return err
+		}
+
+		log.Printf("[DEBUG] Waiting for ENI (%s) to become detached", *ni.NetworkInterfaceId)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"true"},
+			Target:  []string{"false"},
+			Refresh: networkInterfaceAttachmentRefreshFunc(conn, *ni.NetworkInterfaceId),
+			Timeout: 10 * time.Minute,
+		}
+
+		if _, err := stateConf.WaitForState(); err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
+				continue
+			}
+			return fmt.Errorf(
+				"Error waiting for ENI (%s) to become detached: %s", *ni.NetworkInterfaceId, err)
+		}
+	}
+	return nil
+}
+
+func deleteNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
+	log.Printf("[DEBUG] Trying to delete %d leftover ENIs", len(nis))
+	for _, ni := range nis {
+		_, err := conn.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: ni.NetworkInterfaceId,
+		})
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
+				log.Printf("[DEBUG] ENI %s is already deleted", *ni.NetworkInterfaceId)
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func networkInterfaceAttachmentRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
+			NetworkInterfaceIds: []*string{aws.String(id)},
+		}
+		describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
+
+		if err != nil {
+			log.Printf("[ERROR] Could not find network interface %s. %s", id, err)
+			return nil, "", err
+		}
+
+		eni := describeResp.NetworkInterfaces[0]
+		hasAttachment := strconv.FormatBool(eni.Attachment != nil)
+		log.Printf("[DEBUG] ENI %s has attachment state %s", id, hasAttachment)
+		return eni, hasAttachment, nil
+	}
 }

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -976,23 +976,3 @@ func CleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
 	err = tfec2.DeleteNetworkInterfaces(conn, out.NetworkInterfaces)
 	return err
 }
-
-func networkInterfaceAttachmentRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-
-		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIds: []*string{aws.String(id)},
-		}
-		describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
-
-		if err != nil {
-			log.Printf("[ERROR] Could not find network interface %s. %s", id, err)
-			return nil, "", err
-		}
-
-		eni := describeResp.NetworkInterfaces[0]
-		hasAttachment := strconv.FormatBool(eni.Attachment != nil)
-		log.Printf("[DEBUG] ENI %s has attachment state %s", id, hasAttachment)
-		return eni, hasAttachment, nil
-	}
-}

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -802,7 +802,7 @@ func resourceLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error 
 
 	name := d.Get("name").(string)
 
-	err := cleanupNetworkInterfaces(meta.(*conns.AWSClient).EC2Conn, name)
+	err := CleanupNetworkInterfaces(meta.(*conns.AWSClient).EC2Conn, name)
 	if err != nil {
 		log.Printf("[WARN] Failed to cleanup ENIs for ELB %q: %#v", name, err)
 	}
@@ -942,7 +942,7 @@ func validateListenerProtocol() schema.SchemaValidateFunc {
 // but the cleanup is asynchronous and may take time
 // which then blocks IGW, SG or VPC on deletion
 // So we make the cleanup "synchronous" here
-func cleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
+func CleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
 	// https://aws.amazon.com/premiumsupport/knowledge-center/elb-find-load-balancer-IP/.
 	networkInterfaces, err := tfec2.FindNetworkInterfacesByAttachmentInstanceOwnerIDAndDescription(conn, "amazon-elb", "ELB "+name)
 

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -27,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+const detachNetworkInterfaceTimeout = 10 * time.Minute
+
 func ResourceLoadBalancer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceLoadBalancerCreate,
@@ -966,7 +968,7 @@ func CleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
 		return nil
 	}
 
-	err = tfec2.DetachNetworkInterfaces(conn, out.NetworkInterfaces, 10*time.Minute)
+	err = tfec2.DetachNetworkInterfaces(conn, out.NetworkInterfaces, detachNetworkInterfaceTimeout)
 	if err != nil {
 		return err
 	}

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -966,71 +966,13 @@ func CleanupNetworkInterfaces(conn *ec2.EC2, name string) error {
 		return nil
 	}
 
-	err = detachNetworkInterfaces(conn, out.NetworkInterfaces)
+	err = tfec2.DetachNetworkInterfaces(conn, out.NetworkInterfaces, 10*time.Minute)
 	if err != nil {
 		return err
 	}
 
-	err = deleteNetworkInterfaces(conn, out.NetworkInterfaces)
+	err = tfec2.DeleteNetworkInterfaces(conn, out.NetworkInterfaces)
 	return err
-}
-
-func detachNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
-	log.Printf("[DEBUG] Trying to detach %d leftover ENIs", len(nis))
-	for _, ni := range nis {
-		if ni.Attachment == nil {
-			log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
-			continue
-		}
-		_, err := conn.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
-			AttachmentId: ni.Attachment.AttachmentId,
-			Force:        aws.Bool(true),
-		})
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidAttachmentID.NotFound" {
-				log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
-				continue
-			}
-			return err
-		}
-
-		log.Printf("[DEBUG] Waiting for ENI (%s) to become detached", *ni.NetworkInterfaceId)
-		stateConf := &resource.StateChangeConf{
-			Pending: []string{"true"},
-			Target:  []string{"false"},
-			Refresh: networkInterfaceAttachmentRefreshFunc(conn, *ni.NetworkInterfaceId),
-			Timeout: 10 * time.Minute,
-		}
-
-		if _, err := stateConf.WaitForState(); err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				continue
-			}
-			return fmt.Errorf(
-				"Error waiting for ENI (%s) to become detached: %s", *ni.NetworkInterfaceId, err)
-		}
-	}
-	return nil
-}
-
-func deleteNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
-	log.Printf("[DEBUG] Trying to delete %d leftover ENIs", len(nis))
-	for _, ni := range nis {
-		_, err := conn.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-			NetworkInterfaceId: ni.NetworkInterfaceId,
-		})
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				log.Printf("[DEBUG] ENI %s is already deleted", *ni.NetworkInterfaceId)
-				continue
-			}
-			return err
-		}
-	}
-	return nil
 }
 
 func networkInterfaceAttachmentRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -878,23 +878,3 @@ func customizeDiffNLBSubnets(_ context.Context, diff *schema.ResourceDiff, v int
 	}
 	return nil
 }
-
-func networkInterfaceAttachmentRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-
-		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIds: []*string{aws.String(id)},
-		}
-		describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
-
-		if err != nil {
-			log.Printf("[ERROR] Could not find network interface %s. %s", id, err)
-			return nil, "", err
-		}
-
-		eni := describeResp.NetworkInterfaces[0]
-		hasAttachment := strconv.FormatBool(eni.Attachment != nil)
-		log.Printf("[DEBUG] ENI %s has attachment state %s", id, hasAttachment)
-		return eni, hasAttachment, nil
-	}
-}

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -3,18 +3,18 @@ package elbv2
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -565,7 +566,7 @@ func resourceLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error 
 
 	ec2conn := meta.(*conns.AWSClient).EC2Conn
 
-	err := cleanupLBNetworkInterfaces(ec2conn, d.Id())
+	err := cleanupALBNetworkInterfaces(ec2conn, d.Id())
 	if err != nil {
 		log.Printf("[WARN] Failed to cleanup ENIs for ALB %q: %#v", d.Id(), err)
 	}
@@ -582,103 +583,84 @@ func resourceLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error 
 // but the cleanup is asynchronous and may take time
 // which then blocks IGW, SG or VPC on deletion
 // So we make the cleanup "synchronous" here
-func cleanupLBNetworkInterfaces(conn *ec2.EC2, lbArn string) error {
+func cleanupALBNetworkInterfaces(conn *ec2.EC2, lbArn string) error {
 	name, err := getLbNameFromArn(lbArn)
+
 	if err != nil {
 		return err
 	}
 
-	out, err := conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("attachment.instance-owner-id"),
-				Values: []*string{aws.String("amazon-elb")},
-			},
-			{
-				Name:   aws.String("description"),
-				Values: []*string{aws.String("ELB " + name)},
-			},
-		},
-	})
+	networkInterfaces, err := tfec2.FindNetworkInterfacesByAttachmentInstanceOwnerIDAndDescription(conn, "amazon-elb", "ELB "+name)
+
 	if err != nil {
 		return err
 	}
 
-	log.Printf("[DEBUG] Found %d ENIs to cleanup for LB %q",
-		len(out.NetworkInterfaces), name)
+	var errs *multierror.Error
 
-	if len(out.NetworkInterfaces) == 0 {
-		// Nothing to cleanup
-		return nil
+	for _, networkInterface := range networkInterfaces {
+		if networkInterface.Attachment == nil {
+			continue
+		}
+
+		attachmentID := aws.StringValue(networkInterface.Attachment.AttachmentId)
+		networkInterfaceID := aws.StringValue(networkInterface.NetworkInterfaceId)
+
+		err = tfec2.DetachNetworkInterface(conn, networkInterfaceID, attachmentID, tfec2.NetworkInterfaceDetachedTimeout)
+
+		if err != nil {
+			errs = multierror.Append(errs, err)
+
+			continue
+		}
+
+		err = tfec2.DeleteNetworkInterface(conn, networkInterfaceID)
+
+		if err != nil {
+			errs = multierror.Append(errs, err)
+
+			continue
+		}
 	}
 
-	err = detachNetworkInterfaces(conn, out.NetworkInterfaces)
-	if err != nil {
-		return err
-	}
-
-	err = deleteNetworkInterfaces(conn, out.NetworkInterfaces)
-
-	return err
+	return errs.ErrorOrNil()
 }
 
 func waitForNLBNetworkInterfacesToDetach(conn *ec2.EC2, lbArn string) error {
 	name, err := getLbNameFromArn(lbArn)
+
 	if err != nil {
 		return err
 	}
 
-	// We cannot cleanup these ENIs ourselves as that would result in
-	// OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments.
-	// yet presence of these ENIs may prevent us from deleting EIPs associated w/ the NLB
-	input := &ec2.DescribeNetworkInterfacesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("attachment.instance-owner-id"),
-				Values: []*string{aws.String("amazon-aws")},
-			},
-			{
-				Name:   aws.String("attachment.attachment-id"),
-				Values: []*string{aws.String("ela-attach-*")},
-			},
-			{
-				Name:   aws.String("description"),
-				Values: []*string{aws.String("ELB " + name)},
-			},
+	errAttached := errors.New("attached")
+
+	_, err = tfresource.RetryWhen(
+		loadBalancerNetworkInterfaceDetachTimeout,
+		func() (interface{}, error) {
+			networkInterfaces, err := tfec2.FindNetworkInterfacesByAttachmentInstanceOwnerIDAndDescription(conn, "amazon-aws", "ELB "+name)
+
+			if err != nil {
+				return nil, err
+			}
+
+			if len(networkInterfaces) > 0 {
+				return networkInterfaces, errAttached
+			}
+
+			return networkInterfaces, nil
 		},
-	}
-	var out *ec2.DescribeNetworkInterfacesOutput
-	err = resource.Retry(loadBalancerNetworkInterfaceDetachTimeout, func() *resource.RetryError {
-		var err error
-		out, err = conn.DescribeNetworkInterfaces(input)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
+		func(err error) (bool, error) {
+			if errors.Is(err, errAttached) {
+				return true, err
+			}
 
-		niCount := len(out.NetworkInterfaces)
-		if niCount > 0 {
-			log.Printf("[DEBUG] Found %d ENIs to cleanup for NLB %q", niCount, lbArn)
-			return resource.RetryableError(fmt.Errorf("waiting for %d ENIs of %q to clean up", niCount, lbArn))
-		}
-		log.Printf("[DEBUG] ENIs gone for NLB %q", lbArn)
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		out, err = conn.DescribeNetworkInterfaces(input)
-		if err != nil {
-			return fmt.Errorf("error describing network inferfaces: %w", err)
-		}
-
-		niCount := len(out.NetworkInterfaces)
-		if niCount > 0 {
-			return fmt.Errorf("error waiting for %d ENIs of %q to clean up", niCount, lbArn)
-		}
-	}
+			return false, err
+		},
+	)
 
 	if err != nil {
-		return fmt.Errorf("error describing network inferfaces: %w", err)
+		return err
 	}
 
 	return nil
@@ -877,82 +859,4 @@ func customizeDiffNLBSubnets(_ context.Context, diff *schema.ResourceDiff, v int
 		}
 	}
 	return nil
-}
-
-func deleteNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
-	log.Printf("[DEBUG] Trying to delete %d leftover ENIs", len(nis))
-	for _, ni := range nis {
-		_, err := conn.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-			NetworkInterfaceId: ni.NetworkInterfaceId,
-		})
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				log.Printf("[DEBUG] ENI %s is already deleted", *ni.NetworkInterfaceId)
-				continue
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-func detachNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
-	log.Printf("[DEBUG] Trying to detach %d leftover ENIs", len(nis))
-	for _, ni := range nis {
-		if ni.Attachment == nil {
-			log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
-			continue
-		}
-		_, err := conn.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
-			AttachmentId: ni.Attachment.AttachmentId,
-			Force:        aws.Bool(true),
-		})
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidAttachmentID.NotFound" {
-				log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
-				continue
-			}
-			return err
-		}
-
-		log.Printf("[DEBUG] Waiting for ENI (%s) to become detached", *ni.NetworkInterfaceId)
-		stateConf := &resource.StateChangeConf{
-			Pending: []string{"true"},
-			Target:  []string{"false"},
-			Refresh: networkInterfaceAttachmentRefreshFunc(conn, *ni.NetworkInterfaceId),
-			Timeout: 10 * time.Minute,
-		}
-
-		if _, err := stateConf.WaitForState(); err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
-				continue
-			}
-			return fmt.Errorf(
-				"Error waiting for ENI (%s) to become detached: %s", *ni.NetworkInterfaceId, err)
-		}
-	}
-	return nil
-}
-
-func networkInterfaceAttachmentRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-
-		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIds: []*string{aws.String(id)},
-		}
-		describeResp, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
-
-		if err != nil {
-			log.Printf("[ERROR] Could not find network interface %s. %s", id, err)
-			return nil, "", err
-		}
-
-		eni := describeResp.NetworkInterfaces[0]
-		hasAttachment := strconv.FormatBool(eni.Attachment != nil)
-		log.Printf("[DEBUG] ENI %s has attachment state %s", id, hasAttachment)
-		return eni, hasAttachment, nil
-	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21406.
Closes #21647.
Closes #21621.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccELBLoadBalancer_basic" PKG_NAME="internal/service/elb"                 х INT
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elb/... -v -count 1 -parallel 20 -run=TestAccELBLoadBalancer_basic -timeout 180m
=== RUN   TestAccELBLoadBalancer_basic
=== PAUSE TestAccELBLoadBalancer_basic
=== CONT  TestAccELBLoadBalancer_basic
--- PASS: TestAccELBLoadBalancer_basic (48.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	54.305s
```
```
$ make testacc TESTARGS="-run=TestAccELBV2LoadBalancer_ALB_basic" PKG_NAME="internal/service/elbv2"         1m 9s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run=TestAccELBV2LoadBalancer_ALB_basic -timeout 180m
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (275.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	280.868s
```
```
$ make testacc TESTARGS="-run=TestAccEC2NetworkInterface_ENI_basic" PKG_NAME="internal/service/ec2"        4m 55s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run=TestAccEC2NetworkInterface_ENI_basic -timeout 180m
=== RUN   TestAccEC2NetworkInterface_ENI_basic
=== PAUSE TestAccEC2NetworkInterface_ENI_basic
=== CONT  TestAccEC2NetworkInterface_ENI_basic
--- PASS: TestAccEC2NetworkInterface_ENI_basic (104.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	110.448s
```
