### PR TITLE
Add id attribute to server_certificate_data doc

### DIFF
--- a/website/docs/d/iam_server_certificate.html.markdown
+++ b/website/docs/d/iam_server_certificate.html.markdown
@@ -40,6 +40,7 @@ resource "aws_elb" "elb" {
 
 ## Attributes Reference
 
+* `id` is set to the unique id of the IAM Server Certificate
 * `arn` is set to the ARN of the IAM Server Certificate
 * `path` is set to the path of the IAM Server Certificate
 * `expiration_date` is set to the expiration date of the IAM Server Certificate


### PR DESCRIPTION
The `id` attribute is already present[1][2], but not documented.
If not more, at least the `aws_cloudfront_distribution` resource needs[3] to use
`aws_iam_server_certificate.id`, so it make sense to document it.

[1] https://github.com/hashicorp/terraform-provider-aws/blob/187f1659a4fef11ac314567273b5470afe6b662f/internal/service/iam/server_certificate_data_source.go#L138
[2] https://github.com/hashicorp/terraform-provider-aws/blob/187f1659a4fef11ac314567273b5470afe6b662f/internal/service/iam/server_certificate_data_source_test.go#L56
[3] https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#iam_certificate_id

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
