### PR TITLE
Sweeper: Add sweeper for `aws_dms_replication_task`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-SWEEP?=us-east-1,us-east-2,us-west-2
+SWEEP?=us-west-2,us-east-1,us-east-2
 TEST?=./...
 SWEEP_DIR?=./internal/sweep
 PKG_NAME=internal
@@ -16,6 +16,7 @@ gen:
 	go generate ./...
 
 sweep:
+	# make sweep SWEEPARGS=-sweep-run=aws_example_thing
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test $(SWEEP_DIR) -v -tags=sweep -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 

--- a/internal/service/dms/sweep.go
+++ b/internal/service/dms/sweep.go
@@ -19,6 +19,14 @@ func init() {
 	resource.AddTestSweepers("aws_dms_replication_instance", &resource.Sweeper{
 		Name: "aws_dms_replication_instance",
 		F:    sweepReplicationInstances,
+		Dependencies: []string{
+			"aws_dms_replication_task",
+		},
+	})
+
+	resource.AddTestSweepers("aws_dms_replication_task", &resource.Sweeper{
+		Name: "aws_dms_replication_task",
+		F:    sweepReplicationTasks,
 	})
 }
 
@@ -52,6 +60,49 @@ func sweepReplicationInstances(region string) error {
 
 	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("error sweeping DMS Replication Instances for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping DMS Replication Instance sweep for %s: %s", region, err)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepReplicationTasks(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*conns.AWSClient).DMSConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+
+	input := &dms.DescribeReplicationTasksInput{
+		WithoutSettings: aws.Bool(true),
+	}
+	err = conn.DescribeReplicationTasksPages(input, func(page *dms.DescribeReplicationTasksOutput, lastPage bool) bool {
+		for _, instance := range page.ReplicationTasks {
+			r := ResourceReplicationTask()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(instance.ReplicationTaskIdentifier))
+			d.Set("replication_task_arn", instance.ReplicationTaskArn)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error describing DMS Replication Tasks: %w", err))
+	}
+
+	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping DMS Replication Tasks for %s: %w", region, err))
 	}
 
 	if sweep.SkipSweepError(errs.ErrorOrNil()) {

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -170,6 +170,7 @@ func init() {
 			"aws_cloudhsm_v2_cluster",
 			"aws_db_subnet_group",
 			"aws_directory_service_directory",
+			"aws_dms_replication_instance",
 			"aws_ec2_client_vpn_endpoint",
 			"aws_ec2_transit_gateway_vpc_attachment",
 			"aws_efs_file_system",


### PR DESCRIPTION
The sweeper for `aws_dms_replication_instance` was failing due to an existing `aws_dms_replication_task`. Adds a sweeper for `aws_dms_replication_task` to unblock.

Also adds a dependency between the `aws_subnet` sweeper and the `aws_dms_replication_instance` sweeper, since `aws_subnet` was blocked.

Before change:

```
$ make sweep SWEEPARGS=-sweep-run=aws_dms_replication_instance

2021/10/29 16:37:37 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/29 16:37:37 [DEBUG] Running Sweeper (aws_dms_replication_instance) in region (us-west-2)
2021/10/29 16:37:37 [INFO] Attempting to use session-derived credentials
2021/10/29 16:37:40 [INFO] Successfully derived credentials from session
2021/10/29 16:37:40 [INFO] AWS Auth provider used: "CredentialsEndpointProvider"
2021/10/29 16:37:40 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/29 16:37:41 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/29 16:37:42 [DEBUG] Waiting for state to become: [success]
2021/10/29 16:37:42 [DEBUG] DMS delete replication instance: {
  ReplicationInstanceArn: "arn:aws:dms:us-west-2:123456789012:rep:OAZ6SQKIHLR6VOHH3GSKCV36UOY7BRXKU6V7X3I"
}
2021/10/29 16:37:42 [DEBUG] Completed Sweeper (aws_dms_replication_instance) in region (us-west-2) in 5.527915206s
2021/10/29 16:37:42 [ERROR] Error running Sweeper (aws_dms_replication_instance) in region (us-west-2): 1 error occurred:
	* error sweeping DMS Replication Instances for us-west-2: 1 error occurred:
	* error deleting DMS Replication Instance (tf-test-1234): InvalidResourceStateFault: Replication Instance 'tf-test-1234' has one or more replication tasks.
```

After change:

```
$ make sweep SWEEPARGS=-sweep-run=aws_dms_replication_instance

2021/10/29 17:02:46 [DEBUG] Running Sweepers for region (us-west-2):
2021/10/29 17:02:46 [DEBUG] Running Sweeper (aws_dms_replication_task) in region (us-west-2)
2021/10/29 17:02:46 [INFO] Attempting to use session-derived credentials
2021/10/29 17:02:46 [INFO] Successfully derived credentials from session
2021/10/29 17:02:46 [INFO] AWS Auth provider used: "CredentialsEndpointProvider"
2021/10/29 17:02:46 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/29 17:02:46 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/10/29 17:02:47 [DEBUG] Waiting for state to become: [success]
2021/10/29 17:02:47 [DEBUG] DMS delete replication task: {
  ReplicationTaskArn: "arn:aws:dms:us-west-2: 123456789012:task:WJDPISB327EQHSJYC6M5KG4ZQUALG5OHZH6XH7I"
}
2021/10/29 17:02:48 [DEBUG] Waiting for state to become: []
2021/10/29 17:03:18 [DEBUG] Completed Sweeper (aws_dms_replication_task) in region (us-west-2) in 32.023665757s
2021/10/29 17:03:18 [DEBUG] Sweeper (aws_dms_replication_instance) has dependency (aws_dms_replication_task), running..
2021/10/29 17:03:18 [DEBUG] Sweeper (aws_dms_replication_task) already ran in region (us-west-2)
2021/10/29 17:03:18 [DEBUG] Running Sweeper (aws_dms_replication_instance) in region (us-west-2)
2021/10/29 17:03:18 [DEBUG] Waiting for state to become: [success]
2021/10/29 17:03:18 [DEBUG] DMS delete replication instance: {
  ReplicationInstanceArn: "arn:aws:dms:us-west-2: 123456789012:rep:OAZ6SQKIHLR6VOHH3GSKCV36UOY7BRXKU6V7X3I"
}
2021/10/29 17:03:18 [DEBUG] Waiting for state to become: []
2021/10/29 17:03:49 [TRACE] Waiting 10s before next try
2021/10/29 17:03:59 [TRACE] Waiting 10s before next try
2021/10/29 17:04:09 [TRACE] Waiting 10s before next try
2021/10/29 17:04:19 [TRACE] Waiting 10s before next try
2021/10/29 17:04:30 [TRACE] Waiting 10s before next try
2021/10/29 17:04:40 [TRACE] Waiting 10s before next try
2021/10/29 17:04:50 [TRACE] Waiting 10s before next try
2021/10/29 17:05:00 [DEBUG] Completed Sweeper (aws_dms_replication_instance) in region (us-west-2) in 1m42.388365832s
2021/10/29 17:05:00 Completed Sweepers for region (us-west-2) in 2m14.412154353s
2021/10/29 17:05:00 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_dms_replication_task
	- aws_dms_replication_instance
```
