### PR TITLE
Rename canonical_user_id to be in S3

### DIFF
--- a/.changelog/21569.txt
+++ b/.changelog/21569.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+  data-source/aws_canonical_user_id: Rename data source to aws_s3_canonical_user_id (with alias for aws_canonical_user_id)
+  ```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -311,7 +311,7 @@ jobs:
         tfproviderdocs check \
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
-          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
+          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group,aws_canonical_user_id \
           -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -1345,7 +1345,7 @@ Avoid hard coding values in acceptance test checks and configurations for consis
 
 - [ ] __Uses Account Data Sources__: Any hardcoded account numbers in configuration, e.g., `137112412989`, should be replaced with a data source. Depending on the situation, there are several data sources for account IDs including:
     - [`aws_caller_identity` data source](https://www.terraform.io/docs/providers/aws/d/caller_identity.html),
-    - [`aws_canonical_user_id` data source](https://www.terraform.io/docs/providers/aws/d/canonical_user_id.html),
+    - [`aws_s3_canonical_user_id` data source](https://www.terraform.io/docs/providers/aws/d/canonical_user_id.html),
     - [`aws_billing_service_account` data source](https://www.terraform.io/docs/providers/aws/d/billing_service_account.html), and
     - [`aws_sagemaker_prebuilt_ecr_image` data source](https://www.terraform.io/docs/providers/aws/d/sagemaker_prebuilt_ecr_image.html).
 - [ ] __Uses Account Test Checks__: Any check required to verify an AWS Account ID of the current testing account or another account should use one of the following available helper functions over the usage of `resource.TestCheckResourceAttrSet()` and `resource.TestMatchResourceAttr()`:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -637,10 +637,11 @@ func Provider() *schema.Provider {
 			"aws_route53_resolver_rule":     route53resolver.DataSourceRule(),
 			"aws_route53_resolver_rules":    route53resolver.DataSourceRules(),
 
-			"aws_canonical_user_id": s3.DataSourceCanonicalUserID(),
-			"aws_s3_bucket":         s3.DataSourceBucket(),
-			"aws_s3_bucket_object":  s3.DataSourceBucketObject(),
-			"aws_s3_bucket_objects": s3.DataSourceBucketObjects(),
+			"aws_canonical_user_id":    s3.DataSourceCanonicalUserID(), // backward compatible alias
+			"aws_s3_bucket":            s3.DataSourceBucket(),
+			"aws_s3_bucket_object":     s3.DataSourceBucketObject(),
+			"aws_s3_bucket_objects":    s3.DataSourceBucketObjects(),
+			"aws_s3_canonical_user_id": s3.DataSourceCanonicalUserID(),
 
 			"aws_sagemaker_prebuilt_ecr_image": sagemaker.DataSourcePrebuiltECRImage(),
 

--- a/internal/service/ec2/spot_datafeed_subscription_test.go
+++ b/internal/service/ec2/spot_datafeed_subscription_test.go
@@ -169,13 +169,13 @@ func testAccPreCheckSpotDatafeedSubscription(t *testing.T) {
 
 func testAccSpotDatafeedSubscription(rName string) string {
 	return fmt.Sprintf(`
-data "aws_canonical_user_id" "current" {}
+data "aws_s3_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
   grant {
-    id          = data.aws_canonical_user_id.current.id
+    id          = data.aws_s3_canonical_user_id.current.id
     permissions = ["FULL_CONTROL"]
     type        = "CanonicalUser"
   }

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3816,13 +3816,13 @@ resource "aws_s3_bucket" "bucket" {
 
 func testAccBucketWithGrantsConfig(bucketName string) string {
 	return fmt.Sprintf(`
-data "aws_canonical_user_id" "current" {}
+data "aws_s3_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 
   grant {
-    id          = data.aws_canonical_user_id.current.id
+    id          = data.aws_s3_canonical_user_id.current.id
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL", "WRITE"]
   }
@@ -3832,13 +3832,13 @@ resource "aws_s3_bucket" "bucket" {
 
 func testAccBucketWithGrantsUpdateConfig(bucketName string) string {
 	return fmt.Sprintf(`
-data "aws_canonical_user_id" "current" {}
+data "aws_s3_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 
   grant {
-    id          = data.aws_canonical_user_id.current.id
+    id          = data.aws_s3_canonical_user_id.current.id
     type        = "CanonicalUser"
     permissions = ["READ"]
   }

--- a/internal/service/s3/canonical_user_id_data_source_test.go
+++ b/internal/service/s3/canonical_user_id_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccS3CanonicalUserIDDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCanonicalUserIdDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCanonicalUserIdCheckExistsDataSource("data.aws_canonical_user_id.current"),
+					testAccCanonicalUserIdCheckExistsDataSource("data.aws_s3_canonical_user_id.current"),
 				),
 			},
 		},
@@ -45,5 +45,5 @@ func testAccCanonicalUserIdCheckExistsDataSource(name string) resource.TestCheck
 }
 
 const testAccCanonicalUserIdDataSourceConfig = `
-data "aws_canonical_user_id" "current" {}
+data "aws_s3_canonical_user_id" "current" {}
 `

--- a/website/docs/d/s3_canonical_user_id.html.markdown
+++ b/website/docs/d/s3_canonical_user_id.html.markdown
@@ -1,13 +1,13 @@
 ---
 subcategory: "S3"
 layout: "aws"
-page_title: "AWS: aws_canonical_user_id"
+page_title: "AWS: aws_s3_canonical_user_id"
 description: |-
   Provides the canonical user ID for the AWS account associated with the provider
   connection to AWS.
 ---
 
-# Data Source: aws_canonical_user_id
+# Data Source: aws_s3_canonical_user_id
 
 The Canonical User ID data source allows access to the [canonical user ID](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)
 for the effective account in which Terraform is working.  
@@ -15,10 +15,10 @@ for the effective account in which Terraform is working.
 ## Example Usage
 
 ```terraform
-data "aws_canonical_user_id" "current" {}
+data "aws_s3_canonical_user_id" "current" {}
 
 output "canonical_user_id" {
-  value = data.aws_canonical_user_id.current.id
+  value = data.aws_s3_canonical_user_id.current.id
 }
 ```
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -326,13 +326,13 @@ resource "aws_s3_bucket" "mybucket" {
 ### Using ACL policy grants
 
 ```terraform
-data "aws_canonical_user_id" "current_user" {}
+data "aws_s3_canonical_user_id" "current_user" {}
 
 resource "aws_s3_bucket" "bucket" {
   bucket = "mybucket"
 
   grant {
-    id          = data.aws_canonical_user_id.current_user.id
+    id          = data.aws_s3_canonical_user_id.current_user.id
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3CanonicalUserIDDataSource_basic (9.53s)
```
