### PR TITLE
Realign inconsistent CloudControl names

### DIFF
--- a/.changelog/21572.txt
+++ b/.changelog/21572.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+  data-source/aws_cloudcontrolapi_resource: Rename data source to aws_cloudcontrol_resource (with alias for aws_cloudcontrolapi_resource)
+  ```
+
+  ```release-note:enhancement
+ resource/aws_cloudcontrolapi_resource: Rename resource to aws_cloudcontrol_resource (with alias for aws_cloudcontrolapi_resource)
+  ```

--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -79,7 +79,7 @@ service/chime:
 service/cloud9:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloud9_'
 service/cloudcontrolapi:
-  - '((\*|-) ?`?|(data|resource) "?)aws_cloudcontrolapi_'
+  - '((\*|-) ?`?|(data|resource) "?)aws_cloudcontrol_'
 service/clouddirectory:
   - '((\*|-) ?`?|(data|resource) "?)aws_clouddirectory_'
 service/cloudformation:

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -311,8 +311,8 @@ jobs:
         tfproviderdocs check \
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
-          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group,aws_cloudcontrolapi_resource \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_cloudcontrolapi_resource \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -364,7 +364,8 @@ func Provider() *schema.Provider {
 			"aws_batch_compute_environment": batch.DataSourceComputeEnvironment(),
 			"aws_batch_job_queue":           batch.DataSourceJobQueue(),
 
-			"aws_cloudcontrolapi_resource": cloudcontrol.DataSourceResource(),
+			"aws_cloudcontrol_resource":    cloudcontrol.DataSourceResource(),
+			"aws_cloudcontrolapi_resource": cloudcontrol.DataSourceResource(), // backward compatible alias
 
 			"aws_cloudformation_export": cloudformation.DataSourceExport(),
 			"aws_cloudformation_stack":  cloudformation.DataSourceStack(),
@@ -835,7 +836,8 @@ func Provider() *schema.Provider {
 
 			"aws_cloud9_environment_ec2": cloud9.ResourceEnvironmentEC2(),
 
-			"aws_cloudcontrolapi_resource": cloudcontrol.ResourceResource(),
+			"aws_cloudcontrol_resource":    cloudcontrol.ResourceResource(),
+			"aws_cloudcontrolapi_resource": cloudcontrol.ResourceResource(), // backward compatible alias
 
 			"aws_cloudformation_stack":              cloudformation.ResourceStack(),
 			"aws_cloudformation_stack_set":          cloudformation.ResourceStackSet(),

--- a/internal/service/cloudcontrol/resource_data_source_test.go
+++ b/internal/service/cloudcontrol/resource_data_source_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestAccCloudControlResourceDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	dataSourceName := "data.aws_cloudcontrolapi_resource.test"
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	dataSourceName := "data.aws_cloudcontrol_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccCloudControlResourceDataSource_basic(t *testing.T) {
 
 func testAccResourceDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -43,9 +43,9 @@ resource "aws_cloudcontrolapi_resource" "test" {
   })
 }
 
-data "aws_cloudcontrolapi_resource" "test" {
-  identifier = aws_cloudcontrolapi_resource.test.id
-  type_name  = aws_cloudcontrolapi_resource.test.type_name
+data "aws_cloudcontrol_resource" "test" {
+  identifier = aws_cloudcontrol_resource.test.id
+  type_name  = aws_cloudcontrol_resource.test.type_name
 }
 `, rName)
 }

--- a/internal/service/cloudcontrol/resource_test.go
+++ b/internal/service/cloudcontrol/resource_test.go
@@ -29,7 +29,7 @@ func testAccErrorCheckSkipCloudControlAPI(t *testing.T) resource.ErrorCheckFunc 
 
 func TestAccCloudControlResource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -50,7 +50,7 @@ func TestAccCloudControlResource_basic(t *testing.T) {
 
 func TestAccCloudControlResource_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -71,7 +71,7 @@ func TestAccCloudControlResource_disappears(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_booleanValueAdded(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -97,7 +97,7 @@ func TestAccCloudControlResource_DesiredState_booleanValueAdded(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_booleanValueRemoved(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -123,7 +123,7 @@ func TestAccCloudControlResource_DesiredState_booleanValueRemoved(t *testing.T) 
 
 func TestAccCloudControlResource_DesiredState_booleanValueUpdate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -150,7 +150,7 @@ func TestAccCloudControlResource_DesiredState_booleanValueUpdate(t *testing.T) {
 func TestAccCloudControlResource_DesiredState_createOnly(t *testing.T) {
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -176,7 +176,7 @@ func TestAccCloudControlResource_DesiredState_createOnly(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_integerValueAdded(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -202,7 +202,7 @@ func TestAccCloudControlResource_DesiredState_integerValueAdded(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_integerValueRemoved(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -228,7 +228,7 @@ func TestAccCloudControlResource_DesiredState_integerValueRemoved(t *testing.T) 
 
 func TestAccCloudControlResource_DesiredState_integerValueUpdate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -288,7 +288,7 @@ func TestAccCloudControlResource_DesiredState_invalidPropertyValue(t *testing.T)
 
 func TestAccCloudControlResource_DesiredState_objectValueAdded(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -314,7 +314,7 @@ func TestAccCloudControlResource_DesiredState_objectValueAdded(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_objectValueRemoved(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -340,7 +340,7 @@ func TestAccCloudControlResource_DesiredState_objectValueRemoved(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_objectValueUpdate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -372,7 +372,7 @@ func TestAccCloudControlResource_DesiredState_objectValueUpdate(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_stringValueAdded(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -398,7 +398,7 @@ func TestAccCloudControlResource_DesiredState_stringValueAdded(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_stringValueRemoved(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -424,7 +424,7 @@ func TestAccCloudControlResource_DesiredState_stringValueRemoved(t *testing.T) {
 
 func TestAccCloudControlResource_DesiredState_stringValueUpdate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -450,7 +450,7 @@ func TestAccCloudControlResource_DesiredState_stringValueUpdate(t *testing.T) {
 
 func TestAccCloudControlResource_resourceSchema(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudcontrolapi_resource.test"
+	resourceName := "aws_cloudcontrol_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -472,7 +472,7 @@ func testAccCheckResourceDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudControlConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudcontrolapi_resource" {
+		if rs.Type != "aws_cloudcontrol_resource" {
 			continue
 		}
 
@@ -494,7 +494,7 @@ func testAccCheckResourceDestroy(s *terraform.State) error {
 
 func testAccResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -506,7 +506,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateBooleanValueConfig(rName string, booleanValue bool) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::ApiGateway::ApiKey"
 
   desired_state = jsonencode({
@@ -520,7 +520,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateBooleanValueRemovedConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::ApiGateway::ApiKey"
 
   desired_state = jsonencode({
@@ -533,7 +533,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateCreateOnlyConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -545,7 +545,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateIntegerValueConfig(rName string, integerValue int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -558,7 +558,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateIntegerValueRemovedConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -570,7 +570,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateInvalidPropertyNameConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -582,7 +582,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateInvalidPropertyValueConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Logs::LogGroup"
 
   desired_state = jsonencode({
@@ -594,7 +594,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateObjectValue1Config(rName string, key1 string, value1 string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::ECS::Cluster"
 
   desired_state = jsonencode({
@@ -612,7 +612,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateObjectValueRemovedConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::ECS::Cluster"
 
   desired_state = jsonencode({
@@ -624,7 +624,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateStringValueConfig(rName string, stringValue string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Athena::WorkGroup"
 
   desired_state = jsonencode({
@@ -637,7 +637,7 @@ resource "aws_cloudcontrolapi_resource" "test" {
 
 func testAccResourceDesiredStateStringValueRemovedConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   type_name = "AWS::Athena::WorkGroup"
 
   desired_state = jsonencode({
@@ -654,7 +654,7 @@ data "aws_cloudformation_type" "test" {
   type_name = "AWS::Logs::LogGroup"
 }
 
-resource "aws_cloudcontrolapi_resource" "test" {
+resource "aws_cloudcontrol_resource" "test" {
   schema    = data.aws_cloudformation_type.test.schema
   type_name = data.aws_cloudformation_type.test.type_name
 

--- a/website/docs/d/cloudcontrol_resource.html.markdown
+++ b/website/docs/d/cloudcontrol_resource.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "Cloud Control API"
 layout: "aws"
-page_title: "AWS: aws_cloudcontrolapi_resource"
+page_title: "AWS: aws_cloudcontrol_resource"
 description: |-
     Provides details for a Cloud Control API Resource.
 ---
 
-# Data Source: aws_cloudcontrolapi_resource
+# Data Source: aws_cloudcontrol_resource
 
 Provides details for a Cloud Control API Resource. The reading of these resources is proxied through Cloud Control API handlers to the backend service.
 
 ## Example Usage
 
 ```terraform
-data "aws_cloudcontrolapi_resource" "example" {
+data "aws_cloudcontrol_resource" "example" {
   identifier = "example"
   type_name  = "AWS::ECS::Cluster"
 }
@@ -35,4 +35,4 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `properties` - JSON string matching the CloudFormation resource type schema with current configuration. Underlying attributes can be referenced via the [`jsondecode()` function](https://www.terraform.io/docs/language/functions/jsondecode.html), for example, `jsondecode(data.aws_cloudcontrolapi_resource.example.properties)["example"]`.
+* `properties` - JSON string matching the CloudFormation resource type schema with current configuration. Underlying attributes can be referenced via the [`jsondecode()` function](https://www.terraform.io/docs/language/functions/jsondecode.html), for example, `jsondecode(data.aws_cloudcontrol_resource.example.properties)["example"]`.

--- a/website/docs/r/cloudcontrol_resource.html.markdown
+++ b/website/docs/r/cloudcontrol_resource.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "Cloud Control API"
 layout: "aws"
-page_title: "AWS: aws_cloudcontrolapi_resource"
+page_title: "AWS: aws_cloudcontrol_resource"
 description: |-
     Manages a Cloud Control API Resource.
 ---
 
-# Resource: aws_cloudcontrolapi_resource
+# Resource: aws_cloudcontrol_resource
 
 Manages a Cloud Control API Resource. The configuration and lifecycle handling of these resources is proxied through Cloud Control API handlers to the backend service.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudcontrolapi_resource" "example" {
+resource "aws_cloudcontrol_resource" "example" {
   type_name = "AWS::ECS::Cluster"
 
   desired_state = jsonencode({
@@ -45,4 +45,4 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `properties` - JSON string matching the CloudFormation resource type schema with current configuration. Underlying attributes can be referenced via the [`jsondecode()` function](https://www.terraform.io/docs/language/functions/jsondecode.html), for example, `jsondecode(data.aws_cloudcontrolapi_resource.example.properties)["example"]`.
+* `properties` - JSON string matching the CloudFormation resource type schema with current configuration. Underlying attributes can be referenced via the [`jsondecode()` function](https://www.terraform.io/docs/language/functions/jsondecode.html), for example, `jsondecode(data.aws_cloudcontrol_resource.example.properties)["example"]`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
