### PR TITLE
Realign inconsistent cloudhsm resource names

### DIFF
--- a/.changelog/21585.txt
+++ b/.changelog/21585.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+data-source/aws_cloudhsm_v2_cluster: Rename data source to aws_cloudhsmv2_cluster (with alias for aws_cloudhsm_v2_cluster)
+```
+
+```release-note:enhancement
+resource/aws_cloudhsm_v2_cluster: Rename resource to aws_cloudhsmv2_cluster (with alias for aws_cloudhsm_v2_cluster)
+```
+
+```release-note:enhancement
+resource/aws_cloudhsm_v2_hsm: Rename resource to aws_cloudhsmv2_hsm (with alias for aws_cloudhsm_v2_hsm)
+```

--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -87,7 +87,7 @@ service/cloudformation:
 service/cloudfront:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudfront_'
 service/cloudhsmv2:
-  - '((\*|-) ?`?|(data|resource) "?)aws_cloudhsm_v2_'
+  - '((\*|-) ?`?|(data|resource) "?)aws_cloudhsmv2_'
 service/cloudsearch:
   - '((\*|-) ?`?|(data|resource) "?)aws_cloudsearch_'
 service/cloudtrail:

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -311,8 +311,8 @@ jobs:
         tfproviderdocs check \
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
-          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group,aws_cloudhsm_v2_cluster \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_cloudhsm_v2_cluster,aws_cloudhsm_v2_hsm \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/examples/cloudhsm/main.tf
+++ b/examples/cloudhsm/main.tf
@@ -12,7 +12,7 @@ resource "aws_vpc" "cloudhsm_v2_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "example-aws_cloudhsm_v2_cluster"
+    Name = "example-aws_cloudhsmv2_cluster"
   }
 }
 
@@ -24,25 +24,25 @@ resource "aws_subnet" "cloudhsm_v2_subnets" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "example-aws_cloudhsm_v2_cluster"
+    Name = "example-aws_cloudhsmv2_cluster"
   }
 }
 
-resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
+resource "aws_cloudhsmv2_cluster" "cloudhsm_v2_cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.cloudhsm_v2_subnets.*.id
 
   tags = {
-    Name = "example-aws_cloudhsm_v2_cluster"
+    Name = "example-aws_cloudhsmv2_cluster"
   }
 }
 
-resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
+resource "aws_cloudhsmv2_hsm" "cloudhsm_v2_hsm" {
   subnet_id  = aws_subnet.cloudhsm_v2_subnets[0].id
-  cluster_id = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.cluster_id
+  cluster_id = aws_cloudhsmv2_cluster.cloudhsm_v2_cluster.cluster_id
 }
 
-data "aws_cloudhsm_v2_cluster" "cluster" {
-  cluster_id = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.cluster_id
-  depends_on = [aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm]
+data "aws_cloudhsmv2_cluster" "cluster" {
+  cluster_id = aws_cloudhsmv2_cluster.cloudhsm_v2_cluster.cluster_id
+  depends_on = [aws_cloudhsmv2_hsm.cloudhsm_v2_hsm]
 }

--- a/examples/cloudhsm/outputs.tf
+++ b/examples/cloudhsm/outputs.tf
@@ -1,7 +1,7 @@
 output "hsm_ip_address" {
-  value = aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.ip_address
+  value = aws_cloudhsmv2_hsm.cloudhsm_v2_hsm.ip_address
 }
 
 output "cluster_data_certificate" {
-  value = data.aws_cloudhsm_v2_cluster.cluster.cluster_certificates[0].cluster_csr
+  value = data.aws_cloudhsmv2_cluster.cluster.cluster_certificates[0].cluster_csr
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -376,7 +376,8 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_log_delivery_canonical_user_id": cloudfront.DataSourceLogDeliveryCanonicalUserID(),
 			"aws_cloudfront_origin_request_policy":          cloudfront.DataSourceOriginRequestPolicy(),
 
-			"aws_cloudhsm_v2_cluster": cloudhsmv2.DataSourceCluster(),
+			"aws_cloudhsmv2_cluster":  cloudhsmv2.DataSourceCluster(),
+			"aws_cloudhsm_v2_cluster": cloudhsmv2.DataSourceCluster(), // backward compatible alias
 
 			"aws_cloudtrail_service_account": cloudtrail.DataSourceServiceAccount(),
 
@@ -852,8 +853,10 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_public_key":              cloudfront.ResourcePublicKey(),
 			"aws_cloudfront_realtime_log_config":     cloudfront.ResourceRealtimeLogConfig(),
 
-			"aws_cloudhsm_v2_cluster": cloudhsmv2.ResourceCluster(),
-			"aws_cloudhsm_v2_hsm":     cloudhsmv2.ResourceHSM(),
+			"aws_cloudhsmv2_cluster":  cloudhsmv2.ResourceCluster(),
+			"aws_cloudhsmv2_hsm":      cloudhsmv2.ResourceHSM(),
+			"aws_cloudhsm_v2_cluster": cloudhsmv2.ResourceCluster(), // backward compatible alias
+			"aws_cloudhsm_v2_hsm":     cloudhsmv2.ResourceHSM(),     // backward compatible alias
 
 			"aws_cloudtrail": cloudtrail.ResourceCloudTrail(),
 

--- a/internal/service/cloudhsmv2/cluster_data_source_test.go
+++ b/internal/service/cloudhsmv2/cluster_data_source_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func testAccDataSourceCloudHsmV2Cluster_basic(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_cluster.cluster"
-	dataSourceName := "data.aws_cloudhsm_v2_cluster.default"
+	resourceName := "aws_cloudhsmv2_cluster.cluster"
+	dataSourceName := "data.aws_cloudhsmv2_cluster.default"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -44,7 +44,7 @@ resource "aws_vpc" "cloudhsm_v2_test_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-aws_cloudhsm_v2_cluster-data-source-basic"
+    Name = "terraform-testacc-aws_cloudhsmv2_cluster-data-source-basic"
   }
 }
 
@@ -56,20 +56,20 @@ resource "aws_subnet" "cloudhsm_v2_test_subnets" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic"
+    Name = "tf-acc-aws_cloudhsmv2_cluster-data-source-basic"
   }
 }
 
-resource "aws_cloudhsm_v2_cluster" "cluster" {
+resource "aws_cloudhsmv2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.cloudhsm_v2_test_subnets[*].id
 
   tags = {
-    Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic-%d"
+    Name = "tf-acc-aws_cloudhsmv2_cluster-data-source-basic-%d"
   }
 }
 
-data "aws_cloudhsm_v2_cluster" "default" {
-  cluster_id = aws_cloudhsm_v2_cluster.cluster.cluster_id
+data "aws_cloudhsmv2_cluster" "default" {
+  cluster_id = aws_cloudhsmv2_cluster.cluster.cluster_id
 }
 `, sdkacctest.RandInt()))

--- a/internal/service/cloudhsmv2/cluster_test.go
+++ b/internal/service/cloudhsmv2/cluster_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func testAccCluster_basic(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_cluster.test"
+	resourceName := "aws_cloudhsmv2_cluster.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -50,7 +50,7 @@ func testAccCluster_basic(t *testing.T) {
 }
 
 func testAccCluster_disappears(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_cluster.test"
+	resourceName := "aws_cloudhsmv2_cluster.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -73,7 +73,7 @@ func testAccCluster_disappears(t *testing.T) {
 }
 
 func testAccCluster_Tags(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_cluster.test"
+	resourceName := "aws_cloudhsmv2_cluster.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -144,7 +144,7 @@ resource "aws_subnet" "test" {
 
 func testAccClusterConfig() string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), `
-resource "aws_cloudhsm_v2_cluster" "test" {
+resource "aws_cloudhsmv2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.test[*].id
 }
@@ -153,7 +153,7 @@ resource "aws_cloudhsm_v2_cluster" "test" {
 
 func testAccClusterTags1Config(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
-resource "aws_cloudhsm_v2_cluster" "test" {
+resource "aws_cloudhsmv2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.test[*].id
 
@@ -166,7 +166,7 @@ resource "aws_cloudhsm_v2_cluster" "test" {
 
 func testAccClusterTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccClusterBaseConfig(), fmt.Sprintf(`
-resource "aws_cloudhsm_v2_cluster" "test" {
+resource "aws_cloudhsmv2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.test[*].id
 
@@ -182,7 +182,7 @@ func testAccCheckClusterDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudHSMV2Conn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudhsm_v2_cluster" {
+		if rs.Type != "aws_cloudhsmv2_cluster" {
 			continue
 		}
 		cluster, err := tfcloudhsmv2.FindCluster(conn, rs.Primary.ID)

--- a/internal/service/cloudhsmv2/hsm_test.go
+++ b/internal/service/cloudhsmv2/hsm_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func testAccHSM_basic(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_hsm.test"
+	resourceName := "aws_cloudhsmv2_hsm.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -28,7 +28,7 @@ func testAccHSM_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHSMExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", "aws_subnet.test.0", "availability_zone"),
-					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "aws_cloudhsm_v2_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "aws_cloudhsmv2_cluster.test", "id"),
 					resource.TestMatchResourceAttr(resourceName, "hsm_eni_id", regexp.MustCompile(`^eni-.+`)),
 					resource.TestMatchResourceAttr(resourceName, "hsm_id", regexp.MustCompile(`^hsm-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "hsm_state", cloudhsmv2.HsmStateActive),
@@ -46,7 +46,7 @@ func testAccHSM_basic(t *testing.T) {
 }
 
 func testAccHSM_disappears(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_hsm.test"
+	resourceName := "aws_cloudhsmv2_hsm.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -69,8 +69,8 @@ func testAccHSM_disappears(t *testing.T) {
 }
 
 func testAccHSM_disappears_Cluster(t *testing.T) {
-	clusterResourceName := "aws_cloudhsm_v2_cluster.test"
-	resourceName := "aws_cloudhsm_v2_hsm.test"
+	clusterResourceName := "aws_cloudhsmv2_cluster.test"
+	resourceName := "aws_cloudhsmv2_hsm.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -92,7 +92,7 @@ func testAccHSM_disappears_Cluster(t *testing.T) {
 }
 
 func testAccHSM_AvailabilityZone(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_hsm.test"
+	resourceName := "aws_cloudhsmv2_hsm.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -117,7 +117,7 @@ func testAccHSM_AvailabilityZone(t *testing.T) {
 }
 
 func testAccHSM_IPAddress(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_hsm.test"
+	resourceName := "aws_cloudhsmv2_hsm.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -164,7 +164,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 }
 
-resource "aws_cloudhsm_v2_cluster" "test" {
+resource "aws_cloudhsmv2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.test[*].id
 }
@@ -175,9 +175,9 @@ func testAccHSMAvailabilityZoneConfig() string {
 	return acctest.ConfigCompose(
 		testAccHSMBaseConfig(),
 		`
-resource "aws_cloudhsm_v2_hsm" "test" {
+resource "aws_cloudhsmv2_hsm" "test" {
   availability_zone = aws_subnet.test[0].availability_zone
-  cluster_id        = aws_cloudhsm_v2_cluster.test.cluster_id
+  cluster_id        = aws_cloudhsmv2_cluster.test.cluster_id
 }
 `)
 }
@@ -186,8 +186,8 @@ func testAccHSMIPAddressConfig() string {
 	return acctest.ConfigCompose(
 		testAccHSMBaseConfig(),
 		`
-resource "aws_cloudhsm_v2_hsm" "test" {
-  cluster_id = aws_cloudhsm_v2_cluster.test.cluster_id
+resource "aws_cloudhsmv2_hsm" "test" {
+  cluster_id = aws_cloudhsmv2_cluster.test.cluster_id
   ip_address = cidrhost(aws_subnet.test[0].cidr_block, 5)
   subnet_id  = aws_subnet.test[0].id
 }
@@ -198,8 +198,8 @@ func testAccHSMSubnetIDConfig() string {
 	return acctest.ConfigCompose(
 		testAccHSMBaseConfig(),
 		`
-resource "aws_cloudhsm_v2_hsm" "test" {
-  cluster_id = aws_cloudhsm_v2_cluster.test.cluster_id
+resource "aws_cloudhsmv2_hsm" "test" {
+  cluster_id = aws_cloudhsmv2_cluster.test.cluster_id
   subnet_id  = aws_subnet.test[0].id
 }
 `)
@@ -209,7 +209,7 @@ func testAccCheckHSMDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudHSMV2Conn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudhsm_v2_hsm" {
+		if rs.Type != "aws_cloudhsmv2_hsm" {
 			continue
 		}
 

--- a/internal/service/cloudhsmv2/sweep.go
+++ b/internal/service/cloudhsmv2/sweep.go
@@ -15,14 +15,14 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("aws_cloudhsm_v2_cluster", &resource.Sweeper{
-		Name:         "aws_cloudhsm_v2_cluster",
+	resource.AddTestSweepers("aws_cloudhsmv2_cluster", &resource.Sweeper{
+		Name:         "aws_cloudhsmv2_cluster",
 		F:            sweepCloudhsmv2Clusters,
-		Dependencies: []string{"aws_cloudhsm_v2_hsm"},
+		Dependencies: []string{"aws_cloudhsmv2_hsm"},
 	})
 
-	resource.AddTestSweepers("aws_cloudhsm_v2_hsm", &resource.Sweeper{
-		Name: "aws_cloudhsm_v2_hsm",
+	resource.AddTestSweepers("aws_cloudhsmv2_hsm", &resource.Sweeper{
+		Name: "aws_cloudhsmv2_hsm",
 		F:    sweepCloudhsmv2HSMs,
 	})
 }

--- a/internal/service/cloudwatchlogs/sweep.go
+++ b/internal/service/cloudwatchlogs/sweep.go
@@ -21,7 +21,7 @@ func init() {
 		F:    sweepGroups,
 		Dependencies: []string{
 			"aws_api_gateway_rest_api",
-			"aws_cloudhsm_v2_cluster",
+			"aws_cloudhsmv2_cluster",
 			"aws_cloudtrail",
 			"aws_datasync_task",
 			"aws_db_instance",

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -167,7 +167,7 @@ func init() {
 			"aws_autoscaling_group",
 			"aws_batch_compute_environment",
 			"aws_elastic_beanstalk_environment",
-			"aws_cloudhsm_v2_cluster",
+			"aws_cloudhsmv2_cluster",
 			"aws_db_subnet_group",
 			"aws_directory_service_directory",
 			"aws_ec2_client_vpn_endpoint",

--- a/website/docs/d/cloudhsmv2_cluster.html.markdown
+++ b/website/docs/d/cloudhsmv2_cluster.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudHSM v2"
 layout: "aws"
-page_title: "AWS: aws_cloudhsm_v2_cluster"
+page_title: "AWS: aws_cloudhsmv2_cluster"
 description: |-
   Get information on a CloudHSM v2 cluster.
 ---
 
-# Data Source: aws_cloudhsm_v2_cluster
+# Data Source: aws_cloudhsmv2_cluster
 
 Use this data source to get information about a CloudHSM v2 cluster
 
 ## Example Usage
 
 ```terraform
-data "aws_cloudhsm_v2_cluster" "cluster" {
+data "aws_cloudhsmv2_cluster" "cluster" {
   cluster_id = "cluster-testclusterid"
 }
 ```

--- a/website/docs/r/cloudhsmv2_cluster.html.markdown
+++ b/website/docs/r/cloudhsmv2_cluster.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "CloudHSM v2"
 layout: "aws"
-page_title: "AWS: aws_cloudhsm_v2_cluster"
+page_title: "AWS: aws_cloudhsmv2_cluster"
 description: |-
   Provides a CloudHSM v2 resource.
 ---
 
-# Resource: aws_cloudhsm_v2_cluster
+# Resource: aws_cloudhsmv2_cluster
 
 Creates an Amazon CloudHSM v2 cluster.
 
@@ -34,7 +34,7 @@ resource "aws_vpc" "cloudhsm_v2_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "example-aws_cloudhsm_v2_cluster"
+    Name = "example-aws_cloudhsmv2_cluster"
   }
 }
 
@@ -46,16 +46,16 @@ resource "aws_subnet" "cloudhsm_v2_subnets" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
-    Name = "example-aws_cloudhsm_v2_cluster"
+    Name = "example-aws_cloudhsmv2_cluster"
   }
 }
 
-resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
+resource "aws_cloudhsmv2_cluster" "cloudhsm_v2_cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = aws_subnet.cloudhsm_v2_subnets.*.id
 
   tags = {
-    Name = "example-aws_cloudhsm_v2_cluster"
+    Name = "example-aws_cloudhsmv2_cluster"
   }
 }
 ```
@@ -93,5 +93,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudHSM v2 Clusters can be imported using the `cluster id`, e.g.,
 
 ```
-$ terraform import aws_cloudhsm_v2_cluster.test_cluster cluster-aeb282a201
+$ terraform import aws_cloudhsmv2_cluster.test_cluster cluster-aeb282a201
 ```

--- a/website/docs/r/cloudhsmv2_hsm.html.markdown
+++ b/website/docs/r/cloudhsmv2_hsm.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "CloudHSM v2"
 layout: "aws"
-page_title: "AWS: aws_cloudhsm_v2_hsm"
+page_title: "AWS: aws_cloudhsmv2_hsm"
 description: |-
   Provides a CloudHSM v2 HSM module resource.
 ---
 
-# Resource: aws_cloudhsm_v2_hsm
+# Resource: aws_cloudhsmv2_hsm
 
 Creates an HSM module in Amazon CloudHSM v2 cluster.
 
@@ -15,13 +15,13 @@ Creates an HSM module in Amazon CloudHSM v2 cluster.
 The following example below creates an HSM module in CloudHSM cluster.
 
 ```terraform
-data "aws_cloudhsm_v2_cluster" "cluster" {
+data "aws_cloudhsmv2_cluster" "cluster" {
   cluster_id = var.cloudhsm_cluster_id
 }
 
-resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
-  subnet_id  = data.aws_cloudhsm_v2_cluster.cluster.subnet_ids[0]
-  cluster_id = data.aws_cloudhsm_v2_cluster.cluster.cluster_id
+resource "aws_cloudhsmv2_hsm" "cloudhsm_v2_hsm" {
+  subnet_id  = data.aws_cloudhsmv2_cluster.cluster.subnet_ids[0]
+  cluster_id = data.aws_cloudhsmv2_cluster.cluster.cluster_id
 }
 ```
 
@@ -47,5 +47,5 @@ In addition to all arguments above, the following attributes are exported:
 HSM modules can be imported using their HSM ID, e.g.,
 
 ```
-$ terraform import aws_cloudhsm_v2_hsm.bar hsm-quo8dahtaca
+$ terraform import aws_cloudhsmv2_hsm.bar hsm-quo8dahtaca
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
