### PR TITLE
Realign inconsistent cloudwatch_log names

### DIFF
--- a/.changelog/21587.txt
+++ b/.changelog/21587.txt
@@ -33,3 +33,7 @@ resource/aws_cloudwatch_log_stream: Rename resource to aws_cloudwatchlogs_stream
 ```release-note:enhancement
 resource/aws_cloudwatch_log_subscription_filter: Rename resource to aws_cloudwatchlogs_subscription_filter (with alias for aws_cloudwatch_log_subscription_filter)
 ```
+
+```release-note:enhancement
+resource/aws_cloudwatch_query_definition: Rename resource to aws_cloudwatchlogs_query_definition (with alias for aws_cloudwatch_query_definition)
+```

--- a/.changelog/21587.txt
+++ b/.changelog/21587.txt
@@ -1,0 +1,35 @@
+```release-note:enhancement
+data-source/aws_cloudwatch_log_group: Rename data source to aws_cloudwatchlogs_group (with alias for aws_cloudwatch_log_group)
+```
+
+```release-note:enhancement
+data-source/aws_cloudwatch_log_groups: Rename data source to aws_cloudwatchlogs_groups (with alias for aws_cloudwatch_log_groups)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_destination: Rename resource to aws_cloudwatchlogs_destination (with alias for aws_cloudwatch_log_destination)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_destination_policy: Rename resource to aws_cloudwatchlogs_destination_policy (with alias for aws_cloudwatch_log_destination_policy)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_group: Rename resource to aws_cloudwatchlogs_group (with alias for aws_cloudwatch_log_group)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_metric_filter: Rename resource to aws_cloudwatchlogs_metric_filter (with alias for aws_cloudwatch_log_metric_filter)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_resource_policy: Rename resource to aws_cloudwatchlogs_resource_policy (with alias for aws_cloudwatch_log_resource_policy)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_stream: Rename resource to aws_cloudwatchlogs_stream (with alias for aws_cloudwatch_log_stream)
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_subscription_filter: Rename resource to aws_cloudwatchlogs_subscription_filter (with alias for aws_cloudwatch_log_subscription_filter)
+```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -311,8 +311,8 @@ jobs:
         tfproviderdocs check \
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
-          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group,aws_cloudwatch_log_group,aws_cloudwatch_log_groups \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_cloudwatch_log_destination,aws_cloudwatch_log_destination_policy,aws_cloudwatch_log_group,aws_cloudwatch_log_metric_filter,aws_cloudwatch_log_resource_policy,aws_cloudwatch_log_stream,aws_cloudwatch_log_subscription_filter,aws_cloudwatch_query_definition \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -61,7 +61,7 @@ data "template_file" "cloud_config" {
     ecs_cluster_name   = aws_ecs_cluster.main.name
     ecs_log_level      = "info"
     ecs_agent_version  = "latest"
-    ecs_log_group_name = aws_cloudwatch_log_group.ecs.name
+    ecs_log_group_name = aws_cloudwatchlogs_group.ecs.name
   }
 }
 
@@ -175,7 +175,7 @@ data "template_file" "task_definition" {
     image_url        = "ghost:latest"
     container_name   = "ghost"
     log_group_region = var.aws_region
-    log_group_name   = aws_cloudwatch_log_group.app.name
+    log_group_name   = aws_cloudwatchlogs_group.app.name
   }
 }
 
@@ -279,8 +279,8 @@ data "template_file" "instance_profile" {
   template = file("${path.module}/instance-profile-policy.json")
 
   vars = {
-    app_log_group_arn = aws_cloudwatch_log_group.app.arn
-    ecs_log_group_arn = aws_cloudwatch_log_group.ecs.arn
+    app_log_group_arn = aws_cloudwatchlogs_group.app.arn
+    ecs_log_group_arn = aws_cloudwatchlogs_group.ecs.arn
   }
 }
 
@@ -318,10 +318,10 @@ resource "aws_alb_listener" "front_end" {
 
 ## CloudWatch Logs
 
-resource "aws_cloudwatch_log_group" "ecs" {
+resource "aws_cloudwatchlogs_group" "ecs" {
   name = "tf-ecs-group/ecs-agent"
 }
 
-resource "aws_cloudwatch_log_group" "app" {
+resource "aws_cloudwatchlogs_group" "app" {
   name = "tf-ecs-group/app-ghost"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -383,8 +383,10 @@ func Provider() *schema.Provider {
 			"aws_cloudwatch_event_connection": cloudwatchevents.DataSourceConnection(),
 			"aws_cloudwatch_event_source":     cloudwatchevents.DataSourceSource(),
 
-			"aws_cloudwatch_log_group":  cloudwatchlogs.DataSourceGroup(),
-			"aws_cloudwatch_log_groups": cloudwatchlogs.DataSourceGroups(),
+			"aws_cloudwatchlogs_group":  cloudwatchlogs.DataSourceGroup(),
+			"aws_cloudwatchlogs_groups": cloudwatchlogs.DataSourceGroups(),
+			"aws_cloudwatch_log_group":  cloudwatchlogs.DataSourceGroup(),  // backward compatible alias
+			"aws_cloudwatch_log_groups": cloudwatchlogs.DataSourceGroups(), // backward compatible alias
 
 			"aws_codeartifact_authorization_token": codeartifact.DataSourceAuthorizationToken(),
 			"aws_codeartifact_repository_endpoint": codeartifact.DataSourceRepositoryEndpoint(),
@@ -871,14 +873,22 @@ func Provider() *schema.Provider {
 			"aws_cloudwatch_event_rule":            cloudwatchevents.ResourceRule(),
 			"aws_cloudwatch_event_target":          cloudwatchevents.ResourceTarget(),
 
-			"aws_cloudwatch_log_destination":         cloudwatchlogs.ResourceDestination(),
-			"aws_cloudwatch_log_destination_policy":  cloudwatchlogs.ResourceDestinationPolicy(),
-			"aws_cloudwatch_log_group":               cloudwatchlogs.ResourceGroup(),
-			"aws_cloudwatch_log_metric_filter":       cloudwatchlogs.ResourceMetricFilter(),
-			"aws_cloudwatch_log_resource_policy":     cloudwatchlogs.ResourceResourcePolicy(),
-			"aws_cloudwatch_log_stream":              cloudwatchlogs.ResourceStream(),
-			"aws_cloudwatch_log_subscription_filter": cloudwatchlogs.ResourceSubscriptionFilter(),
-			"aws_cloudwatch_query_definition":        cloudwatchlogs.ResourceQueryDefinition(),
+			"aws_cloudwatchlogs_destination":         cloudwatchlogs.ResourceDestination(),
+			"aws_cloudwatchlogs_destination_policy":  cloudwatchlogs.ResourceDestinationPolicy(),
+			"aws_cloudwatchlogs_group":               cloudwatchlogs.ResourceGroup(),
+			"aws_cloudwatchlogs_metric_filter":       cloudwatchlogs.ResourceMetricFilter(),
+			"aws_cloudwatchlogs_resource_policy":     cloudwatchlogs.ResourceResourcePolicy(),
+			"aws_cloudwatchlogs_stream":              cloudwatchlogs.ResourceStream(),
+			"aws_cloudwatchlogs_subscription_filter": cloudwatchlogs.ResourceSubscriptionFilter(),
+			"aws_cloudwatchlogs_query_definition":    cloudwatchlogs.ResourceQueryDefinition(),
+			"aws_cloudwatch_log_destination":         cloudwatchlogs.ResourceDestination(),        // backward compatible alias
+			"aws_cloudwatch_log_destination_policy":  cloudwatchlogs.ResourceDestinationPolicy(),  // backward compatible alias
+			"aws_cloudwatch_log_group":               cloudwatchlogs.ResourceGroup(),              // backward compatible alias
+			"aws_cloudwatch_log_metric_filter":       cloudwatchlogs.ResourceMetricFilter(),       // backward compatible alias
+			"aws_cloudwatch_log_resource_policy":     cloudwatchlogs.ResourceResourcePolicy(),     // backward compatible alias
+			"aws_cloudwatch_log_stream":              cloudwatchlogs.ResourceStream(),             // backward compatible alias
+			"aws_cloudwatch_log_subscription_filter": cloudwatchlogs.ResourceSubscriptionFilter(), // backward compatible alias
+			"aws_cloudwatch_query_definition":        cloudwatchlogs.ResourceQueryDefinition(),    // backward compatible alias
 
 			"aws_codeartifact_domain":                        codeartifact.ResourceDomain(),
 			"aws_codeartifact_domain_permissions_policy":     codeartifact.ResourceDomainPermissionsPolicy(),

--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -135,7 +135,7 @@ func TestAccAPIGatewayStage_disappears(t *testing.T) {
 func TestAccAPIGatewayStage_accessLogSettings(t *testing.T) {
 	var conf apigateway.Stage
 	rName := sdkacctest.RandString(5)
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	resourceName := "aws_api_gateway_stage.test"
 	clf := `$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId`
 	json := `{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod", "resourcePath":"$context.resourcePath", "status":"$context.status", "protocol":"$context.protocol", "responseLength":"$context.responseLength" }`
@@ -514,7 +514,7 @@ resource "aws_api_gateway_stage" "test" {
 
 func testAccStageConfig_accessLogSettings(rName string, format string) string {
 	return testAccStageConfig_base(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "foo-bar-%s"
 }
 
@@ -532,7 +532,7 @@ resource "aws_api_gateway_stage" "test" {
     Name = "tf-test"
   }
   access_log_settings {
-    destination_arn = aws_cloudwatch_log_group.test.arn
+    destination_arn = aws_cloudwatchlogs_group.test.arn
     format          = %q
   }
 }

--- a/internal/service/apigatewayv2/stage_test.go
+++ b/internal/service/apigatewayv2/stage_test.go
@@ -255,7 +255,7 @@ func TestAccAPIGatewayV2Stage_accessLogSettings(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	cloudWatchResourceName := "aws_cloudwatch_log_group.test"
+	cloudWatchResourceName := "aws_cloudwatchlogs_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1230,7 +1230,7 @@ func testAccStageConfig_accessLogSettings(rName, format string) string {
 	return acctest.ConfigCompose(
 		testAccStageConfig_apiWebSocket(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -1239,7 +1239,7 @@ resource "aws_apigatewayv2_stage" "test" {
   name   = %[1]q
 
   access_log_settings {
-    destination_arn = aws_cloudwatch_log_group.test.arn
+    destination_arn = aws_cloudwatchlogs_group.test.arn
     format          = %[2]q
   }
 }

--- a/internal/service/cloudformation/type_test.go
+++ b/internal/service/cloudformation/type_test.go
@@ -115,7 +115,7 @@ func TestAccCloudFormationType_logging(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	typeName := fmt.Sprintf("HashiCorp::TerraformAwsProvider::TfAccTest%s", sdkacctest.RandString(8))
 	zipPath := testAccTypeZipGenerator(t, typeName)
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	iamRoleResourceName := "aws_iam_role.test"
 	resourceName := "aws_cloudformation_type.test"
 
@@ -417,7 +417,7 @@ func testAccCloudformationTypeConfigLoggingConfig(rName string, zipPath string, 
 	return acctest.ConfigCompose(
 		testAccCloudformationTypeConfigBase(rName, zipPath),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -442,7 +442,7 @@ resource "aws_cloudformation_type" "test" {
   type_name              = %[2]q
 
   logging_config {
-    log_group_name = aws_cloudwatch_log_group.test.name
+    log_group_name = aws_cloudwatchlogs_group.test.name
     log_role_arn   = aws_iam_role.test.arn
   }
 }

--- a/internal/service/cloudtrail/cloudtrail_test.go
+++ b/internal/service/cloudtrail/cloudtrail_test.go
@@ -818,11 +818,11 @@ resource "aws_cloudtrail" "test" {
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
-  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
+  cloud_watch_logs_group_arn = "${aws_cloudwatchlogs_group.test.arn}:*"
   cloud_watch_logs_role_arn  = aws_iam_role.test.arn
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -854,7 +854,7 @@ resource "aws_iam_role_policy" "test" {
     Statement = [{
       Sid      = "AWSCloudTrailCreateLogStream"
       Effect   = "Allow"
-      Resource = "${aws_cloudwatch_log_group.test.arn}:*"
+      Resource = "${aws_cloudwatchlogs_group.test.arn}:*"
 
       Action = [
         "logs:CreateLogStream",
@@ -872,15 +872,15 @@ resource "aws_cloudtrail" "test" {
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
-  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.test2.arn}:*"
+  cloud_watch_logs_group_arn = "${aws_cloudwatchlogs_group.test2.arn}:*"
   cloud_watch_logs_role_arn  = aws_iam_role.test.arn
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_group" "test2" {
+resource "aws_cloudwatchlogs_group" "test2" {
   name = "%[1]s-2"
 }
 
@@ -912,7 +912,7 @@ resource "aws_iam_role_policy" "test" {
     Statement = [{
       Sid      = "AWSCloudTrailCreateLogStream"
       Effect   = "Allow"
-      Resource = "${aws_cloudwatch_log_group.test2.arn}:*"
+      Resource = "${aws_cloudwatchlogs_group.test2.arn}:*"
 
       Action = [
         "logs:CreateLogStream",

--- a/internal/service/cloudwatchlogs/destination_policy_test.go
+++ b/internal/service/cloudwatchlogs/destination_policy_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccCloudWatchLogsDestinationPolicy_basic(t *testing.T) {
 	var destination cloudwatchlogs.Destination
-	resourceName := "aws_cloudwatch_log_destination_policy.test"
+	resourceName := "aws_cloudwatchlogs_destination_policy.test"
 	rstring := sdkacctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,7 +43,7 @@ func testAccCheckDestinationPolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_destination_policy" {
+		if rs.Type != "aws_cloudwatchlogs_destination_policy" {
 			continue
 		}
 		_, exists, err := tfcloudwatchlogs.LookupDestination(conn, rs.Primary.ID, nil)
@@ -148,7 +148,7 @@ resource "aws_iam_role_policy" "test" {
   policy = data.aws_iam_policy_document.policy.json
 }
 
-resource "aws_cloudwatch_log_destination" "test" {
+resource "aws_cloudwatchlogs_destination" "test" {
   name       = "testDestination_%s"
   target_arn = aws_kinesis_stream.test.arn
   role_arn   = aws_iam_role.test.arn
@@ -172,13 +172,13 @@ data "aws_iam_policy_document" "access" {
     ]
 
     resources = [
-      aws_cloudwatch_log_destination.test.arn,
+      aws_cloudwatchlogs_destination.test.arn,
     ]
   }
 }
 
-resource "aws_cloudwatch_log_destination_policy" "test" {
-  destination_name = aws_cloudwatch_log_destination.test.name
+resource "aws_cloudwatchlogs_destination_policy" "test" {
+  destination_name = aws_cloudwatchlogs_destination.test.name
   access_policy    = data.aws_iam_policy_document.access.json
 }
 `, rstring, rstring, rstring, rstring)

--- a/internal/service/cloudwatchlogs/destination_test.go
+++ b/internal/service/cloudwatchlogs/destination_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccCloudWatchLogsDestination_basic(t *testing.T) {
 	var destination cloudwatchlogs.Destination
-	resourceName := "aws_cloudwatch_log_destination.test"
+	resourceName := "aws_cloudwatchlogs_destination.test"
 	streamResourceName := "aws_kinesis_stream.test"
 	roleResourceName := "aws_iam_role.test"
 	rstring := sdkacctest.RandString(5)
@@ -47,7 +47,7 @@ func TestAccCloudWatchLogsDestination_basic(t *testing.T) {
 
 func TestAccCloudWatchLogsDestination_disappears(t *testing.T) {
 	var destination cloudwatchlogs.Destination
-	resourceName := "aws_cloudwatch_log_destination.test"
+	resourceName := "aws_cloudwatchlogs_destination.test"
 
 	rstring := sdkacctest.RandString(5)
 
@@ -73,7 +73,7 @@ func testAccCheckDestinationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_destination" {
+		if rs.Type != "aws_cloudwatchlogs_destination" {
 			continue
 		}
 		_, exists, err := tfcloudwatchlogs.LookupDestination(conn, rs.Primary.ID, nil)
@@ -178,7 +178,7 @@ resource "aws_iam_role_policy" "test" {
   policy = data.aws_iam_policy_document.policy.json
 }
 
-resource "aws_cloudwatch_log_destination" "test" {
+resource "aws_cloudwatchlogs_destination" "test" {
   name       = "testDestination_%[1]s"
   target_arn = aws_kinesis_stream.test.arn
   role_arn   = aws_iam_role.test.arn
@@ -202,13 +202,13 @@ data "aws_iam_policy_document" "access" {
     ]
 
     resources = [
-      aws_cloudwatch_log_destination.test.arn,
+      aws_cloudwatchlogs_destination.test.arn,
     ]
   }
 }
 
-resource "aws_cloudwatch_log_destination_policy" "test" {
-  destination_name = aws_cloudwatch_log_destination.test.name
+resource "aws_cloudwatchlogs_destination_policy" "test" {
+  destination_name = aws_cloudwatchlogs_destination.test.name
   access_policy    = data.aws_iam_policy_document.access.json
 }
 `, rstring)

--- a/internal/service/cloudwatchlogs/group_data_source_test.go
+++ b/internal/service/cloudwatchlogs/group_data_source_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccCloudWatchLogsGroupDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "data.aws_cloudwatch_log_group.test"
+	resourceName := "data.aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccCloudWatchLogsGroupDataSource_basic(t *testing.T) {
 
 func TestAccCloudWatchLogsGroupDataSource_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "data.aws_cloudwatch_log_group.test"
+	resourceName := "data.aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -59,7 +59,7 @@ func TestAccCloudWatchLogsGroupDataSource_tags(t *testing.T) {
 
 func TestAccCloudWatchLogsGroupDataSource_kms(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "data.aws_cloudwatch_log_group.test"
+	resourceName := "data.aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -82,7 +82,7 @@ func TestAccCloudWatchLogsGroupDataSource_kms(t *testing.T) {
 
 func TestAccCloudWatchLogsGroupDataSource_retention(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "data.aws_cloudwatch_log_group.test"
+	resourceName := "data.aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -105,19 +105,19 @@ func TestAccCloudWatchLogsGroupDataSource_retention(t *testing.T) {
 
 func testAccCheckGroupDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource aws_cloudwatch_log_group "test" {
+resource aws_cloudwatchlogs_group "test" {
   name = "%s"
 }
 
-data aws_cloudwatch_log_group "test" {
-  name = aws_cloudwatch_log_group.test.name
+data aws_cloudwatchlogs_group "test" {
+  name = aws_cloudwatchlogs_group.test.name
 }
 `, rName)
 }
 
 func testAccCheckGroupTagsDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource aws_cloudwatch_log_group "test" {
+resource aws_cloudwatchlogs_group "test" {
   name = "%s"
 
   tags = {
@@ -127,8 +127,8 @@ resource aws_cloudwatch_log_group "test" {
   }
 }
 
-data aws_cloudwatch_log_group "test" {
-  name = aws_cloudwatch_log_group.test.name
+data aws_cloudwatchlogs_group "test" {
+  name = aws_cloudwatchlogs_group.test.name
 }
 `, rName)
 }
@@ -158,26 +158,26 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
-resource aws_cloudwatch_log_group "test" {
+resource aws_cloudwatchlogs_group "test" {
   name       = "%s"
   kms_key_id = aws_kms_key.foo.arn
 }
 
-data aws_cloudwatch_log_group "test" {
-  name = aws_cloudwatch_log_group.test.name
+data aws_cloudwatchlogs_group "test" {
+  name = aws_cloudwatchlogs_group.test.name
 }
 `, rName, rName)
 }
 
 func testAccCheckGroupRetentionDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource aws_cloudwatch_log_group "test" {
+resource aws_cloudwatchlogs_group "test" {
   name              = "%s"
   retention_in_days = 365
 }
 
-data aws_cloudwatch_log_group "test" {
-  name = aws_cloudwatch_log_group.test.name
+data aws_cloudwatchlogs_group "test" {
+  name = aws_cloudwatchlogs_group.test.name
 }
 `, rName)
 }

--- a/internal/service/cloudwatchlogs/group_test.go
+++ b/internal/service/cloudwatchlogs/group_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccCloudWatchLogsGroup_basic(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -47,7 +47,7 @@ func TestAccCloudWatchLogsGroup_basic(t *testing.T) {
 
 func TestAccCloudWatchLogsGroup_namePrefix(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -75,7 +75,7 @@ func TestAccCloudWatchLogsGroup_namePrefix(t *testing.T) {
 func TestAccCloudWatchLogsGroup_NamePrefix_retention(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rName := sdkacctest.RandString(5)
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -111,7 +111,7 @@ func TestAccCloudWatchLogsGroup_NamePrefix_retention(t *testing.T) {
 
 func TestAccCloudWatchLogsGroup_generatedName(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -138,7 +138,7 @@ func TestAccCloudWatchLogsGroup_generatedName(t *testing.T) {
 func TestAccCloudWatchLogsGroup_retentionPolicy(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -173,7 +173,7 @@ func TestAccCloudWatchLogsGroup_retentionPolicy(t *testing.T) {
 func TestAccCloudWatchLogsGroup_multiple(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_group.alpha"
+	resourceName := "aws_cloudwatchlogs_group.alpha"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -184,12 +184,12 @@ func TestAccCloudWatchLogsGroup_multiple(t *testing.T) {
 			{
 				Config: testAccGroupConfig_multiple(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.alpha", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.alpha", "retention_in_days", "14"),
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.beta", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.beta", "retention_in_days", "0"),
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.charlie", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.charlie", "retention_in_days", "3653"),
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatchlogs_group.alpha", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatchlogs_group.alpha", "retention_in_days", "14"),
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatchlogs_group.beta", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatchlogs_group.beta", "retention_in_days", "0"),
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatchlogs_group.charlie", &lg),
+					resource.TestCheckResourceAttr("aws_cloudwatchlogs_group.charlie", "retention_in_days", "3653"),
 				),
 			},
 			{
@@ -205,7 +205,7 @@ func TestAccCloudWatchLogsGroup_multiple(t *testing.T) {
 func TestAccCloudWatchLogsGroup_disappears(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -228,7 +228,7 @@ func TestAccCloudWatchLogsGroup_disappears(t *testing.T) {
 func TestAccCloudWatchLogsGroup_tagging(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -291,7 +291,7 @@ func TestAccCloudWatchLogsGroup_tagging(t *testing.T) {
 func TestAccCloudWatchLogsGroup_kmsKey(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -359,7 +359,7 @@ func testAccCheckGroupDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_group" {
+		if rs.Type != "aws_cloudwatchlogs_group" {
 			continue
 		}
 		logGroup, err := tfcloudwatchlogs.LookupGroup(conn, rs.Primary.ID)
@@ -379,7 +379,7 @@ func testAccCheckGroupDestroy(s *terraform.State) error {
 
 func testAccGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "foo-bar-%d"
 }
 `, rInt)
@@ -387,7 +387,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccGroupWithTagsConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "foo-bar-%d"
 
   tags = {
@@ -401,7 +401,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccGroupWithTagsAddedConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "foo-bar-%d"
 
   tags = {
@@ -416,7 +416,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccGroupWithTagsUpdatedConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "foo-bar-%d"
 
   tags = {
@@ -431,7 +431,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccGroupConfig_withRetention(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name              = "foo-bar-%d"
   retention_in_days = 365
 }
@@ -440,7 +440,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccGroupModifiedConfig_withRetention(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "foo-bar-%d"
 }
 `, rInt)
@@ -448,16 +448,16 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccGroupConfig_multiple(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "alpha" {
+resource "aws_cloudwatchlogs_group" "alpha" {
   name              = "foo-bar-%d"
   retention_in_days = 14
 }
 
-resource "aws_cloudwatch_log_group" "beta" {
+resource "aws_cloudwatchlogs_group" "beta" {
   name = "foo-bar-%d"
 }
 
-resource "aws_cloudwatch_log_group" "charlie" {
+resource "aws_cloudwatchlogs_group" "charlie" {
   name              = "foo-bar-%d"
   retention_in_days = 3653
 }
@@ -489,7 +489,7 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name       = "foo-bar-%d"
   kms_key_id = aws_kms_key.foo.arn
 }
@@ -497,14 +497,14 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 
 const testAccGroup_namePrefix = `
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name_prefix = "tf-test-"
 }
 `
 
 func testAccGroup_namePrefix_retention(rName string, retention int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name_prefix       = "tf-test-%s"
   retention_in_days = %d
 }
@@ -512,5 +512,5 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 
 const testAccGroup_generatedName = `
-resource "aws_cloudwatch_log_group" "test" {}
+resource "aws_cloudwatchlogs_group" "test" {}
 `

--- a/internal/service/cloudwatchlogs/groups_data_source_test.go
+++ b/internal/service/cloudwatchlogs/groups_data_source_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccCloudWatchLogsGroupsDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "data.aws_cloudwatch_log_groups.test"
+	resourceName := "data.aws_cloudwatchlogs_groups.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -23,11 +23,11 @@ func TestAccCloudWatchLogsGroupsDataSource_basic(t *testing.T) {
 				Config: testAccCheckGroupsDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "arns.#", "2"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "arns.*", "aws_cloudwatch_log_group.test1", "arn"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "arns.*", "aws_cloudwatch_log_group.test2", "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "arns.*", "aws_cloudwatchlogs_group.test1", "arn"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "arns.*", "aws_cloudwatchlogs_group.test2", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "2"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_group_names.*", "aws_cloudwatch_log_group.test1", "name"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_group_names.*", "aws_cloudwatch_log_group.test2", "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_group_names.*", "aws_cloudwatchlogs_group.test1", "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "log_group_names.*", "aws_cloudwatchlogs_group.test2", "name"),
 				),
 			},
 		},
@@ -36,18 +36,18 @@ func TestAccCloudWatchLogsGroupsDataSource_basic(t *testing.T) {
 
 func testAccCheckGroupsDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource aws_cloudwatch_log_group "test1" {
+resource aws_cloudwatchlogs_group "test1" {
   name = "%[1]s/1"
 }
 
-resource aws_cloudwatch_log_group "test2" {
+resource aws_cloudwatchlogs_group "test2" {
   name = "%[1]s/2"
 }
 
-data aws_cloudwatch_log_groups "test" {
+data aws_cloudwatchlogs_groups "test" {
   log_group_name_prefix = %[1]q
 
-  depends_on = [aws_cloudwatch_log_group.test1,aws_cloudwatch_log_group.test2]
+  depends_on = [aws_cloudwatchlogs_group.test1,aws_cloudwatchlogs_group.test2]
 }
 `, rName)
 }

--- a/internal/service/cloudwatchlogs/metric_filter_test.go
+++ b/internal/service/cloudwatchlogs/metric_filter_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccCloudWatchLogsMetricFilter_basic(t *testing.T) {
 	var mf cloudwatchlogs.MetricFilter
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_metric_filter.test"
+	resourceName := "aws_cloudwatchlogs_metric_filter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -101,7 +101,7 @@ func TestAccCloudWatchLogsMetricFilter_basic(t *testing.T) {
 			},
 			{
 				Config: testAccMetricFilterManyConfig(rInt),
-				Check:  testAccCheckCloudwatchLogMetricFilterManyExist("aws_cloudwatch_log_metric_filter.test", &mf),
+				Check:  testAccCheckCloudwatchLogMetricFilterManyExist("aws_cloudwatchlogs_metric_filter.test", &mf),
 			},
 		},
 	})
@@ -110,7 +110,7 @@ func TestAccCloudWatchLogsMetricFilter_basic(t *testing.T) {
 func TestAccCloudWatchLogsMetricFilter_disappears(t *testing.T) {
 	var mf cloudwatchlogs.MetricFilter
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_metric_filter.test"
+	resourceName := "aws_cloudwatchlogs_metric_filter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -133,7 +133,7 @@ func TestAccCloudWatchLogsMetricFilter_disappears(t *testing.T) {
 func TestAccCloudWatchLogsMetricFilter_Disappears_logGroup(t *testing.T) {
 	var mf cloudwatchlogs.MetricFilter
 	rInt := sdkacctest.RandInt()
-	resourceName := "aws_cloudwatch_log_metric_filter.test"
+	resourceName := "aws_cloudwatchlogs_metric_filter.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -145,7 +145,7 @@ func TestAccCloudWatchLogsMetricFilter_Disappears_logGroup(t *testing.T) {
 				Config: testAccMetricFilterConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogMetricFilterExists(resourceName, &mf),
-					acctest.CheckResourceDisappears(acctest.Provider, tfcloudwatchlogs.ResourceGroup(), "aws_cloudwatch_log_group.test"),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcloudwatchlogs.ResourceGroup(), "aws_cloudwatchlogs_group.test"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -252,7 +252,7 @@ func testAccCheckMetricFilterDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_metric_filter" {
+		if rs.Type != "aws_cloudwatchlogs_metric_filter" {
 			continue
 		}
 
@@ -282,10 +282,10 @@ func testAccCheckCloudwatchLogMetricFilterManyExist(basename string, mf *cloudwa
 
 func testAccMetricFilterConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "test" {
+resource "aws_cloudwatchlogs_metric_filter" "test" {
   name           = "MyAppAccessCount-%d"
   pattern        = ""
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 
   metric_transformation {
     name      = "EventCount"
@@ -294,7 +294,7 @@ resource "aws_cloudwatch_log_metric_filter" "test" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "MyApp/access-%d.log"
 }
 `, rInt, rInt)
@@ -302,7 +302,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccMetricFilterModifiedConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "test" {
+resource "aws_cloudwatchlogs_metric_filter" "test" {
   name = "MyAppAccessCount-%d"
 
   pattern = <<PATTERN
@@ -310,7 +310,7 @@ resource "aws_cloudwatch_log_metric_filter" "test" {
 PATTERN
 
 
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 
   metric_transformation {
     name          = "AccessDeniedCount"
@@ -320,7 +320,7 @@ PATTERN
   }
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "MyApp/access-%d.log"
 }
 `, rInt, rInt)
@@ -328,7 +328,7 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccMetricFilterModifiedWithDimensionsConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "test" {
+resource "aws_cloudwatchlogs_metric_filter" "test" {
   name = "MyAppAccessCount-%d"
 
   pattern = <<PATTERN
@@ -336,7 +336,7 @@ resource "aws_cloudwatch_log_metric_filter" "test" {
 PATTERN
 
 
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 
   metric_transformation {
     name      = "AccessDeniedCount"
@@ -349,7 +349,7 @@ PATTERN
   }
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "MyApp/access-%d.log"
 }
 `, rInt, rInt)
@@ -357,11 +357,11 @@ resource "aws_cloudwatch_log_group" "test" {
 
 func testAccMetricFilterManyConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_metric_filter" "test" {
+resource "aws_cloudwatchlogs_metric_filter" "test" {
   count          = 15
   name           = "MyAppCountLog-${count.index}-%d"
   pattern        = "count ${count.index}"
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 
   metric_transformation {
     name      = "CountDracula-${count.index}"
@@ -370,7 +370,7 @@ resource "aws_cloudwatch_log_metric_filter" "test" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "MyApp/count-log-%d.log"
 }
 `, rInt, rInt)

--- a/internal/service/cloudwatchlogs/query_definition_test.go
+++ b/internal/service/cloudwatchlogs/query_definition_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAccCloudWatchLogsQueryDefinition_basic(t *testing.T) {
 	var v cloudwatchlogs.QueryDefinition
-	resourceName := "aws_cloudwatch_query_definition.test"
+	resourceName := "aws_cloudwatchlogs_query_definition.test"
 	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	expectedQueryString := `fields @timestamp, @message
@@ -70,7 +70,7 @@ func testAccQueryDefinitionImportStateID(v *cloudwatchlogs.QueryDefinition) reso
 
 func TestAccCloudWatchLogsQueryDefinition_disappears(t *testing.T) {
 	var v cloudwatchlogs.QueryDefinition
-	resourceName := "aws_cloudwatch_query_definition.test"
+	resourceName := "aws_cloudwatchlogs_query_definition.test"
 	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -93,7 +93,7 @@ func TestAccCloudWatchLogsQueryDefinition_disappears(t *testing.T) {
 
 func TestAccCloudWatchLogsQueryDefinition_rename(t *testing.T) {
 	var v1, v2 cloudwatchlogs.QueryDefinition
-	resourceName := "aws_cloudwatch_query_definition.test"
+	resourceName := "aws_cloudwatchlogs_query_definition.test"
 	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	updatedQueryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -129,7 +129,7 @@ func TestAccCloudWatchLogsQueryDefinition_rename(t *testing.T) {
 
 func TestAccCloudWatchLogsQueryDefinition_logGroups(t *testing.T) {
 	var v1, v2 cloudwatchlogs.QueryDefinition
-	resourceName := "aws_cloudwatch_query_definition.test"
+	resourceName := "aws_cloudwatchlogs_query_definition.test"
 	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -195,7 +195,7 @@ func testAccCheckQueryDefinitionDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_query_definition" {
+		if rs.Type != "aws_cloudwatchlogs_query_definition" {
 			continue
 		}
 
@@ -214,7 +214,7 @@ func testAccCheckQueryDefinitionDestroy(s *terraform.State) error {
 
 func testAccQueryDefinitionConfig_Basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_query_definition" "test" {
+resource "aws_cloudwatchlogs_query_definition" "test" {
   name = %[1]q
 
   query_string = <<EOF
@@ -228,7 +228,7 @@ EOF
 
 func testAccQueryDefinitionConfig_LogGroups(rName string, count int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_query_definition" "test" {
+resource "aws_cloudwatchlogs_query_definition" "test" {
   name = %[1]q
 
   log_group_names = aws_cloudwatchlogs_group.test[*].name

--- a/internal/service/cloudwatchlogs/query_definition_test.go
+++ b/internal/service/cloudwatchlogs/query_definition_test.go
@@ -144,7 +144,7 @@ func TestAccCloudWatchLogsQueryDefinition_logGroups(t *testing.T) {
 					testAccCheckQueryDefinitionExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", queryName),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatch_log_group.test.0", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatchlogs_group.test.0", "name"),
 				),
 			},
 			{
@@ -153,8 +153,8 @@ func TestAccCloudWatchLogsQueryDefinition_logGroups(t *testing.T) {
 					testAccCheckQueryDefinitionExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "name", queryName),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "5"),
-					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatch_log_group.test.0", "name"),
-					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.1", "aws_cloudwatch_log_group.test.1", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatchlogs_group.test.0", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.1", "aws_cloudwatchlogs_group.test.1", "name"),
 				),
 			},
 			{
@@ -231,7 +231,7 @@ func testAccQueryDefinitionConfig_LogGroups(rName string, count int) string {
 resource "aws_cloudwatch_query_definition" "test" {
   name = %[1]q
 
-  log_group_names = aws_cloudwatch_log_group.test[*].name
+  log_group_names = aws_cloudwatchlogs_group.test[*].name
 
   query_string = <<EOF
 fields @timestamp, @message
@@ -240,7 +240,7 @@ fields @timestamp, @message
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   count = %[2]d
 
   name = "%[1]s-${count.index}"

--- a/internal/service/cloudwatchlogs/resource_policy_test.go
+++ b/internal/service/cloudwatchlogs/resource_policy_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccCloudWatchLogsResourcePolicy_basic(t *testing.T) {
 	name := sdkacctest.RandString(5)
-	resourceName := "aws_cloudwatch_log_resource_policy.test"
+	resourceName := "aws_cloudwatchlogs_resource_policy.test"
 	var resourcePolicy cloudwatchlogs.ResourcePolicy
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -79,7 +79,7 @@ func testAccCheckCloudWatchLogResourcePolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_resource_policy" {
+		if rs.Type != "aws_cloudwatchlogs_resource_policy" {
 			continue
 		}
 
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "test" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "test" {
+resource "aws_cloudwatchlogs_resource_policy" "test" {
   policy_name     = "%s"
   policy_document = data.aws_iam_policy_document.test.json
 }
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "test" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "test" {
+resource "aws_cloudwatchlogs_resource_policy" "test" {
   policy_name     = "%s"
   policy_document = data.aws_iam_policy_document.test.json
 }

--- a/internal/service/cloudwatchlogs/stream_test.go
+++ b/internal/service/cloudwatchlogs/stream_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccCloudWatchLogsStream_basic(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
-	resourceName := "aws_cloudwatch_log_stream.test"
+	resourceName := "aws_cloudwatchlogs_stream.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,7 +43,7 @@ func TestAccCloudWatchLogsStream_basic(t *testing.T) {
 
 func TestAccCloudWatchLogsStream_disappears(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
-	resourceName := "aws_cloudwatch_log_stream.test"
+	resourceName := "aws_cloudwatchlogs_stream.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,8 +67,8 @@ func TestAccCloudWatchLogsStream_disappears(t *testing.T) {
 func TestAccCloudWatchLogsStream_Disappears_logGroup(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
 	var lg cloudwatchlogs.LogGroup
-	resourceName := "aws_cloudwatch_log_stream.test"
-	logGroupResourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_cloudwatchlogs_stream.test"
+	logGroupResourceName := "aws_cloudwatchlogs_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -117,7 +117,7 @@ func testAccCheckStreamDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_stream" {
+		if rs.Type != "aws_cloudwatchlogs_stream" {
 			continue
 		}
 
@@ -181,13 +181,13 @@ func TestValidateCloudWatchLogStreamName(t *testing.T) {
 
 func testAccStreamConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_stream" "test" {
+resource "aws_cloudwatchlogs_stream" "test" {
   name           = %[1]q
-  log_group_name = aws_cloudwatch_log_group.test.id
+  log_group_name = aws_cloudwatchlogs_group.test.id
 }
 `, rName)
 }

--- a/internal/service/cloudwatchlogs/subscription_filter_test.go
+++ b/internal/service/cloudwatchlogs/subscription_filter_test.go
@@ -17,8 +17,8 @@ func TestAccCloudWatchLogsSubscriptionFilter_basic(t *testing.T) {
 	var filter cloudwatchlogs.SubscriptionFilter
 
 	lambdaFunctionResourceName := "aws_lambda_function.test"
-	logGroupResourceName := "aws_cloudwatch_log_group.test"
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	logGroupResourceName := "aws_cloudwatchlogs_group.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -51,7 +51,7 @@ func TestAccCloudWatchLogsSubscriptionFilter_basic(t *testing.T) {
 func TestAccCloudWatchLogsSubscriptionFilter_disappears(t *testing.T) {
 	var filter cloudwatchlogs.SubscriptionFilter
 
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -76,8 +76,8 @@ func TestAccCloudWatchLogsSubscriptionFilter_Disappears_logGroup(t *testing.T) {
 	var filter cloudwatchlogs.SubscriptionFilter
 	var logGroup cloudwatchlogs.LogGroup
 
-	logGroupResourceName := "aws_cloudwatch_log_group.test"
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	logGroupResourceName := "aws_cloudwatchlogs_group.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -103,7 +103,7 @@ func TestAccCloudWatchLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose(
 	var filter cloudwatchlogs.SubscriptionFilter
 
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +133,7 @@ func TestAccCloudWatchLogsSubscriptionFilter_DestinationARN_kinesisStream(t *tes
 	var filter cloudwatchlogs.SubscriptionFilter
 
 	kinesisStream := "aws_kinesis_stream.test"
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -162,7 +162,7 @@ func TestAccCloudWatchLogsSubscriptionFilter_DestinationARN_kinesisStream(t *tes
 func TestAccCloudWatchLogsSubscriptionFilter_distribution(t *testing.T) {
 	var filter cloudwatchlogs.SubscriptionFilter
 
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -200,7 +200,7 @@ func TestAccCloudWatchLogsSubscriptionFilter_roleARN(t *testing.T) {
 
 	iamRoleResourceName1 := "aws_iam_role.test"
 	iamRoleResourceName2 := "aws_iam_role.test2"
-	resourceName := "aws_cloudwatch_log_subscription_filter.test"
+	resourceName := "aws_cloudwatchlogs_subscription_filter.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -252,7 +252,7 @@ func testAccCheckCloudwatchLogSubscriptionFilterDestroy(s *terraform.State) erro
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_cloudwatch_log_subscription_filter" {
+		if rs.Type != "aws_cloudwatchlogs_subscription_filter" {
 			continue
 		}
 
@@ -342,7 +342,7 @@ data "aws_partition" "current" {
 data "aws_region" "current" {
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name              = %[1]q
   retention_in_days = 1
 }
@@ -465,7 +465,7 @@ func testAccSubscriptionFilterKinesisStreamBaseConfig(rName string) string {
 data "aws_region" "current" {
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name              = %[1]q
   retention_in_days = 1
 }
@@ -524,7 +524,7 @@ func testAccSubscriptionFilterLambdaBaseConfig(rName string) string {
 data "aws_partition" "current" {
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name              = %[1]q
   retention_in_days = 1
 }
@@ -573,10 +573,10 @@ resource "aws_lambda_permission" "test" {
 
 func testAccSubscriptionFilterDestinationARNKinesisDataFirehoseConfig(rName string) string {
 	return testAccSubscriptionFilterKinesisDataFirehoseBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_subscription_filter" "test" {
+resource "aws_cloudwatchlogs_subscription_filter" "test" {
   destination_arn = aws_kinesis_firehose_delivery_stream.test.arn
   filter_pattern  = "logtype test"
-  log_group_name  = aws_cloudwatch_log_group.test.name
+  log_group_name  = aws_cloudwatchlogs_group.test.name
   name            = %[1]q
   role_arn        = aws_iam_role.cloudwatchlogs.arn
 }
@@ -585,10 +585,10 @@ resource "aws_cloudwatch_log_subscription_filter" "test" {
 
 func testAccSubscriptionFilterDestinationARNKinesisStreamConfig(rName string) string {
 	return testAccSubscriptionFilterKinesisStreamBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_subscription_filter" "test" {
+resource "aws_cloudwatchlogs_subscription_filter" "test" {
   destination_arn = aws_kinesis_stream.test.arn
   filter_pattern  = "logtype test"
-  log_group_name  = aws_cloudwatch_log_group.test.name
+  log_group_name  = aws_cloudwatchlogs_group.test.name
   name            = %[1]q
   role_arn        = aws_iam_role.test.arn
 }
@@ -597,10 +597,10 @@ resource "aws_cloudwatch_log_subscription_filter" "test" {
 
 func testAccSubscriptionFilterDestinationARNLambdaConfig(rName string) string {
 	return testAccSubscriptionFilterLambdaBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_subscription_filter" "test" {
+resource "aws_cloudwatchlogs_subscription_filter" "test" {
   destination_arn = aws_lambda_function.test.arn
   filter_pattern  = "logtype test"
-  log_group_name  = aws_cloudwatch_log_group.test.name
+  log_group_name  = aws_cloudwatchlogs_group.test.name
   name            = %[1]q
 }
 `, rName)
@@ -608,11 +608,11 @@ resource "aws_cloudwatch_log_subscription_filter" "test" {
 
 func testAccSubscriptionFilterDistributionConfig(rName, distribution string) string {
 	return testAccSubscriptionFilterLambdaBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_subscription_filter" "test" {
+resource "aws_cloudwatchlogs_subscription_filter" "test" {
   destination_arn = aws_lambda_function.test.arn
   distribution    = %[2]q
   filter_pattern  = "logtype test"
-  log_group_name  = aws_cloudwatch_log_group.test.name
+  log_group_name  = aws_cloudwatchlogs_group.test.name
   name            = %[1]q
 }
 `, rName, distribution)
@@ -620,10 +620,10 @@ resource "aws_cloudwatch_log_subscription_filter" "test" {
 
 func testAccSubscriptionFilterRoleARN1Config(rName string) string {
 	return testAccSubscriptionFilterKinesisStreamBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_subscription_filter" "test" {
+resource "aws_cloudwatchlogs_subscription_filter" "test" {
   destination_arn = aws_kinesis_stream.test.arn
   filter_pattern  = "logtype test"
-  log_group_name  = aws_cloudwatch_log_group.test.name
+  log_group_name  = aws_cloudwatchlogs_group.test.name
   name            = %[1]q
   role_arn        = aws_iam_role.test.arn
 }
@@ -674,10 +674,10 @@ resource "aws_iam_role_policy" "test2" {
 EOF
 }
 
-resource "aws_cloudwatch_log_subscription_filter" "test" {
+resource "aws_cloudwatchlogs_subscription_filter" "test" {
   destination_arn = aws_kinesis_stream.test.arn
   filter_pattern  = "logtype test"
-  log_group_name  = aws_cloudwatch_log_group.test.name
+  log_group_name  = aws_cloudwatchlogs_group.test.name
   name            = %[1]q
   role_arn        = aws_iam_role.test2.arn
 }

--- a/internal/service/cloudwatchlogs/sweep.go
+++ b/internal/service/cloudwatchlogs/sweep.go
@@ -43,8 +43,8 @@ func init() {
 		},
 	})
 
-	resource.AddTestSweepers("aws_cloudwatch_query_definition", &resource.Sweeper{
-		Name: "aws_cloudwatch_query_definition",
+	resource.AddTestSweepers("aws_cloudwatchlogs_query_definition", &resource.Sweeper{
+		Name: "aws_cloudwatchlogs_query_definition",
 		F:    sweeplogQueryDefinitions,
 	})
 

--- a/internal/service/cloudwatchlogs/sweep.go
+++ b/internal/service/cloudwatchlogs/sweep.go
@@ -16,8 +16,8 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("aws_cloudwatch_log_group", &resource.Sweeper{
-		Name: "aws_cloudwatch_log_group",
+	resource.AddTestSweepers("aws_cloudwatchlogs_group", &resource.Sweeper{
+		Name: "aws_cloudwatchlogs_group",
 		F:    sweepGroups,
 		Dependencies: []string{
 			"aws_api_gateway_rest_api",
@@ -48,8 +48,8 @@ func init() {
 		F:    sweeplogQueryDefinitions,
 	})
 
-	resource.AddTestSweepers("aws_cloudwatch_log_resource_policy", &resource.Sweeper{
-		Name: "aws_cloudwatch_log_resource_policy",
+	resource.AddTestSweepers("aws_cloudwatchlogs_resource_policy", &resource.Sweeper{
+		Name: "aws_cloudwatchlogs_resource_policy",
 		F:    sweepResourcePolicies,
 	})
 }

--- a/internal/service/datasync/task_test.go
+++ b/internal/service/datasync/task_test.go
@@ -141,7 +141,7 @@ func TestAccDataSyncTask_cloudWatchLogGroupARN(t *testing.T) {
 				Config: testAccTaskCloudWatchLogGroupARNConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskExists(resourceName, &task1),
-					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_log_group_arn", "aws_cloudwatch_log_group.test1", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_log_group_arn", "aws_cloudwatchlogs_group.test1", "arn"),
 				),
 			},
 			{
@@ -153,7 +153,7 @@ func TestAccDataSyncTask_cloudWatchLogGroupARN(t *testing.T) {
 				Config: testAccTaskCloudWatchLogGroupARN2Config(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskExists(resourceName, &task1),
-					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_log_group_arn", "aws_cloudwatch_log_group.test2", "arn")),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_log_group_arn", "aws_cloudwatchlogs_group.test2", "arn")),
 			},
 		},
 	})
@@ -983,12 +983,12 @@ func testAccTaskCloudWatchLogGroupARNConfig(rName string) string {
 		testAccTaskDestinationLocationS3BaseConfig(rName),
 		testAccTaskSourceLocationNFSBaseConfig(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test1" {
+resource "aws_cloudwatchlogs_group" "test1" {
   name = "%[1]s-1"
 }
 
 resource "aws_datasync_task" "test" {
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.test1.arn
+  cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test1.arn
   destination_location_arn = aws_datasync_location_s3.destination.arn
   name                     = %[1]q
   source_location_arn      = aws_datasync_location_nfs.source.arn
@@ -1001,16 +1001,16 @@ func testAccTaskCloudWatchLogGroupARN2Config(rName string) string {
 		testAccTaskDestinationLocationS3BaseConfig(rName),
 		testAccTaskSourceLocationNFSBaseConfig(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test1" {
+resource "aws_cloudwatchlogs_group" "test1" {
   name = "%[1]s-1"
 }
 
-resource "aws_cloudwatch_log_group" "test2" {
+resource "aws_cloudwatchlogs_group" "test2" {
   name = "%[1]s-2"
 }
 
 resource "aws_datasync_task" "test" {
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.test2.arn
+  cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test2.arn
   destination_location_arn = aws_datasync_location_s3.destination.arn
   name                     = %[1]q
   source_location_arn      = aws_datasync_location_nfs.source.arn
@@ -1093,12 +1093,12 @@ func testAccTaskDefaultSyncOptionsLogLevelConfig(rName, logLevel string) string 
 		testAccTaskDestinationLocationS3BaseConfig(rName),
 		testAccTaskSourceLocationNFSBaseConfig(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_datasync_task" "test" {
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
+  cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test.arn
   destination_location_arn = aws_datasync_location_s3.destination.arn
   name                     = %[1]q
   source_location_arn      = aws_datasync_location_nfs.source.arn

--- a/internal/service/ds/log_subscription_test.go
+++ b/internal/service/ds/log_subscription_test.go
@@ -159,7 +159,7 @@ resource "aws_subnet" "bar" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "logs" {
+resource "aws_cloudwatchlogs_group" "logs" {
   name              = "%s"
   retention_in_days = 1
 }
@@ -176,20 +176,20 @@ data "aws_iam_policy_document" "ad-log-policy" {
       type        = "Service"
     }
 
-    resources = ["${aws_cloudwatch_log_group.logs.arn}:*"]
+    resources = ["${aws_cloudwatchlogs_group.logs.arn}:*"]
 
     effect = "Allow"
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
+resource "aws_cloudwatchlogs_resource_policy" "ad-log-policy" {
   policy_document = data.aws_iam_policy_document.ad-log-policy.json
   policy_name     = "ad-log-policy"
 }
 
 resource "aws_directory_service_log_subscription" "subscription" {
   directory_id   = aws_directory_service_directory.bar.id
-  log_group_name = aws_cloudwatch_log_group.logs.name
+  log_group_name = aws_cloudwatchlogs_group.logs.name
 }
 `, logGroupName)
 }

--- a/internal/service/ec2/client_vpn_endpoint_test.go
+++ b/internal/service/ec2/client_vpn_endpoint_test.go
@@ -232,8 +232,8 @@ func testAccClientVPNEndpoint_withLogGroup(t *testing.T) {
 	var v1, v2 ec2.ClientVpnEndpoint
 	rStr := sdkacctest.RandString(5)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	logGroupResourceName := "aws_cloudwatch_log_group.lg"
-	logStreamResourceName := "aws_cloudwatch_log_stream.ls"
+	logGroupResourceName := "aws_cloudwatchlogs_group.lg"
+	logStreamResourceName := "aws_cloudwatchlogs_stream.ls"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckClientVPNSyncronize(t); acctest.PreCheck(t) },
@@ -525,13 +525,13 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 
 func testAccEc2ClientVpnEndpointConfigWithLogGroup(rName string) string {
 	return testAccEc2ClientVpnEndpointConfigAcmCertificateBase() + fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "lg" {
+resource "aws_cloudwatchlogs_group" "lg" {
   name = "terraform-testacc-clientvpn-loggroup-%s"
 }
 
-resource "aws_cloudwatch_log_stream" "ls" {
-  name           = "${aws_cloudwatch_log_group.lg.name}-stream"
-  log_group_name = aws_cloudwatch_log_group.lg.name
+resource "aws_cloudwatchlogs_stream" "ls" {
+  name           = "${aws_cloudwatchlogs_group.lg.name}-stream"
+  log_group_name = aws_cloudwatchlogs_group.lg.name
 }
 
 resource "aws_ec2_client_vpn_endpoint" "test" {
@@ -546,8 +546,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 
   connection_log_options {
     enabled               = true
-    cloudwatch_log_group  = aws_cloudwatch_log_group.lg.name
-    cloudwatch_log_stream = aws_cloudwatch_log_stream.ls.name
+    cloudwatch_log_group  = aws_cloudwatchlogs_group.lg.name
+    cloudwatch_log_stream = aws_cloudwatchlogs_stream.ls.name
   }
 }
 `, rName, rName)

--- a/internal/service/ec2/flow_log_test.go
+++ b/internal/service/ec2/flow_log_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccEC2FlowLog_vpcID(t *testing.T) {
 	var flowLog ec2.FlowLog
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	iamRoleResourceName := "aws_iam_role.test"
 	resourceName := "aws_flow_log.test"
 	vpcResourceName := "aws_vpc.test"
@@ -90,7 +90,7 @@ func TestAccEC2FlowLog_logFormat(t *testing.T) {
 
 func TestAccEC2FlowLog_subnetID(t *testing.T) {
 	var flowLog ec2.FlowLog
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	iamRoleResourceName := "aws_iam_role.test"
 	resourceName := "aws_flow_log.test"
 	subnetResourceName := "aws_subnet.test"
@@ -126,7 +126,7 @@ func TestAccEC2FlowLog_subnetID(t *testing.T) {
 
 func TestAccEC2FlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
 	var flowLog ec2.FlowLog
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	resourceName := "aws_flow_log.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -545,13 +545,13 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
   iam_role_arn         = aws_iam_role.test.arn
-  log_destination      = aws_cloudwatch_log_group.test.arn
+  log_destination      = aws_cloudwatchlogs_group.test.arn
   log_destination_type = "cloud-watch-logs"
   traffic_type         = "ALL"
   vpc_id               = aws_vpc.test.id
@@ -724,13 +724,13 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
   iam_role_arn   = aws_iam_role.test.arn
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
   subnet_id      = aws_subnet.test.id
   traffic_type   = "ALL"
 }
@@ -764,13 +764,13 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
   iam_role_arn   = aws_iam_role.test.arn
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
   traffic_type   = "ALL"
   vpc_id         = aws_vpc.test.id
 }
@@ -804,7 +804,7 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -850,13 +850,13 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
   iam_role_arn   = aws_iam_role.test.arn
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
   traffic_type   = "ALL"
   vpc_id         = aws_vpc.test.id
 
@@ -894,13 +894,13 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
   iam_role_arn   = aws_iam_role.test.arn
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
   traffic_type   = "ALL"
   vpc_id         = aws_vpc.test.id
 
@@ -939,13 +939,13 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
   iam_role_arn   = aws_iam_role.test.arn
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
   traffic_type   = "ALL"
   vpc_id         = aws_vpc.test.id
 

--- a/internal/service/ecs/cluster_test.go
+++ b/internal/service/ecs/cluster_test.go
@@ -311,7 +311,7 @@ func TestAccECSCluster_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.logging", "OVERRIDE"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.0.cloud_watch_encryption_enabled", "true"),
-					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.0.cloud_watch_log_group_name", "aws_cloudwatch_log_group.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.0.cloud_watch_log_group_name", "aws_cloudwatchlogs_group.test", "name"),
 				),
 			},
 			{
@@ -330,7 +330,7 @@ func TestAccECSCluster_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.logging", "OVERRIDE"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.0.cloud_watch_encryption_enabled", "false"),
-					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.0.cloud_watch_log_group_name", "aws_cloudwatch_log_group.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.execute_command_configuration.0.log_configuration.0.cloud_watch_log_group_name", "aws_cloudwatchlogs_group.test", "name"),
 				),
 			},
 		},
@@ -576,7 +576,7 @@ resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -590,7 +590,7 @@ resource "aws_ecs_cluster" "test" {
 
       log_configuration {
         cloud_watch_encryption_enabled = %[2]t
-        cloud_watch_log_group_name     = aws_cloudwatch_log_group.test.name
+        cloud_watch_log_group_name     = aws_cloudwatchlogs_group.test.name
       }
     }
   }

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -156,11 +156,11 @@ locals {
   random_name = "test-es-%d"
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = local.random_name
 }
 
-resource "aws_cloudwatch_log_resource_policy" "test" {
+resource "aws_cloudwatchlogs_resource_policy" "test" {
   policy_name = local.random_name
 
   policy_document = <<CONFIG
@@ -256,7 +256,7 @@ POLICY
   }
 
   log_publishing_options {
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
+    cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test.arn
     log_type                 = "INDEX_SLOW_LOGS"
   }
 

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -2269,11 +2269,11 @@ func testAccESDomain_LogPublishingOptions_BaseConfig(randInt int) string {
 data "aws_partition" "current" {
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "tf-test-%[1]d"
 }
 
-resource "aws_cloudwatch_log_resource_policy" "example" {
+resource "aws_cloudwatchlogs_resource_policy" "example" {
   policy_name = "tf-cwlp-%[1]d"
 
   policy_document = <<CONFIG
@@ -2339,7 +2339,7 @@ resource "aws_elasticsearch_domain" "test" {
 
   log_publishing_options {
     log_type                 = "%s"
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
+    cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test.arn
   }
 }
 `, randInt, auditLogsConfig, logType))

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -1960,13 +1960,13 @@ resource "aws_s3_bucket" "bucket" {
   acl    = "private"
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "tf-acc-test-%[1]d"
 }
 
-resource "aws_cloudwatch_log_stream" "test" {
+resource "aws_cloudwatchlogs_stream" "test" {
   name           = "tf-acc-test-%[1]d"
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
@@ -1980,8 +1980,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
     cloudwatch_logging_options {
       enabled         = true
-      log_group_name  = aws_cloudwatch_log_group.test.name
-      log_stream_name = aws_cloudwatch_log_stream.test.name
+      log_group_name  = aws_cloudwatchlogs_group.test.name
+      log_stream_name = aws_cloudwatchlogs_stream.test.name
     }
   }
 }

--- a/internal/service/fsx/windows_file_system_test.go
+++ b/internal/service/fsx/windows_file_system_test.go
@@ -1256,7 +1256,7 @@ resource "aws_fsx_windows_file_system" "test" {
 
 func testAccWindowsFileSystemAuditConfig(rName, status string) string {
 	return testAccWindowsFileSystemBaseConfig() + fmt.Sprintf(`
-resource aws_cloudwatch_log_group "test" {
+resource aws_cloudwatchlogs_group "test" {
   name = "/aws/fsx/%[1]s"
 }
 
@@ -1268,7 +1268,7 @@ resource "aws_fsx_windows_file_system" "test" {
   throughput_capacity = 32
 
   audit_log_configuration {
-    audit_log_destination             = aws_cloudwatch_log_group.test.arn
+    audit_log_destination             = aws_cloudwatchlogs_group.test.arn
     file_access_audit_log_level       = %[2]q
     file_share_access_audit_log_level = %[2]q
   }

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -1386,7 +1386,7 @@ func testAccMskClusterConfigLoggingInfo(rName string, cloudwatchLogsEnabled bool
 	s3Bucket := "\"\""
 
 	if cloudwatchLogsEnabled {
-		cloudwatchLogsLogGroup = "aws_cloudwatch_log_group.test.name"
+		cloudwatchLogsLogGroup = "aws_cloudwatchlogs_group.test.name"
 	}
 	if firehoseEnabled {
 		firehoseDeliveryStream = "aws_kinesis_firehose_delivery_stream.test.name"
@@ -1396,7 +1396,7 @@ func testAccMskClusterConfigLoggingInfo(rName string, cloudwatchLogsEnabled bool
 	}
 
 	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 

--- a/internal/service/kinesisanalytics/application_test.go
+++ b/internal/service/kinesisanalytics/application_test.go
@@ -190,7 +190,7 @@ func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_add(t *testing.
 	var v kinesisanalytics.ApplicationDetail
 	resourceName := "aws_kinesis_analytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -254,7 +254,7 @@ func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_delete(t *testi
 	var v kinesisanalytics.ApplicationDetail
 	resourceName := "aws_kinesis_analytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -319,8 +319,8 @@ func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_update(t *testi
 	resourceName := "aws_kinesis_analytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
-	cloudWatchLogStream1ResourceName := "aws_cloudwatch_log_stream.test.0"
-	cloudWatchLogStream2ResourceName := "aws_cloudwatch_log_stream.test.1"
+	cloudWatchLogStream1ResourceName := "aws_cloudwatchlogs_stream.test.0"
+	cloudWatchLogStream2ResourceName := "aws_cloudwatchlogs_stream.test.1"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -935,7 +935,7 @@ func TestAccKinesisAnalyticsApplication_Multiple_update(t *testing.T) {
 	resourceName := "aws_kinesis_analytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test"
 	lambdaResourceName := "aws_lambda_function.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	streamsResourceName := "aws_kinesis_stream.test"
@@ -1706,7 +1706,7 @@ func TestAccKinesisAnalyticsApplication_StartApplication_update(t *testing.T) {
 	resourceName := "aws_kinesis_analytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test"
 	lambdaResourceName := "aws_lambda_function.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	streamsResourceName := "aws_kinesis_stream.test"
@@ -2070,22 +2070,22 @@ func testAccKinesisAnalyticsApplicationConfigCloudWatchLoggingOptions(rName stri
 	return acctest.ConfigCompose(
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_stream" "test" {
+resource "aws_cloudwatchlogs_stream" "test" {
   count = 2
 
   name           = "%[1]s.${count.index}"
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 }
 
 resource "aws_kinesis_analytics_application" "test" {
   name = %[1]q
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.test.%[2]d.arn
+    log_stream_arn = aws_cloudwatchlogs_stream.test.%[2]d.arn
     role_arn       = aws_iam_role.test.%[2]d.arn
   }
 }
@@ -2233,20 +2233,20 @@ func testAccKinesisAnalyticsApplicationConfigMultiple(rName, startApplication, s
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_stream" "test" {
+resource "aws_cloudwatchlogs_stream" "test" {
   name           = %[1]q
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 }
 
 resource "aws_kinesis_analytics_application" "test" {
   name = %[1]q
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.test.arn
+    log_stream_arn = aws_cloudwatchlogs_stream.test.arn
     role_arn       = aws_iam_role.test[1].arn
   }
 

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -403,7 +403,7 @@ func TestAccKinesisAnalyticsV2Application_CloudWatchLoggingOptions_add(t *testin
 	var v kinesisanalyticsv2.ApplicationDetail
 	resourceName := "aws_kinesisanalyticsv2_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -466,7 +466,7 @@ func TestAccKinesisAnalyticsV2Application_CloudWatchLoggingOptions_delete(t *tes
 	var v kinesisanalyticsv2.ApplicationDetail
 	resourceName := "aws_kinesisanalyticsv2_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -529,8 +529,8 @@ func TestAccKinesisAnalyticsV2Application_CloudWatchLoggingOptions_update(t *tes
 	var v kinesisanalyticsv2.ApplicationDetail
 	resourceName := "aws_kinesisanalyticsv2_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
-	cloudWatchLogStream1ResourceName := "aws_cloudwatch_log_stream.test.0"
-	cloudWatchLogStream2ResourceName := "aws_cloudwatch_log_stream.test.1"
+	cloudWatchLogStream1ResourceName := "aws_cloudwatchlogs_stream.test.0"
+	cloudWatchLogStream2ResourceName := "aws_cloudwatchlogs_stream.test.1"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -2444,7 +2444,7 @@ func TestAccKinesisAnalyticsV2Application_SQLApplicationMultiple_update(t *testi
 	resourceName := "aws_kinesisanalyticsv2_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test"
 	lambdaResourceName := "aws_lambda_function.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	streamsResourceName := "aws_kinesis_stream.test"
@@ -3397,7 +3397,7 @@ func TestAccKinesisAnalyticsV2Application_SQLApplication_updateRunning(t *testin
 	resourceName := "aws_kinesisanalyticsv2_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
-	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
+	cloudWatchLogStreamResourceName := "aws_cloudwatchlogs_stream.test"
 	lambdaResourceName := "aws_lambda_function.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	streamsResourceName := "aws_kinesis_stream.test"
@@ -4415,15 +4415,15 @@ func testAccApplicationConfigCloudWatchLoggingOptions(rName string, streamIndex 
 	return acctest.ConfigCompose(
 		testAccApplicationConfigBaseServiceExecutionIamRole(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_stream" "test" {
+resource "aws_cloudwatchlogs_stream" "test" {
   count = 2
 
   name           = "%[1]s.${count.index}"
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 }
 
 resource "aws_kinesisanalyticsv2_application" "test" {
@@ -4432,7 +4432,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
   service_execution_role = aws_iam_role.test[0].arn
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.test.%[2]d.arn
+    log_stream_arn = aws_cloudwatchlogs_stream.test.%[2]d.arn
   }
 }
 `, rName, streamIndex))
@@ -5218,13 +5218,13 @@ func testAccApplicationConfigSQLApplicationConfigurationMultiple(rName, startApp
 		testAccApplicationConfigBaseServiceExecutionIamRole(rName),
 		testAccApplicationConfigBaseSQLApplication(rName),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_stream" "test" {
+resource "aws_cloudwatchlogs_stream" "test" {
   name           = %[1]q
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name = aws_cloudwatchlogs_group.test.name
 }
 
 resource "aws_kinesisanalyticsv2_application" "test" {
@@ -5293,7 +5293,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
   }
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.test.arn
+    log_stream_arn = aws_cloudwatchlogs_stream.test.arn
   }
 
   tags = {

--- a/internal/service/lexmodelbuilding/bot_alias_test.go
+++ b/internal/service/lexmodelbuilding/bot_alias_test.go
@@ -119,7 +119,7 @@ func TestAccLexModelBuildingBotAlias_conversationLogsText(t *testing.T) {
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -218,7 +218,7 @@ func TestAccLexModelBuildingBotAlias_conversationLogsBoth(t *testing.T) {
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	kmsKeyResourceName := "aws_kms_key.test"
 
@@ -433,12 +433,12 @@ resource "aws_lex_bot_alias" "test" {
     log_settings {
       destination  = "CLOUDWATCH_LOGS"
       log_type     = "TEXT"
-      resource_arn = aws_cloudwatch_log_group.test.arn
+      resource_arn = aws_cloudwatchlogs_group.test.arn
     }
   }
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "%[1]s"
 }
 
@@ -466,7 +466,7 @@ data "aws_iam_policy_document" "lex_cloud_watch_logs_policy" {
       "logs:PutLogEvents",
     ]
     resources = [
-      aws_cloudwatch_log_group.test.arn,
+      aws_cloudwatchlogs_group.test.arn,
     ]
   }
 }
@@ -551,7 +551,7 @@ resource "aws_lex_bot_alias" "test" {
     log_settings {
       destination  = "CLOUDWATCH_LOGS"
       log_type     = "TEXT"
-      resource_arn = aws_cloudwatch_log_group.test.arn
+      resource_arn = aws_cloudwatchlogs_group.test.arn
     }
     log_settings {
       destination  = "S3"
@@ -562,7 +562,7 @@ resource "aws_lex_bot_alias" "test" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "%[1]s"
 }
 
@@ -596,7 +596,7 @@ data "aws_iam_policy_document" "lex_cloud_watch_logs_policy" {
       "logs:PutLogEvents",
     ]
     resources = [
-      aws_cloudwatch_log_group.test.arn,
+      aws_cloudwatchlogs_group.test.arn,
     ]
   }
 }

--- a/internal/service/networkfirewall/logging_configuration_test.go
+++ b/internal/service/networkfirewall/logging_configuration_test.go
@@ -757,7 +757,7 @@ resource "aws_s3_bucket" "test" {
 
 func testAccNetworkFirewallLoggingConfigurationCloudWatchDependencyConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %q
 
   lifecycle {
@@ -964,7 +964,7 @@ resource "aws_networkfirewall_logging_configuration" "test" {
   logging_configuration {
     log_destination_config {
       log_destination = {
-        logGroup = aws_cloudwatch_log_group.test.name
+        logGroup = aws_cloudwatchlogs_group.test.name
       }
       log_destination_type = %[2]q
       log_type             = %[3]q
@@ -1024,7 +1024,7 @@ resource "aws_networkfirewall_logging_configuration" "test" {
 
     log_destination_config {
       log_destination = {
-        logGroup = aws_cloudwatch_log_group.test.name
+        logGroup = aws_cloudwatchlogs_group.test.name
       }
       log_destination_type = "CloudWatchLogs"
       log_type             = %[3]q

--- a/internal/service/route53/query_log_test.go
+++ b/internal/service/route53/query_log_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestAccRoute53QueryLog_basic(t *testing.T) {
-	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cloudwatchLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 	resourceName := "aws_route53_query_log.test"
 	route53ZoneResourceName := "aws_route53_zone.test"
 
@@ -166,7 +166,7 @@ func testAccCheckQueryLogResourceBasic1Config(rName, domainName string) string {
 	return acctest.ConfigCompose(
 		testAccRoute53QueryLogRegionProviderConfig(),
 		fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name              = "/aws/route53/${aws_route53_zone.test.name}"
   retention_in_days = 1
 }
@@ -189,7 +189,7 @@ data "aws_iam_policy_document" "test" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "test" {
+resource "aws_cloudwatchlogs_resource_policy" "test" {
   policy_name     = %[1]q
   policy_document = data.aws_iam_policy_document.test.json
 }
@@ -199,9 +199,9 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_route53_query_log" "test" {
-  depends_on = [aws_cloudwatch_log_resource_policy.test]
+  depends_on = [aws_cloudwatchlogs_resource_policy.test]
 
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
+  cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test.arn
   zone_id                  = aws_route53_zone.test.zone_id
 }
 `, rName, domainName))

--- a/internal/service/route53resolver/query_log_config_association_test.go
+++ b/internal/service/route53resolver/query_log_config_association_test.go
@@ -115,7 +115,7 @@ func testAccCheckRoute53ResolverQueryLogConfigAssociationExists(n string, v *rou
 
 func testAccRoute53ResolverQueryLogConfigAssociationConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -129,7 +129,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_route53_resolver_query_log_config" "test" {
   name            = %[1]q
-  destination_arn = aws_cloudwatch_log_group.test.arn
+  destination_arn = aws_cloudwatchlogs_group.test.arn
 }
 
 resource "aws_route53_resolver_query_log_config_association" "test" {

--- a/internal/service/route53resolver/query_log_config_test.go
+++ b/internal/service/route53resolver/query_log_config_test.go
@@ -73,7 +73,7 @@ func TestAccRoute53ResolverQueryLogConfig_tags(t *testing.T) {
 	var v route53resolver.ResolverQueryLogConfig
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_route53_resolver_query_log_config.test"
-	cwLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	cwLogGroupResourceName := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -189,13 +189,13 @@ resource "aws_route53_resolver_query_log_config" "test" {
 
 func testAccRoute53ResolverQueryLogConfigConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_route53_resolver_query_log_config" "test" {
   name            = %[1]q
-  destination_arn = aws_cloudwatch_log_group.test.arn
+  destination_arn = aws_cloudwatchlogs_group.test.arn
 
   tags = {
     %[2]q = %[3]q
@@ -206,13 +206,13 @@ resource "aws_route53_resolver_query_log_config" "test" {
 
 func testAccRoute53ResolverQueryLogConfigConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
 resource "aws_route53_resolver_query_log_config" "test" {
   name            = %[1]q
-  destination_arn = aws_cloudwatch_log_group.test.arn
+  destination_arn = aws_cloudwatchlogs_group.test.arn
 
   tags = {
     %[2]q = %[3]q

--- a/internal/service/sfn/state_machine_test.go
+++ b/internal/service/sfn/state_machine_test.go
@@ -594,7 +594,7 @@ EOF
 
 func testAccStateMachineExpressLogConfigurationConfig(rName string, rLevel string) string {
 	return acctest.ConfigCompose(testAccStateMachineBaseConfig(rName), fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -628,7 +628,7 @@ resource "aws_sfn_state_machine" "test" {
 EOF
 
   logging_configuration {
-    log_destination        = "${aws_cloudwatch_log_group.test.arn}:*"
+    log_destination        = "${aws_cloudwatchlogs_group.test.arn}:*"
     include_execution_data = false
     level                  = %[2]q
   }

--- a/internal/service/ssm/maintenance_window_task_test.go
+++ b/internal/service/ssm/maintenance_window_task_test.go
@@ -263,7 +263,7 @@ func TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatc
 	var task ssm.MaintenanceWindowTask
 	resourceName := "aws_ssm_maintenance_window_task.test"
 	serviceRoleResourceName := "aws_iam_role.test"
-	cwResourceName := "aws_cloudwatch_log_group.test"
+	cwResourceName := "aws_cloudwatchlogs_group.test"
 
 	name := sdkacctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
@@ -941,7 +941,7 @@ resource "aws_ssm_maintenance_window_task" "test" {
 
 func testAccMaintenanceWindowTaskRunCommandCloudWatchConfig(rName string, enabled bool) string {
 	return fmt.Sprintf(testAccMaintenanceWindowTaskBaseConfig(rName)+`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -971,7 +971,7 @@ resource "aws_ssm_maintenance_window_task" "test" {
       }
 
       cloudwatch_config {
-        cloudwatch_log_group_name = aws_cloudwatch_log_group.test.name
+        cloudwatch_log_group_name = aws_cloudwatchlogs_group.test.name
         cloudwatch_output_enabled = %[2]t
       }
     }

--- a/internal/service/storagegateway/file_system_association_test.go
+++ b/internal/service/storagegateway/file_system_association_test.go
@@ -156,10 +156,10 @@ func TestAccStorageGatewayFileSystemAssociation_auditDestination(t *testing.T) {
 		CheckDestroy: testAccCheckFileSystemAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFileSystemAssociationConfig_Audit(rName, domainName, username, "aws_cloudwatch_log_group.test.arn"),
+				Config: testAccFileSystemAssociationConfig_Audit(rName, domainName, username, "aws_cloudwatchlogs_group.test.arn"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemAssociationExists(resourceName, &fileSystemAssociation),
-					resource.TestCheckResourceAttrPair(resourceName, "audit_destination_arn", "aws_cloudwatch_log_group.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "audit_destination_arn", "aws_cloudwatchlogs_group.test", "arn"),
 				),
 			}, {
 				ResourceName:            resourceName,
@@ -175,10 +175,10 @@ func TestAccStorageGatewayFileSystemAssociation_auditDestination(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFileSystemAssociationConfig_Audit(rName, domainName, username, "aws_cloudwatch_log_group.test2.arn"),
+				Config: testAccFileSystemAssociationConfig_Audit(rName, domainName, username, "aws_cloudwatchlogs_group.test2.arn"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFileSystemAssociationExists(resourceName, &fileSystemAssociation),
-					resource.TestCheckResourceAttrPair(resourceName, "audit_destination_arn", "aws_cloudwatch_log_group.test2", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "audit_destination_arn", "aws_cloudwatchlogs_group.test2", "arn"),
 				),
 			},
 		},
@@ -405,8 +405,8 @@ resource "aws_storagegateway_file_system_association" "test" {
   audit_destination_arn = %[2]s
 }
 
-resource "aws_cloudwatch_log_group" "test" {}
-resource "aws_cloudwatch_log_group" "test2" {}
+resource "aws_cloudwatchlogs_group" "test" {}
+resource "aws_cloudwatchlogs_group" "test2" {}
 `, username, loggingDestination)
 }
 func testAccFileSystemAssociationConfig_AuditDisabled(rName, domainName, username string) string {
@@ -419,8 +419,8 @@ resource "aws_storagegateway_file_system_association" "test" {
   audit_destination_arn = ""
 }
 
-resource "aws_cloudwatch_log_group" "test" {}
-resource "aws_cloudwatch_log_group" "test2" {}
+resource "aws_cloudwatchlogs_group" "test" {}
+resource "aws_cloudwatchlogs_group" "test2" {}
 `, username)
 }
 

--- a/internal/service/storagegateway/gateway_test.go
+++ b/internal/service/storagegateway/gateway_test.go
@@ -306,7 +306,7 @@ func TestAccStorageGatewayGateway_cloudWatchLogs(t *testing.T) {
 	var gateway storagegateway.DescribeGatewayInformationOutput
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_gateway.test"
-	resourceName2 := "aws_cloudwatch_log_group.test"
+	resourceName2 := "aws_cloudwatchlogs_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -992,7 +992,7 @@ resource "aws_storagegateway_gateway" "test" {
 
 func testAccGatewayConfig_Log_Group(rName string) string {
 	return testAcc_FileGatewayBase(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -1001,7 +1001,7 @@ resource "aws_storagegateway_gateway" "test" {
   gateway_name             = %[1]q
   gateway_timezone         = "GMT"
   gateway_type             = "FILE_S3"
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
+  cloudwatch_log_group_arn = aws_cloudwatchlogs_group.test.arn
 }
 `, rName)
 }

--- a/internal/service/storagegateway/nfs_file_share_test.go
+++ b/internal/service/storagegateway/nfs_file_share_test.go
@@ -70,8 +70,8 @@ func TestAccStorageGatewayNFSFileShare_audit(t *testing.T) {
 	var nfsFileShare storagegateway.NFSFileShareInfo
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_nfs_file_share.test"
-	logResourceName := "aws_cloudwatch_log_group.test"
-	logResourceNameSecond := "aws_cloudwatch_log_group.test2"
+	logResourceName := "aws_cloudwatchlogs_group.test"
+	logResourceNameSecond := "aws_cloudwatchlogs_group.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -1034,7 +1034,7 @@ resource "aws_storagegateway_nfs_file_share" "test" {
 
 func testAccNFSFileShareAuditConfig(rName string) string {
 	return testAcc_S3FileShareBase(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -1043,18 +1043,18 @@ resource "aws_storagegateway_nfs_file_share" "test" {
   gateway_arn           = aws_storagegateway_gateway.test.arn
   location_arn          = aws_s3_bucket.test.arn
   role_arn              = aws_iam_role.test.arn
-  audit_destination_arn = aws_cloudwatch_log_group.test.arn
+  audit_destination_arn = aws_cloudwatchlogs_group.test.arn
 }
 `, rName)
 }
 
 func testAccNFSFileShareAuditUpdatedConfig(rName string) string {
 	return testAcc_S3FileShareBase(rName) + fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_group" "test2" {
+resource "aws_cloudwatchlogs_group" "test2" {
   name = "%[1]s-updated"
 }
 
@@ -1063,7 +1063,7 @@ resource "aws_storagegateway_nfs_file_share" "test" {
   gateway_arn           = aws_storagegateway_gateway.test.arn
   location_arn          = aws_s3_bucket.test.arn
   role_arn              = aws_iam_role.test.arn
-  audit_destination_arn = aws_cloudwatch_log_group.test2.arn
+  audit_destination_arn = aws_cloudwatchlogs_group.test2.arn
 }
 `, rName)
 }

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -705,8 +705,8 @@ func TestAccStorageGatewaySMBFileShare_audit(t *testing.T) {
 	var smbFileShare storagegateway.SMBFileShareInfo
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_storagegateway_smb_file_share.test"
-	logResourceName := "aws_cloudwatch_log_group.test"
-	logResourceNameSecond := "aws_cloudwatch_log_group.test2"
+	logResourceName := "aws_cloudwatchlogs_group.test"
+	logResourceNameSecond := "aws_cloudwatchlogs_group.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -1354,7 +1354,7 @@ resource "aws_storagegateway_smb_file_share" "test" {
 
 func testAccSMBFileShareAuditDestinationConfig(rName string) string {
 	return acctest.ConfigCompose(testAcc_SMBFileShare_GuestAccessBase(rName), fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
@@ -1364,18 +1364,18 @@ resource "aws_storagegateway_smb_file_share" "test" {
   gateway_arn           = aws_storagegateway_gateway.test.arn
   location_arn          = aws_s3_bucket.test.arn
   role_arn              = aws_iam_role.test.arn
-  audit_destination_arn = aws_cloudwatch_log_group.test.arn
+  audit_destination_arn = aws_cloudwatchlogs_group.test.arn
 }
 `, rName))
 }
 
 func testAccSMBFileShareAuditDestinationUpdatedConfig(rName string) string {
 	return acctest.ConfigCompose(testAcc_SMBFileShare_GuestAccessBase(rName), fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = %[1]q
 }
 
-resource "aws_cloudwatch_log_group" "test2" {
+resource "aws_cloudwatchlogs_group" "test2" {
   name = "%[1]s-updated"
 }
 
@@ -1385,7 +1385,7 @@ resource "aws_storagegateway_smb_file_share" "test" {
   gateway_arn           = aws_storagegateway_gateway.test.arn
   location_arn          = aws_s3_bucket.test.arn
   role_arn              = aws_iam_role.test.arn
-  audit_destination_arn = aws_cloudwatch_log_group.test2.arn
+  audit_destination_arn = aws_cloudwatchlogs_group.test2.arn
 }
 `, rName))
 }

--- a/internal/service/synthetics/sweep.go
+++ b/internal/service/synthetics/sweep.go
@@ -22,7 +22,7 @@ func init() {
 		Dependencies: []string{
 			"aws_lambda_function",
 			"aws_lambda_layer",
-			"aws_cloudwatch_log_group",
+			"aws_cloudwatchlogs_group",
 		},
 	})
 }

--- a/website/docs/d/cloudwatchlogs_group.html.markdown
+++ b/website/docs/d/cloudwatchlogs_group.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_group"
+page_title: "AWS: aws_cloudwatchlogs_group"
 description: |-
   Get information on a Cloudwatch Log Group.
 ---
 
-# Data Source: aws_cloudwatch_log_group
+# Data Source: aws_cloudwatchlogs_group
 
 Use this data source to get information about an AWS Cloudwatch Log Group
 
 ## Example Usage
 
 ```terraform
-data "aws_cloudwatch_log_group" "example" {
+data "aws_cloudwatchlogs_group" "example" {
   name = "MyImportantLogs"
 }
 ```

--- a/website/docs/d/cloudwatchlogs_groups.html.markdown
+++ b/website/docs/d/cloudwatchlogs_groups.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_groups"
+page_title: "AWS: aws_cloudwatchlogs_groups"
 description: |-
   Get list of Cloudwatch Log Groups.
 ---
 
-# Data Source: aws_cloudwatch_log_groups
+# Data Source: aws_cloudwatchlogs_groups
 
 Use this data source to get a list of AWS Cloudwatch Log Groups
 
 ## Example Usage
 
 ```terraform
-data "aws_cloudwatch_log_groups" "example" {
+data "aws_cloudwatchlogs_groups" "example" {
   log_group_name_prefix = "/MyImportantLogs"
 }
 ```

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -30,7 +30,7 @@ Upgrade topics:
 - [Resource: aws_api_gateway_method_settings](#resource-aws_api_gateway_method_settings)
 - [Resource: aws_autoscaling_group](#resource-aws_autoscaling_group)
 - [Resource: aws_cloudfront_distribution](#resource-aws_cloudfront_distribution)
-- [Resource: aws_cloudwatch_log_group](#resource-aws_cloudwatch_log_group)
+- [Resource: aws_cloudwatchlogs_group](#resource-aws_cloudwatchlogs_group)
 - [Resource: aws_codepipeline](#resource-aws_codepipeline)
 - [Resource: aws_cognito_user_pool](#resource-aws_cognito_user_pool)
 - [Resource: aws_dx_gateway](#resource-aws_dx_gateway)
@@ -767,7 +767,7 @@ aws_cloudfront_distribution.example.trusted_signers[0].enabled
 aws_cloudfront_distribution.example.trusted_signers[0].items
 ```
 
-## Resource: aws_cloudwatch_log_group
+## Resource: aws_cloudwatchlogs_group
 
 ### Removal of arn Wildcard Suffix
 
@@ -776,12 +776,12 @@ Previously, the resource returned the Amazon Resource Name (ARN) directly from t
 Workarounds, such as using `replace()` as shown below, should be removed:
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "example"
 }
 resource "aws_datasync_task" "example" {
   # ... other configuration ...
-  cloudwatch_log_group_arn = replace(aws_cloudwatch_log_group.example.arn, ":*", "")
+  cloudwatch_log_group_arn = replace(aws_cloudwatchlogs_group.example.arn, ":*", "")
 }
 ```
 
@@ -798,7 +798,7 @@ data "aws_iam_policy_document" "ad-log-policy" {
       identifiers = ["ds.amazonaws.com"]
       type        = "Service"
     }
-    resources = [aws_cloudwatch_log_group.example.arn]
+    resources = [aws_cloudwatchlogs_group.example.arn]
     effect = "Allow"
   }
 }
@@ -817,7 +817,7 @@ data "aws_iam_policy_document" "ad-log-policy" {
       identifiers = ["ds.amazonaws.com"]
       type        = "Service"
     }
-    resources = ["${aws_cloudwatch_log_group.example.arn}:*"]
+    resources = ["${aws_cloudwatchlogs_group.example.arn}:*"]
     effect = "Allow"
   }
 }

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -71,7 +71,7 @@ resource "aws_api_gateway_method_settings" "example" {
 
 ### Managing the API Logging CloudWatch Log Group
 
-API Gateway provides the ability to [enable CloudWatch API logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html). To manage the CloudWatch Log Group when this feature is enabled, the [`aws_cloudwatch_log_group` resource](/docs/providers/aws/r/cloudwatch_log_group.html) can be used where the name matches the API Gateway naming convention. If the CloudWatch Log Group previously exists, the [`aws_cloudwatch_log_group` resource can be imported into Terraform](/docs/providers/aws/r/cloudwatch_log_group.html#import) as a one time operation and recreation of the environment can occur without import.
+API Gateway provides the ability to [enable CloudWatch API logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html). To manage the CloudWatch Log Group when this feature is enabled, the [`aws_cloudwatchlogs_group` resource](/docs/providers/aws/r/cloudwatch_log_group.html) can be used where the name matches the API Gateway naming convention. If the CloudWatch Log Group previously exists, the [`aws_cloudwatchlogs_group` resource can be imported into Terraform](/docs/providers/aws/r/cloudwatch_log_group.html#import) as a one time operation and recreation of the environment can occur without import.
 
 -> The below configuration uses [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html) to prevent ordering issues with API Gateway automatically creating the log group first and a variable for naming consistency. Other ordering and naming methodologies may be more appropriate for your environment.
 
@@ -86,13 +86,13 @@ resource "aws_api_gateway_rest_api" "example" {
 }
 
 resource "aws_api_gateway_stage" "example" {
-  depends_on = [aws_cloudwatch_log_group.example]
+  depends_on = [aws_cloudwatchlogs_group.example]
 
   stage_name = var.stage_name
   # ... other configuration ...
 }
 
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.example.id}/${var.stage_name}"
   retention_in_days = 7
   # ... potentially other configuration ...

--- a/website/docs/r/cloudformation_type.html.markdown
+++ b/website/docs/r/cloudformation_type.html.markdown
@@ -21,7 +21,7 @@ resource "aws_cloudformation_type" "example" {
   type_name              = "ExampleCompany::ExampleService::ExampleResource"
 
   logging_config {
-    log_group_name = aws_cloudwatch_log_group.example.name
+    log_group_name = aws_cloudwatchlogs_group.example.name
     log_role_arn   = aws_iam_role.example.arn
   }
 

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -278,14 +278,14 @@ resource "aws_cloudtrail" "example" {
 #### Sending Events to CloudWatch Logs
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "Example"
 }
 
 resource "aws_cloudtrail" "example" {
   # ... other configuration ...
 
-  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.example.arn}:*" # CloudTrail requires the Log Stream wildcard
+  cloud_watch_logs_group_arn = "${aws_cloudwatchlogs_group.example.arn}:*" # CloudTrail requires the Log Stream wildcard
 }
 ```
 

--- a/website/docs/r/cloudwatchlogs_destination.html.markdown
+++ b/website/docs/r/cloudwatchlogs_destination.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_destination"
+page_title: "AWS: aws_cloudwatchlogs_destination"
 description: |-
   Provides a CloudWatch Logs destination.
 ---
 
-# Resource: aws_cloudwatch_log_destination
+# Resource: aws_cloudwatchlogs_destination
 
 Provides a CloudWatch Logs destination resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_destination" "test_destination" {
+resource "aws_cloudwatchlogs_destination" "test_destination" {
   name       = "test_destination"
   role_arn   = aws_iam_role.iam_for_cloudwatch.arn
   target_arn = aws_kinesis_stream.kinesis_for_cloudwatch.arn
@@ -39,5 +39,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudWatch Logs destinations can be imported using the `name`, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_log_destination.test_destination test_destination
+$ terraform import aws_cloudwatchlogs_destination.test_destination test_destination
 ```

--- a/website/docs/r/cloudwatchlogs_destination_policy.html.markdown
+++ b/website/docs/r/cloudwatchlogs_destination_policy.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_destination_policy"
+page_title: "AWS: aws_cloudwatchlogs_destination_policy"
 description: |-
   Provides a CloudWatch Logs destination policy.
 ---
 
-# Resource: aws_cloudwatch_log_destination_policy
+# Resource: aws_cloudwatchlogs_destination_policy
 
 Provides a CloudWatch Logs destination policy resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_destination" "test_destination" {
+resource "aws_cloudwatchlogs_destination" "test_destination" {
   name       = "test_destination"
   role_arn   = aws_iam_role.iam_for_cloudwatch.arn
   target_arn = aws_kinesis_stream.kinesis_for_cloudwatch.arn
@@ -36,13 +36,13 @@ data "aws_iam_policy_document" "test_destination_policy" {
     ]
 
     resources = [
-      aws_cloudwatch_log_destination.test_destination.arn,
+      aws_cloudwatchlogs_destination.test_destination.arn,
     ]
   }
 }
 
-resource "aws_cloudwatch_log_destination_policy" "test_destination_policy" {
-  destination_name = aws_cloudwatch_log_destination.test_destination.name
+resource "aws_cloudwatchlogs_destination_policy" "test_destination_policy" {
+  destination_name = aws_cloudwatchlogs_destination.test_destination.name
   access_policy    = data.aws_iam_policy_document.test_destination_policy.json
 }
 ```
@@ -63,5 +63,5 @@ No additional attributes are exported.
 CloudWatch Logs destination policies can be imported using the `destination_name`, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_log_destination_policy.test_destination_policy test_destination
+$ terraform import aws_cloudwatchlogs_destination_policy.test_destination_policy test_destination
 ```

--- a/website/docs/r/cloudwatchlogs_group.html.markdown
+++ b/website/docs/r/cloudwatchlogs_group.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_group"
+page_title: "AWS: aws_cloudwatchlogs_group"
 description: |-
   Provides a CloudWatch Log Group resource.
 ---
 
-# Resource: aws_cloudwatch_log_group
+# Resource: aws_cloudwatchlogs_group
 
 Provides a CloudWatch Log Group resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_group" "yada" {
+resource "aws_cloudwatchlogs_group" "yada" {
   name = "Yada"
 
   tags = {
@@ -49,5 +49,5 @@ In addition to all arguments above, the following attributes are exported:
 Cloudwatch Log Groups can be imported using the `name`, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_log_group.test_group yada
+$ terraform import aws_cloudwatchlogs_group.test_group yada
 ```

--- a/website/docs/r/cloudwatchlogs_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatchlogs_metric_filter.html.markdown
@@ -1,22 +1,22 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_metric_filter"
+page_title: "AWS: aws_cloudwatchlogs_metric_filter"
 description: |-
   Provides a CloudWatch Log Metric Filter resource.
 ---
 
-# Resource: aws_cloudwatch_log_metric_filter
+# Resource: aws_cloudwatchlogs_metric_filter
 
 Provides a CloudWatch Log Metric Filter resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_metric_filter" "yada" {
+resource "aws_cloudwatchlogs_metric_filter" "yada" {
   name           = "MyAppAccessCount"
   pattern        = ""
-  log_group_name = aws_cloudwatch_log_group.dada.name
+  log_group_name = aws_cloudwatchlogs_group.dada.name
 
   metric_transformation {
     name      = "EventCount"
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_log_metric_filter" "yada" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "dada" {
+resource "aws_cloudwatchlogs_group" "dada" {
   name = "MyApp/access.log"
 }
 ```
@@ -60,5 +60,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudWatch Log Metric Filter can be imported using the `log_group_name:name`, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_log_metric_filter.test /aws/lambda/function:test
+$ terraform import aws_cloudwatchlogs_metric_filter.test /aws/lambda/function:test
 ```

--- a/website/docs/r/cloudwatchlogs_query_definition.html.markdown
+++ b/website/docs/r/cloudwatchlogs_query_definition.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_query_definition"
+page_title: "AWS: aws_cloudwatchlogs_query_definition"
 description: |-
   Provides a CloudWatch Logs query definition resource.
 ---
 
-# Resource: aws_cloudwatch_query_definition
+# Resource: aws_cloudwatchlogs_query_definition
 
 Provides a CloudWatch Logs query definition resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_query_definition" "example" {
+resource "aws_cloudwatchlogs_query_definition" "example" {
   name = "custom_query"
 
   log_group_names = [
@@ -48,5 +48,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudWatch query definitions can be imported using the query definition ARN. The ARN can be found on the "Edit Query" page for the query in the AWS Console.
 
 ```
-$ terraform import aws_cloudwatch_query_definition.example arn:aws:logs:us-west-2:123456789012:query-definition:269951d7-6f75-496d-9d7b-6b7a5486bdbd
+$ terraform import aws_cloudwatchlogs_query_definition.example arn:aws:logs:us-west-2:123456789012:query-definition:269951d7-6f75-496d-9d7b-6b7a5486bdbd
 ```

--- a/website/docs/r/cloudwatchlogs_resource_policy.html.markdown
+++ b/website/docs/r/cloudwatchlogs_resource_policy.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_resource_policy"
+page_title: "AWS: aws_cloudwatchlogs_resource_policy"
 description: |-
   Provides a resource to manage a CloudWatch log resource policy
 ---
 
-# Resource: aws_cloudwatch_log_resource_policy
+# Resource: aws_cloudwatchlogs_resource_policy
 
 Provides a resource to manage a CloudWatch log resource policy.
 
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "elasticsearch-log-publishing-policy" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "elasticsearch-log-publishing-policy" {
+resource "aws_cloudwatchlogs_resource_policy" "elasticsearch-log-publishing-policy" {
   policy_document = data.aws_iam_policy_document.elasticsearch-log-publishing-policy.json
   policy_name     = "elasticsearch-log-publishing-policy"
 }
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
+resource "aws_cloudwatchlogs_resource_policy" "route53-query-logging-policy" {
   policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
   policy_name     = "route53-query-logging-policy"
 }
@@ -81,5 +81,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudWatch log resource policies can be imported using the policy name, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_log_resource_policy.MyPolicy MyPolicy
+$ terraform import aws_cloudwatchlogs_resource_policy.MyPolicy MyPolicy
 ```

--- a/website/docs/r/cloudwatchlogs_stream.html.markdown
+++ b/website/docs/r/cloudwatchlogs_stream.html.markdown
@@ -1,25 +1,25 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_stream"
+page_title: "AWS: aws_cloudwatchlogs_stream"
 description: |-
   Provides a CloudWatch Log Stream resource.
 ---
 
-# Resource: aws_cloudwatch_log_stream
+# Resource: aws_cloudwatchlogs_stream
 
 Provides a CloudWatch Log Stream resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_group" "yada" {
+resource "aws_cloudwatchlogs_group" "yada" {
   name = "Yada"
 }
 
-resource "aws_cloudwatch_log_stream" "foo" {
+resource "aws_cloudwatchlogs_stream" "foo" {
   name           = "SampleLogStream1234"
-  log_group_name = aws_cloudwatch_log_group.yada.name
+  log_group_name = aws_cloudwatchlogs_group.yada.name
 }
 ```
 
@@ -41,5 +41,5 @@ In addition to all arguments above, the following attributes are exported:
 Cloudwatch Log Stream can be imported using the stream's `log_group_name` and `name`, e.g.,
 
 ```
-$ terraform import aws_cloudwatch_log_stream.foo Yada:SampleLogStream1234
+$ terraform import aws_cloudwatchlogs_stream.foo Yada:SampleLogStream1234
 ```

--- a/website/docs/r/cloudwatchlogs_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatchlogs_subscription_filter.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "CloudWatch"
 layout: "aws"
-page_title: "AWS: aws_cloudwatch_log_subscription_filter"
+page_title: "AWS: aws_cloudwatchlogs_subscription_filter"
 description: |-
   Provides a CloudWatch Logs subscription filter.
 ---
 
-# Resource: aws_cloudwatch_log_subscription_filter
+# Resource: aws_cloudwatchlogs_subscription_filter
 
 Provides a CloudWatch Logs subscription filter resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
+resource "aws_cloudwatchlogs_subscription_filter" "test_lambdafunction_logfilter" {
   name            = "test_lambdafunction_logfilter"
   role_arn        = aws_iam_role.iam_for_lambda.arn
   log_group_name  = "/aws/lambda/example_lambda_name"
@@ -43,5 +43,5 @@ No additional attributes are exported.
 CloudWatch Logs subscription filter can be imported using the log group name and subscription filter name separated by `|`.
 
 ```
-$ terraform import aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter /aws/lambda/example_lambda_name|test_lambdafunction_logfilter
+$ terraform import aws_cloudwatchlogs_subscription_filter.test_lambdafunction_logfilter /aws/lambda/example_lambda_name|test_lambdafunction_logfilter
 ```

--- a/website/docs/r/directory_service_log_subscription.html.markdown
+++ b/website/docs/r/directory_service_log_subscription.html.markdown
@@ -13,7 +13,7 @@ Provides a Log subscription for AWS Directory Service that pushes logs to cloudw
 ## Example Usage
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name              = "/aws/directoryservice/${aws_directory_service_directory.example.id}"
   retention_in_days = 14
 }
@@ -30,20 +30,20 @@ data "aws_iam_policy_document" "ad-log-policy" {
       type        = "Service"
     }
 
-    resources = ["${aws_cloudwatch_log_group.example.arn}:*"]
+    resources = ["${aws_cloudwatchlogs_group.example.arn}:*"]
 
     effect = "Allow"
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
+resource "aws_cloudwatchlogs_resource_policy" "ad-log-policy" {
   policy_document = data.aws_iam_policy_document.ad-log-policy.json
   policy_name     = "ad-log-policy"
 }
 
 resource "aws_directory_service_log_subscription" "example" {
   directory_id   = aws_directory_service_directory.example.id
-  log_group_name = aws_cloudwatch_log_group.example.name
+  log_group_name = aws_cloudwatchlogs_group.example.name
 }
 ```
 

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -26,8 +26,8 @@ resource "aws_ec2_client_vpn_endpoint" "example" {
 
   connection_log_options {
     enabled               = true
-    cloudwatch_log_group  = aws_cloudwatch_log_group.lg.name
-    cloudwatch_log_stream = aws_cloudwatch_log_stream.ls.name
+    cloudwatch_log_group  = aws_cloudwatchlogs_group.lg.name
+    cloudwatch_log_stream = aws_cloudwatchlogs_stream.ls.name
   }
 }
 ```

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -31,7 +31,7 @@ resource "aws_kms_key" "example" {
   deletion_window_in_days = 7
 }
 
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "example"
 }
 
@@ -45,7 +45,7 @@ resource "aws_ecs_cluster" "test" {
 
       log_configuration {
         cloud_watch_encryption_enabled = true
-        cloud_watch_log_group_name     = aws_cloudwatch_log_group.example.name
+        cloud_watch_log_group_name     = aws_cloudwatchlogs_group.example.name
       }
     }
   }

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -79,7 +79,7 @@ resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceControlle
 
 ### Enabling Control Plane Logging
 
-[EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) can be enabled via the `enabled_cluster_log_types` argument. To manage the CloudWatch Log Group retention period, the [`aws_cloudwatch_log_group` resource](/docs/providers/aws/r/cloudwatch_log_group.html) can be used.
+[EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) can be enabled via the `enabled_cluster_log_types` argument. To manage the CloudWatch Log Group retention period, the [`aws_cloudwatchlogs_group` resource](/docs/providers/aws/r/cloudwatch_log_group.html) can be used.
 
 -> The below configuration uses [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html) to prevent ordering issues with EKS automatically creating the log group first and a variable for naming consistency. Other ordering and naming methodologies may be more appropriate for your environment.
 
@@ -90,7 +90,7 @@ variable "cluster_name" {
 }
 
 resource "aws_eks_cluster" "example" {
-  depends_on = [aws_cloudwatch_log_group.example]
+  depends_on = [aws_cloudwatchlogs_group.example]
 
   enabled_cluster_log_types = ["api", "audit"]
   name                      = var.cluster_name
@@ -98,7 +98,7 @@ resource "aws_eks_cluster" "example" {
   # ... other configuration ...
 }
 
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   # The log group name format is /aws/eks/<cluster-name>/cluster
   # Reference: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
   name              = "/aws/eks/${var.cluster_name}/cluster"

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -69,11 +69,11 @@ POLICY
 ### Log Publishing to CloudWatch Logs
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "example"
 }
 
-resource "aws_cloudwatch_log_resource_policy" "example" {
+resource "aws_cloudwatchlogs_resource_policy" "example" {
   policy_name = "example"
 
   policy_document = <<CONFIG
@@ -101,7 +101,7 @@ resource "aws_elasticsearch_domain" "example" {
   # .. other configuration ...
 
   log_publishing_options {
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    cloudwatch_log_group_arn = aws_cloudwatchlogs_group.example.arn
     log_type                 = "INDEX_SLOW_LOGS"
   }
 }

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -18,12 +18,12 @@ interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group or a S3 Bucke
 ```terraform
 resource "aws_flow_log" "example" {
   iam_role_arn    = aws_iam_role.example.arn
-  log_destination = aws_cloudwatch_log_group.example.arn
+  log_destination = aws_cloudwatchlogs_group.example.arn
   traffic_type    = "ALL"
   vpc_id          = aws_vpc.example.id
 }
 
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "example"
 }
 

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -47,7 +47,7 @@ resource "aws_glue_job" "example" {
 ### Enabling CloudWatch Logs and Metrics
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name              = "example"
   retention_in_days = 14
 }
@@ -57,7 +57,7 @@ resource "aws_glue_job" "example" {
 
   default_arguments = {
     # ... potentially other arguments ...
-    "--continuous-log-logGroup"          = aws_cloudwatch_log_group.example.name
+    "--continuous-log-logGroup"          = aws_cloudwatchlogs_group.example.name
     "--enable-continuous-cloudwatch-log" = "true"
     "--enable-continuous-log-filter"     = "true"
     "--enable-metrics"                   = ""

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -64,13 +64,13 @@ resource "aws_kinesis_analytics_application" "test_application" {
 ### Starting An Application
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "analytics"
 }
 
-resource "aws_cloudwatch_log_stream" "example" {
+resource "aws_cloudwatchlogs_stream" "example" {
   name           = "example-kinesis-application"
-  log_group_name = aws_cloudwatch_log_group.example.name
+  log_group_name = aws_cloudwatchlogs_group.example.name
 }
 
 resource "aws_kinesis_stream" "example" {
@@ -92,7 +92,7 @@ resource "aws_kinesis_analytics_application" "test" {
   name = "example-application"
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.example.arn
+    log_stream_arn = aws_cloudwatchlogs_stream.example.arn
     role_arn       = aws_iam_role.example.arn
   }
 

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -93,13 +93,13 @@ resource "aws_kinesisanalyticsv2_application" "example" {
 ### SQL Application
 
 ```terraform
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name = "example-sql-application"
 }
 
-resource "aws_cloudwatch_log_stream" "example" {
+resource "aws_cloudwatchlogs_stream" "example" {
   name           = "example-sql-application"
-  log_group_name = aws_cloudwatch_log_group.example.name
+  log_group_name = aws_cloudwatchlogs_group.example.name
 }
 
 resource "aws_kinesisanalyticsv2_application" "example" {
@@ -208,7 +208,7 @@ resource "aws_kinesisanalyticsv2_application" "example" {
   }
 
   cloudwatch_logging_options {
-    log_stream_arn = aws_cloudwatch_log_stream.example.arn
+    log_stream_arn = aws_cloudwatchlogs_stream.example.arn
   }
 }
 ```

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -160,13 +160,13 @@ resource "aws_lambda_function" "test_lambda" {
   # ... other configuration ...
   depends_on = [
     aws_iam_role_policy_attachment.lambda_logs,
-    aws_cloudwatch_log_group.example,
+    aws_cloudwatchlogs_group.example,
   ]
 }
 
 # This is to optionally manage the CloudWatch Log Group for the Lambda Function.
 # If skipping this resource configuration, also add "logs:CreateLogGroup" to the IAM policy below.
-resource "aws_cloudwatch_log_group" "example" {
+resource "aws_cloudwatchlogs_group" "example" {
   name              = "/aws/lambda/${var.lambda_function_name}"
   retention_in_days = 14
 }

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -135,18 +135,18 @@ resource "aws_lambda_permission" "logging" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logging.function_name
   principal     = "logs.eu-west-1.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_log_group.default.arn}:*"
+  source_arn    = "${aws_cloudwatchlogs_group.default.arn}:*"
 }
 
-resource "aws_cloudwatch_log_group" "default" {
+resource "aws_cloudwatchlogs_group" "default" {
   name = "/default"
 }
 
-resource "aws_cloudwatch_log_subscription_filter" "logging" {
+resource "aws_cloudwatchlogs_subscription_filter" "logging" {
   depends_on      = [aws_lambda_permission.logging]
   destination_arn = aws_lambda_function.logging.arn
   filter_pattern  = ""
-  log_group_name  = aws_cloudwatch_log_group.default.name
+  log_group_name  = aws_cloudwatchlogs_group.default.name
   name            = "logging_default"
 }
 

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -47,7 +47,7 @@ resource "aws_kms_key" "kms" {
   description = "example"
 }
 
-resource "aws_cloudwatch_log_group" "test" {
+resource "aws_cloudwatchlogs_group" "test" {
   name = "msk_broker_logs"
 }
 
@@ -131,7 +131,7 @@ resource "aws_msk_cluster" "example" {
     broker_logs {
       cloudwatch_logs {
         enabled   = true
-        log_group = aws_cloudwatch_log_group.test.name
+        log_group = aws_cloudwatchlogs_group.test.name
       }
       firehose {
         enabled         = true

--- a/website/docs/r/networkfirewall_logging_configuration.html.markdown
+++ b/website/docs/r/networkfirewall_logging_configuration.html.markdown
@@ -38,7 +38,7 @@ resource "aws_networkfirewall_logging_configuration" "example" {
   logging_configuration {
     log_destination_config {
       log_destination = {
-        logGroup = aws_cloudwatch_log_group.example.name
+        logGroup = aws_cloudwatchlogs_group.example.name
       }
       log_destination_type = "CloudWatchLogs"
       log_type             = "ALERT"

--- a/website/docs/r/route53_query_log.html.markdown
+++ b/website/docs/r/route53_query_log.html.markdown
@@ -26,7 +26,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_cloudwatch_log_group" "aws_route53_example_com" {
+resource "aws_cloudwatchlogs_group" "aws_route53_example_com" {
   provider = aws.us-east-1
 
   name              = "/aws/route53/${aws_route53_zone.example_com.name}"
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
   }
 }
 
-resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
+resource "aws_cloudwatchlogs_resource_policy" "route53-query-logging-policy" {
   provider = aws.us-east-1
 
   policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
@@ -66,9 +66,9 @@ resource "aws_route53_zone" "example_com" {
 }
 
 resource "aws_route53_query_log" "example_com" {
-  depends_on = [aws_cloudwatch_log_resource_policy.route53-query-logging-policy]
+  depends_on = [aws_cloudwatchlogs_resource_policy.route53-query-logging-policy]
 
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.aws_route53_example_com.arn
+  cloudwatch_log_group_arn = aws_cloudwatchlogs_group.aws_route53_example_com.arn
   zone_id                  = aws_route53_zone.example_com.zone_id
 }
 ```

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -88,7 +88,7 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
 EOF
 
   logging_configuration {
-    log_destination        = "${aws_cloudwatch_log_group.log_group_for_sfn.arn}:*"
+    log_destination        = "${aws_cloudwatchlogs_group.log_group_for_sfn.arn}:*"
     include_execution_data = true
     level                  = "ERROR"
   }

--- a/website/docs/r/storagegateway_file_system_association.html.markdown
+++ b/website/docs/r/storagegateway_file_system_association.html.markdown
@@ -74,7 +74,7 @@ resource "aws_storagegateway_file_system_association" "fsx" {
   cache_attributes {
     cache_stale_timeout_in_seconds = 400
   }
-  audit_destination_arn = aws_cloudwatch_log_group.test.arn
+  audit_destination_arn = aws_cloudwatchlogs_group.test.arn
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
