### PR TITLE
Realign inconsistent kinesis analytics names

### DIFF
--- a/.changelog/21599.txt
+++ b/.changelog/21599.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kinesis_analytics_application: Rename data source to aws_kinesisanalytics_application (with alias for aws_kinesis_analytics_application)
+```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -312,7 +312,7 @@ jobs:
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
           -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_kinesis_analytics_application \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1263,7 +1263,9 @@ func Provider() *schema.Provider {
 			"aws_kinesis_stream":          kinesis.ResourceStream(),
 			"aws_kinesis_stream_consumer": kinesis.ResourceStreamConsumer(),
 
-			"aws_kinesis_analytics_application":           kinesisanalytics.ResourceApplication(),
+			"aws_kinesisanalytics_application":  kinesisanalytics.ResourceApplication(),
+			"aws_kinesis_analytics_application": kinesisanalytics.ResourceApplication(), // backward compatible alias
+
 			"aws_kinesisanalyticsv2_application":          kinesisanalyticsv2.ResourceApplication(),
 			"aws_kinesisanalyticsv2_application_snapshot": kinesisanalyticsv2.ResourceApplicationSnapshot(),
 

--- a/internal/service/cloudwatchlogs/sweep.go
+++ b/internal/service/cloudwatchlogs/sweep.go
@@ -31,7 +31,7 @@ func init() {
 			"aws_elasticsearch_domain",
 			"aws_flow_log",
 			"aws_glue_job",
-			"aws_kinesis_analytics_application",
+			"aws_kinesisanalytics_application",
 			"aws_kinesis_firehose_delivery_stream",
 			"aws_lambda_function",
 			"aws_mq_broker",

--- a/internal/service/kinesisanalytics/application_test.go
+++ b/internal/service/kinesisanalytics/application_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccKinesisAnalyticsApplication_basic(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -57,7 +57,7 @@ func TestAccKinesisAnalyticsApplication_basic(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_disappears(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -80,7 +80,7 @@ func TestAccKinesisAnalyticsApplication_disappears(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_tags(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -128,7 +128,7 @@ func TestAccKinesisAnalyticsApplication_tags(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_Code_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -188,7 +188,7 @@ func TestAccKinesisAnalyticsApplication_Code_update(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_add(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -252,7 +252,7 @@ func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_add(t *testing.
 
 func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_delete(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -316,7 +316,7 @@ func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_delete(t *testi
 
 func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	cloudWatchLogStream1ResourceName := "aws_cloudwatch_log_stream.test.0"
@@ -384,7 +384,7 @@ func TestAccKinesisAnalyticsApplication_CloudWatchLoggingOptions_update(t *testi
 
 func TestAccKinesisAnalyticsApplication_Input_add(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -470,7 +470,7 @@ func TestAccKinesisAnalyticsApplication_Input_add(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_Input_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
@@ -585,7 +585,7 @@ func TestAccKinesisAnalyticsApplication_Input_update(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_InputProcessing_add(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	lambdaResourceName := "aws_lambda_function.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
@@ -699,7 +699,7 @@ func TestAccKinesisAnalyticsApplication_InputProcessing_add(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_InputProcessing_delete(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	lambdaResourceName := "aws_lambda_function.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
@@ -813,7 +813,7 @@ func TestAccKinesisAnalyticsApplication_InputProcessing_delete(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_InputProcessing_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	lambda1ResourceName := "aws_lambda_function.test.0"
@@ -932,7 +932,7 @@ func TestAccKinesisAnalyticsApplication_InputProcessing_update(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_Multiple_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
@@ -1104,7 +1104,7 @@ func TestAccKinesisAnalyticsApplication_Multiple_update(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_Output_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	lambdaResourceName := "aws_lambda_function.test.0"
@@ -1219,7 +1219,7 @@ func TestAccKinesisAnalyticsApplication_Output_update(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_ReferenceDataSource_add(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1299,7 +1299,7 @@ func TestAccKinesisAnalyticsApplication_ReferenceDataSource_add(t *testing.T) {
 
 func TestAccKinesisAnalyticsApplication_ReferenceDataSource_delete(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRoleResourceName := "aws_iam_role.test.0"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1379,7 +1379,7 @@ func TestAccKinesisAnalyticsApplication_ReferenceDataSource_delete(t *testing.T)
 
 func TestAccKinesisAnalyticsApplication_ReferenceDataSource_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	s3BucketResourceName := "aws_s3_bucket.test"
@@ -1481,7 +1481,7 @@ func TestAccKinesisAnalyticsApplication_ReferenceDataSource_update(t *testing.T)
 
 func TestAccKinesisAnalyticsApplication_StartApplication_onCreate(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1548,7 +1548,7 @@ func TestAccKinesisAnalyticsApplication_StartApplication_onCreate(t *testing.T) 
 
 func TestAccKinesisAnalyticsApplication_StartApplication_onUpdate(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1703,7 +1703,7 @@ func TestAccKinesisAnalyticsApplication_StartApplication_onUpdate(t *testing.T) 
 
 func TestAccKinesisAnalyticsApplication_StartApplication_update(t *testing.T) {
 	var v kinesisanalytics.ApplicationDetail
-	resourceName := "aws_kinesis_analytics_application.test"
+	resourceName := "aws_kinesisanalytics_application.test"
 	iamRole1ResourceName := "aws_iam_role.test.0"
 	iamRole2ResourceName := "aws_iam_role.test.1"
 	cloudWatchLogStreamResourceName := "aws_cloudwatch_log_stream.test"
@@ -1880,7 +1880,7 @@ func testAccCheckKinesisAnalyticsApplicationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).KinesisAnalyticsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_kinesis_analytics_application" {
+		if rs.Type != "aws_kinesisanalytics_application" {
 			continue
 		}
 
@@ -2050,7 +2050,7 @@ resource "aws_kinesis_stream" "test" {
 
 func testAccKinesisAnalyticsApplicationConfigBasic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 }
 `, rName)
@@ -2058,7 +2058,7 @@ resource "aws_kinesis_analytics_application" "test" {
 
 func testAccKinesisAnalyticsApplicationConfigCode(rName, code string) string {
 	return fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name        = %[1]q
   description = "test"
   code        = %[2]q
@@ -2081,7 +2081,7 @@ resource "aws_cloudwatch_log_stream" "test" {
   log_group_name = aws_cloudwatch_log_group.test.name
 }
 
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   cloudwatch_logging_options {
@@ -2097,7 +2097,7 @@ func testAccKinesisAnalyticsApplicationConfigInput(rName string) string {
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   inputs {
@@ -2133,7 +2133,7 @@ func testAccKinesisAnalyticsApplicationConfigInputUpdated(rName string) string {
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   inputs {
@@ -2181,7 +2181,7 @@ func testAccKinesisAnalyticsApplicationConfigInputProcessingConfiguration(rName 
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   inputs {
@@ -2242,7 +2242,7 @@ resource "aws_cloudwatch_log_stream" "test" {
   log_group_name = aws_cloudwatch_log_group.test.name
 }
 
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   cloudwatch_logging_options {
@@ -2322,7 +2322,7 @@ func testAccKinesisAnalyticsApplicationConfigMultipleUpdated(rName, startApplica
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   inputs {
@@ -2433,7 +2433,7 @@ func testAccKinesisAnalyticsApplicationOutput(rName string) string {
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   outputs {
@@ -2457,7 +2457,7 @@ func testAccKinesisAnalyticsApplicationOutputUpdated(rName string) string {
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   outputs {
@@ -2497,7 +2497,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   reference_data_sources {
@@ -2537,7 +2537,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   reference_data_sources {
@@ -2582,7 +2582,7 @@ func testAccKinesisAnalyticsApplicationConfigStartApplication(rName string, star
 		testAccKinesisAnalyticsApplicationConfigBaseIamRole(rName),
 		testAccKinesisAnalyticsApplicationConfigBaseInputOutput(rName),
 		fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   inputs {
@@ -2621,7 +2621,7 @@ resource "aws_kinesis_analytics_application" "test" {
 
 func testAccKinesisAnalyticsApplicationConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   tags = {
@@ -2633,7 +2633,7 @@ resource "aws_kinesis_analytics_application" "test" {
 
 func testAccKinesisAnalyticsApplicationConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = %[1]q
 
   tags = {

--- a/internal/service/kinesisanalytics/sweep.go
+++ b/internal/service/kinesisanalytics/sweep.go
@@ -18,8 +18,8 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("aws_kinesis_analytics_application", &resource.Sweeper{
-		Name: "aws_kinesis_analytics_application",
+	resource.AddTestSweepers("aws_kinesisanalytics_application", &resource.Sweeper{
+		Name: "aws_kinesisanalytics_application",
 		F:    sweepApplications,
 	})
 }

--- a/website/docs/r/kinesisanalytics_application.html.markdown
+++ b/website/docs/r/kinesisanalytics_application.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Kinesis Data Analytics (SQL Applications)"
 layout: "aws"
-page_title: "AWS: aws_kinesis_analytics_application"
+page_title: "AWS: aws_kinesisanalytics_application"
 description: |-
   Provides a AWS Kinesis Analytics Application
 ---
 
-# Resource: aws_kinesis_analytics_application
+# Resource: aws_kinesisanalytics_application
 
 Provides a Kinesis Analytics Application resource. Kinesis Analytics is a managed service that
 allows processing and analyzing streaming data using standard SQL.
@@ -25,7 +25,7 @@ resource "aws_kinesis_stream" "test_stream" {
   shard_count = 1
 }
 
-resource "aws_kinesis_analytics_application" "test_application" {
+resource "aws_kinesisanalytics_application" "test_application" {
   name = "kinesis-analytics-application-test"
 
   inputs {
@@ -88,7 +88,7 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
   }
 }
 
-resource "aws_kinesis_analytics_application" "test" {
+resource "aws_kinesisanalytics_application" "test" {
   name = "example-application"
 
   cloudwatch_logging_options {
@@ -359,5 +359,5 @@ In addition to all arguments above, the following attributes are exported:
 Kinesis Analytics Application can be imported by using ARN, e.g.,
 
 ```
-$ terraform import aws_kinesis_analytics_application.example arn:aws:kinesisanalytics:us-west-2:1234567890:application/example
+$ terraform import aws_kinesisanalytics_application.example arn:aws:kinesisanalytics:us-west-2:1234567890:application/example
 ```

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Manages a Kinesis Analytics v2 Application.
 This resource can be used to manage both Kinesis Data Analytics for SQL applications and Kinesis Data Analytics for Apache Flink applications.
 
--> **Note:** Kinesis Data Analytics for SQL applications created using this resource cannot currently be viewed in the AWS Console. To manage Kinesis Data Analytics for SQL applications that can also be viewed in the AWS Console, use the [`aws_kinesis_analytics_application`](/docs/providers/aws/r/kinesis_analytics_application.html) resource.
+-> **Note:** Kinesis Data Analytics for SQL applications created using this resource cannot currently be viewed in the AWS Console. To manage Kinesis Data Analytics for SQL applications that can also be viewed in the AWS Console, use the [`aws_kinesisanalytics_application`](/docs/providers/aws/r/kinesis_analytics_application.html) resource.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
