### PR TITLE
Realign inconsistent mediapackage names

### DIFF
--- a/.changelog/21602.txt
+++ b/.changelog/21602.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_media_package_channel: Rename data source to aws_mediapackage_channel (with alias for aws_media_package_channel)
+```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -312,7 +312,7 @@ jobs:
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
           -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_media_package_channel \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1318,7 +1318,8 @@ func Provider() *schema.Provider {
 
 			"aws_media_convert_queue": mediaconvert.ResourceQueue(),
 
-			"aws_media_package_channel": mediapackage.ResourceChannel(),
+			"aws_mediapackage_channel":  mediapackage.ResourceChannel(),
+			"aws_media_package_channel": mediapackage.ResourceChannel(), // backward compatible alias
 
 			"aws_media_store_container":        mediastore.ResourceContainer(),
 			"aws_media_store_container_policy": mediastore.ResourceContainerPolicy(),

--- a/internal/service/mediapackage/channel_test.go
+++ b/internal/service/mediapackage/channel_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccMediaPackageChannel_basic(t *testing.T) {
-	resourceName := "aws_media_package_channel.test"
+	resourceName := "aws_mediapackage_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -47,7 +47,7 @@ func TestAccMediaPackageChannel_basic(t *testing.T) {
 }
 
 func TestAccMediaPackageChannel_description(t *testing.T) {
-	resourceName := "aws_media_package_channel.test"
+	resourceName := "aws_mediapackage_channel.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -80,7 +80,7 @@ func TestAccMediaPackageChannel_description(t *testing.T) {
 }
 
 func TestAccMediaPackageChannel_tags(t *testing.T) {
-	resourceName := "aws_media_package_channel.test"
+	resourceName := "aws_mediapackage_channel.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -127,7 +127,7 @@ func testAccCheckChannelDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).MediaPackageConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_media_package_channel" {
+		if rs.Type != "aws_mediapackage_channel" {
 			continue
 		}
 
@@ -185,7 +185,7 @@ func testAccPreCheck(t *testing.T) {
 
 func testAccMediaPackageChannelConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_media_package_channel" "test" {
+resource "aws_mediapackage_channel" "test" {
   channel_id = "tf_mediachannel_%s"
 }
 `, rName)
@@ -193,7 +193,7 @@ resource "aws_media_package_channel" "test" {
 
 func testAccMediaPackageChannelConfigDescription(rName, description string) string {
 	return fmt.Sprintf(`
-resource "aws_media_package_channel" "test" {
+resource "aws_mediapackage_channel" "test" {
   channel_id  = %q
   description = %q
 }
@@ -202,7 +202,7 @@ resource "aws_media_package_channel" "test" {
 
 func testAccMediaPackageChannelConfigWithTags(rName, key, value string) string {
 	return fmt.Sprintf(`
-resource "aws_media_package_channel" "test" {
+resource "aws_mediapackage_channel" "test" {
   channel_id = "%[1]s"
 
   tags = {

--- a/website/docs/r/mediapackage_channel.html.markdown
+++ b/website/docs/r/mediapackage_channel.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "MediaPackage"
 layout: "aws"
-page_title: "AWS: aws_media_package_channel"
+page_title: "AWS: aws_mediapackage_channel"
 description: |-
   Provides an AWS Elemental MediaPackage Channel.
 ---
 
-# Resource: aws_media_package_channel
+# Resource: aws_mediapackage_channel
 
 Provides an AWS Elemental MediaPackage Channel.
 
 ## Example Usage
 
 ```terraform
-resource "aws_media_package_channel" "kittens" {
+resource "aws_mediapackage_channel" "kittens" {
   channel_id  = "kitten-channel"
   description = "A channel dedicated to amusing videos of kittens."
 }
@@ -45,5 +45,5 @@ In addition to all arguments above, the following attributes are exported:
 Media Package Channels can be imported via the channel ID, e.g.,
 
 ```
-$ terraform import aws_media_package_channel.kittens kittens-channel
+$ terraform import aws_mediapackage_channel.kittens kittens-channel
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
