### PR TITLE
Realign inconsistent resourcegroupstagging names

### DIFF
--- a/.changelog/21604.txt
+++ b/.changelog/21604.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_resourcegroupstaggingapi_resources: Rename data source to aws_resourcegroupstagging_resources (with alias for aws_resourcegroupstaggingapi_resources)
+```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -312,7 +312,7 @@ jobs:
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
           -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_resourcegroupstaggingapi_resources \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -628,7 +628,8 @@ func Provider() *schema.Provider {
 			"aws_redshift_orderable_cluster": redshift.DataSourceOrderableCluster(),
 			"aws_redshift_service_account":   redshift.DataSourceServiceAccount(),
 
-			"aws_resourcegroupstaggingapi_resources": resourcegroupstagging.DataSourceResources(),
+			"aws_resourcegroupstagging_resources":    resourcegroupstagging.DataSourceResources(),
+			"aws_resourcegroupstaggingapi_resources": resourcegroupstagging.DataSourceResources(), // backward compatible alias
 
 			"aws_route53_delegation_set": route53.DataSourceDelegationSet(),
 			"aws_route53_zone":           route53.DataSourceZone(),

--- a/internal/service/resourcegroupstagging/resources_data_source_test.go
+++ b/internal/service/resourcegroupstagging/resources_data_source_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccResourceGroupsTaggingResourcesDataSource_tagFilter(t *testing.T) {
-	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+	dataSourceName := "data.aws_resourcegroupstagging_resources.test"
 	resourceName := "aws_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -34,7 +34,7 @@ func TestAccResourceGroupsTaggingResourcesDataSource_tagFilter(t *testing.T) {
 }
 
 func TestAccResourceGroupsTaggingResourcesDataSource_includeComplianceDetails(t *testing.T) {
-	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+	dataSourceName := "data.aws_resourcegroupstagging_resources.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -54,7 +54,7 @@ func TestAccResourceGroupsTaggingResourcesDataSource_includeComplianceDetails(t 
 }
 
 func TestAccResourceGroupsTaggingResourcesDataSource_resourceTypeFilters(t *testing.T) {
-	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+	dataSourceName := "data.aws_resourcegroupstagging_resources.test"
 	resourceName := "aws_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -77,7 +77,7 @@ func TestAccResourceGroupsTaggingResourcesDataSource_resourceTypeFilters(t *test
 }
 
 func TestAccResourceGroupsTaggingResourcesDataSource_resourceARNList(t *testing.T) {
-	dataSourceName := "data.aws_resourcegroupstaggingapi_resources.test"
+	dataSourceName := "data.aws_resourcegroupstagging_resources.test"
 	resourceName := "aws_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -109,7 +109,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-data "aws_resourcegroupstaggingapi_resources" "test" {
+data "aws_resourcegroupstagging_resources" "test" {
   tag_filter {
     key    = "Key"
     values = [aws_vpc.test.tags["Key"]]
@@ -128,7 +128,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-data "aws_resourcegroupstaggingapi_resources" "test" {
+data "aws_resourcegroupstagging_resources" "test" {
   resource_type_filters = ["ec2:vpc"]
 
   depends_on = [aws_vpc.test]
@@ -146,7 +146,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-data "aws_resourcegroupstaggingapi_resources" "test" {
+data "aws_resourcegroupstagging_resources" "test" {
   resource_arn_list = [aws_vpc.test.arn]
 }
 `, rName)
@@ -162,7 +162,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-data "aws_resourcegroupstaggingapi_resources" "test" {
+data "aws_resourcegroupstagging_resources" "test" {
   include_compliance_details  = true
   exclude_compliant_resources = false
   resource_arn_list           = [aws_vpc.test.arn]

--- a/website/docs/d/resourcegroupstagging_resources.html.markdown
+++ b/website/docs/d/resourcegroupstagging_resources.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Resource Groups Tagging API"
 layout: "aws"
-page_title: "AWS: aws_resourcegroupstaggingapi_resources"
+page_title: "AWS: aws_resourcegroupstagging_resources"
 description: |-
   Provides details about resource tagging.
 ---
 
-# Data Source: aws_resourcegroupstaggingapi_resources
+# Data Source: aws_resourcegroupstagging_resources
 
 Provides details about resource tagging.
 
@@ -15,13 +15,13 @@ Provides details about resource tagging.
 ### Get All Resource Tag Mappings
 
 ```terraform
-data "aws_resourcegroupstaggingapi_resources" "test" {}
+data "aws_resourcegroupstagging_resources" "test" {}
 ```
 
 ### Filter By Tag Key and Value
 
 ```terraform
-data "aws_resourcegroupstaggingapi_resources" "test" {
+data "aws_resourcegroupstagging_resources" "test" {
   tag_filter {
     key    = "tag-key"
     values = ["tag-value-1", "tag-value-2"]
@@ -32,7 +32,7 @@ data "aws_resourcegroupstaggingapi_resources" "test" {
 ### Filter By Resource Type
 
 ```terraform
-data "aws_resourcegroupstaggingapi_resources" "test" {
+data "aws_resourcegroupstagging_resources" "test" {
   resource_type_filters = ["ec2:instance"]
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
