### PR TITLE
Realign inconsistent route53 resolver names

### DIFF
--- a/.changelog/21605.txt
+++ b/.changelog/21605.txt
@@ -1,0 +1,55 @@
+```release-note:enhancement
+data-source/aws_route53_resolver_endpoint: Rename data source to aws_route53resolver_endpoint (with alias for aws_route53_resolver_endpoint)
+```
+
+```release-note:enhancement
+data-source/aws_route53_resolver_rule: Rename data source to aws_route53resolver_rule (with alias for aws_route53_resolver_rule)
+```
+
+```release-note:enhancement
+data-source/aws_route53_resolver_rules: Rename data source to aws_route53resolver_rules (with alias for aws_route53_resolver_rules)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_dnssec_config: Rename resource to aws_route53resolver_dnssec_config (with alias for aws_route53_resolver_dnssec_config)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_endpoint: Rename resource to aws_route53resolver_endpoint (with alias for aws_route53_resolver_endpoint)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_firewall_config: Rename resource to aws_route53resolver_firewall_config (with alias for aws_route53_resolver_firewall_config)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_firewall_domain_list: Rename resource to aws_route53resolver_firewall_domain_list (with alias for aws_route53_resolver_firewall_domain_list)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_firewall_rule: Rename resource to aws_route53resolver_firewall_rule (with alias for aws_route53_resolver_firewall_rule)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_firewall_rule_group: Rename resource to aws_route53resolver_firewall_rule_group (with alias for aws_route53_resolver_firewall_rule_group)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_firewall_rule_group_association: Rename resource to aws_route53resolver_firewall_rule_group_association (with alias for aws_route53_resolver_firewall_rule_group_association)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_query_log_config: Rename resource to aws_route53resolver_query_log_config (with alias for aws_route53_resolver_query_log_config)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_query_log_config_association: Rename resource to aws_route53resolver_query_log_config_association (with alias for aws_route53_resolver_query_log_config_association)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_rule: Rename resource to aws_route53resolver_rule (with alias for aws_route53_resolver_rule)
+```
+
+```release-note:enhancement
+resource/aws_route53_resolver_rule_association: Rename resource to aws_route53resolver_rule_association (with alias for aws_route53_resolver_rule_association)
+```

--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -305,7 +305,7 @@ service/route53recoverycontrolconfig:
 service/route53recoveryreadiness:
   - '((\*|-) ?`?|(data|resource) "?)aws_route53recoveryreadiness_'
 service/route53resolver:
-  - '((\*|-) ?`?|(data|resource) "?)aws_route53_resolver_'
+  - '((\*|-) ?`?|(data|resource) "?)aws_route53resolver_'
 service/s3:
   - '((\*|-) ?`?|(data|resource) "?)aws_(canonical_user_id|s3_bucket|s3_object)'
 service/s3control:

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -311,8 +311,8 @@ jobs:
         tfproviderdocs check \
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
-          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group,aws_route53_resolver_endpoint,aws_route53_resolver_rule,aws_route53_resolver_rules \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_route53_resolver_dnssec_config,aws_route53_resolver_endpoint,aws_route53_resolver_firewall_config,aws_route53_resolver_firewall_domain_list,aws_route53_resolver_firewall_rule,aws_route53_resolver_firewall_rule_group,aws_route53_resolver_firewall_rule_group_association,aws_route53_resolver_query_log_config,aws_route53_resolver_query_log_config_association,aws_route53_resolver_rule,aws_route53_resolver_rule_association \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -633,9 +633,12 @@ func Provider() *schema.Provider {
 			"aws_route53_delegation_set": route53.DataSourceDelegationSet(),
 			"aws_route53_zone":           route53.DataSourceZone(),
 
-			"aws_route53_resolver_endpoint": route53resolver.DataSourceEndpoint(),
-			"aws_route53_resolver_rule":     route53resolver.DataSourceRule(),
-			"aws_route53_resolver_rules":    route53resolver.DataSourceRules(),
+			"aws_route53resolver_endpoint":  route53resolver.DataSourceEndpoint(),
+			"aws_route53resolver_rule":      route53resolver.DataSourceRule(),
+			"aws_route53resolver_rules":     route53resolver.DataSourceRules(),
+			"aws_route53_resolver_endpoint": route53resolver.DataSourceEndpoint(), // backward compatible alias
+			"aws_route53_resolver_rule":     route53resolver.DataSourceRule(),     // backward compatible alias
+			"aws_route53_resolver_rules":    route53resolver.DataSourceRules(),    // backward compatible alias
 
 			"aws_canonical_user_id": s3.DataSourceCanonicalUserID(),
 			"aws_s3_bucket":         s3.DataSourceBucket(),
@@ -1447,17 +1450,28 @@ func Provider() *schema.Provider {
 			"aws_route53recoveryreadiness_recovery_group":  route53recoveryreadiness.ResourceRecoveryGroup(),
 			"aws_route53recoveryreadiness_resource_set":    route53recoveryreadiness.ResourceResourceSet(),
 
-			"aws_route53_resolver_dnssec_config":                   route53resolver.ResourceDNSSECConfig(),
-			"aws_route53_resolver_endpoint":                        route53resolver.ResourceEndpoint(),
-			"aws_route53_resolver_firewall_config":                 route53resolver.ResourceFirewallConfig(),
-			"aws_route53_resolver_firewall_domain_list":            route53resolver.ResourceFirewallDomainList(),
-			"aws_route53_resolver_firewall_rule":                   route53resolver.ResourceFirewallRule(),
-			"aws_route53_resolver_firewall_rule_group":             route53resolver.ResourceFirewallRuleGroup(),
-			"aws_route53_resolver_firewall_rule_group_association": route53resolver.ResourceFirewallRuleGroupAssociation(),
-			"aws_route53_resolver_query_log_config":                route53resolver.ResourceQueryLogConfig(),
-			"aws_route53_resolver_query_log_config_association":    route53resolver.ResourceQueryLogConfigAssociation(),
-			"aws_route53_resolver_rule":                            route53resolver.ResourceRule(),
-			"aws_route53_resolver_rule_association":                route53resolver.ResourceRuleAssociation(),
+			"aws_route53resolver_dnssec_config":                    route53resolver.ResourceDNSSECConfig(),
+			"aws_route53resolver_endpoint":                         route53resolver.ResourceEndpoint(),
+			"aws_route53resolver_firewall_config":                  route53resolver.ResourceFirewallConfig(),
+			"aws_route53resolver_firewall_domain_list":             route53resolver.ResourceFirewallDomainList(),
+			"aws_route53resolver_firewall_rule":                    route53resolver.ResourceFirewallRule(),
+			"aws_route53resolver_firewall_rule_group":              route53resolver.ResourceFirewallRuleGroup(),
+			"aws_route53resolver_firewall_rule_group_association":  route53resolver.ResourceFirewallRuleGroupAssociation(),
+			"aws_route53resolver_query_log_config":                 route53resolver.ResourceQueryLogConfig(),
+			"aws_route53resolver_query_log_config_association":     route53resolver.ResourceQueryLogConfigAssociation(),
+			"aws_route53resolver_rule":                             route53resolver.ResourceRule(),
+			"aws_route53resolver_rule_association":                 route53resolver.ResourceRuleAssociation(),
+			"aws_route53_resolver_dnssec_config":                   route53resolver.ResourceDNSSECConfig(),                 // backward compatible alias
+			"aws_route53_resolver_endpoint":                        route53resolver.ResourceEndpoint(),                     // backward compatible alias
+			"aws_route53_resolver_firewall_config":                 route53resolver.ResourceFirewallConfig(),               // backward compatible alias
+			"aws_route53_resolver_firewall_domain_list":            route53resolver.ResourceFirewallDomainList(),           // backward compatible alias
+			"aws_route53_resolver_firewall_rule":                   route53resolver.ResourceFirewallRule(),                 // backward compatible alias
+			"aws_route53_resolver_firewall_rule_group":             route53resolver.ResourceFirewallRuleGroup(),            // backward compatible alias
+			"aws_route53_resolver_firewall_rule_group_association": route53resolver.ResourceFirewallRuleGroupAssociation(), // backward compatible alias
+			"aws_route53_resolver_query_log_config":                route53resolver.ResourceQueryLogConfig(),               // backward compatible alias
+			"aws_route53_resolver_query_log_config_association":    route53resolver.ResourceQueryLogConfigAssociation(),    // backward compatible alias
+			"aws_route53_resolver_rule":                            route53resolver.ResourceRule(),                         // backward compatible alias
+			"aws_route53_resolver_rule_association":                route53resolver.ResourceRuleAssociation(),              // backward compatible alias
 
 			"aws_s3_bucket":                         s3.ResourceBucket(),
 			"aws_s3_bucket_analytics_configuration": s3.ResourceBucketAnalyticsConfiguration(),

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -189,7 +189,7 @@ func init() {
 			"aws_network_interface",
 			"aws_networkfirewall_firewall",
 			"aws_redshift_cluster",
-			"aws_route53_resolver_endpoint",
+			"aws_route53resolver_endpoint",
 			"aws_sagemaker_notebook_instance",
 			"aws_spot_fleet_request",
 			"aws_vpc_endpoint",

--- a/internal/service/route53resolver/dnssec_config_test.go
+++ b/internal/service/route53resolver/dnssec_config_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestAccRoute53ResolverDNSSECConfig_basic(t *testing.T) {
-	resourceName := "aws_route53_resolver_dnssec_config.test"
+	resourceName := "aws_route53resolver_dnssec_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestAccRoute53ResolverDNSSECConfig_basic(t *testing.T) {
 }
 
 func TestAccRoute53ResolverDNSSECConfig_disappear(t *testing.T) {
-	resourceName := "aws_route53_resolver_dnssec_config.test"
+	resourceName := "aws_route53resolver_dnssec_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -72,7 +72,7 @@ func testAccCheckRoute53ResolverDnssecConfigDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_dnssec_config" {
+		if rs.Type != "aws_route53resolver_dnssec_config" {
 			continue
 		}
 
@@ -144,7 +144,7 @@ resource "aws_vpc" "test" {
 
 func testAccRoute53ResolverDnssecConfigConfigBasic(rName string) string {
 	return testAccRoute53ResolverDnssecConfigBase(rName) + `
-resource "aws_route53_resolver_dnssec_config" "test" {
+resource "aws_route53resolver_dnssec_config" "test" {
   resource_id = aws_vpc.test.id
 }
 `

--- a/internal/service/route53resolver/endpoint_data_source_test.go
+++ b/internal/service/route53resolver/endpoint_data_source_test.go
@@ -15,8 +15,8 @@ func TestAccRoute53ResolverEndpointDataSource_basic(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rInt := sdkacctest.RandInt()
 	direction := "INBOUND"
-	resourceName := "aws_route53_resolver_endpoint.foo"
-	datasourceName := "data.aws_route53_resolver_endpoint.foo"
+	resourceName := "aws_route53resolver_endpoint.foo"
+	datasourceName := "data.aws_route53resolver_endpoint.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -44,8 +44,8 @@ func TestAccRoute53ResolverEndpointDataSource_filter(t *testing.T) {
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rInt := sdkacctest.RandInt()
 	direction := "OUTBOUND"
-	resourceName := "aws_route53_resolver_endpoint.foo"
-	datasourceName := "data.aws_route53_resolver_endpoint.foo"
+	resourceName := "aws_route53resolver_endpoint.foo"
+	datasourceName := "data.aws_route53resolver_endpoint.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -133,7 +133,7 @@ resource "aws_security_group" "sg2" {
 
 func testAccDataSourceRoute53ResolverEndpointConfig_initial(rInt int, direction, name string) string {
 	return acctest.ConfigCompose(testAccDataSourceRoute53ResolverEndpointConfig_base(rInt), fmt.Sprintf(`
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   direction = "%s"
   name      = "%s"
 
@@ -157,15 +157,15 @@ resource "aws_route53_resolver_endpoint" "foo" {
   }
 }
 
-data "aws_route53_resolver_endpoint" "foo" {
-  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
+data "aws_route53resolver_endpoint" "foo" {
+  resolver_endpoint_id = aws_route53resolver_endpoint.foo.id
 }
 `, direction, name))
 }
 
 func testAccDataSourceRoute53ResolverEndpointConfig_filter(rInt int, direction, name string) string {
 	return acctest.ConfigCompose(testAccDataSourceRoute53ResolverEndpointConfig_base(rInt), fmt.Sprintf(`
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   direction = "%s"
   name      = "%s"
 
@@ -189,10 +189,10 @@ resource "aws_route53_resolver_endpoint" "foo" {
   }
 }
 
-data "aws_route53_resolver_endpoint" "foo" {
+data "aws_route53resolver_endpoint" "foo" {
   filter {
     name   = "Name"
-    values = [aws_route53_resolver_endpoint.foo.name]
+    values = [aws_route53resolver_endpoint.foo.name]
   }
 
   filter {
@@ -204,13 +204,13 @@ data "aws_route53_resolver_endpoint" "foo" {
 }
 
 const testAccEndpointDataSourceConfig_NonExistent = `
-data "aws_route53_resolver_endpoint" "foo" {
+data "aws_route53resolver_endpoint" "foo" {
   resolver_endpoint_id = "rslvr-in-8g85830108dd4c82b"
 }
 `
 
 const testAccEndpointDataSourceConfig_NonExistentFilter = `
-data "aws_route53_resolver_endpoint" "foo" {
+data "aws_route53resolver_endpoint" "foo" {
   filter {
     name   = "Name"
     values = ["None-Existent-Resource"]

--- a/internal/service/route53resolver/endpoint_test.go
+++ b/internal/service/route53resolver/endpoint_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 	var ep route53resolver.ResolverEndpoint
-	resourceName := "aws_route53_resolver_endpoint.foo"
+	resourceName := "aws_route53resolver_endpoint.foo"
 	rInt := sdkacctest.RandInt()
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", rInt)
 
@@ -48,7 +48,7 @@ func TestAccRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 
 func TestAccRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 	var ep route53resolver.ResolverEndpoint
-	resourceName := "aws_route53_resolver_endpoint.foo"
+	resourceName := "aws_route53resolver_endpoint.foo"
 	rInt := sdkacctest.RandInt()
 	initialName := fmt.Sprintf("terraform-testacc-r53-resolver-%d", rInt)
 	updatedName := fmt.Sprintf("terraform-testacc-r53-rupdated-%d", rInt)
@@ -89,7 +89,7 @@ func testAccCheckRoute53ResolverEndpointDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_endpoint" {
+		if rs.Type != "aws_route53resolver_endpoint" {
 			continue
 		}
 
@@ -226,7 +226,7 @@ func testAccRoute53ResolverEndpointConfig_initial(rInt int, direction, name stri
 	return fmt.Sprintf(`
 %s
 
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   direction = "%s"
   name      = "%s"
 
@@ -256,7 +256,7 @@ func testAccRoute53ResolverEndpointConfig_updated(rInt int, direction, name stri
 	return fmt.Sprintf(`
 %s
 
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   direction = "%s"
   name      = "%s"
 

--- a/internal/service/route53resolver/firewall_config_test.go
+++ b/internal/service/route53resolver/firewall_config_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccRoute53ResolverFirewallConfig_basic(t *testing.T) {
 	var v route53resolver.FirewallConfig
-	resourceName := "aws_route53_resolver_firewall_config.test"
+	resourceName := "aws_route53resolver_firewall_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,7 +45,7 @@ func TestAccRoute53ResolverFirewallConfig_basic(t *testing.T) {
 
 func TestAccRoute53ResolverFirewallConfig_disappears(t *testing.T) {
 	var v route53resolver.FirewallConfig
-	resourceName := "aws_route53_resolver_firewall_config.test"
+	resourceName := "aws_route53resolver_firewall_config.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -70,7 +70,7 @@ func testAccCheckRoute53ResolverFirewallConfigDestroy(s *terraform.State) error 
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_firewall_config" {
+		if rs.Type != "aws_route53resolver_firewall_config" {
 			continue
 		}
 
@@ -129,7 +129,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_route53_resolver_firewall_config" "test" {
+resource "aws_route53resolver_firewall_config" "test" {
   resource_id        = aws_vpc.test.id
   firewall_fail_open = "ENABLED"
 }

--- a/internal/service/route53resolver/firewall_domain_list_test.go
+++ b/internal/service/route53resolver/firewall_domain_list_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccRoute53ResolverFirewallDomainList_basic(t *testing.T) {
 	var v route53resolver.FirewallDomainList
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+	resourceName := "aws_route53resolver_firewall_domain_list.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -45,7 +45,7 @@ func TestAccRoute53ResolverFirewallDomainList_basic(t *testing.T) {
 func TestAccRoute53ResolverFirewallDomainList_domains(t *testing.T) {
 	var v route53resolver.FirewallDomainList
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+	resourceName := "aws_route53resolver_firewall_domain_list.test"
 
 	domainName1 := acctest.RandomFQDomainName()
 	domainName2 := acctest.RandomFQDomainName()
@@ -94,7 +94,7 @@ func TestAccRoute53ResolverFirewallDomainList_domains(t *testing.T) {
 func TestAccRoute53ResolverFirewallDomainList_disappears(t *testing.T) {
 	var v route53resolver.FirewallDomainList
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+	resourceName := "aws_route53resolver_firewall_domain_list.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -117,7 +117,7 @@ func TestAccRoute53ResolverFirewallDomainList_disappears(t *testing.T) {
 func TestAccRoute53ResolverFirewallDomainList_tags(t *testing.T) {
 	var v route53resolver.FirewallDomainList
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_domain_list.test"
+	resourceName := "aws_route53resolver_firewall_domain_list.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -166,7 +166,7 @@ func testAccCheckRoute53ResolverFirewallDomainListDestroy(s *terraform.State) er
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_firewall_domain_list" {
+		if rs.Type != "aws_route53resolver_firewall_domain_list" {
 			continue
 		}
 
@@ -210,7 +210,7 @@ func testAccCheckRoute53ResolverFirewallDomainListExists(n string, v *route53res
 
 func testAccRoute53ResolverFirewallDomainListConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name = %[1]q
 }
 `, rName)
@@ -218,7 +218,7 @@ resource "aws_route53_resolver_firewall_domain_list" "test" {
 
 func testAccRoute53ResolverFirewallDomainListConfigDomains(rName, domain string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name    = %[1]q
   domains = [%[2]q]
 }
@@ -227,7 +227,7 @@ resource "aws_route53_resolver_firewall_domain_list" "test" {
 
 func testAccRoute53ResolverFirewallDomainListConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name = %[1]q
   tags = {
     %[2]q = %[3]q
@@ -238,7 +238,7 @@ resource "aws_route53_resolver_firewall_domain_list" "test" {
 
 func testAccRoute53ResolverFirewallDomainListConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name = %[1]q
   tags = {
     %[2]q = %[3]q

--- a/internal/service/route53resolver/firewall_rule_group_association_test.go
+++ b/internal/service/route53resolver/firewall_rule_group_association_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccRoute53ResolverFirewallRuleGroupAssociation_basic(t *testing.T) {
 	var v route53resolver.FirewallRuleGroupAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
+	resourceName := "aws_route53resolver_firewall_rule_group_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -30,7 +30,7 @@ func TestAccRoute53ResolverFirewallRuleGroupAssociation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverFirewallRuleGroupAssociationExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrPair(resourceName, "firewall_rule_group_id", "aws_route53_resolver_firewall_rule_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "firewall_rule_group_id", "aws_route53resolver_firewall_rule_group.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "mutation_protection", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, "priority", "101"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
@@ -50,7 +50,7 @@ func TestAccRoute53ResolverFirewallRuleGroupAssociation_name(t *testing.T) {
 	var v route53resolver.FirewallRuleGroupAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNewName := sdkacctest.RandomWithPrefix("tf-acc-test2")
-	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
+	resourceName := "aws_route53resolver_firewall_rule_group_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -84,7 +84,7 @@ func TestAccRoute53ResolverFirewallRuleGroupAssociation_name(t *testing.T) {
 func TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection(t *testing.T) {
 	var v route53resolver.FirewallRuleGroupAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
+	resourceName := "aws_route53resolver_firewall_rule_group_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -118,7 +118,7 @@ func TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection(t *te
 func TestAccRoute53ResolverFirewallRuleGroupAssociation_priority(t *testing.T) {
 	var v route53resolver.FirewallRuleGroupAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
+	resourceName := "aws_route53resolver_firewall_rule_group_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -152,7 +152,7 @@ func TestAccRoute53ResolverFirewallRuleGroupAssociation_priority(t *testing.T) {
 func TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears(t *testing.T) {
 	var v route53resolver.FirewallRuleGroupAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
+	resourceName := "aws_route53resolver_firewall_rule_group_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -175,7 +175,7 @@ func TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears(t *testing.T)
 func TestAccRoute53ResolverFirewallRuleGroupAssociation_tags(t *testing.T) {
 	var v route53resolver.FirewallRuleGroupAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group_association.test"
+	resourceName := "aws_route53resolver_firewall_rule_group_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -221,7 +221,7 @@ func testAccCheckRoute53ResolverFirewallRuleGroupAssociationDestroy(s *terraform
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_firewall_rule_group_association" {
+		if rs.Type != "aws_route53resolver_firewall_rule_group_association" {
 			continue
 		}
 
@@ -269,7 +269,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
 
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
 }
 `, rName)
@@ -279,9 +279,9 @@ func testAccRoute53ResolverFirewallRuleGroupAssociationConfig(rName string) stri
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_firewall_rule_group_association" "test" {
+resource "aws_route53resolver_firewall_rule_group_association" "test" {
   name                   = %[2]q
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.test.id
+  firewall_rule_group_id = aws_route53resolver_firewall_rule_group.test.id
   mutation_protection    = "DISABLED"
   priority               = 101
   vpc_id                 = aws_vpc.test.id
@@ -293,9 +293,9 @@ func testAccRoute53ResolverFirewallRuleGroupAssociationConfig_mutationProtection
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_firewall_rule_group_association" "test" {
+resource "aws_route53resolver_firewall_rule_group_association" "test" {
   name                   = %[2]q
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.test.id
+  firewall_rule_group_id = aws_route53resolver_firewall_rule_group.test.id
   mutation_protection    = %[3]q
   priority               = 101
   vpc_id                 = aws_vpc.test.id
@@ -307,9 +307,9 @@ func testAccRoute53ResolverFirewallRuleGroupAssociationConfig_priority(rName str
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_firewall_rule_group_association" "test" {
+resource "aws_route53resolver_firewall_rule_group_association" "test" {
   name                   = %[2]q
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.test.id
+  firewall_rule_group_id = aws_route53resolver_firewall_rule_group.test.id
   priority               = %[3]d
   vpc_id                 = aws_vpc.test.id
 }
@@ -320,9 +320,9 @@ func testAccRoute53ResolverFirewallRuleGroupAssociationConfigTags1(rName, tagKey
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_firewall_rule_group_association" "test" {
+resource "aws_route53resolver_firewall_rule_group_association" "test" {
   name                   = %[2]q
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.test.id
+  firewall_rule_group_id = aws_route53resolver_firewall_rule_group.test.id
   priority               = 101
   vpc_id                 = aws_vpc.test.id
 
@@ -337,9 +337,9 @@ func testAccRoute53ResolverFirewallRuleGroupAssociationConfigTags2(rName, tagKey
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_firewall_rule_group_association" "test" {
+resource "aws_route53resolver_firewall_rule_group_association" "test" {
   name                   = %[2]q
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.test.id
+  firewall_rule_group_id = aws_route53resolver_firewall_rule_group.test.id
   priority               = 101
   vpc_id                 = aws_vpc.test.id
 

--- a/internal/service/route53resolver/firewall_rule_group_test.go
+++ b/internal/service/route53resolver/firewall_rule_group_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccRoute53ResolverFirewallRuleGroup_basic(t *testing.T) {
 	var v route53resolver.FirewallRuleGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group.test"
+	resourceName := "aws_route53resolver_firewall_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -47,7 +47,7 @@ func TestAccRoute53ResolverFirewallRuleGroup_basic(t *testing.T) {
 func TestAccRoute53ResolverFirewallRuleGroup_disappears(t *testing.T) {
 	var v route53resolver.FirewallRuleGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group.test"
+	resourceName := "aws_route53resolver_firewall_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -70,7 +70,7 @@ func TestAccRoute53ResolverFirewallRuleGroup_disappears(t *testing.T) {
 func TestAccRoute53ResolverFirewallRuleGroup_tags(t *testing.T) {
 	var v route53resolver.FirewallRuleGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule_group.test"
+	resourceName := "aws_route53resolver_firewall_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -125,7 +125,7 @@ func testAccCheckRoute53ResolverFirewallRuleGroupDestroy(s *terraform.State) err
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_firewall_rule_group" {
+		if rs.Type != "aws_route53resolver_firewall_rule_group" {
 			continue
 		}
 
@@ -169,7 +169,7 @@ func testAccCheckRoute53ResolverFirewallRuleGroupExists(n string, v *route53reso
 
 func testAccRoute53ResolverFirewallRuleGroupConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
 }
 `, rName)
@@ -177,7 +177,7 @@ resource "aws_route53_resolver_firewall_rule_group" "test" {
 
 func testAccRoute53ResolverFirewallRuleGroupConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
   tags = {
     %[2]q = %[3]q
@@ -188,7 +188,7 @@ resource "aws_route53_resolver_firewall_rule_group" "test" {
 
 func testAccRoute53ResolverFirewallRuleGroupConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
   tags = {
     %[2]q = %[3]q

--- a/internal/service/route53resolver/firewall_rule_test.go
+++ b/internal/service/route53resolver/firewall_rule_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccRoute53ResolverFirewallRule_basic(t *testing.T) {
 	var v route53resolver.FirewallRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule.test"
+	resourceName := "aws_route53resolver_firewall_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -31,8 +31,8 @@ func TestAccRoute53ResolverFirewallRule_basic(t *testing.T) {
 					testAccCheckRoute53ResolverFirewallRuleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "action", "ALLOW"),
-					resource.TestCheckResourceAttrPair(resourceName, "firewall_rule_group_id", "aws_route53_resolver_firewall_rule_group.test", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "firewall_domain_list_id", "aws_route53_resolver_firewall_domain_list.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "firewall_rule_group_id", "aws_route53resolver_firewall_rule_group.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "firewall_domain_list_id", "aws_route53resolver_firewall_domain_list.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 				),
 			},
@@ -48,7 +48,7 @@ func TestAccRoute53ResolverFirewallRule_basic(t *testing.T) {
 func TestAccRoute53ResolverFirewallRule_block(t *testing.T) {
 	var v route53resolver.FirewallRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule.test"
+	resourceName := "aws_route53resolver_firewall_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -77,7 +77,7 @@ func TestAccRoute53ResolverFirewallRule_block(t *testing.T) {
 func TestAccRoute53ResolverFirewallRule_blockOverride(t *testing.T) {
 	var v route53resolver.FirewallRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule.test"
+	resourceName := "aws_route53resolver_firewall_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -109,7 +109,7 @@ func TestAccRoute53ResolverFirewallRule_blockOverride(t *testing.T) {
 func TestAccRoute53ResolverFirewallRule_disappears(t *testing.T) {
 	var v route53resolver.FirewallRule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_firewall_rule.test"
+	resourceName := "aws_route53resolver_firewall_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -133,7 +133,7 @@ func testAccCheckRoute53ResolverFirewallRuleDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_firewall_rule" {
+		if rs.Type != "aws_route53resolver_firewall_rule" {
 			continue
 		}
 
@@ -177,19 +177,19 @@ func testAccCheckRoute53ResolverFirewallRuleExists(n string, v *route53resolver.
 
 func testAccRoute53ResolverFirewallRuleConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_firewall_rule" "test" {
+resource "aws_route53resolver_firewall_rule" "test" {
   name                    = %[1]q
   action                  = "ALLOW"
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.test.id
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.test.id
+  firewall_rule_group_id  = aws_route53resolver_firewall_rule_group.test.id
+  firewall_domain_list_id = aws_route53resolver_firewall_domain_list.test.id
   priority                = 100
 }
 `, rName)
@@ -197,20 +197,20 @@ resource "aws_route53_resolver_firewall_rule" "test" {
 
 func testAccRoute53ResolverFirewallRuleConfig_block(rName, blockResponse string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_firewall_rule" "test" {
+resource "aws_route53resolver_firewall_rule" "test" {
   name                    = %[1]q
   action                  = "BLOCK"
   block_response          = %[2]q
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.test.id
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.test.id
+  firewall_rule_group_id  = aws_route53resolver_firewall_rule_group.test.id
+  firewall_domain_list_id = aws_route53resolver_firewall_domain_list.test.id
   priority                = 100
 }
 `, rName, blockResponse)
@@ -218,23 +218,23 @@ resource "aws_route53_resolver_firewall_rule" "test" {
 
 func testAccRoute53ResolverFirewallRuleConfig_blockOverride(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_firewall_rule_group" "test" {
+resource "aws_route53resolver_firewall_rule_group" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_firewall_domain_list" "test" {
+resource "aws_route53resolver_firewall_domain_list" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_firewall_rule" "test" {
+resource "aws_route53resolver_firewall_rule" "test" {
   name                    = %[1]q
   action                  = "BLOCK"
   block_override_dns_type = "CNAME"
   block_override_domain   = "example.com."
   block_override_ttl      = 60
   block_response          = "OVERRIDE"
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.test.id
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.test.id
+  firewall_rule_group_id  = aws_route53resolver_firewall_rule_group.test.id
+  firewall_domain_list_id = aws_route53resolver_firewall_domain_list.test.id
   priority                = 100
 }
 `, rName)

--- a/internal/service/route53resolver/query_log_config_association_test.go
+++ b/internal/service/route53resolver/query_log_config_association_test.go
@@ -17,8 +17,8 @@ import (
 func TestAccRoute53ResolverQueryLogConfigAssociation_basic(t *testing.T) {
 	var v route53resolver.ResolverQueryLogConfigAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_query_log_config_association.test"
-	queryLogConfigResourceName := "aws_route53_resolver_query_log_config.test"
+	resourceName := "aws_route53resolver_query_log_config_association.test"
+	queryLogConfigResourceName := "aws_route53resolver_query_log_config.test"
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestAccRoute53ResolverQueryLogConfigAssociation_basic(t *testing.T) {
 func TestAccRoute53ResolverQueryLogConfigAssociation_disappears(t *testing.T) {
 	var v route53resolver.ResolverQueryLogConfigAssociation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_query_log_config_association.test"
+	resourceName := "aws_route53resolver_query_log_config_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -71,7 +71,7 @@ func testAccCheckRoute53ResolverQueryLogConfigAssociationDestroy(s *terraform.St
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_query_log_config_association" {
+		if rs.Type != "aws_route53resolver_query_log_config_association" {
 			continue
 		}
 
@@ -127,13 +127,13 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_route53_resolver_query_log_config" "test" {
+resource "aws_route53resolver_query_log_config" "test" {
   name            = %[1]q
   destination_arn = aws_cloudwatch_log_group.test.arn
 }
 
-resource "aws_route53_resolver_query_log_config_association" "test" {
-  resolver_query_log_config_id = aws_route53_resolver_query_log_config.test.id
+resource "aws_route53resolver_query_log_config_association" "test" {
+  resolver_query_log_config_id = aws_route53resolver_query_log_config.test.id
   resource_id                  = aws_vpc.test.id
 }
 `, rName)

--- a/internal/service/route53resolver/query_log_config_test.go
+++ b/internal/service/route53resolver/query_log_config_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccRoute53ResolverQueryLogConfig_basic(t *testing.T) {
 	var v route53resolver.ResolverQueryLogConfig
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_query_log_config.test"
+	resourceName := "aws_route53resolver_query_log_config.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,7 +49,7 @@ func TestAccRoute53ResolverQueryLogConfig_basic(t *testing.T) {
 func TestAccRoute53ResolverQueryLogConfig_disappears(t *testing.T) {
 	var v route53resolver.ResolverQueryLogConfig
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_query_log_config.test"
+	resourceName := "aws_route53resolver_query_log_config.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -72,7 +72,7 @@ func TestAccRoute53ResolverQueryLogConfig_disappears(t *testing.T) {
 func TestAccRoute53ResolverQueryLogConfig_tags(t *testing.T) {
 	var v route53resolver.ResolverQueryLogConfig
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_query_log_config.test"
+	resourceName := "aws_route53resolver_query_log_config.test"
 	cwLogGroupResourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -131,7 +131,7 @@ func testAccCheckRoute53ResolverQueryLogConfigDestroy(s *terraform.State) error 
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_query_log_config" {
+		if rs.Type != "aws_route53resolver_query_log_config" {
 			continue
 		}
 
@@ -180,7 +180,7 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_route53_resolver_query_log_config" "test" {
+resource "aws_route53resolver_query_log_config" "test" {
   name            = %[1]q
   destination_arn = aws_s3_bucket.test.arn
 }
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_query_log_config" "test" {
+resource "aws_route53resolver_query_log_config" "test" {
   name            = %[1]q
   destination_arn = aws_cloudwatch_log_group.test.arn
 
@@ -210,7 +210,7 @@ resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
 
-resource "aws_route53_resolver_query_log_config" "test" {
+resource "aws_route53resolver_query_log_config" "test" {
   name            = %[1]q
   destination_arn = aws_cloudwatch_log_group.test.arn
 

--- a/internal/service/route53resolver/rule_association_test.go
+++ b/internal/service/route53resolver/rule_association_test.go
@@ -17,8 +17,8 @@ import (
 func TestAccRoute53ResolverRuleAssociation_basic(t *testing.T) {
 	var assn route53resolver.ResolverRuleAssociation
 	resourceNameVpc := "aws_vpc.example"
-	resourceNameRule := "aws_route53_resolver_rule.example"
-	resourceNameAssoc := "aws_route53_resolver_rule_association.example"
+	resourceNameRule := "aws_route53resolver_rule.example"
+	resourceNameAssoc := "aws_route53resolver_rule_association.example"
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccRoute53ResolverRuleAssociation_basic(t *testing.T) {
 func testAccCheckRoute53ResolverRuleAssociationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_rule_association" {
+		if rs.Type != "aws_route53resolver_rule_association" {
 			continue
 		}
 
@@ -105,15 +105,15 @@ resource "aws_vpc" "example" {
   }
 }
 
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   name        = %[1]q
   rule_type   = "SYSTEM"
 }
 
-resource "aws_route53_resolver_rule_association" "example" {
+resource "aws_route53resolver_rule_association" "example" {
   name             = %[1]q
-  resolver_rule_id = aws_route53_resolver_rule.example.id
+  resolver_rule_id = aws_route53resolver_rule.example.id
   vpc_id           = aws_vpc.example.id
 }
 `, name)

--- a/internal/service/route53resolver/rule_data_source_test.go
+++ b/internal/service/route53resolver/rule_data_source_test.go
@@ -17,10 +17,10 @@ func init() {
 
 func TestAccRoute53ResolverRuleDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_rule.example"
-	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_rule_id"
-	ds2ResourceName := "data.aws_route53_resolver_rule.by_domain_name"
-	ds3ResourceName := "data.aws_route53_resolver_rule.by_name_and_rule_type"
+	resourceName := "aws_route53resolver_rule.example"
+	ds1ResourceName := "data.aws_route53resolver_rule.by_resolver_rule_id"
+	ds2ResourceName := "data.aws_route53resolver_rule.by_domain_name"
+	ds3ResourceName := "data.aws_route53resolver_rule.by_name_and_rule_type"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -70,8 +70,8 @@ func TestAccRoute53ResolverRuleDataSource_basic(t *testing.T) {
 
 func TestAccRoute53ResolverRuleDataSource_resolverEndpointIdWithTags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_rule.example"
-	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
+	resourceName := "aws_route53resolver_rule.example"
+	ds1ResourceName := "data.aws_route53resolver_rule.by_resolver_endpoint_id"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -103,8 +103,8 @@ func TestAccRoute53ResolverRuleDataSource_resolverEndpointIdWithTags(t *testing.
 func TestAccRoute53ResolverRuleDataSource_sharedByMe(t *testing.T) {
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_rule.example"
-	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
+	resourceName := "aws_route53resolver_rule.example"
+	ds1ResourceName := "data.aws_route53resolver_rule.by_resolver_endpoint_id"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -141,8 +141,8 @@ func TestAccRoute53ResolverRuleDataSource_sharedByMe(t *testing.T) {
 func TestAccRoute53ResolverRuleDataSource_sharedWithMe(t *testing.T) {
 	var providers []*schema.Provider
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_route53_resolver_rule.example"
-	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
+	resourceName := "aws_route53resolver_rule.example"
+	ds1ResourceName := "data.aws_route53resolver_rule.by_resolver_endpoint_id"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -176,35 +176,35 @@ func TestAccRoute53ResolverRuleDataSource_sharedWithMe(t *testing.T) {
 
 func testAccRuleDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
   rule_type   = "SYSTEM"
   name        = %[1]q
 }
 
-data "aws_route53_resolver_rule" "by_resolver_rule_id" {
-  resolver_rule_id = aws_route53_resolver_rule.example.id
+data "aws_route53resolver_rule" "by_resolver_rule_id" {
+  resolver_rule_id = aws_route53resolver_rule.example.id
 }
 
-data "aws_route53_resolver_rule" "by_domain_name" {
-  domain_name = aws_route53_resolver_rule.example.domain_name
+data "aws_route53resolver_rule" "by_domain_name" {
+  domain_name = aws_route53resolver_rule.example.domain_name
 }
 
-data "aws_route53_resolver_rule" "by_name_and_rule_type" {
-  name      = aws_route53_resolver_rule.example.name
-  rule_type = aws_route53_resolver_rule.example.rule_type
+data "aws_route53resolver_rule" "by_name_and_rule_type" {
+  name      = aws_route53resolver_rule.example.name
+  rule_type = aws_route53resolver_rule.example.rule_type
 }
 `, rName)
 }
 
 func testAccRuleDataSource_resolverEndpointIdWithTags(rName string) string {
 	return testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -216,20 +216,20 @@ resource "aws_route53_resolver_rule" "example" {
   }
 }
 
-data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
-  resolver_endpoint_id = aws_route53_resolver_rule.example.resolver_endpoint_id
+data "aws_route53resolver_rule" "by_resolver_endpoint_id" {
+  resolver_endpoint_id = aws_route53resolver_rule.example.resolver_endpoint_id
 }
 `, rName)
 }
 
 func testAccRuleDataSource_sharedByMe(rName string) string {
 	return acctest.ConfigAlternateAccountProvider() + testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -247,7 +247,7 @@ resource "aws_ram_resource_share" "test" {
 }
 
 resource "aws_ram_resource_association" "test" {
-  resource_arn       = aws_route53_resolver_rule.example.arn
+  resource_arn       = aws_route53resolver_rule.example.arn
   resource_share_arn = aws_ram_resource_share.test.arn
 }
 
@@ -258,8 +258,8 @@ resource "aws_ram_principal_association" "test" {
   resource_share_arn = aws_ram_resource_share.test.arn
 }
 
-data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
-  resolver_endpoint_id = aws_route53_resolver_rule.example.resolver_endpoint_id
+data "aws_route53resolver_rule" "by_resolver_endpoint_id" {
+  resolver_endpoint_id = aws_route53resolver_rule.example.resolver_endpoint_id
 
   depends_on = [aws_ram_resource_association.test, aws_ram_principal_association.test]
 }
@@ -268,12 +268,12 @@ data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
 
 func testAccRuleDataSource_sharedWithMe(rName string) string {
 	return acctest.ConfigAlternateAccountProvider() + testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "%[1]s.example.com"
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -291,7 +291,7 @@ resource "aws_ram_resource_share" "test" {
 }
 
 resource "aws_ram_resource_association" "test" {
-  resource_arn       = aws_route53_resolver_rule.example.arn
+  resource_arn       = aws_route53resolver_rule.example.arn
   resource_share_arn = aws_ram_resource_share.test.arn
 }
 
@@ -302,10 +302,10 @@ resource "aws_ram_principal_association" "test" {
   resource_share_arn = aws_ram_resource_share.test.arn
 }
 
-data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
+data "aws_route53resolver_rule" "by_resolver_endpoint_id" {
   provider = "awsalternate"
 
-  resolver_endpoint_id = aws_route53_resolver_rule.example.resolver_endpoint_id
+  resolver_endpoint_id = aws_route53resolver_rule.example.resolver_endpoint_id
 
   depends_on = [aws_ram_resource_association.test, aws_ram_principal_association.test]
 }

--- a/internal/service/route53resolver/rule_test.go
+++ b/internal/service/route53resolver/rule_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccRoute53ResolverRule_basic(t *testing.T) {
 	var rule route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
+	resourceName := "aws_route53resolver_rule.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -46,7 +46,7 @@ func TestAccRoute53ResolverRule_basic(t *testing.T) {
 
 func TestAccRoute53ResolverRule_justDotDomainName(t *testing.T) {
 	var rule route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
+	resourceName := "aws_route53resolver_rule.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -76,7 +76,7 @@ func TestAccRoute53ResolverRule_justDotDomainName(t *testing.T) {
 
 func TestAccRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
 	var rule route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
+	resourceName := "aws_route53resolver_rule.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -106,7 +106,7 @@ func TestAccRoute53ResolverRule_trailingDotDomainName(t *testing.T) {
 
 func TestAccRoute53ResolverRule_tags(t *testing.T) {
 	var rule route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
+	resourceName := "aws_route53resolver_rule.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -157,7 +157,7 @@ func TestAccRoute53ResolverRule_tags(t *testing.T) {
 
 func TestAccRoute53ResolverRule_updateName(t *testing.T) {
 	var rule1, rule2 route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
+	resourceName := "aws_route53resolver_rule.example"
 	name1 := fmt.Sprintf("terraform-testacc-r53-resolver-%d", sdkacctest.RandInt())
 	name2 := fmt.Sprintf("terraform-testacc-r53-resolver-%d", sdkacctest.RandInt())
 
@@ -197,9 +197,9 @@ func TestAccRoute53ResolverRule_updateName(t *testing.T) {
 
 func TestAccRoute53ResolverRule_forward(t *testing.T) {
 	var rule1, rule2, rule3 route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
-	resourceNameEp1 := "aws_route53_resolver_endpoint.foo"
-	resourceNameEp2 := "aws_route53_resolver_endpoint.bar"
+	resourceName := "aws_route53resolver_rule.example"
+	resourceNameEp1 := "aws_route53resolver_endpoint.foo"
+	resourceNameEp2 := "aws_route53resolver_endpoint.bar"
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -274,8 +274,8 @@ func TestAccRoute53ResolverRule_forward(t *testing.T) {
 
 func TestAccRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
 	var rule1, rule2 route53resolver.ResolverRule
-	resourceName := "aws_route53_resolver_rule.example"
-	resourceNameEp := "aws_route53_resolver_endpoint.foo"
+	resourceName := "aws_route53resolver_rule.example"
+	resourceNameEp := "aws_route53resolver_endpoint.foo"
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -341,7 +341,7 @@ func testAccCheckRoute53ResolverRuleDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).Route53ResolverConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_route53_resolver_rule" {
+		if rs.Type != "aws_route53resolver_rule" {
 			continue
 		}
 
@@ -388,7 +388,7 @@ func testAccCheckRoute53ResolverRuleExists(n string, rule *route53resolver.Resol
 
 func testAccRoute53ResolverRuleConfig(domainName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = %[1]q
   rule_type   = "SYSTEM"
 }
@@ -396,14 +396,14 @@ resource "aws_route53_resolver_rule" "example" {
 }
 
 const testAccRoute53ResolverRuleConfig_basicNoTags = `
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"
 }
 `
 
 const testAccRoute53ResolverRuleConfig_basicTags = `
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"
 
@@ -415,7 +415,7 @@ resource "aws_route53_resolver_rule" "example" {
 `
 
 const testAccRoute53ResolverRuleConfig_basicTagsChanged = `
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"
 
@@ -427,7 +427,7 @@ resource "aws_route53_resolver_rule" "example" {
 
 func testAccRoute53ResolverRuleConfig_basicName(name string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "SYSTEM"
   name        = %q
@@ -439,12 +439,12 @@ func testAccRoute53ResolverRuleConfig_forward(name string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "FORWARD"
   name        = %q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.foo.id
 
   target_ip {
     ip = "192.0.2.6"
@@ -457,12 +457,12 @@ func testAccRoute53ResolverRuleConfig_forwardTargetIpChanged(name string) string
 	return fmt.Sprintf(`
 %s
 
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "FORWARD"
   name        = %q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.foo.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -480,12 +480,12 @@ func testAccRoute53ResolverRuleConfig_forwardEndpointChanged(name string) string
 	return fmt.Sprintf(`
 %s
 
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "FORWARD"
   name        = %q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -503,12 +503,12 @@ func testAccRoute53ResolverRuleConfig_forwardEndpointRecreate(name string) strin
 	return fmt.Sprintf(`
 %s
 
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53resolver_rule" "example" {
   domain_name = "example.com"
   rule_type   = "FORWARD"
   name        = %q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.foo.id
 
   target_ip {
     ip = "192.0.2.6"
@@ -592,7 +592,7 @@ func testAccRoute53ResolverRuleConfig_resolverEndpoint(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   direction = "OUTBOUND"
   name      = "%[2]s_1"
 
@@ -609,7 +609,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
   }
 }
 
-resource "aws_route53_resolver_endpoint" "bar" {
+resource "aws_route53resolver_endpoint" "bar" {
   direction = "OUTBOUND"
   name      = "%[2]s_2"
 
@@ -632,7 +632,7 @@ func testAccRoute53ResolverRuleConfig_resolverEndpointRecreate(name string) stri
 	return fmt.Sprintf(`
 %[1]s
 
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   direction = "OUTBOUND"
   name      = "%[2]s_1"
 
@@ -649,7 +649,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
   }
 }
 
-resource "aws_route53_resolver_endpoint" "bar" {
+resource "aws_route53resolver_endpoint" "bar" {
   direction = "OUTBOUND"
   name      = "%[2]s_2"
 

--- a/internal/service/route53resolver/rules_data_source_test.go
+++ b/internal/service/route53resolver/rules_data_source_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccRoute53ResolverRulesDataSource_basic(t *testing.T) {
-	dsResourceName := "data.aws_route53_resolver_rules.test"
+	dsResourceName := "data.aws_route53resolver_rules.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -32,9 +32,9 @@ func TestAccRoute53ResolverRulesDataSource_basic(t *testing.T) {
 func TestAccRoute53ResolverRulesDataSource_resolverEndpointID(t *testing.T) {
 	rName1 := fmt.Sprintf("tf-testacc-r53-resolver-%s", sdkacctest.RandString(8))
 	rName2 := fmt.Sprintf("tf-testacc-r53-resolver-%s", sdkacctest.RandString(8))
-	ds1ResourceName := "data.aws_route53_resolver_rules.by_resolver_endpoint_id"
-	ds2ResourceName := "data.aws_route53_resolver_rules.by_resolver_endpoint_id_rule_type_share_status"
-	ds3ResourceName := "data.aws_route53_resolver_rules.by_invalid_owner_id"
+	ds1ResourceName := "data.aws_route53resolver_rules.by_resolver_endpoint_id"
+	ds2ResourceName := "data.aws_route53resolver_rules.by_resolver_endpoint_id_rule_type_share_status"
+	ds3ResourceName := "data.aws_route53resolver_rules.by_invalid_owner_id"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -55,7 +55,7 @@ func TestAccRoute53ResolverRulesDataSource_resolverEndpointID(t *testing.T) {
 
 const testAccRulesDataSource_basic = `
 # The default Internet Resolver rule.
-data "aws_route53_resolver_rules" "test" {
+data "aws_route53resolver_rules" "test" {
   owner_id     = "Route 53 Resolver"
   rule_type    = "RECURSIVE"
   share_status = "NOT_SHARED"
@@ -64,37 +64,37 @@ data "aws_route53_resolver_rules" "test" {
 
 func testAccRulesDataSource_resolverEndpointID(rName1, rName2 string) string {
 	return testAccRoute53ResolverRuleConfig_resolverEndpoint(rName1) + fmt.Sprintf(`
-resource "aws_route53_resolver_rule" "forward" {
+resource "aws_route53resolver_rule" "forward" {
   domain_name = "%[1]s.example.com"
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
   }
 }
 
-resource "aws_route53_resolver_rule" "recursive" {
+resource "aws_route53resolver_rule" "recursive" {
   domain_name = "%[2]s.example.org"
   rule_type   = "RECURSIVE"
   name        = %[2]q
 }
 
-data "aws_route53_resolver_rules" "by_resolver_endpoint_id" {
-  owner_id             = aws_route53_resolver_rule.forward.owner_id
-  resolver_endpoint_id = aws_route53_resolver_rule.forward.resolver_endpoint_id
+data "aws_route53resolver_rules" "by_resolver_endpoint_id" {
+  owner_id             = aws_route53resolver_rule.forward.owner_id
+  resolver_endpoint_id = aws_route53resolver_rule.forward.resolver_endpoint_id
 }
 
-data "aws_route53_resolver_rules" "by_resolver_endpoint_id_rule_type_share_status" {
-  owner_id             = aws_route53_resolver_rule.recursive.owner_id
-  resolver_endpoint_id = aws_route53_resolver_rule.recursive.resolver_endpoint_id
-  rule_type            = aws_route53_resolver_rule.recursive.rule_type
-  share_status         = aws_route53_resolver_rule.recursive.share_status
+data "aws_route53resolver_rules" "by_resolver_endpoint_id_rule_type_share_status" {
+  owner_id             = aws_route53resolver_rule.recursive.owner_id
+  resolver_endpoint_id = aws_route53resolver_rule.recursive.resolver_endpoint_id
+  rule_type            = aws_route53resolver_rule.recursive.rule_type
+  share_status         = aws_route53resolver_rule.recursive.share_status
 }
 
-data "aws_route53_resolver_rules" "by_invalid_owner_id" {
+data "aws_route53resolver_rules" "by_invalid_owner_id" {
   owner_id     = "000000000000"
   share_status = "SHARED_WITH_ME"
 }

--- a/internal/service/route53resolver/sweep.go
+++ b/internal/service/route53resolver/sweep.go
@@ -17,80 +17,80 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("aws_route53_resolver_dnssec_config", &resource.Sweeper{
-		Name: "aws_route53_resolver_dnssec_config",
+	resource.AddTestSweepers("aws_route53resolver_dnssec_config", &resource.Sweeper{
+		Name: "aws_route53resolver_dnssec_config",
 		F:    sweepDNSSECConfig,
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_endpoint", &resource.Sweeper{
-		Name: "aws_route53_resolver_endpoint",
+	resource.AddTestSweepers("aws_route53resolver_endpoint", &resource.Sweeper{
+		Name: "aws_route53resolver_endpoint",
 		F:    sweepEndpoints,
 		Dependencies: []string{
-			"aws_route53_resolver_rule",
+			"aws_route53resolver_rule",
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_firewall_config", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_config",
+	resource.AddTestSweepers("aws_route53resolver_firewall_config", &resource.Sweeper{
+		Name: "aws_route53resolver_firewall_config",
 		F:    sweepFirewallsConfig,
 		Dependencies: []string{
-			"aws_route53_resolver_firewall_config_association",
+			"aws_route53resolver_firewall_config_association",
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_firewall_domain_list", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_domain_list",
+	resource.AddTestSweepers("aws_route53resolver_firewall_domain_list", &resource.Sweeper{
+		Name: "aws_route53resolver_firewall_domain_list",
 		F:    sweepFirewallDomainLists,
 		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule",
+			"aws_route53resolver_firewall_rule",
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_firewall_rule_group_association", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_rule_group_association",
+	resource.AddTestSweepers("aws_route53resolver_firewall_rule_group_association", &resource.Sweeper{
+		Name: "aws_route53resolver_firewall_rule_group_association",
 		F:    sweepFirewallRuleGroupAssociations,
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_firewall_rule_group", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_rule_group",
+	resource.AddTestSweepers("aws_route53resolver_firewall_rule_group", &resource.Sweeper{
+		Name: "aws_route53resolver_firewall_rule_group",
 		F:    sweepFirewallRuleGroups,
 		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule",
-			"aws_route53_resolver_firewall_rule_group_association",
+			"aws_route53resolver_firewall_rule",
+			"aws_route53resolver_firewall_rule_group_association",
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_firewall_rule", &resource.Sweeper{
-		Name: "aws_route53_resolver_firewall_rule",
+	resource.AddTestSweepers("aws_route53resolver_firewall_rule", &resource.Sweeper{
+		Name: "aws_route53resolver_firewall_rule",
 		F:    sweepFirewallRules,
 		Dependencies: []string{
-			"aws_route53_resolver_firewall_rule_group_association",
+			"aws_route53resolver_firewall_rule_group_association",
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_query_log_config_association", &resource.Sweeper{
-		Name: "aws_route53_resolver_query_log_config_association",
+	resource.AddTestSweepers("aws_route53resolver_query_log_config_association", &resource.Sweeper{
+		Name: "aws_route53resolver_query_log_config_association",
 		F:    sweepQueryLogAssociationsConfig,
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_query_log_config", &resource.Sweeper{
-		Name: "aws_route53_resolver_query_log_config",
+	resource.AddTestSweepers("aws_route53resolver_query_log_config", &resource.Sweeper{
+		Name: "aws_route53resolver_query_log_config",
 		F:    sweepQueryLogsConfig,
 		Dependencies: []string{
-			"aws_route53_resolver_query_log_config_association",
+			"aws_route53resolver_query_log_config_association",
 		},
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_rule_association", &resource.Sweeper{
-		Name: "aws_route53_resolver_rule_association",
+	resource.AddTestSweepers("aws_route53resolver_rule_association", &resource.Sweeper{
+		Name: "aws_route53resolver_rule_association",
 		F:    sweepRuleAssociations,
 	})
 
-	resource.AddTestSweepers("aws_route53_resolver_rule", &resource.Sweeper{
-		Name: "aws_route53_resolver_rule",
+	resource.AddTestSweepers("aws_route53resolver_rule", &resource.Sweeper{
+		Name: "aws_route53resolver_rule",
 		F:    sweepRules,
 		Dependencies: []string{
-			"aws_route53_resolver_rule_association",
+			"aws_route53resolver_rule_association",
 		},
 	})
 }

--- a/internal/service/route53resolver/validate_test.go
+++ b/internal/service/route53resolver/validate_test.go
@@ -37,7 +37,7 @@ func TestValidResolverName(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, errors := validResolverName(tc.Value, "aws_route53_resolver_endpoint")
+		_, errors := validResolverName(tc.Value, "aws_route53resolver_endpoint")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the AWS Route 53 Resolver Endpoint Name to not trigger a validation error for %q", tc.Value)
 		}

--- a/website/docs/d/route53resolver_endpoint.html.markdown
+++ b/website/docs/d/route53resolver_endpoint.html.markdown
@@ -1,27 +1,27 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_endpoint"
+page_title: "AWS: aws_route53resolver_endpoint"
 description: |-
     Provides details about a specific Route 53 Resolver Endpoint
 ---
 
-# Data Source: aws_route53_resolver_endpoint
+# Data Source: aws_route53resolver_endpoint
 
-`aws_route53_resolver_endpoint` provides details about a specific Route53 Resolver Endpoint.
+`aws_route53resolver_endpoint` provides details about a specific Route53 Resolver Endpoint.
 
 This data source allows to find a list of IPaddresses associated with a specific Route53 Resolver Endpoint.
 
 ## Example Usage
 
 ```terraform
-data "aws_route53_resolver_endpoint" "example" {
+data "aws_route53resolver_endpoint" "example" {
   resolver_endpoint_id = "rslvr-in-1abc2345ef678g91h"
 }
 ```
 
 ```terraform
-data "aws_route53_resolver_endpoint" "example" {
+data "aws_route53resolver_endpoint" "example" {
   filter {
     name   = "NAME"
     values = ["MyResolverExampleName"]

--- a/website/docs/d/route53resolver_rule.html.markdown
+++ b/website/docs/d/route53resolver_rule.html.markdown
@@ -1,21 +1,21 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_rule"
+page_title: "AWS: aws_route53resolver_rule"
 description: |-
     Provides details about a specific Route53 Resolver rule
 ---
 
-# Data Source: aws_route53_resolver_rule
+# Data Source: aws_route53resolver_rule
 
-`aws_route53_resolver_rule` provides details about a specific Route53 Resolver rule.
+`aws_route53resolver_rule` provides details about a specific Route53 Resolver rule.
 
 ## Example Usage
 
 The following example shows how to get a Route53 Resolver rule based on its associated domain name and rule type.
 
 ```terraform
-data "aws_route53_resolver_rule" "example" {
+data "aws_route53resolver_rule" "example" {
   domain_name = "subdomain.example.com"
   rule_type   = "SYSTEM"
 }

--- a/website/docs/d/route53resolver_rules.html.markdown
+++ b/website/docs/d/route53resolver_rules.html.markdown
@@ -1,21 +1,21 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_rules"
+page_title: "AWS: aws_route53resolver_rules"
 description: |-
     Provides details about a set of Route53 Resolver rules
 ---
 
-# Data Source: aws_route53_resolver_rules
+# Data Source: aws_route53resolver_rules
 
-`aws_route53_resolver_rules` provides details about a set of Route53 Resolver rules.
+`aws_route53resolver_rules` provides details about a set of Route53 Resolver rules.
 
 ## Example Usage
 
 Retrieving the default resolver rule.
 
 ```terraform
-data "aws_route53_resolver_rules" "example" {
+data "aws_route53resolver_rules" "example" {
   owner_id     = "Route 53 Resolver"
   rule_type    = "RECURSIVE"
   share_status = "NOT_SHARED"
@@ -23,7 +23,7 @@ data "aws_route53_resolver_rules" "example" {
 ```
 
 ```terraform
-data "aws_route53_resolver_rules" "example" {
+data "aws_route53resolver_rules" "example" {
   rule_type    = "FORWARD"
   share_status = "SHARED_WITH_ME"
 }

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -24,7 +24,7 @@ Upgrade topics:
 - [Data Source: aws_availability_zones](#data-source-aws_availability_zones)
 - [Data Source: aws_lambda_invocation](#data-source-aws_lambda_invocation)
 - [Data Source: aws_launch_template](#data-source-aws_launch_template)
-- [Data Source: aws_route53_resolver_rule](#data-source-aws_route53_resolver_rule)
+- [Data Source: aws_route53resolver_rule](#data-source-aws_route53resolver_rule)
 - [Data Source: aws_route53_zone](#data-source-aws_route53_zone)
 - [Resource: aws_acm_certificate](#resource-aws_acm_certificate)
 - [Resource: aws_api_gateway_method_settings](#resource-aws_api_gateway_method_settings)
@@ -49,7 +49,7 @@ Upgrade topics:
 - [Resource: aws_lb_listener_rule](#resource-aws_lb_listener_rule)
 - [Resource: aws_msk_cluster](#resource-aws_msk_cluster)
 - [Resource: aws_rds_cluster](#resource-aws_rds_cluster)
-- [Resource: aws_route53_resolver_rule](#resource-aws_route53_resolver_rule)
+- [Resource: aws_route53resolver_rule](#resource-aws_route53resolver_rule)
 - [Resource: aws_route53_zone](#resource-aws_route53_zone)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_s3_bucket_metric](#resource-aws_s3_bucket_metric)
@@ -233,7 +233,7 @@ Error: error reading launch template: empty output
 
 Configuration that depend on the previous behavior will need to be updated.
 
-## Data Source: aws_route53_resolver_rule
+## Data Source: aws_route53resolver_rule
 
 ### Removal of trailing period in domain_name argument
 
@@ -1307,7 +1307,7 @@ resource "aws_msk_cluster" "example" {
 
 Previously when the `min_capacity` argument in a `scaling_configuration` block was not configured, the resource would default to 2. This behavior has been updated to align with the AWS RDS Cluster API default of 1.
 
-## Resource: aws_route53_resolver_rule
+## Resource: aws_route53resolver_rule
 
 ### Removal of trailing period in domain_name argument
 

--- a/website/docs/r/route53resolver_dnssec_config.html.markdown
+++ b/website/docs/r/route53resolver_dnssec_config.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_dnssec_config"
+page_title: "AWS: aws_route53resolver_dnssec_config"
 description: |-
   Provides a Route 53 Resolver DNSSEC config resource.
 ---
 
-# Resource: aws_route53_resolver_dnssec_config
+# Resource: aws_route53resolver_dnssec_config
 
 Provides a Route 53 Resolver DNSSEC config resource.
 
@@ -19,7 +19,7 @@ resource "aws_vpc" "example" {
   enable_dns_hostnames = true
 }
 
-resource "aws_route53_resolver_dnssec_config" "example" {
+resource "aws_route53resolver_dnssec_config" "example" {
   resource_id = aws_vpc.example.id
 }
 ```
@@ -44,5 +44,5 @@ In addition to all arguments above, the following attributes are exported:
  Route 53 Resolver DNSSEC configs can be imported using the Route 53 Resolver DNSSEC config ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_dnssec_config.example rdsc-be1866ecc1683e95
+$ terraform import aws_route53resolver_dnssec_config.example rdsc-be1866ecc1683e95
 ```

--- a/website/docs/r/route53resolver_endpoint.html.markdown
+++ b/website/docs/r/route53resolver_endpoint.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_endpoint"
+page_title: "AWS: aws_route53resolver_endpoint"
 description: |-
   Provides a Route 53 Resolver endpoint resource.
 ---
 
-# Resource: aws_route53_resolver_endpoint
+# Resource: aws_route53resolver_endpoint
 
 Provides a Route 53 Resolver endpoint resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_endpoint" "foo" {
+resource "aws_route53resolver_endpoint" "foo" {
   name      = "foo"
   direction = "INBOUND"
 
@@ -66,7 +66,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-`aws_route53_resolver_endpoint` provides the following
+`aws_route53resolver_endpoint` provides the following
 [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) configuration options:
 
 - `create` - (Default `10 minutes`) Used for creating Route 53 Resolver endpoint
@@ -78,5 +78,5 @@ In addition to all arguments above, the following attributes are exported:
  Route 53 Resolver endpoints can be imported using the Route 53 Resolver endpoint ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_endpoint.foo rslvr-in-abcdef01234567890
+$ terraform import aws_route53resolver_endpoint.foo rslvr-in-abcdef01234567890
 ```

--- a/website/docs/r/route53resolver_firewall_config.markdown
+++ b/website/docs/r/route53resolver_firewall_config.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_firewall_config"
+page_title: "AWS: aws_route53resolver_firewall_config"
 description: |-
   Provides a Route 53 Resolver DNS Firewall config resource.
 ---
 
-# Resource: aws_route53_resolver_firewall_config
+# Resource: aws_route53resolver_firewall_config
 
 Provides a Route 53 Resolver DNS Firewall config resource.
 
@@ -19,7 +19,7 @@ resource "aws_vpc" "example" {
   enable_dns_hostnames = true
 }
 
-resource "aws_route53_resolver_firewall_config" "example" {
+resource "aws_route53resolver_firewall_config" "example" {
   resource_id        = aws_vpc.example.id
   firewall_fail_open = "ENABLED"
 }
@@ -44,5 +44,5 @@ In addition to all arguments above, the following attributes are exported:
 Route 53 Resolver DNS Firewall configs can be imported using the Route 53 Resolver DNS Firewall config ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_firewall_config.example rdsc-be1866ecc1683e95
+$ terraform import aws_route53resolver_firewall_config.example rdsc-be1866ecc1683e95
 ```

--- a/website/docs/r/route53resolver_firewall_domain_list.markdown
+++ b/website/docs/r/route53resolver_firewall_domain_list.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_firewall_domain_list"
+page_title: "AWS: aws_route53resolver_firewall_domain_list"
 description: |-
   Provides a Route 53 Resolver DNS Firewall domain list resource.
 ---
 
-# Resource: aws_route53_resolver_firewall_domain_list
+# Resource: aws_route53resolver_firewall_domain_list
 
 Provides a Route 53 Resolver DNS Firewall domain list resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_firewall_domain_list" "example" {
+resource "aws_route53resolver_firewall_domain_list" "example" {
   name = "example"
 }
 ```
@@ -39,5 +39,5 @@ In addition to all arguments above, the following attributes are exported:
  Route 53 Resolver DNS Firewall domain lists can be imported using the Route 53 Resolver DNS Firewall domain list ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
+$ terraform import aws_route53resolver_firewall_domain_list.example rslvr-fdl-0123456789abcdef
 ```

--- a/website/docs/r/route53resolver_firewall_rule.markdown
+++ b/website/docs/r/route53resolver_firewall_rule.markdown
@@ -1,38 +1,38 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_firewall_rule"
+page_title: "AWS: aws_route53resolver_firewall_rule"
 description: |-
   Provides a Route 53 Resolver DNS Firewall rule resource.
 ---
 
-# Resource: aws_route53_resolver_firewall_rule
+# Resource: aws_route53resolver_firewall_rule
 
 Provides a Route 53 Resolver DNS Firewall rule resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_firewall_domain_list" "example" {
+resource "aws_route53resolver_firewall_domain_list" "example" {
   name    = "example"
   domains = ["example.com"]
   tags    = {}
 }
 
-resource "aws_route53_resolver_firewall_rule_group" "example" {
+resource "aws_route53resolver_firewall_rule_group" "example" {
   name = "example"
   tags = {}
 }
 
-resource "aws_route53_resolver_firewall_rule" "example" {
+resource "aws_route53resolver_firewall_rule" "example" {
   name                    = "example"
   action                  = "BLOCK"
   block_override_dns_type = "CNAME"
   block_override_domain   = "example.com"
   block_override_ttl      = 1
   block_response          = "OVERRIDE"
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.example.id
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.example.id
+  firewall_domain_list_id = aws_route53resolver_firewall_domain_list.example.id
+  firewall_rule_group_id  = aws_route53resolver_firewall_rule_group.example.id
   priority                = 100
 }
 ```
@@ -62,5 +62,5 @@ In addition to all arguments above, the following attributes are exported:
  Route 53 Resolver DNS Firewall rules can be imported using the Route 53 Resolver DNS Firewall rule group ID and domain list ID separated by ':', e.g.,
 
 ```
-$ terraform import aws_route53_resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
+$ terraform import aws_route53resolver_firewall_rule.example rslvr-frg-0123456789abcdef:rslvr-fdl-0123456789abcdef
 ```

--- a/website/docs/r/route53resolver_firewall_rule_group.markdown
+++ b/website/docs/r/route53resolver_firewall_rule_group.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_firewall_rule_group"
+page_title: "AWS: aws_route53resolver_firewall_rule_group"
 description: |-
   Provides a Route 53 Resolver DNS Firewall rule group resource.
 ---
 
-# Resource: aws_route53_resolver_firewall_rule_group
+# Resource: aws_route53resolver_firewall_rule_group
 
 Provides a Route 53 Resolver DNS Firewall rule group resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_firewall_rule_group" "example" {
+resource "aws_route53resolver_firewall_rule_group" "example" {
   name = "example"
 }
 ```
@@ -40,5 +40,5 @@ In addition to all arguments above, the following attributes are exported:
  Route 53 Resolver DNS Firewall rule groups can be imported using the Route 53 Resolver DNS Firewall rule group ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
+$ terraform import aws_route53resolver_firewall_rule_group.example rslvr-frg-0123456789abcdef
 ```

--- a/website/docs/r/route53resolver_firewall_rule_group_association.markdown
+++ b/website/docs/r/route53resolver_firewall_rule_group_association.markdown
@@ -1,25 +1,25 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_firewall_rule_group_association"
+page_title: "AWS: aws_route53resolver_firewall_rule_group_association"
 description: |-
   Provides a Route 53 Resolver DNS Firewall rule group association resource.
 ---
 
-# Resource: aws_route53_resolver_firewall_rule_group_association
+# Resource: aws_route53resolver_firewall_rule_group_association
 
 Provides a Route 53 Resolver DNS Firewall rule group association resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_firewall_rule_group" "example" {
+resource "aws_route53resolver_firewall_rule_group" "example" {
   name = "example"
 }
 
-resource "aws_route53_resolver_firewall_rule_group_association" "example" {
+resource "aws_route53resolver_firewall_rule_group_association" "example" {
   name                   = "example"
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.example.id
+  firewall_rule_group_id = aws_route53resolver_firewall_rule_group.example.id
   priority               = 100
   vpc_id                 = aws_vpc.example.id
 }
@@ -49,5 +49,5 @@ In addition to all arguments above, the following attributes are exported:
 Route 53 Resolver DNS Firewall rule group associations can be imported using the Route 53 Resolver DNS Firewall rule group association ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
+$ terraform import aws_route53resolver_firewall_rule_group_association.example rslvr-frgassoc-0123456789abcdef
 ```

--- a/website/docs/r/route53resolver_query_log_config.html.markdown
+++ b/website/docs/r/route53resolver_query_log_config.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_query_log_config"
+page_title: "AWS: aws_route53resolver_query_log_config"
 description: |-
   Provides a Route 53 Resolver query logging configuration resource.
 ---
 
-# Resource: aws_route53_resolver_query_log_config
+# Resource: aws_route53resolver_query_log_config
 
 Provides a Route 53 Resolver query logging configuration resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_query_log_config" "example" {
+resource "aws_route53resolver_query_log_config" "example" {
   name            = "example"
   destination_arn = aws_s3_bucket.example.arn
 
@@ -49,5 +49,5 @@ Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
  Route 53 Resolver query logging configurations can be imported using the Route 53 Resolver query logging configuration ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_query_log_config.example rqlc-92edc3b1838248bf
+$ terraform import aws_route53resolver_query_log_config.example rqlc-92edc3b1838248bf
 ```

--- a/website/docs/r/route53resolver_query_log_config_association.html.markdown
+++ b/website/docs/r/route53resolver_query_log_config_association.html.markdown
@@ -1,20 +1,20 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_query_log_config_association"
+page_title: "AWS: aws_route53resolver_query_log_config_association"
 description: |-
   Provides a Route 53 Resolver query logging configuration association resource.
 ---
 
-# Resource: aws_route53_resolver_query_log_config_association
+# Resource: aws_route53resolver_query_log_config_association
 
 Provides a Route 53 Resolver query logging configuration association resource.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_query_log_config_association" "example" {
-  resolver_query_log_config_id = aws_route53_resolver_query_log_config.example.id
+resource "aws_route53resolver_query_log_config_association" "example" {
+  resolver_query_log_config_id = aws_route53resolver_query_log_config.example.id
   resource_id                  = aws_vpc.example.id
 }
 ```
@@ -37,5 +37,5 @@ In addition to all arguments above, the following attributes are exported:
  Route 53 Resolver query logging configuration associations can be imported using the Route 53 Resolver query logging configuration association ID, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_query_log_config_association.example rqlca-b320624fef3c4d70
+$ terraform import aws_route53resolver_query_log_config_association.example rqlca-b320624fef3c4d70
 ```

--- a/website/docs/r/route53resolver_rule.html.markdown
+++ b/website/docs/r/route53resolver_rule.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_rule"
+page_title: "AWS: aws_route53resolver_rule"
 description: |-
   Provides a Route53 Resolver rule.
 ---
 
-# Resource: aws_route53_resolver_rule
+# Resource: aws_route53resolver_rule
 
 Provides a Route53 Resolver rule.
 
@@ -15,7 +15,7 @@ Provides a Route53 Resolver rule.
 ### System rule
 
 ```terraform
-resource "aws_route53_resolver_rule" "sys" {
+resource "aws_route53resolver_rule" "sys" {
   domain_name = "subdomain.example.com"
   rule_type   = "SYSTEM"
 }
@@ -24,11 +24,11 @@ resource "aws_route53_resolver_rule" "sys" {
 ### Forward rule
 
 ```terraform
-resource "aws_route53_resolver_rule" "fwd" {
+resource "aws_route53resolver_rule" "fwd" {
   domain_name          = "example.com"
   name                 = "example"
   rule_type            = "FORWARD"
-  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
+  resolver_endpoint_id = aws_route53resolver_endpoint.foo.id
 
   target_ip {
     ip = "123.45.67.89"
@@ -74,5 +74,5 @@ Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
 Route53 Resolver rules can be imported using the `id`, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_rule.sys rslvr-rr-0123456789abcdef0
+$ terraform import aws_route53resolver_rule.sys rslvr-rr-0123456789abcdef0
 ```

--- a/website/docs/r/route53resolver_rule_association.html.markdown
+++ b/website/docs/r/route53resolver_rule_association.html.markdown
@@ -1,20 +1,20 @@
 ---
 subcategory: "Route53 Resolver"
 layout: "aws"
-page_title: "AWS: aws_route53_resolver_rule_association"
+page_title: "AWS: aws_route53resolver_rule_association"
 description: |-
   Provides a Route53 Resolver rule association.
 ---
 
-# Resource: aws_route53_resolver_rule_association
+# Resource: aws_route53resolver_rule_association
 
 Provides a Route53 Resolver rule association.
 
 ## Example Usage
 
 ```terraform
-resource "aws_route53_resolver_rule_association" "example" {
-  resolver_rule_id = aws_route53_resolver_rule.sys.id
+resource "aws_route53resolver_rule_association" "example" {
+  resolver_rule_id = aws_route53resolver_rule.sys.id
   vpc_id           = aws_vpc.foo.id
 }
 ```
@@ -38,5 +38,5 @@ In addition to all arguments above, the following attributes are exported:
 Route53 Resolver rule associations can be imported using the `id`, e.g.,
 
 ```
-$ terraform import aws_route53_resolver_rule_association.example rslvr-rrassoc-97242eaf88example
+$ terraform import aws_route53resolver_rule_association.example rslvr-rrassoc-97242eaf88example
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
