### PR TITLE
Realign inconsistent s3control names

### DIFF
--- a/.changelog/21606.txt
+++ b/.changelog/21606.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_s3_access_point: Rename data source to aws_s3control_access_point (with alias for aws_s3_access_point)
+```
+
+```release-note:enhancement
+resource/aws_s3_account_public_access_block: Rename data source to aws_s3control_account_public_access_block (with alias for aws_s3_account_public_access_block)
+```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -312,7 +312,7 @@ jobs:
           -allowed-resource-subcategories-file website/allowed-subcategories.txt \
           -enable-contents-check \
           -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
-          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment \
+          -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_s3_access_point,aws_s3_account_public_access_block \
           -provider-source registry.terraform.io/hashicorp/aws \
           -providers-schema-json terraform-providers-schema/schema.json \
           -require-resource-subcategory

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1470,11 +1470,13 @@ func Provider() *schema.Provider {
 			"aws_s3_bucket_public_access_block":     s3.ResourceBucketPublicAccessBlock(),
 			"aws_s3_object_copy":                    s3.ResourceObjectCopy(),
 
-			"aws_s3_access_point":                          s3control.ResourceAccessPoint(),
-			"aws_s3_account_public_access_block":           s3control.ResourceAccountPublicAccessBlock(),
+			"aws_s3control_access_point":                   s3control.ResourceAccessPoint(),
+			"aws_s3control_account_public_access_block":    s3control.ResourceAccountPublicAccessBlock(),
 			"aws_s3control_bucket":                         s3control.ResourceBucket(),
 			"aws_s3control_bucket_lifecycle_configuration": s3control.ResourceBucketLifecycleConfiguration(),
 			"aws_s3control_bucket_policy":                  s3control.ResourceBucketPolicy(),
+			"aws_s3_access_point":                          s3control.ResourceAccessPoint(),              // backward compatible alias
+			"aws_s3_account_public_access_block":           s3control.ResourceAccountPublicAccessBlock(), // backward compatible alias
 
 			"aws_s3outposts_endpoint": s3outposts.ResourceEndpoint(),
 

--- a/internal/service/s3/bucket_object_data_source_test.go
+++ b/internal/service/s3/bucket_object_data_source_test.go
@@ -57,7 +57,7 @@ func TestAccS3BucketObjectDataSource_basicViaAccessPoint(t *testing.T) {
 
 	dataSourceName := "data.aws_s3_bucket_object.test"
 	resourceName := "aws_s3_bucket_object.test"
-	accessPointResourceName := "aws_s3_access_point.test"
+	accessPointResourceName := "aws_s3control_access_point.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(t) },
@@ -482,7 +482,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 }
@@ -494,7 +494,7 @@ resource "aws_s3_bucket_object" "test" {
 }
 
 data "aws_s3_bucket_object" "test" {
-  bucket = aws_s3_access_point.test.arn
+  bucket = aws_s3control_access_point.test.arn
   key    = aws_s3_bucket_object.test.key
 }
 `, rName)

--- a/internal/service/s3/bucket_object_test.go
+++ b/internal/service/s3/bucket_object_test.go
@@ -456,7 +456,7 @@ func TestAccS3BucketObject_updatesWithVersioningViaAccessPoint(t *testing.T) {
 	var originalObj, modifiedObj s3.GetObjectOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_object.test"
-	accessPointResourceName := "aws_s3_access_point.test"
+	accessPointResourceName := "aws_s3control_access_point.test"
 
 	sourceInitial := testAccBucketObjectCreateTempFile(t, "initial versioned object state")
 	defer os.Remove(sourceInitial)
@@ -1702,13 +1702,13 @@ resource "aws_s3_bucket" "test" {
   }
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 }
 
 resource "aws_s3_bucket_object" "test" {
-  bucket = aws_s3_access_point.test.arn
+  bucket = aws_s3control_access_point.test.arn
   key    = "updateable-key"
   source = %[3]q
   etag   = filemd5(%[3]q)

--- a/internal/service/s3/bucket_objects_data_source_test.go
+++ b/internal/service/s3/bucket_objects_data_source_test.go
@@ -293,7 +293,7 @@ resource "aws_s3_bucket_object" "object7" {
 
 func testAccObjectsResourcesPlusAccessPointDataSourceConfig(randInt int) string {
 	return testAccObjectsResourcesDataSourceConfig(randInt) + fmt.Sprintf(`
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.objects_bucket.bucket
   name   = "tf-objects-test-access-point-%[1]d"
 }
@@ -315,7 +315,7 @@ data "aws_s3_bucket_objects" "yesh" {
 func testAccObjectsBasicViaAccessPointDataSourceConfig(randInt int) string {
 	return testAccObjectsResourcesPlusAccessPointDataSourceConfig(randInt) + `
 data "aws_s3_bucket_objects" "yesh" {
-  bucket    = aws_s3_access_point.test.arn
+  bucket    = aws_s3control_access_point.test.arn
   prefix    = "arch/navajo/"
   delimiter = "/"
 }

--- a/internal/service/s3/sweep.go
+++ b/internal/service/s3/sweep.go
@@ -31,7 +31,7 @@ func init() {
 		Name: "aws_s3_bucket",
 		F:    sweepBuckets,
 		Dependencies: []string{
-			"aws_s3_access_point",
+			"aws_s3control_access_point",
 			"aws_s3_bucket_object",
 		},
 	})

--- a/internal/service/s3control/access_point_test.go
+++ b/internal/service/s3control/access_point_test.go
@@ -21,7 +21,7 @@ func TestAccS3ControlAccessPoint_basic(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	accessPointName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -62,7 +62,7 @@ func TestAccS3ControlAccessPoint_disappears(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	accessPointName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -86,7 +86,7 @@ func TestAccS3ControlAccessPoint_Disappears_bucket(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	accessPointName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 	bucketResourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -110,7 +110,7 @@ func TestAccS3ControlAccessPoint_Disappears_bucket(t *testing.T) {
 func TestAccS3ControlAccessPoint_Bucket_arn(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
@@ -151,7 +151,7 @@ func TestAccS3ControlAccessPoint_Bucket_arn(t *testing.T) {
 func TestAccS3ControlAccessPoint_policy(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 
 	expectedPolicyText1 := func() string {
 		return fmt.Sprintf(`{
@@ -245,7 +245,7 @@ func TestAccS3ControlAccessPoint_policy(t *testing.T) {
 func TestAccS3ControlAccessPoint_publicAccessBlock(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -284,7 +284,7 @@ func TestAccS3ControlAccessPoint_publicAccessBlock(t *testing.T) {
 func TestAccS3ControlAccessPoint_vpc(t *testing.T) {
 	var v s3control.GetAccessPointOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_access_point.test"
+	resourceName := "aws_s3control_access_point.test"
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -356,7 +356,7 @@ func testAccCheckAccessPointDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).S3ControlConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_s3_access_point" {
+		if rs.Type != "aws_s3control_access_point" {
 			continue
 		}
 
@@ -456,7 +456,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[2]q
 }
@@ -484,7 +484,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3control_bucket.test.arn
   name   = %[1]q
 
@@ -501,7 +501,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
   policy = data.aws_iam_policy_document.test.json
@@ -545,7 +545,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
   policy = data.aws_iam_policy_document.test.json
@@ -590,7 +590,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 
@@ -610,7 +610,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 
@@ -638,7 +638,7 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_access_point" "test" {
+resource "aws_s3control_access_point" "test" {
   bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 

--- a/internal/service/s3control/account_public_access_block_test.go
+++ b/internal/service/s3control/account_public_access_block_test.go
@@ -46,7 +46,7 @@ func TestAccS3ControlAccountPublicAccessBlock_serial(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_basic(t *testing.T) {
 	var configuration1 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -76,7 +76,7 @@ func testAccAccountPublicAccessBlock_basic(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_disappears(t *testing.T) {
 	var configuration1 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -98,7 +98,7 @@ func testAccAccountPublicAccessBlock_disappears(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_AccountID(t *testing.T) {
 	var configuration1 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -124,7 +124,7 @@ func testAccAccountPublicAccessBlock_AccountID(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_BlockPublicACLs(t *testing.T) {
 	var configuration1, configuration2, configuration3 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -164,7 +164,7 @@ func testAccAccountPublicAccessBlock_BlockPublicACLs(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_BlockPublicPolicy(t *testing.T) {
 	var configuration1, configuration2, configuration3 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -204,7 +204,7 @@ func testAccAccountPublicAccessBlock_BlockPublicPolicy(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_IgnorePublicACLs(t *testing.T) {
 	var configuration1, configuration2, configuration3 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -244,7 +244,7 @@ func testAccAccountPublicAccessBlock_IgnorePublicACLs(t *testing.T) {
 
 func testAccAccountPublicAccessBlock_RestrictPublicBuckets(t *testing.T) {
 	var configuration1, configuration2, configuration3 s3control.PublicAccessBlockConfiguration
-	resourceName := "aws_s3_account_public_access_block.test"
+	resourceName := "aws_s3control_account_public_access_block.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -334,7 +334,7 @@ func testAccCheckAccountPublicAccessBlockDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).S3ControlConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_s3_account_public_access_block" {
+		if rs.Type != "aws_s3control_account_public_access_block" {
 			continue
 		}
 
@@ -402,14 +402,14 @@ func testAccCheckAccountPublicAccessBlockDisappears() resource.TestCheckFunc {
 }
 
 func testAccAccountPublicAccessBlockConfig() string {
-	return `resource "aws_s3_account_public_access_block" "test" {}`
+	return `resource "aws_s3control_account_public_access_block" "test" {}`
 }
 
 func testAccAccountPublicAccessBlockAccountIDConfig() string {
 	return `
 data "aws_caller_identity" "test" {}
 
-resource "aws_s3_account_public_access_block" "test" {
+resource "aws_s3control_account_public_access_block" "test" {
   account_id = data.aws_caller_identity.test.account_id
 }
 `
@@ -417,7 +417,7 @@ resource "aws_s3_account_public_access_block" "test" {
 
 func testAccAccountPublicAccessBlockBlockPublicACLsConfig(blockPublicAcls bool) string {
 	return fmt.Sprintf(`
-resource "aws_s3_account_public_access_block" "test" {
+resource "aws_s3control_account_public_access_block" "test" {
   block_public_acls = %t
 }
 `, blockPublicAcls)
@@ -425,7 +425,7 @@ resource "aws_s3_account_public_access_block" "test" {
 
 func testAccAccountPublicAccessBlockBlockPublicPolicyConfig(blockPublicPolicy bool) string {
 	return fmt.Sprintf(`
-resource "aws_s3_account_public_access_block" "test" {
+resource "aws_s3control_account_public_access_block" "test" {
   block_public_policy = %t
 }
 `, blockPublicPolicy)
@@ -433,7 +433,7 @@ resource "aws_s3_account_public_access_block" "test" {
 
 func testAccAccountPublicAccessBlockIgnorePublicACLsConfig(ignorePublicAcls bool) string {
 	return fmt.Sprintf(`
-resource "aws_s3_account_public_access_block" "test" {
+resource "aws_s3control_account_public_access_block" "test" {
   ignore_public_acls = %t
 }
 `, ignorePublicAcls)
@@ -441,7 +441,7 @@ resource "aws_s3_account_public_access_block" "test" {
 
 func testAccAccountPublicAccessBlockRestrictPublicBucketsConfig(restrictPublicBuckets bool) string {
 	return fmt.Sprintf(`
-resource "aws_s3_account_public_access_block" "test" {
+resource "aws_s3control_account_public_access_block" "test" {
   restrict_public_buckets = %t
 }
 `, restrictPublicBuckets)

--- a/internal/service/s3control/sweep.go
+++ b/internal/service/s3control/sweep.go
@@ -17,8 +17,8 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("aws_s3_access_point", &resource.Sweeper{
-		Name: "aws_s3_access_point",
+	resource.AddTestSweepers("aws_s3control_access_point", &resource.Sweeper{
+		Name: "aws_s3control_access_point",
 		F:    sweepAccessPoints,
 	})
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -330,7 +330,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_redshift_snapshot_copy_grant` resource](/docs/providers/aws/r/redshift_snapshot_copy_grant.html)
     - [`aws_redshift_snapshot_schedule` resource](/docs/providers/aws/r/redshift_snapshot_schedule.html)
     - [`aws_redshift_subnet_group` resource](/docs/providers/aws/r/redshift_subnet_group.html)
-    - [`aws_s3_account_public_access_block` resource](/docs/providers/aws/r/s3_account_public_access_block.html)
+    - [`aws_s3control_account_public_access_block` resource](/docs/providers/aws/r/s3_account_public_access_block.html)
     - [`aws_ses_active_receipt_rule_set` resource](/docs/providers/aws/r/ses_active_receipt_rule_set.html)
     - [`aws_ses_configuration_set` resource](/docs/providers/aws/r/ses_configuration_set.html)
     - [`aws_ses_domain_identity_verification` resource](/docs/providers/aws/r/ses_domain_identity_verification.html)

--- a/website/docs/r/s3control_access_point.html.markdown
+++ b/website/docs/r/s3control_access_point.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "S3"
 layout: "aws"
-page_title: "AWS: aws_s3_access_point"
+page_title: "AWS: aws_s3control_access_point"
 description: |-
   Manages an S3 Access Point.
 ---
 
-# Resource: aws_s3_access_point
+# Resource: aws_s3control_access_point
 
 Provides a resource to manage an S3 Access Point.
 
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "example" {
   bucket = "example"
 }
 
-resource "aws_s3_access_point" "example" {
+resource "aws_s3control_access_point" "example" {
   bucket = aws_s3_bucket.example.id
   name   = "example"
 }
@@ -34,7 +34,7 @@ resource "aws_s3control_bucket" "example" {
   bucket = "example"
 }
 
-resource "aws_s3_access_point" "example" {
+resource "aws_s3control_access_point" "example" {
   bucket = aws_s3control_bucket.example.arn
   name   = "example"
 
@@ -100,11 +100,11 @@ Note: S3 access points only support secure access by HTTPS. HTTP isn't supported
 For Access Points associated with an AWS Partition S3 Bucket, this resource can be imported using the `account_id` and `name` separated by a colon (`:`), e.g.,
 
 ```
-$ terraform import aws_s3_access_point.example 123456789012:example
+$ terraform import aws_s3control_access_point.example 123456789012:example
 ```
 
 For Access Points associated with an S3 on Outposts Bucket, this resource can be imported using the Amazon Resource Name (ARN), e.g.,
 
 ```
-$ terraform import aws_s3_access_point.example arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/example
+$ terraform import aws_s3control_access_point.example arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/example
 ```

--- a/website/docs/r/s3control_account_public_access_block.html.markdown
+++ b/website/docs/r/s3control_account_public_access_block.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "S3"
 layout: "aws"
-page_title: "AWS: aws_s3_account_public_access_block"
+page_title: "AWS: aws_s3control_account_public_access_block"
 description: |-
   Manages S3 account-level Public Access Block Configuration
 ---
 
-# Resource: aws_s3_account_public_access_block
+# Resource: aws_s3control_account_public_access_block
 
 Manages S3 account-level Public Access Block configuration. For more information about these settings, see the [AWS S3 Block Public Access documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html).
 
@@ -17,7 +17,7 @@ Manages S3 account-level Public Access Block configuration. For more information
 ## Example Usage
 
 ```terraform
-resource "aws_s3_account_public_access_block" "example" {
+resource "aws_s3control_account_public_access_block" "example" {
   block_public_acls   = true
   block_public_policy = true
 }
@@ -46,8 +46,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_s3_account_public_access_block` can be imported by using the AWS account ID, e.g.,
+`aws_s3control_account_public_access_block` can be imported by using the AWS account ID, e.g.,
 
 ```
-$ terraform import aws_s3_account_public_access_block.example 123456789012
+$ terraform import aws_s3control_account_public_access_block.example 123456789012
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19999

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
