### PR TITLE
r/datasync_s3_location - add validation `agent_arns`, `s3_bucket_arn` and `s3_config. bucket_access_role_arn`

### DIFF
--- a/.changelog/21661.txt
+++ b/.changelog/21661.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_datasync_s3_location: Add validation `agent_arns``, `s3_bucket_arn`` and `s3_config.bucket_access_role_arn`.`
+resource/aws_datasync_s3_location: Add validation to `agent_arns`, `s3_bucket_arn` and `s3_config.bucket_access_role_arn` arguments
 ```

--- a/.changelog/21661.txt
+++ b/.changelog/21661.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_datasync_s3_location: Add validation `agent_arns``, `s3_bucket_arn`` and `s3_config.bucket_access_role_arn`.`
+```

--- a/internal/service/datasync/location_s3.go
+++ b/internal/service/datasync/location_s3.go
@@ -38,13 +38,16 @@ func ResourceLocationS3() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: verify.ValidARN,
+				},
 			},
 			"s3_bucket_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: verify.ValidARN,
 			},
 			"s3_config": {
 				Type:     schema.TypeList,
@@ -57,7 +60,7 @@ func ResourceLocationS3() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
-							ValidateFunc: validation.NoZeroValues,
+							ValidateFunc: verify.ValidARN,
 						},
 					},
 				},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG_NAME=internal/service/datasync TESTARGS='-run=TestAccDataSyncLocationS3_'
--- PASS: TestAccDataSyncLocationS3_storageClass (76.79s)
--- PASS: TestAccDataSyncLocationS3_disappears (82.97s)
--- PASS: TestAccDataSyncLocationS3_basic (85.00s)
--- PASS: TestAccDataSyncLocationS3_tags (209.89s)
```
