### PR TITLE
Fix #20125: aws_budgets_budget_action creation error timeout

### DIFF
--- a/.changelog/21664.txt
+++ b/.changelog/21664.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_budgets_budget_action: Fix aws_budgets_budget_action creation timeout error
+```

--- a/internal/service/budgets/wait.go
+++ b/internal/service/budgets/wait.go
@@ -13,15 +13,7 @@ const (
 
 func waitActionAvailable(conn *budgets.Budgets, accountID, actionID, budgetName string) (*budgets.Action, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			budgets.ActionStatusExecutionInProgress,
-			budgets.ActionStatusStandby,
-		},
-		Target: []string{
-			budgets.ActionStatusExecutionSuccess,
-			budgets.ActionStatusExecutionFailure,
-			budgets.ActionStatusPending,
-		},
+		Target:  budgets.ActionStatus_Values(),
 		Refresh: statusAction(conn, accountID, actionID, budgetName),
 		Timeout: actionAvailableTimeout,
 	}


### PR DESCRIPTION
… waiting for state to become 'EXECUTION_SUCCESS, EXECUTION_FAILURE, PENDING'

Sure, that any response status is viable, cause it returned only in case of successful budget action creation. 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #20125

Output from acceptance testing of budget service:
```
% AWS_PROFILE=default TF_ACC=1 go test ./internal/service/budgets/... -v -count 1 -parallel 20 -timeout 180m
=== RUN   TestAccBudgetsBudgetAction_basic
=== PAUSE TestAccBudgetsBudgetAction_basic
=== RUN   TestAccBudgetsBudgetAction_disappears
=== PAUSE TestAccBudgetsBudgetAction_disappears
=== RUN   TestAccBudgetsBudget_basic
=== PAUSE TestAccBudgetsBudget_basic
=== RUN   TestAccBudgetsBudget_Name_generated
=== PAUSE TestAccBudgetsBudget_Name_generated
=== RUN   TestAccBudgetsBudget_namePrefix
=== PAUSE TestAccBudgetsBudget_namePrefix
=== RUN   TestAccBudgetsBudget_disappears
=== PAUSE TestAccBudgetsBudget_disappears
=== RUN   TestAccBudgetsBudget_costTypes
=== PAUSE TestAccBudgetsBudget_costTypes
=== RUN   TestAccBudgetsBudget_notifications
=== PAUSE TestAccBudgetsBudget_notifications
=== CONT  TestAccBudgetsBudgetAction_basic
=== CONT  TestAccBudgetsBudget_namePrefix
=== CONT  TestAccBudgetsBudget_costTypes
=== CONT  TestAccBudgetsBudget_notifications
=== CONT  TestAccBudgetsBudget_disappears
=== CONT  TestAccBudgetsBudget_basic
=== CONT  TestAccBudgetsBudget_Name_generated
=== CONT  TestAccBudgetsBudgetAction_disappears
--- PASS: TestAccBudgetsBudget_disappears (40.47s)
--- PASS: TestAccBudgetsBudget_namePrefix (54.86s)
--- PASS: TestAccBudgetsBudget_basic (55.11s)
--- PASS: TestAccBudgetsBudget_Name_generated (55.19s)
--- PASS: TestAccBudgetsBudgetAction_disappears (55.68s)
--- PASS: TestAccBudgetsBudgetAction_basic (65.29s)
--- PASS: TestAccBudgetsBudget_costTypes (80.40s)
--- PASS: TestAccBudgetsBudget_notifications (89.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/budgets    91.276s
...
```
