### PR TITLE
Disables acceptance tests for AWS Config aggregate authorization

### DIFF
--- a/internal/service/config/aggregate_authorization_test.go
+++ b/internal/service/config/aggregate_authorization_test.go
@@ -1,145 +1,130 @@
 package config_test
 
-import (
-	"fmt"
-	"regexp"
-	"testing"
+// func TestAccConfigAggregateAuthorization_basic(t *testing.T) {
+// 	rString := sdkacctest.RandStringFromCharSet(12, "0123456789")
+// 	resourceName := "aws_config_aggregate_authorization.example"
+// 	dataSourceName := "data.aws_region.current"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/configservice"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	tfconfig "github.com/hashicorp/terraform-provider-aws/internal/service/config"
-)
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:     func() { acctest.PreCheck(t) },
+// 		ErrorCheck:   acctest.ErrorCheck(t, configservice.EndpointsID),
+// 		Providers:    acctest.Providers,
+// 		CheckDestroy: testAccCheckAggregateAuthorizationDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccAggregateAuthorizationConfig_basic(rString),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "account_id", rString),
+// 					resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "name"),
+// 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "config", regexp.MustCompile(fmt.Sprintf(`aggregation-authorization/%s/%s$`, rString, acctest.Region()))),
+// 				),
+// 			},
+// 			{
+// 				ResourceName:      resourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccConfigAggregateAuthorization_basic(t *testing.T) {
-	rString := sdkacctest.RandStringFromCharSet(12, "0123456789")
-	resourceName := "aws_config_aggregate_authorization.example"
-	dataSourceName := "data.aws_region.current"
+// func TestAccConfigAggregateAuthorization_tags(t *testing.T) {
+// 	rString := sdkacctest.RandStringFromCharSet(12, "0123456789")
+// 	resourceName := "aws_config_aggregate_authorization.example"
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, configservice.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAggregateAuthorizationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAggregateAuthorizationConfig_basic(rString),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "account_id", rString),
-					resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "name"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "config", regexp.MustCompile(fmt.Sprintf(`aggregation-authorization/%s/%s$`, rString, acctest.Region()))),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:     func() { acctest.PreCheck(t) },
+// 		ErrorCheck:   acctest.ErrorCheck(t, configservice.EndpointsID),
+// 		Providers:    acctest.Providers,
+// 		CheckDestroy: testAccCheckAggregateAuthorizationDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccAggregateAuthorizationConfig_tags(rString, "foo", "bar", "fizz", "buzz"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+// 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rString),
+// 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+// 					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccAggregateAuthorizationConfig_tags(rString, "foo", "bar2", "fizz2", "buzz2"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+// 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rString),
+// 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
+// 					resource.TestCheckResourceAttr(resourceName, "tags.fizz2", "buzz2"),
+// 				),
+// 			},
+// 			{
+// 				ResourceName:      resourceName,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
+// 			{
+// 				Config: testAccAggregateAuthorizationConfig_basic(rString),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccConfigAggregateAuthorization_tags(t *testing.T) {
-	rString := sdkacctest.RandStringFromCharSet(12, "0123456789")
-	resourceName := "aws_config_aggregate_authorization.example"
+// func testAccCheckAggregateAuthorizationDestroy(s *terraform.State) error {
+// 	conn := acctest.Provider.Meta().(*conns.AWSClient).ConfigConn
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, configservice.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckAggregateAuthorizationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAggregateAuthorizationConfig_tags(rString, "foo", "bar", "fizz", "buzz"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rString),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
-				),
-			},
-			{
-				Config: testAccAggregateAuthorizationConfig_tags(rString, "foo", "bar2", "fizz2", "buzz2"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rString),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.fizz2", "buzz2"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAggregateAuthorizationConfig_basic(rString),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-				),
-			},
-		},
-	})
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "aws_config_aggregate_authorization" {
+// 			continue
+// 		}
 
-func testAccCheckAggregateAuthorizationDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ConfigConn
+// 		accountId, region, err := tfconfig.AggregateAuthorizationParseID(rs.Primary.ID)
+// 		if err != nil {
+// 			return err
+// 		}
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_config_aggregate_authorization" {
-			continue
-		}
+// 		aggregateAuthorizations, err := tfconfig.DescribeAggregateAuthorizations(conn)
 
-		accountId, region, err := tfconfig.AggregateAuthorizationParseID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
+// 		if err != nil {
+// 			return err
+// 		}
 
-		aggregateAuthorizations, err := tfconfig.DescribeAggregateAuthorizations(conn)
+// 		for _, auth := range aggregateAuthorizations {
+// 			if accountId == aws.StringValue(auth.AuthorizedAccountId) && region == aws.StringValue(auth.AuthorizedAwsRegion) {
+// 				return fmt.Errorf("Config aggregate authorization still exists: %s", rs.Primary.ID)
+// 			}
+// 		}
+// 	}
 
-		if err != nil {
-			return err
-		}
+// 	return nil
+// }
 
-		for _, auth := range aggregateAuthorizations {
-			if accountId == aws.StringValue(auth.AuthorizedAccountId) && region == aws.StringValue(auth.AuthorizedAwsRegion) {
-				return fmt.Errorf("Config aggregate authorization still exists: %s", rs.Primary.ID)
-			}
-		}
-	}
+// func testAccAggregateAuthorizationConfig_basic(rString string) string {
+// 	return fmt.Sprintf(`
+// data "aws_region" "current" {}
 
-	return nil
-}
+// resource "aws_config_aggregate_authorization" "example" {
+//   account_id = %[1]q
+//   region     = data.aws_region.current.name
+// }
+// `, rString)
+// }
 
-func testAccAggregateAuthorizationConfig_basic(rString string) string {
-	return fmt.Sprintf(`
-data "aws_region" "current" {}
+// func testAccAggregateAuthorizationConfig_tags(rString, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+// 	return fmt.Sprintf(`
+// data "aws_region" "current" {}
 
-resource "aws_config_aggregate_authorization" "example" {
-  account_id = %[1]q
-  region     = data.aws_region.current.name
-}
-`, rString)
-}
+// resource "aws_config_aggregate_authorization" "example" {
+//   account_id = %[1]q
+//   region     = data.aws_region.current.name
 
-func testAccAggregateAuthorizationConfig_tags(rString, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_region" "current" {}
+//   tags = {
+//     Name = %[1]q
 
-resource "aws_config_aggregate_authorization" "example" {
-  account_id = %[1]q
-  region     = data.aws_region.current.name
-
-  tags = {
-    Name = %[1]q
-
-    %[2]s = %[3]q
-    %[4]s = %[5]q
-  }
-}
-`, rString, tagKey1, tagValue1, tagKey2, tagValue2)
-}
+//     %[2]s = %[3]q
+//     %[4]s = %[5]q
+//   }
+// }
+// `, rString, tagKey1, tagValue1, tagKey2, tagValue2)
+// }


### PR DESCRIPTION
The acceptance tests for AWS Config aggregate authorization were authorizing random AWS accounts. Disable the tests. They will be changed later.