### PR TITLE
r/aws_ebs_encryption_by_default - add import support

### DIFF
--- a/.changelog/21717.txt
+++ b/.changelog/21717.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ebs_encryption_by_default: Add import support
+```

--- a/internal/service/ec2/ebs_encryption_by_default.go
+++ b/internal/service/ec2/ebs_encryption_by_default.go
@@ -15,7 +15,9 @@ func ResourceEBSEncryptionByDefault() *schema.Resource {
 		Read:   resourceEBSEncryptionByDefaultRead,
 		Update: resourceEBSEncryptionByDefaultUpdate,
 		Delete: resourceEBSEncryptionByDefaultDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"enabled": {
 				Type:     schema.TypeBool,

--- a/internal/service/ec2/ebs_encryption_by_default_test.go
+++ b/internal/service/ec2/ebs_encryption_by_default_test.go
@@ -29,6 +29,11 @@ func TestAccEC2EBSEncryptionByDefault_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccEBSEncryptionByDefaultConfig(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEbsEncryptionByDefault(resourceName, true),

--- a/website/docs/r/ebs_encryption_by_default.html.markdown
+++ b/website/docs/r/ebs_encryption_by_default.html.markdown
@@ -29,3 +29,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 No additional attributes are exported.
+
+## Import
+
+Default EBS encryption state can be imported, e.g.,
+
+```
+$ terraform import aws_ebs_encryption_by_default.example default
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21699.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccEC2EBSEncryptionByDefault_basic" PKG_NAME="internal/service/ec2"                                                                                                                                           4s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run=TestAccEC2EBSEncryptionByDefault_basic -timeout 180m
=== RUN   TestAccEC2EBSEncryptionByDefault_basic
=== PAUSE TestAccEC2EBSEncryptionByDefault_basic
=== CONT  TestAccEC2EBSEncryptionByDefault_basic
--- PASS: TestAccEC2EBSEncryptionByDefault_basic (43.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        51.769s
```
