### PR TITLE
Note that aws_docdb_cluster_parameter_group.parameter.* should be strings

### DIFF
--- a/website/docs/r/docdb_cluster_parameter_group.html.markdown
+++ b/website/docs/r/docdb_cluster_parameter_group.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 Parameter blocks support the following:
 
+~> **NOTE:** These arguments take a `string` representation of their values.
+
 * `name` - (Required) The name of the documentDB parameter.
 * `value` - (Required) The value of the documentDB parameter.
 * `apply_method` - (Optional) Valid values are `immediate` and `pending-reboot`. Defaults to `pending-reboot`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21679

Output from acceptance testing: N/a, docs

### Information

This PR clarifies that the values passed to the `parameter.*` arguments of the `aws_docdb_cluster_parameter_group` resource should be string representations of their values. Passing the values as an `int`, or `float` can lead to unexpected behavior and persistent diffs, as seen in the linked issue. 