### PR TITLE
Correct cloudfront_response_headers_policy docs

### DIFF
--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -15,7 +15,7 @@ When it’s attached to a cache behavior, CloudFront adds the headers in the pol
 
 ## Example Usage
 
-The following example below creates a CloudFront response headers policy.
+The example below creates a CloudFront response headers policy.
 
 ```terraform
 resource "aws_cloudfront_response_headers_policy" "example" {
@@ -38,6 +38,28 @@ resource "aws_cloudfront_response_headers_policy" "example" {
     }
 
     origin_override = true
+  }
+}
+```
+
+The example below creates a CloudFront response headers policy with a custom headers config.
+
+```terraform
+resource "aws_cloudfront_response_headers_policy" "example" {
+  name = "example-headers-policy"
+
+  custom_headers_config {
+    items {
+      header   = "X-Permitted-Cross-Domain-Policies"
+      override = true
+      value    = "none"
+    }
+
+    items {
+      header   = "X-Test"
+      override = true
+      value    = "none"
+    }
   }
 }
 ```

--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -54,12 +54,12 @@ The following arguments are supported:
 
 ### Cors Config
 
-* `access_control_allow_credentials` - (Required) A Boolean value that CloudFront uses as the value for the Access-Control-Allow-Credentials HTTP response header.
-* `access_control_allow_headers` - (Required) Object that contains an attribute `items` that contains a list of HTTP header names that CloudFront includes as values for the Access-Control-Allow-Headers HTTP response header.
-* `access_control_allow_methods` - (Required) Object that contains an attribute `items` that contains a list of HTTP methods that CloudFront includes as values for the Access-Control-Allow-Methods HTTP response header. Valid values: `GET` | `POST` | `OPTIONS` | `PUT` | `DELETE` | `HEAD` | `ALL`
-* `access_control_allow_origins` - (Optional) Object that contains an attribute `items` that contains a list of origins that CloudFront can use as the value for the Access-Control-Allow-Origin HTTP response header.
-* `access_control_expose_headers` - (Optional) Object that contains an attribute `items` that contains a list of HTTP headers that CloudFront includes as values for the Access-Control-Expose-Headers HTTP response header.
-* `access_control_max_age_sec` - (Required) A number that CloudFront uses as the value for the Access-Control-Max-Age HTTP response header.
+* `access_control_allow_credentials` - (Required) A Boolean value that CloudFront uses as the value for the `Access-Control-Allow-Credentials` HTTP response header.
+* `access_control_allow_headers` - (Required) Object that contains an attribute `items` that contains a list of HTTP header names that CloudFront includes as values for the `Access-Control-Allow-Headers` HTTP response header.
+* `access_control_allow_methods` - (Required) Object that contains an attribute `items` that contains a list of HTTP methods that CloudFront includes as values for the `Access-Control-Allow-Methods` HTTP response header. Valid values: `GET` | `POST` | `OPTIONS` | `PUT` | `DELETE` | `HEAD` | `ALL`
+* `access_control_allow_origins` - (Optional) Object that contains an attribute `items` that contains a list of origins that CloudFront can use as the value for the `Access-Control-Allow-Origin` HTTP response header.
+* `access_control_expose_headers` - (Optional) Object that contains an attribute `items` that contains a list of HTTP headers that CloudFront includes as values for the `Access-Control-Expose-Headers` HTTP response header.
+* `access_control_max_age_sec` - (Required) A number that CloudFront uses as the value for the `Access-Control-Max-Age` HTTP response header.
 
 ### Custom Header
 
@@ -69,44 +69,45 @@ The following arguments are supported:
 
 ### Security Headers Config
 
-* `content_security_policy` - (Optional) The policy directives and their values that CloudFront includes as values for the Content-Security-Policy HTTP response header. See [Content Security Policy](#content_security_policy) for more information.
-* `content_type_options` - (Optional) TA setting that determines whether CloudFront includes the X-Content-Type-Options HTTP response header with its value set to nosniff. See [Content Type Options](#content_type_options) for more information.
-* `frame_options` - (Optional) TA setting that determines whether CloudFront includes the X-Frame-Options HTTP response header and the header’s value. See [Frame Options](#frame_options) for more information.
-* `referrer_policy` - (Optional) TA setting that determines whether CloudFront includes the Referrer-Policy HTTP response header and the header’s value. See [Referrer Policy](#referrer_policy) for more information.
-* `xss_protection` - (Optional) TSettings that determine whether CloudFront includes the X-XSS-Protection HTTP response header and the header’s value. See [XSS Protection](#xss_protection) for more information.
+* `content_security_policy` - (Optional) The policy directives and their values that CloudFront includes as values for the `Content-Security-Policy` HTTP response header. See [Content Security Policy](#content_security_policy) for more information.
+* `content_type_options` - (Optional) Determines whether CloudFront includes the `X-Content-Type-Options` HTTP response header with its value set to `nosniff`. See [Content Type Options](#content_type_options) for more information.
+* `frame_options` - (Optional) Determines whether CloudFront includes the `X-Frame-Options` HTTP response header and the header’s value. See [Frame Options](#frame_options) for more information.
+* `referrer_policy` - (Optional) Determines whether CloudFront includes the `Referrer-Policy` HTTP response header and the header’s value. See [Referrer Policy](#referrer_policy) for more information.
+* `strict_transport_security` - (Optional) Determines whether CloudFront includes the `Strict-Transport-Security` HTTP response header and the header’s value. See [Strict Transport Security](#strict_transport_security) for more information.
+* `xss_protection` - (Optional) Determine whether CloudFront includes the `X-XSS-Protection` HTTP response header and the header’s value. See [XSS Protection](#xss_protection) for more information.
 
 ### Content Security Policy
 
-* `content_security_policy` - (Required) TThe policy directives and their values that CloudFront includes as values for the Content-Security-Policy HTTP response header.
-* `override` - (Required) A Boolean value that determines whether CloudFront overrides the Content-Security-Policy HTTP response header received from the origin with the one specified in this response headers policy.
+* `content_security_policy` - (Required) The policy directives and their values that CloudFront includes as values for the `Content-Security-Policy` HTTP response header.
+* `override` - (Required) A Boolean value that determines whether CloudFront overrides the `Content-Security-Policy` HTTP response header received from the origin with the one specified in this response headers policy.
 
 ### Content Type Options
 
-* `override` - (Required) A Boolean value that determines whether CloudFront overrides the X-Content-Type-Options HTTP response header received from the origin with the one specified in this response headers policy.
+* `override` - (Required) A Boolean value that determines whether CloudFront overrides the `X-Content-Type-Options` HTTP response header received from the origin with the one specified in this response headers policy.
 
 ### Frame Options
 
-* `frame_option` - (Required) The value of the X-Frame-Options HTTP response header. Valid values: `DENY` | `SAMEORIGIN`
-* `override` - (Required) A Boolean value that determines whether CloudFront overrides the X-Frame-Options HTTP response header received from the origin with the one specified in this response headers policy.
+* `frame_option` - (Required) The value of the `X-Frame-Options` HTTP response header. Valid values: `DENY` | `SAMEORIGIN`
+* `override` - (Required) A Boolean value that determines whether CloudFront overrides the `X-Frame-Options` HTTP response header received from the origin with the one specified in this response headers policy.
 
 ### Referrer Policy
 
-* `referrer_policy` - (Required) The value of the Referrer-Policy HTTP response header. Valid Values: `no-referrer` | `no-referrer-when-downgrade` | `origin` | `origin-when-cross-origin` | `same-origin` | `strict-origin` | `strict-origin-when-cross-origin` | `unsafe-url`
-* `override` - (Required) A Boolean value that determines whether CloudFront overrides the Referrer-Policy HTTP response header received from the origin with the one specified in this response headers policy.
+* `referrer_policy` - (Required) The value of the `Referrer-Policy` HTTP response header. Valid Values: `no-referrer` | `no-referrer-when-downgrade` | `origin` | `origin-when-cross-origin` | `same-origin` | `strict-origin` | `strict-origin-when-cross-origin` | `unsafe-url`
+* `override` - (Required) A Boolean value that determines whether CloudFront overrides the `Referrer-Policy` HTTP response header received from the origin with the one specified in this response headers policy.
 
 ### Strict Transport Security
 
-* `access_control_max_age_sec` - (Required) A number that CloudFront uses as the value for the max-age directive in the Strict-Transport-Security HTTP response header.
-* `include_subdomains` - (Optional) A Boolean value that determines whether CloudFront includes the includeSubDomains directive in the Strict-Transport-Security HTTP response header.
-* `override` - (Required) A Boolean value that determines whether CloudFront overrides the Strict-Transport-Security HTTP response header received from the origin with the one specified in this response headers policy.
-* `preload` - (Optional) A Boolean value that determines whether CloudFront includes the preload directive in the Strict-Transport-Security HTTP response header.
+* `access_control_max_age_sec` - (Required) A number that CloudFront uses as the value for the `max-age` directive in the `Strict-Transport-Security` HTTP response header.
+* `include_subdomains` - (Optional) A Boolean value that determines whether CloudFront includes the `includeSubDomains` directive in the `Strict-Transport-Security` HTTP response header.
+* `override` - (Required) A Boolean value that determines whether CloudFront overrides the `Strict-Transport-Security` HTTP response header received from the origin with the one specified in this response headers policy.
+* `preload` - (Optional) A Boolean value that determines whether CloudFront includes the `preload` directive in the `Strict-Transport-Security` HTTP response header.
 
 ### XSS Protection
 
-* `mode_block` - (Required) A Boolean value that determines whether CloudFront includes the mode=block directive in the X-XSS-Protection header.
-* `override` - (Required) A Boolean value that determines whether CloudFront overrides the X-XSS-Protection HTTP response header received from the origin with the one specified in this response headers policy.
-* `protection` - (Required) A Boolean value that determines the value of the X-XSS-Protection HTTP response header. When this setting is true, the value of the X-XSS-Protection header is 1. When this setting is false, the value of the X-XSS-Protection header is 0.
-* `report_uri` - (Optional) A Boolean value that determines whether CloudFront sets a reporting URI in the X-XSS-Protection header.
+* `mode_block` - (Required) A Boolean value that determines whether CloudFront includes the `mode=block` directive in the `X-XSS-Protection` header.
+* `override` - (Required) A Boolean value that determines whether CloudFront overrides the `X-XSS-Protection` HTTP response header received from the origin with the one specified in this response headers policy.
+* `protection` - (Required) A Boolean value that determines the value of the `X-XSS-Protection` HTTP response header. When this setting is `true`, the value of the `X-XSS-Protection` header is `1`. When this setting is `false`, the value of the `X-XSS-Protection` header is `0`.
+* `report_uri` - (Optional) A reporting URI, which CloudFront uses as the value of the report directive in the `X-XSS-Protection` header. You cannot specify a `report_uri` when `mode_block` is `true`.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `name` - (Required) A unique name to identify the response headers policy.
 * `comment` - (Optional) A comment to describe the response headers policy. The comment cannot be longer than 128 characters.
 * `cors_config` - (Optional) A configuration for a set of HTTP response headers that are used for Cross-Origin Resource Sharing (CORS). See [Cors Config](#cors_config) for more information.
-* `custom_headers_config` - (Optional) Object that contains an attribute `items` that contains a list of Custom Headers See [Custom Header](#custom_header) for more information.
+* `custom_headers_config` - (Optional) Object that contains an attribute `items` that contains a list of custom headers. See [Custom Header](#custom_header) for more information.
 * `security_headers_config` - (Optional) A configuration for a set of security-related HTTP response headers. See [Security Headers Config](#security_headers_config) for more information.
 
 ### Cors Config


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21660

Output from acceptance testing: N/a, docs

### Information

This PR updates the documentation around the `cloudfront_response_headers_policy` resource to clarify, correct formatting, and provide additional information.

### References

AWS API:
- [ResponseHeadersPolicySecurityHeadersConfig](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ResponseHeadersPolicySecurityHeadersConfig.html)
- [ResponseHeadersPolicyStrictTransportSecurity](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ResponseHeadersPolicyStrictTransportSecurity.html)
- [ResponseHeadersPolicyXSSProtection](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ResponseHeadersPolicyXSSProtection.html)