### PR TITLE
Remove MaxItems Limit from CreateJobQueue

### DIFF
--- a/.changelog/21737.txt
+++ b/.changelog/21737.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_batch_job_queue: Remove MaxItems from CreateJobQueue for ComputeEnviornments, which was restricting to default service quotas.
+resource/aws_batch_job_queue: Remove limit of 3 items from the `compute_environments` argument
 ```

--- a/.changelog/21737.txt
+++ b/.changelog/21737.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_job_queue: Remove MaxItems from CreateJobQueue for ComputeEnviornments, which was restricting to default service quotas.
+```

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -34,7 +34,6 @@ func ResourceJobQueue() *schema.Resource {
 			"compute_environments": {
 				Type:     schema.TypeList,
 				Required: true,
-				MaxItems: 3,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"name": {

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -31,8 +31,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the job queue.
 * `compute_environments` - (Required) Specifies the set of compute environments
     mapped to a job queue and their order.  The position of the compute environments
-    in the list will dictate the order. You can associate up to 3 compute environments
-    with a job queue.
+    in the list will dictate the order.
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.
 * `state` - (Required) The state of the job queue. Must be one of: `ENABLED` or `DISABLED`


### PR DESCRIPTION
* When creating a new job queue in AWS Batch, there is no actual limit
in the API to the number of compute environments you can create. This is
controlled by a service quota that can be adjusted. Other systems such
as CloudFormation allow you to submit more than 3 compute environments
per job queue, so I'm removing that limit here.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
