### PR TITLE
r/elasticsearch_domin: use tags as `KeyValueTags` type instead of as `[]*elasticsearchservice.Tag` in `UpdateTags`

### DIFF
--- a/.changelog/21738.txt
+++ b/.changelog/21738.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticsearch_domain: Fix tagging on creation
+```

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -626,7 +626,7 @@ func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
 	// whilst the operation is being performed), we still get the required tags on
 	// the resources.
 	if len(tags) > 0 {
-		if err := UpdateTags(conn, d.Id(), nil, Tags(tags.IgnoreAWS())); err != nil {
+		if err := UpdateTags(conn, d.Id(), nil, tags); err != nil {
 			return fmt.Errorf("error adding Elasticsearch Cluster (%s) tags: %s", d.Id(), err)
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/20498

Output from acceptance testing (with code change):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccElasticsearchDomainDataSource_Data_advanced
=== PAUSE TestAccElasticsearchDomainDataSource_Data_advanced
=== CONT  TestAccElasticsearchDomainDataSource_Data_advanced
--- PASS: TestAccElasticsearchDomainDataSource_Data_advanced (1401.62s)
```

Output from acceptance testing (without code change):
```
=== RUN   TestAccElasticsearchDomainDataSource_Data_advanced
=== PAUSE TestAccElasticsearchDomainDataSource_Data_advanced
=== CONT  TestAccElasticsearchDomainDataSource_Data_advanced
    domain_data_source_test.go:51: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
         <= read (data resources)
        
        Terraform will perform the following actions:
        
          # data.aws_elasticsearch_domain.test will be read during apply
          # (config refers to values not yet known)
         <= data "aws_elasticsearch_domain" "test"  {
              ~ access_policies           = jsonencode(
                    {
                      - Statement = [
                          - {
                              - Action    = "es:*"
                              - Effect    = "Allow"
                              - Principal = "*"
                              - Resource  = "arn:aws:es:us-west-2:*******:domain/test-es-3701786318374044886/*"
                            },
                        ]
                      - Version   = "2012-10-17"
                    }
                ) -> (known after apply)
              ~ advanced_options          = {
                  - "override_main_response_version"         = "false"
                  - "rest.action.multi.allow_explicit_index" = "true"
                } -> (known after apply)
              ~ advanced_security_options = [
                  - {
                      - enabled                        = false
                      - internal_user_database_enabled = false
                    },
                ] -> (known after apply)
              ~ arn                       = "arn:aws:es:us-west-2:*******:domain/test-es-3701786318374044886" -> (known after apply)
              ~ cluster_config            = [
                  - {
                      - dedicated_master_count   = 0
                      - dedicated_master_enabled = false
                      - dedicated_master_type    = ""
                      - instance_count           = 2
                      - instance_type            = "t2.small.elasticsearch"
                      - warm_count               = 0
                      - warm_enabled             = false
                      - warm_type                = ""
                      - zone_awareness_config    = [
                          - {
                              - availability_zone_count = 2
                            },
                        ]
                      - zone_awareness_enabled   = true
                    },
                ] -> (known after apply)
              ~ cognito_options           = [
                  - {
                      - enabled          = false
                      - identity_pool_id = ""
                      - role_arn         = ""
                      - user_pool_id     = ""
                    },
                ] -> (known after apply)
              ~ created                   = true -> (known after apply)
              ~ deleted                   = false -> (known after apply)
              ~ domain_id                 = "*******/test-es-3701786318374044886" -> (known after apply)
              ~ ebs_options               = [
                  - {
                      - ebs_enabled = true
                      - iops        = 0
                      - volume_size = 20
                      - volume_type = "gp2"
                    },
                ] -> (known after apply)
              ~ elasticsearch_version     = "1.5" -> (known after apply)
              ~ encryption_at_rest        = [
                  - {
                      - enabled    = false
                      - kms_key_id = ""
                    },
                ] -> (known after apply)
              ~ endpoint                  = "vpc-test-es-3701786318374044886-u7nswcfkpnjqs2ib3uwxnqo3i4.us-west-2.es.amazonaws.com" -> (known after apply)
              ~ id                        = "arn:aws:es:us-west-2:*******:domain/test-es-3701786318374044886" -> (known after apply)
              ~ kibana_endpoint           = "vpc-test-es-3701786318374044886-u7nswcfkpnjqs2ib3uwxnqo3i4.us-west-2.es.amazonaws.com/_plugin/kibana/" -> (known after apply)
              ~ log_publishing_options    = [
                  - {
                      - cloudwatch_log_group_arn = "arn:aws:logs:us-west-2:*******:log-group:test-es-3701786318374044886"
                      - enabled                  = true
                      - log_type                 = "INDEX_SLOW_LOGS"
                    },
                ] -> (known after apply)
              ~ node_to_node_encryption   = [
                  - {
                      - enabled = false
                    },
                ] -> (known after apply)
              ~ processing                = false -> (known after apply)
              ~ snapshot_options          = [
                  - {
                      - automated_snapshot_start_hour = 23
                    },
                ] -> (known after apply)
              ~ tags                      = {} -> (known after apply)
              ~ vpc_options               = [
                  - {
                      - availability_zones = [
                          - "us-west-2a",
                          - "us-west-2b",
                        ]
                      - security_group_ids = [
                          - "sg-0da6055a2dfdbdd73",
                        ]
                      - subnet_ids         = [
                          - "subnet-08d711d42ca468ad1",
                          - "subnet-09a041bafd06afd9e",
                        ]
                      - vpc_id             = "vpc-098bfc466539ebfc8"
                    },
                ] -> (known after apply)
                # (1 unchanged attribute hidden)
            }
        
          # aws_elasticsearch_domain.test will be updated in-place
          ~ resource "aws_elasticsearch_domain" "test" {
                id                    = "arn:aws:es:us-west-2:*******:domain/test-es-3701786318374044886"
              ~ tags                  = {
                  + "Domain" = "TestDomain"
                }
              ~ tags_all              = {
                  + "Domain" = "TestDomain"
                }
                # (8 unchanged attributes hidden)
        
        
        
        
        
        
        
        
        
        
                # (10 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccElasticsearchDomainDataSource_Data_advanced (2031.73s)
```
