### PR TITLE
Remove "ForceNew" from ec2_managed_prefix_list's max_entries

### DIFF
--- a/website/docs/r/ec2_managed_prefix_list.html.markdown
+++ b/website/docs/r/ec2_managed_prefix_list.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `address_family` - (Required, Forces new resource) Address family (`IPv4` or `IPv6`) of this prefix list.
 * `entry` - (Optional) Configuration block for prefix list entry. Detailed below. Different entries may have overlapping CIDR blocks, but a particular CIDR should not be duplicated.
-* `max_entries` - (Required, Forces new resource) Maximum number of entries that this prefix list can contain.
+* `max_entries` - (Required) Maximum number of entries that this prefix list can contain.
 * `name` - (Required) Name of this resource. The name must not start with `com.amazonaws`.
 * `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

https://github.com/hashicorp/terraform-provider-aws/pull/20797 removed `ForceNew` for this argument. This updates the website to match.


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
