### PR TITLE
r/security_group: add pagination to security group find method

### DIFF
--- a/.changelog/21743.txt
+++ b/.changelog/21743.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_security_group: Fix lack of pagination when describing security groups
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -553,7 +553,44 @@ func FindSecurityGroupByNameAndVPCID(conn *ec2.EC2, name, vpcID string) (*ec2.Se
 
 // FindSecurityGroup looks up a security group using an ec2.DescribeSecurityGroupsInput. Returns a resource.NotFoundError if not found.
 func FindSecurityGroup(conn *ec2.EC2, input *ec2.DescribeSecurityGroupsInput) (*ec2.SecurityGroup, error) {
-	result, err := conn.DescribeSecurityGroups(input)
+	output, err := FindSecurityGroups(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 || output[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output[0], nil
+}
+
+// FindSecurityGroups returns an array of security groups that match an ec2.DescribeSecurityGroupsInput.
+// Returns a resource.NotFoundError if no group is found for a specified SecurityGroup or SecurityGroupId.
+func FindSecurityGroups(conn *ec2.EC2, input *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
+	var output []*ec2.SecurityGroup
+
+	err := conn.DescribeSecurityGroupsPages(input, func(page *ec2.DescribeSecurityGroupsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, sg := range page.SecurityGroups {
+			if sg == nil {
+				continue
+			}
+
+			output = append(output, sg)
+		}
+
+		return !lastPage
+	})
+
 	if tfawserr.ErrCodeEquals(err, InvalidSecurityGroupIDNotFound) ||
 		tfawserr.ErrCodeEquals(err, InvalidGroupNotFound) {
 		return nil, &resource.NotFoundError{
@@ -561,19 +598,12 @@ func FindSecurityGroup(conn *ec2.EC2, input *ec2.DescribeSecurityGroupsInput) (*
 			LastRequest: input,
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	if result == nil || len(result.SecurityGroups) == 0 || result.SecurityGroups[0] == nil {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	if len(result.SecurityGroups) > 1 {
-		return nil, tfresource.NewTooManyResultsError(len(result.SecurityGroups), input)
-	}
-
-	return result.SecurityGroups[0], nil
+	return output, nil
 }
 
 // FindSpotInstanceRequestByID looks up a SpotInstanceRequest by ID. When not found, returns nil and potentially an API error.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/21628

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
in progress

--- SKIP: TestAccEC2DefaultSecurityGroup_Classic_empty (0.00s)
--- SKIP: TestAccEC2DefaultSecurityGroup_Classic_basic (2.25s)
--- PASS: TestAccEC2SecurityGroupRule_expectInvalidTypeError (13.94s)
--- PASS: TestAccEC2SecurityGroupRule_expectInvalidCIDR (22.87s)
--- PASS: TestAccEC2SecurityGroupDataSource_basic (79.42s)
--- PASS: TestAccEC2SecurityGroupRule_Ingress_vpc (84.90s)
--- PASS: TestAccEC2SecurityGroupRule_PartialMatching_source (86.89s)
--- PASS: TestAccEC2SecurityGroupRule_Ingress_icmpv6 (87.70s)
--- PASS: TestAccEC2SecurityGroupRule_IngressSourceWithAccount_id (87.13s)
--- PASS: TestAccEC2SecurityGroupRule_egress (87.44s)
--- PASS: TestAccEC2SecurityGroupRule_multiIngress (89.19s)
--- PASS: TestAccEC2SecurityGroupRule_selfSource (90.34s)
--- PASS: TestAccEC2SecurityGroupRule_Ingress_protocol (92.10s)
--- PASS: TestAccEC2SecurityGroupRule_issue5310 (92.57s)
--- PASS: TestAccEC2SecurityGroupRule_Ingress_classic (92.99s)
--- PASS: TestAccEC2DefaultSecurityGroup_VPC_empty (95.00s)
--- PASS: TestAccEC2SecurityGroupRule_Ingress_ipv6 (95.06s)
--- PASS: TestAccEC2SecurityGroupRule_selfReference (95.44s)
--- PASS: TestAccEC2SecurityGroupRule_ingressDescription (86.25s)
--- PASS: TestAccEC2SecurityGroupRule_egressDescription (80.90s)
--- PASS: TestAccEC2SecurityGroupRule_prefixListEgress (105.06s)
--- PASS: TestAccEC2SecurityGroupRule_PartialMatching_basic (120.14s)
--- PASS: TestAccEC2DefaultSecurityGroup_VPC_basic (135.39s)
--- PASS: TestAccEC2SecurityGroupRule_MultipleRuleSearching_allProtocolCrash (81.93s)
--- PASS: TestAccEC2SecurityGroup_allowAll (95.14s)
--- PASS: TestAccEC2SecurityGroup_basic (94.43s)
--- PASS: TestAccEC2SecurityGroup_sourceSecurityGroup (96.81s)
--- PASS: TestAccEC2SecurityGroup_ipRangesWithSameRules (96.43s)
--- PASS: TestAccEC2SecurityGroup_ipRangeAndSecurityGroupWithSameRules (97.00s)
--- PASS: TestAccEC2SecurityGroup_ipv6 (97.20s)
--- PASS: TestAccEC2SecurityGroup_ruleGathering (109.50s)
--- PASS: TestAccEC2SecurityGroup_Name_generated (94.21s)
--- PASS: TestAccEC2SecurityGroup_Name_terraformPrefix (95.01s)
--- PASS: TestAccEC2SecurityGroupRule_IngressDescription_updates (152.75s)
--- SKIP: TestAccEC2SecurityGroup_defaultEgressClassic (2.48s)
--- PASS: TestAccEC2SecurityGroupRule_EgressDescription_updates (151.02s)
--- PASS: TestAccEC2SecurityGroupRule_race (238.18s)
--- PASS: TestAccEC2SecurityGroupRule_Description_allPorts (152.08s)
--- PASS: TestAccEC2SecurityGroupRule_DescriptionAllPorts_nonZeroPorts (151.71s)
--- PASS: TestAccEC2SecurityGroup_namePrefix (89.12s)
--- PASS: TestAccEC2SecurityGroup_NamePrefix_terraformPrefix (85.36s)
--- SKIP: TestAccEC2SecurityGroup_ingressWithCIDRAndSGsClassic (2.32s)
--- PASS: TestAccEC2SecurityGroup_invalidCIDRBlock (35.42s)
--- PASS: TestAccEC2SecurityGroup_self (86.41s)
--- PASS: TestAccEC2SecurityGroup_vpcProtoNumIngress (85.55s)
--- PASS: TestAccEC2SecurityGroup_vpcNegOneIngress (86.68s)
--- PASS: TestAccEC2SecurityGroup_vpc (88.51s)
--- PASS: TestAccEC2SecurityGroup_multiIngress (88.28s)
--- PASS: TestAccEC2SecurityGroup_ingressMode (211.57s)
--- PASS: TestAccEC2SecurityGroup_egressMode (212.60s)
--- PASS: TestAccEC2SecurityGroup_defaultEgressVPC (82.65s)
--- PASS: TestAccEC2SecurityGroup_drift (80.67s)
--- PASS: TestAccEC2SecurityGroupRule_multiDescription (232.49s)
--- PASS: TestAccEC2SecurityGroup_driftComplex (85.32s)
--- PASS: TestAccEC2SecurityGroup_cidrAndGroups (85.43s)
--- PASS: TestAccEC2SecurityGroup_ingressWithCIDRAndSGsVPC (81.27s)
--- PASS: TestAccEC2SecurityGroup_change (137.77s)
--- PASS: TestAccEC2SecurityGroup_failWithDiffMismatch (68.49s)
--- PASS: TestAccEC2SecurityGroup_ipv4AndIPv6Egress (76.82s)
--- PASS: TestAccEC2SecurityGroup_egressWithPrefixList (85.85s)
--- PASS: TestAccEC2SecurityGroup_ingressWithPrefixList (86.12s)
--- PASS: TestAccEC2SecurityGroupsDataSource_tag (50.79s)
--- PASS: TestAccEC2SecurityGroupsDataSource_filter (51.80s)
--- PASS: TestAccEC2SecurityGroup_ruleDescription (163.34s)
--- PASS: TestAccEC2SecurityGroup_tags (145.77s)
--- PASS: TestAccEC2SecurityGroup_ruleLimitCIDRBlockExceededAppend (107.30s)
--- PASS: TestAccEC2SecurityGroup_rulesDropOnError (79.60s)
--- PASS: TestAccEC2SecurityGroup_ruleLimitExceededAppend (120.76s)
--- PASS: TestAccEC2SecurityGroup_ruleLimitExceededPrepend (109.70s)
--- PASS: TestAccEC2SecurityGroup_ruleLimitExceededAllNew (97.70s)
--- PASS: TestAccEC2SecurityGroup_forceRevokeRulesFalse (1034.67s)
--- PASS: TestAccEC2SecurityGroup_forceRevokeRulesTrue (1057.82s)

--- PASS: TestAccELBLoadBalancer_generatesNameForZeroValue (41.39s)
--- PASS: TestAccELBLoadBalancer_healthCheck (72.06s)
--- PASS: TestAccELBLoadBalancer_availabilityZones (78.73s)
--- PASS: TestAccELBLoadBalancer_generatedName (81.78s)
--- PASS: TestAccELBLoadBalancer_timeout (97.46s)
--- PASS: TestAccELBLoadBalancer_basic (100.83s)
--- PASS: TestAccELBLoadBalancer_tags (116.84s)
--- PASS: TestAccELBLoadBalancer_disappears (123.14s)
--- PASS: TestAccELBLoadBalancer_fullCharacterRange (133.32s)
--- PASS: TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate (139.98s)
--- PASS: TestAccELBLoadBalancer_securityGroups (165.86s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_enabled (175.07s)
--- PASS: TestAccELBLoadBalancer_connectionDraining (181.25s)
--- PASS: TestAccELBLoadBalancer_Swap_subnets (181.50s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_disabled (187.16s)
--- PASS: TestAccELBLoadBalancer_listener (208.95s)
--- PASS: TestAccELBLoadBalancer_instanceAttaching (234.95s)
--- PASS: TestAccELBLoadBalancerDataSource_basic (255.27s)
--- PASS: TestAccELBLoadBalancer_namePrefix (256.26s)
```
