### PR TITLE
r/aws_accessanalyzer_analyzer: Add test sweeper

### DIFF
--- a/internal/service/accessanalyzer/analyzer.go
+++ b/internal/service/accessanalyzer/analyzer.go
@@ -169,19 +169,18 @@ func resourceAnalyzerUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAnalyzerDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).AccessAnalyzerConn
 
-	input := &accessanalyzer.DeleteAnalyzerInput{
+	log.Printf("[DEBUG] Deleting Access Analyzer Analyzer: (%s)", d.Id())
+	_, err := conn.DeleteAnalyzer(&accessanalyzer.DeleteAnalyzerInput{
 		AnalyzerName: aws.String(d.Id()),
 		ClientToken:  aws.String(resource.UniqueId()),
-	}
+	})
 
-	_, err := conn.DeleteAnalyzer(input)
-
-	if tfawserr.ErrMessageContains(err, accessanalyzer.ErrCodeResourceNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Access Analyzer Analyzer (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting Access Analyzer Analyzer (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/accessanalyzer/sweep.go
+++ b/internal/service/accessanalyzer/sweep.go
@@ -1,0 +1,65 @@
+//go:build sweep
+// +build sweep
+
+package accessanalyzer
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/accessanalyzer"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_accessanalyzer_analyzer", &resource.Sweeper{
+		Name: "aws_accessanalyzer_analyzer",
+		F:    sweepAnalyzers,
+	})
+}
+
+func sweepAnalyzers(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).AccessAnalyzerConn
+	input := &accessanalyzer.ListAnalyzersInput{}
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.ListAnalyzersPages(input, func(page *accessanalyzer.ListAnalyzersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, analyzer := range page.Analyzers {
+			r := ResourceAnalyzer()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(analyzer.Name))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Access Analyzer Analyzer sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Access Analyzer Analyzers (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Access Analyzer Analyzers (%s): %w", region, err)
+	}
+
+	return nil
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/acm"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/acmpca"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/amplify"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21649.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS=-sweep-run=aws_accessanalyzer_analyzer SWEEP=us-west-2 
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_accessanalyzer_analyzer -timeout 60m
2021/11/12 09:29:16 [DEBUG] Running Sweepers for region (us-west-2):
2021/11/12 09:29:16 [DEBUG] Running Sweeper (aws_accessanalyzer_analyzer) in region (us-west-2)
2021/11/12 09:29:16 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/12 09:29:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/11/12 09:29:17 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/11/12 09:29:18 [DEBUG] Waiting for state to become: [success]
2021/11/12 09:29:18 [DEBUG] Deleting Access Analyzer Analyzer: (tf-acc-test-8360977933789595448)
2021/11/12 09:29:18 [DEBUG] Completed Sweeper (aws_accessanalyzer_analyzer) in region (us-west-2) in 1.894390422s
2021/11/12 09:29:18 Completed Sweepers for region (us-west-2) in 1.894589185s
2021/11/12 09:29:18 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_accessanalyzer_analyzer
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	5.139s
```
