### PR TITLE
Acceptance tests: Replace `nodejs10.x` Lambda runtime with `nodejs14.x`

### DIFF
--- a/internal/service/apigatewayv2/authorizer_test.go
+++ b/internal/service/apigatewayv2/authorizer_test.go
@@ -429,7 +429,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs10.x"
+  runtime       = "nodejs14.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -578,14 +578,14 @@ func TestAccLambdaFunction_versionedUpdate(t *testing.T) {
 				PreConfig: func() {
 					timeBeforeUpdate = time.Now()
 				},
-				Config: testAccVersionedNodeJs10xRuntimeConfig(path, funcName, policyName, roleName, sgName),
+				Config: testAccVersionedNodeJs14xRuntimeConfig(path, funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(resourceName, funcName, &conf),
 					testAccCheckFunctionName(&conf, funcName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "version", versionUpdated),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "qualified_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, versionUpdated)),
-					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs10X),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs14X),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
@@ -2764,7 +2764,7 @@ resource "aws_lambda_function" "test" {
 `, layerName, funcName)
 }
 
-func testAccVersionedNodeJs10xRuntimeConfig(fileName, funcName, policyName, roleName, sgName string) string {
+func testAccVersionedNodeJs14xRuntimeConfig(fileName, funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(acctest.ConfigLambdaBase(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "test" {
   filename      = "%s"
@@ -2772,7 +2772,7 @@ resource "aws_lambda_function" "test" {
   publish       = true
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs10.x"
+  runtime       = "nodejs14.x"
 }
 `, fileName, funcName)
 }

--- a/internal/service/lambda/layer_version_test.go
+++ b/internal/service/lambda/layer_version_test.go
@@ -357,7 +357,7 @@ resource "aws_lambda_layer_version" "lambda_layer_test" {
   filename   = "test-fixtures/lambdatest.zip"
   layer_name = "%s"
 
-  compatible_runtimes = ["nodejs12.x", "nodejs10.x"]
+  compatible_runtimes = ["nodejs12.x", "nodejs14.x"]
 }
 `, layerName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21650.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/apigatewayv2 TESTARGS='-run=TestAccAPIGatewayV2Authorizer_'     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run=TestAccAPIGatewayV2Authorizer_ -timeout 180m
=== RUN   TestAccAPIGatewayV2Authorizer_basic
=== PAUSE TestAccAPIGatewayV2Authorizer_basic
=== RUN   TestAccAPIGatewayV2Authorizer_disappears
=== PAUSE TestAccAPIGatewayV2Authorizer_disappears
=== RUN   TestAccAPIGatewayV2Authorizer_credentials
=== PAUSE TestAccAPIGatewayV2Authorizer_credentials
=== RUN   TestAccAPIGatewayV2Authorizer_jwt
=== PAUSE TestAccAPIGatewayV2Authorizer_jwt
=== RUN   TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialMissingCacheTTL
=== PAUSE TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialMissingCacheTTL
=== RUN   TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialZeroCacheTTL
=== PAUSE TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialZeroCacheTTL
=== CONT  TestAccAPIGatewayV2Authorizer_basic
=== CONT  TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialMissingCacheTTL
=== CONT  TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialZeroCacheTTL
=== CONT  TestAccAPIGatewayV2Authorizer_credentials
=== CONT  TestAccAPIGatewayV2Authorizer_jwt
=== CONT  TestAccAPIGatewayV2Authorizer_disappears
--- PASS: TestAccAPIGatewayV2Authorizer_disappears (54.50s)
--- PASS: TestAccAPIGatewayV2Authorizer_jwt (79.58s)
--- PASS: TestAccAPIGatewayV2Authorizer_basic (89.01s)
--- PASS: TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialZeroCacheTTL (94.79s)
--- PASS: TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialMissingCacheTTL (102.71s)
--- PASS: TestAccAPIGatewayV2Authorizer_credentials (110.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	113.746s
% make testacc PKG_NAME=internal/service/lambda TESTARGS='-run=TestAccLambdaLayerVersion_compatibleRuntimes'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run=TestAccLambdaLayerVersion_compatibleRuntimes -timeout 180m
=== RUN   TestAccLambdaLayerVersion_compatibleRuntimes
=== PAUSE TestAccLambdaLayerVersion_compatibleRuntimes
=== CONT  TestAccLambdaLayerVersion_compatibleRuntimes
--- PASS: TestAccLambdaLayerVersion_compatibleRuntimes (17.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	20.951s
% make testacc PKG_NAME=internal/service/lambda TESTARGS='-run=TestAccLambdaFunction_versionedUpdate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run=TestAccLambdaFunction_versionedUpdate -timeout 180m
=== RUN   TestAccLambdaFunction_versionedUpdate
=== PAUSE TestAccLambdaFunction_versionedUpdate
=== CONT  TestAccLambdaFunction_versionedUpdate
--- PASS: TestAccLambdaFunction_versionedUpdate (92.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	96.918s
```
