### PR TITLE
r/neptune_cluster: support in-place update of `engine_version`

### DIFF
--- a/.changelog/21760.txt
+++ b/.changelog/21760.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_neptune_cluster: Support in-place update of `engine_version`
+```

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -140,7 +140,6 @@ func ResourceCluster() *schema.Resource {
 			"engine_version": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 
@@ -625,8 +624,14 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		req.EnableIAMDatabaseAuthentication = aws.Bool(d.Get("iam_database_authentication_enabled").(bool))
 		requestUpdate = true
 	}
+
 	if d.HasChange("deletion_protection") {
 		req.DeletionProtection = aws.Bool(d.Get("deletion_protection").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("engine_version") {
+		req.EngineVersion = aws.String(d.Get("engine_version").(string))
 		requestUpdate = true
 	}
 

--- a/internal/service/neptune/wait.go
+++ b/internal/service/neptune/wait.go
@@ -71,6 +71,7 @@ func WaitDBClusterAvailable(conn *neptune.Neptune, id string, timeout time.Durat
 			"preparing-data-migration",
 			"migrating",
 			"configuring-iam-database-auth",
+			"upgrading",
 		},
 		Target:     []string{"available"},
 		Refresh:    StatusCluster(conn, id),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21378

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccNeptuneCluster_updateEngineVersion (1659.73s)

--- PASS: TestAccNeptuneClusterParameterGroup_description (50.76s)
--- PASS: TestAccNeptuneClusterParameterGroup_basic (51.99s)
--- PASS: TestAccNeptuneClusterParameterGroup_generatedName (52.91s)
--- PASS: TestAccNeptuneClusterParameterGroup_namePrefix (53.21s)
--- PASS: TestAccNeptuneClusterParameterGroup_NamePrefix_parameter (67.93s)
--- PASS: TestAccNeptuneClusterParameterGroup_parameter (68.82s)
--- PASS: TestAccNeptuneClusterParameterGroup_tags (82.36s)
--- PASS: TestAccNeptuneCluster_basic (163.58s)
--- PASS: TestAccNeptuneCluster_namePrefix (134.36s)
--- PASS: TestAccNeptuneClusterEndpoint_Disappears_cluster (196.53s)
--- PASS: TestAccNeptuneCluster_kmsKey (158.87s)
--- PASS: TestAccNeptuneCluster_updateIAMRoles (177.79s)
--- PASS: TestAccNeptuneCluster_encrypted (164.08s)
--- PASS: TestAccNeptuneClusterEndpoint_tags (274.00s)
--- PASS: TestAccNeptuneCluster_takeFinalSnapshot (225.76s)
--- PASS: TestAccNeptuneClusterSnapshot_basic (289.31s)
--- PASS: TestAccNeptuneCluster_backupsUpdate (207.18s)
--- PASS: TestAccNeptuneClusterEndpoint_disappears (290.69s)
--- PASS: TestAccNeptuneCluster_iamAuth (128.90s)
--- PASS: TestAccNeptuneClusterEndpoint_basic (293.70s)
--- PASS: TestAccNeptuneCluster_copyTagsToSnapshot (295.20s)
--- PASS: TestAccNeptuneCluster_tags (246.26s)
--- PASS: TestAccNeptuneCluster_disappears (165.95s)
--- PASS: TestAccNeptuneCluster_updateCloudWatchLogsExports (234.08s)
--- PASS: TestAccNeptuneCluster_deleteProtection (231.15s)
--- PASS: TestAccNeptuneClusterInstance_namePrefix (745.17s)
--- PASS: TestAccNeptuneClusterInstance_withSubnetGroup (773.37s)
--- PASS: TestAccNeptuneClusterInstance_kmsKey (815.54s)
--- PASS: TestAccNeptuneClusterInstance_withAZ (952.68s)
--- PASS: TestAccNeptuneClusterInstance_generatedName (1714.76s)
--- PASS: TestAccNeptuneClusterInstance_basic (2030.08s)
```
