### PR TITLE
r/sagemaker_endpoint - add `deployment_config` argument

### DIFF
--- a/.changelog/21765.txt
+++ b/.changelog/21765.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint: Add `deployment_config` argument
+```

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -467,7 +467,7 @@ func expandEndpointDeploymentConfigAutoRollbackConfig(configured []interface{}) 
 	m := configured[0].(map[string]interface{})
 
 	c := &sagemaker.AutoRollbackConfig{
-		Alarms: expandEndpointDeploymentConfigAutoRollbackConfigAlarms(m["alarms"].([]interface{})),
+		Alarms: expandEndpointDeploymentConfigAutoRollbackConfigAlarms(m["alarms"].(*schema.Set).List()),
 	}
 
 	return c

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -37,6 +37,30 @@ func ResourceEndpoint() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"auto_rollback_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"alarms": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MinItems: 1,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"alarm_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"blue_green_update_policy": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -107,30 +131,6 @@ func ResourceEndpoint() *schema.Resource {
 													Type:         schema.TypeInt,
 													Required:     true,
 													ValidateFunc: validation.IntBetween(0, 3600),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						"auto_rollback_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"alarms": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										MinItems: 1,
-										MaxItems: 10,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"alarm_name": {
-													Type:     schema.TypeString,
-													Required: true,
 												},
 											},
 										},

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -29,7 +31,121 @@ func ResourceEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"deployment_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"blue_green_update_policy": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"maximum_execution_timeout_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(600, 14400),
+									},
+									"termination_wait_in_seconds": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntBetween(0, 3600),
+									},
+									"traffic_routing_configuration": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"canary_size": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"type": {
+																Type:         schema.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringInSlice(sagemaker.CapacitySizeType_Values(), false),
+															},
+															"value": {
+																Type:         schema.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntAtLeast(1),
+															},
+														},
+													},
+												},
+												"linear_step_size": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"type": {
+																Type:         schema.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringInSlice(sagemaker.CapacitySizeType_Values(), false),
+															},
+															"value": {
+																Type:         schema.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntAtLeast(1),
+															},
+														},
+													},
+												},
+												"type": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.TrafficRoutingConfigType_Values(), false),
+												},
+												"wait_interval_in_seconds": {
+													Type:         schema.TypeInt,
+													Required:     true,
+													ValidateFunc: validation.IntBetween(0, 3600),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"auto_rollback_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"alarms": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MinItems: 1,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"alarm_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"endpoint_config_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validName,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -37,13 +153,6 @@ func ResourceEndpoint() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validName,
 			},
-
-			"endpoint_config_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validName,
-			},
-
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -69,6 +178,10 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		EndpointConfigName: aws.String(d.Get("endpoint_config_name").(string)),
 	}
 
+	if v, ok := d.GetOk("deployment_config"); ok && (len(v.([]interface{})) > 0) {
+		createOpts.DeploymentConfig = expandEndpointDeploymentConfig(v.([]interface{}))
+	}
+
 	if len(tags) > 0 {
 		createOpts.Tags = Tags(tags.IgnoreAWS())
 	}
@@ -86,7 +199,7 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := conn.WaitUntilEndpointInService(describeInput); err != nil {
-		return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be in service: %s", name, err)
+		return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be in service: %w", name, err)
 	}
 
 	return resourceEndpointRead(d, meta)
@@ -97,34 +210,24 @@ func resourceEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	describeInput := &sagemaker.DescribeEndpointInput{
-		EndpointName: aws.String(d.Id()),
-	}
+	endpoint, err := FindEndpointByName(conn, d.Id())
 
-	endpoint, err := conn.DescribeEndpoint(describeInput)
-	if err != nil {
-		if tfawserr.ErrMessageContains(err, "ValidationException", "") {
-			log.Printf("[INFO] unable to find the SageMaker Endpoint resource and therefore it is removed from the state: %s", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
-	}
-	if aws.StringValue(endpoint.EndpointStatus) == sagemaker.EndpointStatusDeleting {
-		log.Printf("[WARN] SageMaker Endpoint (%s) is deleting, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SageMaker Endpoint (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	if err := d.Set("name", endpoint.EndpointName); err != nil {
-		return err
-	}
-	if err := d.Set("endpoint_config_name", endpoint.EndpointConfigName); err != nil {
-		return err
+	if err != nil {
+		return fmt.Errorf("error reading SageMaker Endpoint (%s): %w", d.Id(), err)
 	}
 
-	if err := d.Set("arn", endpoint.EndpointArn); err != nil {
-		return err
+	d.Set("name", endpoint.EndpointName)
+	d.Set("endpoint_config_name", endpoint.EndpointConfigName)
+	d.Set("arn", endpoint.EndpointArn)
+
+	if err := d.Set("deployment_config", flattenEndpointDeploymentConfig(endpoint.LastDeploymentConfig)); err != nil {
+		return fmt.Errorf("error setting deployment_config for SageMaker Endpoint (%s): %w", d.Id(), err)
 	}
 
 	tags, err := ListTags(conn, aws.StringValue(endpoint.EndpointArn))
@@ -153,19 +256,23 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Sagemaker Endpoint (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error updating Sagemaker Endpoint (%s) tags: %w", d.Id(), err)
 		}
 	}
 
-	if d.HasChange("endpoint_config_name") {
+	if d.HasChanges("endpoint_config_name", "deployment_config") {
 		modifyOpts := &sagemaker.UpdateEndpointInput{
 			EndpointName:       aws.String(d.Id()),
 			EndpointConfigName: aws.String(d.Get("endpoint_config_name").(string)),
 		}
 
+		if v, ok := d.GetOk("deployment_config"); ok && (len(v.([]interface{})) > 0) {
+			modifyOpts.DeploymentConfig = expandEndpointDeploymentConfig(v.([]interface{}))
+		}
+
 		log.Printf("[INFO] Modifying endpoint_config_name attribute for %s: %#v", d.Id(), modifyOpts)
 		if _, err := conn.UpdateEndpoint(modifyOpts); err != nil {
-			return fmt.Errorf("error updating SageMaker Endpoint (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating SageMaker Endpoint (%s): %w", d.Id(), err)
 		}
 
 		describeInput := &sagemaker.DescribeEndpointInput{
@@ -174,7 +281,7 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := conn.WaitUntilEndpointInService(describeInput)
 		if err != nil {
-			return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be in service: %s", d.Id(), err)
+			return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be in service: %w", d.Id(), err)
 		}
 	}
 
@@ -196,7 +303,7 @@ func resourceEndpointDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting SageMaker Endpoint (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting SageMaker Endpoint (%s): %w", d.Id(), err)
 	}
 
 	describeInput := &sagemaker.DescribeEndpointInput{
@@ -204,8 +311,210 @@ func resourceEndpointDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := conn.WaitUntilEndpointDeleted(describeInput); err != nil {
-		return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be deleted: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be deleted: %w", d.Id(), err)
 	}
 
 	return nil
+}
+
+func expandEndpointDeploymentConfig(configured []interface{}) *sagemaker.DeploymentConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]interface{})
+
+	c := &sagemaker.DeploymentConfig{
+		BlueGreenUpdatePolicy: expandEndpointDeploymentConfigBlueGreenUpdatePolicy(m["blue_green_update_policy"].([]interface{})),
+	}
+
+	if v, ok := m["auto_rollback_configuration"].([]interface{}); ok && len(v) > 0 {
+		c.AutoRollbackConfiguration = expandEndpointDeploymentConfigAutoRollbackConfig(v)
+	}
+
+	return c
+}
+
+func flattenEndpointDeploymentConfig(configured *sagemaker.DeploymentConfig) []map[string]interface{} {
+	if configured == nil {
+		return []map[string]interface{}{}
+	}
+
+	cfg := map[string]interface{}{
+		"blue_green_update_policy": flattenEndpointDeploymentConfigBlueGreenUpdatePolicy(configured.BlueGreenUpdatePolicy),
+	}
+
+	if configured.AutoRollbackConfiguration != nil {
+		cfg["auto_rollback_configuration"] = flattenEndpointDeploymentConfigAutoRollbackConfig(configured.AutoRollbackConfiguration)
+	}
+
+	return []map[string]interface{}{cfg}
+}
+
+func expandEndpointDeploymentConfigBlueGreenUpdatePolicy(configured []interface{}) *sagemaker.BlueGreenUpdatePolicy {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]interface{})
+
+	c := &sagemaker.BlueGreenUpdatePolicy{
+		TerminationWaitInSeconds:    aws.Int64(int64(m["termination_wait_in_seconds"].(int))),
+		TrafficRoutingConfiguration: expandEndpointDeploymentConfigTrafficRoutingConfiguration(m["traffic_routing_configuration"].([]interface{})),
+	}
+
+	if v, ok := m["maximum_execution_timeout_in_seconds"].(int); ok && v > 0 {
+		c.MaximumExecutionTimeoutInSeconds = aws.Int64(int64(v))
+	}
+
+	return c
+}
+
+func flattenEndpointDeploymentConfigBlueGreenUpdatePolicy(configured *sagemaker.BlueGreenUpdatePolicy) []map[string]interface{} {
+	if configured == nil {
+		return []map[string]interface{}{}
+	}
+
+	cfg := map[string]interface{}{
+		"termination_wait_in_seconds":   aws.Int64Value(configured.TerminationWaitInSeconds),
+		"traffic_routing_configuration": flattenEndpointDeploymentConfigTrafficRoutingConfiguration(configured.TrafficRoutingConfiguration),
+	}
+
+	if configured.MaximumExecutionTimeoutInSeconds != nil {
+		cfg["maximum_execution_timeout_in_seconds"] = aws.Int64Value(configured.MaximumExecutionTimeoutInSeconds)
+	}
+
+	return []map[string]interface{}{cfg}
+}
+
+func expandEndpointDeploymentConfigTrafficRoutingConfiguration(configured []interface{}) *sagemaker.TrafficRoutingConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]interface{})
+
+	c := &sagemaker.TrafficRoutingConfig{
+		Type:                  aws.String(m["type"].(string)),
+		WaitIntervalInSeconds: aws.Int64(int64(m["wait_interval_in_seconds"].(int))),
+	}
+
+	if v, ok := m["canary_size"].([]interface{}); ok && len(v) > 0 {
+		c.CanarySize = expandEndpointDeploymentConfigTrafficRoutingConfigurationCapacitySize(v)
+	}
+
+	if v, ok := m["linear_step_size"].([]interface{}); ok && len(v) > 0 {
+		c.LinearStepSize = expandEndpointDeploymentConfigTrafficRoutingConfigurationCapacitySize(v)
+	}
+
+	return c
+}
+
+func flattenEndpointDeploymentConfigTrafficRoutingConfiguration(configured *sagemaker.TrafficRoutingConfig) []map[string]interface{} {
+	if configured == nil {
+		return []map[string]interface{}{}
+	}
+
+	cfg := map[string]interface{}{
+		"type":                     aws.StringValue(configured.Type),
+		"wait_interval_in_seconds": aws.Int64Value(configured.WaitIntervalInSeconds),
+	}
+
+	if configured.CanarySize != nil {
+		cfg["canary_size"] = flattenEndpointDeploymentConfigTrafficRoutingConfigurationCapacitySize(configured.CanarySize)
+	}
+
+	if configured.LinearStepSize != nil {
+		cfg["linear_step_size"] = flattenEndpointDeploymentConfigTrafficRoutingConfigurationCapacitySize(configured.LinearStepSize)
+	}
+
+	return []map[string]interface{}{cfg}
+}
+
+func expandEndpointDeploymentConfigTrafficRoutingConfigurationCapacitySize(configured []interface{}) *sagemaker.CapacitySize {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]interface{})
+
+	c := &sagemaker.CapacitySize{
+		Type:  aws.String(m["type"].(string)),
+		Value: aws.Int64(int64(m["value"].(int))),
+	}
+
+	return c
+}
+
+func flattenEndpointDeploymentConfigTrafficRoutingConfigurationCapacitySize(configured *sagemaker.CapacitySize) []map[string]interface{} {
+	if configured == nil {
+		return []map[string]interface{}{}
+	}
+
+	cfg := map[string]interface{}{
+		"type":  aws.StringValue(configured.Type),
+		"value": aws.Int64Value(configured.Value),
+	}
+
+	return []map[string]interface{}{cfg}
+}
+
+func expandEndpointDeploymentConfigAutoRollbackConfig(configured []interface{}) *sagemaker.AutoRollbackConfig {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	m := configured[0].(map[string]interface{})
+
+	c := &sagemaker.AutoRollbackConfig{
+		Alarms: expandEndpointDeploymentConfigAutoRollbackConfigAlarms(m["alarms"].([]interface{})),
+	}
+
+	return c
+}
+
+func flattenEndpointDeploymentConfigAutoRollbackConfig(configured *sagemaker.AutoRollbackConfig) []map[string]interface{} {
+	if configured == nil {
+		return []map[string]interface{}{}
+	}
+
+	cfg := map[string]interface{}{
+		"alarms": flattenEndpointDeploymentConfigAutoRollbackConfigAlarms(configured.Alarms),
+	}
+
+	return []map[string]interface{}{cfg}
+}
+
+func expandEndpointDeploymentConfigAutoRollbackConfigAlarms(configured []interface{}) []*sagemaker.Alarm {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	alarms := make([]*sagemaker.Alarm, 0, len(configured))
+
+	for _, alarmRaw := range configured {
+
+		m := alarmRaw.(map[string]interface{})
+
+		alarm := &sagemaker.Alarm{
+			AlarmName: aws.String(m["alarm_name"].(string)),
+		}
+
+		alarms = append(alarms, alarm)
+	}
+
+	return alarms
+}
+
+func flattenEndpointDeploymentConfigAutoRollbackConfigAlarms(configured []*sagemaker.Alarm) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(configured))
+
+	for _, i := range configured {
+		l := map[string]interface{}{
+			"alarm_name": aws.StringValue(i.AlarmName),
+		}
+
+		result = append(result, l)
+	}
+	return result
 }

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -409,11 +409,11 @@ resource "aws_sagemaker_endpoint" "test" {
 
   deployment_config {
     blue_green_update_policy {
-	  traffic_routing_configuration {
+      traffic_routing_configuration {
         type                     = %[2]q
         wait_interval_in_seconds = %[3]d
-	  }
-	}
+      }
+    }
   }
 }
 `, rName, tType, wait)

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -444,22 +444,22 @@ resource "aws_sagemaker_endpoint" "test" {
 
   deployment_config {
     blue_green_update_policy {
-	  traffic_routing_configuration {
+      traffic_routing_configuration {
         type                     = "LINEAR"
         wait_interval_in_seconds = "60"
 
-		linear_step_size {
+        linear_step_size {
           type  = "INSTANCE_COUNT"
           value = 1
-		}
-	  }
-	}
+        }
+      }
+    }
 
-	auto_rollback_configuration {
+    auto_rollback_configuration {
       alarms {
         alarm_name = aws_cloudwatch_metric_alarm.test.alarm_name
-	  }
-	}
+      }
+    }
   }
 }
 `, rName)

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -335,7 +335,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
 
   production_variants {
-    initial_instance_count = 1
+    initial_instance_count = 2
     initial_variant_weight = 1
     instance_type          = "ml.t2.medium"
     model_name             = aws_sagemaker_model.test.name

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccSageMakerEndpoint_basic(t *testing.T) {
@@ -200,13 +199,9 @@ func testAccCheckSagemakerEndpointDestroy(s *terraform.State) error {
 			continue
 		}
 
-		describeInput := &sagemaker.DescribeEndpointInput{
-			EndpointName: aws.String(rs.Primary.ID),
-		}
+		_, err := tfsagemaker.FindEndpointByName(conn, rs.Primary.ID)
 
-		_, err := conn.DescribeEndpoint(describeInput)
-
-		if tfawserr.ErrMessageContains(err, "ValidationException", "") {
+		if tfresource.NotFound(err) {
 			continue
 		}
 
@@ -231,10 +226,7 @@ func testAccCheckSagemakerEndpointExists(n string) resource.TestCheckFunc {
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SageMakerConn
-		opts := &sagemaker.DescribeEndpointInput{
-			EndpointName: aws.String(rs.Primary.ID),
-		}
-		_, err := conn.DescribeEndpoint(opts)
+		_, err := tfsagemaker.FindEndpointByName(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -30,8 +30,45 @@ resource "aws_sagemaker_endpoint" "e" {
 The following arguments are supported:
 
 * `endpoint_config_name` - (Required) The name of the endpoint configuration to use.
+* `deployment_config` - (Optional) The deployment configuration for an endpoint, which contains the desired deployment strategy and rollback configurations. See [Deployment Config](#deployment-config).
 * `name` - (Optional) The name of the endpoint. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Deployment Config
+
+* `blue_green_update_policy` - (Required) Update policy for a blue/green deployment. If this update policy is specified, SageMaker creates a new fleet during the deployment while maintaining the old fleet. See [Blue Green Update Config](#blue-green-update-policy).
+* `auto_rollback_configuration` - (Optional) Automatic rollback configuration for handling endpoint deployment failures and recovery. See [Auto Rollback Configuration](#auto-rollback-configuration).
+
+#### Blue Green Update Config
+
+* `traffic_routing_configuration` - (Required) Defines the traffic routing strategy to shift traffic from the old fleet to the new fleet during an endpoint deployment. See [Traffic Routing Configuration](#traffic-routing-configuration).
+* `maximum_execution_timeout_in_seconds` - (Optional) Maximum execution timeout for the deployment. Note that the timeout value should be larger than the total waiting time specified in `termination_wait_in_seconds` and `wait_interval_in_seconds`. Valid values are between `600` and `14400`.
+* `termination_wait_in_seconds` - (Optional) Additional waiting time in seconds after the completion of an endpoint deployment before terminating the old endpoint fleet. Default is `0`. Valid values are between `0` and `3600`.
+
+##### Traffic Routing Configuration
+
+* `type` - (Required) Traffic routing strategy type. Valid values are: `ALL_AT_ONCE`, `CANARY`, and `LINEAR`.
+* `wait_interval_in_seconds` - (Required) The waiting time (in seconds) between incremental steps to turn on traffic on the new endpoint fleet. Valid values are between `0` and `3600`.
+* `canary_size` - (Optional) Batch size for the first step to turn on traffic on the new endpoint fleet. Value must be less than or equal to 50% of the variant's total instance count. See [Canary Size](#canary-size).
+* `linear_step_size` - (Optional) Batch size for each step to turn on traffic on the new endpoint fleet. Value must be 10-50% of the variant's total instance count. See [Linear Step Size](#linear-step-size).
+
+###### Canary Size
+
+* `type` - (Required) Specifies the endpoint capacity type. Valid values are: `INSTANCE_COUNT`, or `CAPACITY_PERCENT`.
+* `value` - (Required) Defines the capacity size, either as a number of instances or a capacity percentage.
+
+###### Linear Step Size
+
+* `type` - (Required) Specifies the endpoint capacity type. Valid values are: `INSTANCE_COUNT`, or `CAPACITY_PERCENT`.
+* `value` - (Required) Defines the capacity size, either as a number of instances or a capacity percentage.
+
+#### Auto Rollback Configuration
+
+* `alarms` - (Required) List of CloudWatch alarms in your account that are configured to monitor metrics on an endpoint. If any alarms are tripped during a deployment, SageMaker rolls back the deployment. See [Alarms](#alarms).
+
+##### Alarms
+
+* `alarm_name` - (Required) The name of a CloudWatch alarm in your account.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccSageMakerEndpoint_'
--- PASS: TestAccSageMakerEndpoint_deploymentConfig (268.33s)
--- PASS: TestAccSageMakerEndpoint_basic (298.94s)
--- PASS: TestAccSageMakerEndpoint_disappears (319.65s)
--- PASS: TestAccSageMakerEndpoint_tags (350.58s)
--- PASS: TestAccSageMakerEndpoint_endpointName (700.24s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_full (292.43s)
```
