### PR TITLE
aws_iot_thing_type tags support

### DIFF
--- a/.changelog/21769.txt
+++ b/.changelog/21769.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_thing_type: Add `tags` argument and `tags_all` attribute to support of resource tagging
+```

--- a/.changelog/21769.txt
+++ b/.changelog/21769.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_iot_thing_type: Add `tags` argument and `tags_all` attribute to support of resource tagging
+resource/aws_iot_thing_type: Add `tags` argument and `tags_all` attribute to support resource tagging
 ```

--- a/internal/service/iot/thing_type_test.go
+++ b/internal/service/iot/thing_type_test.go
@@ -215,8 +215,8 @@ resource "aws_iot_thing_type" "foo" {
 func testAccIoTThingTypeTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_iot_thing_type" "foo" {
-  name        = "tf_acc_iot_thing_type_%[1]s"
-  deprecated  = false
+  name       = "tf_acc_iot_thing_type_%[1]s"
+  deprecated = false
 
   tags = {
     %[2]q = %[3]q
@@ -228,8 +228,8 @@ resource "aws_iot_thing_type" "foo" {
 func testAccIoTThingTypeTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_iot_thing_type" "foo" {
-  name        = "tf_acc_iot_thing_type_%[1]s"
-  deprecated  = false
+  name       = "tf_acc_iot_thing_type_%[1]s"
+  deprecated = false
 
   tags = {
     %[2]q = %[3]q

--- a/internal/service/iot/thing_type_test.go
+++ b/internal/service/iot/thing_type_test.go
@@ -25,8 +25,11 @@ func TestAccIoTThingType_basic(t *testing.T) {
 			{
 				Config: testAccThingTypeConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists("aws_iot_thing_type.foo"),
 					resource.TestCheckResourceAttrSet("aws_iot_thing_type.foo", "arn"),
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "name", fmt.Sprintf("tf_acc_iot_thing_type_%d", rInt)),
+					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags.%", "0"),
+					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags_all.%", "0"),
 				),
 			},
 			{
@@ -50,10 +53,13 @@ func TestAccIoTThingType_full(t *testing.T) {
 			{
 				Config: testAccThingTypeConfig_full(rInt),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists("aws_iot_thing_type.foo"),
 					resource.TestCheckResourceAttrSet("aws_iot_thing_type.foo", "arn"),
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "properties.0.description", "MyDescription"),
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "properties.0.searchable_attributes.#", "3"),
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "deprecated", "true"),
+					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "tags_all.%", "1"),
 				),
 			},
 			{
@@ -69,6 +75,76 @@ func TestAccIoTThingType_full(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccIoTThingType_tags(t *testing.T) {
+	rName := sdkacctest.RandString(5)
+	resourceName := "aws_iot_thing_type.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, iot.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckThingTypeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIoTThingTypeTags1(rName, "key1", "user@example"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists("aws_iot_thing_type.foo"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "user@example"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIoTThingTypeTags2(rName, "key1", "user@example", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists("aws_iot_thing_type.foo"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "user@example"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccIoTThingTypeTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThingTypeExists("aws_iot_thing_type.foo"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckThingTypeExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IoTConn
+		input := &iot.ListThingTypesInput{}
+
+		output, err := conn.ListThingTypes(input)
+
+		if err != nil {
+			return err
+		}
+
+		for _, rule := range output.ThingTypes {
+			if aws.StringValue(rule.ThingTypeName) == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("IoT Topic Rule (%s) not found", rs.Primary.ID)
+	}
 }
 
 func testAccCheckThingTypeDestroy(s *terraform.State) error {
@@ -87,7 +163,6 @@ func testAccCheckThingTypeDestroy(s *terraform.State) error {
 		if err == nil {
 			return fmt.Errorf("Expected IoT Thing Type to be destroyed, %s found", rs.Primary.ID)
 		}
-
 	}
 
 	return nil
@@ -111,6 +186,10 @@ resource "aws_iot_thing_type" "foo" {
     description           = "MyDescription"
     searchable_attributes = ["foo", "bar", "baz"]
   }
+
+  tags = {
+    testtag = "MyTagValue"
+  }
 }
 `, rName)
 }
@@ -125,6 +204,37 @@ resource "aws_iot_thing_type" "foo" {
     description           = "MyDescription"
     searchable_attributes = ["foo", "bar", "baz"]
   }
+
+  tags = {
+    testtag = "MyTagValue"
+  }
 }
 `, rName)
+}
+
+func testAccIoTThingTypeTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_thing_type" "foo" {
+  name        = "tf_acc_iot_thing_type_%[1]s"
+  deprecated  = false
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccIoTThingTypeTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_thing_type" "foo" {
+  name        = "tf_acc_iot_thing_type_%[1]s"
+  deprecated  = false
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/iot_thing_type.html.markdown
+++ b/website/docs/r/iot_thing_type.html.markdown
@@ -25,6 +25,7 @@ resource "aws_iot_thing_type" "foo" {
 * `properties` - (Optional), Configuration block that can contain the following properties of the thing type:
     * `description` - (Optional, Forces New Resource) The description of the thing type.
     * `searchable_attributes` - (Optional, Forces New Resource) A list of searchable thing attribute names.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 
 ## Attributes Reference
@@ -32,6 +33,7 @@ resource "aws_iot_thing_type" "foo" {
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the created AWS IoT Thing Type.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_PROFILE=default make testacc TESTARGS='-run=TestAccIoTThingType' PKG_NAME=internal/service/iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run=TestAccIoTThingType -timeout 180m
=== RUN   TestAccIoTThingType_basic
=== PAUSE TestAccIoTThingType_basic
=== RUN   TestAccIoTThingType_full
=== PAUSE TestAccIoTThingType_full
=== RUN   TestAccIoTThingType_tags
=== PAUSE TestAccIoTThingType_tags
=== CONT  TestAccIoTThingType_basic
=== CONT  TestAccIoTThingType_tags
=== CONT  TestAccIoTThingType_full
--- PASS: TestAccIoTThingType_basic (344.52s)
--- PASS: TestAccIoTThingType_full (369.34s)
--- PASS: TestAccIoTThingType_tags (396.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	396.123s


...
```
