### PR TITLE
fix missing provisionSsoAdminPermissionSet() after delete a policy

### DIFF
--- a/.changelog/21773.txt
+++ b/.changelog/21773.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssoadmin_managed_policy_attachment: Fix missing call to `ProvisionPermissionSet` after detaching the managed policy
+```

--- a/internal/service/ssoadmin/managed_policy_attachment.go
+++ b/internal/service/ssoadmin/managed_policy_attachment.go
@@ -137,6 +137,11 @@ func resourceManagedPolicyAttachmentDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error detaching Managed Policy (%s) from SSO Permission Set (%s): %w", managedPolicyArn, permissionSetArn, err)
 	}
 
+	// Provision ALL accounts after delete the managed policy
+	if err := provisionSsoAdminPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/service/ssoadmin/managed_policy_attachment.go
+++ b/internal/service/ssoadmin/managed_policy_attachment.go
@@ -137,7 +137,7 @@ func resourceManagedPolicyAttachmentDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error detaching Managed Policy (%s) from SSO Permission Set (%s): %w", managedPolicyArn, permissionSetArn, err)
 	}
 
-	// Provision ALL accounts after delete the managed policy
+	// Provision ALL accounts after detaching the managed policy
 	if err := provisionSsoAdminPermissionSet(conn, permissionSetArn, instanceArn); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

fix missing provisionSsoAdminPermissionSet() after delete a policy in permissionSet otherwise  we get a message in AWS WebConsole "Requires reapplying permission set"

![image](https://user-images.githubusercontent.com/21083497/141776637-f1aab2af-eae1-41fd-a425-dea75dce1b98.png)

Note: aame API-Call is used if we add new policy to permissionSet eg. https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ssoadmin/managed_policy_attachment.go#L75-L78 - so it is save to use 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/22198