### PR TITLE
 fixed null "" issue in terraform state when health_check_id is nil

### DIFF
--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -612,7 +612,10 @@ func resourceRecordRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("set_identifier", record.SetIdentifier)
-	d.Set("health_check_id", record.HealthCheckId)
+
+	if record.HealthCheckId != nil {
+		d.Set("health_check_id", record.HealthCheckId)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

when health_check_id is nil no update for field health_check_id  in statefile otherwise we get missleading information that the resource record was changed outside terraform 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21774
