### PR TITLE
resource/aws_autoscaling_group: Fix autoscaling groups stuck in `pending` instance refresh

### DIFF
--- a/.changelog/21777.txt
+++ b/.changelog/21777.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_group: Fix pending state in instance refresh
+```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -2217,8 +2217,7 @@ func expandAutoScalingGroupInstanceRefreshPreferences(l []interface{}) *autoscal
 		}
 	}
 
-	if v, ok := m["checkpoint_percentages"]; ok {
-		l := v.([]interface{})
+	if l, ok := m["checkpoint_percentages"].([]interface{}); ok && len(l) > 0 {
 		p := make([]*int64, len(l))
 		for i, v := range l {
 			p[i] = aws.Int64(int64(v.(int)))

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -974,6 +974,19 @@ func TestAccAutoScalingGroup_InstanceRefresh_basic(t *testing.T) {
 				},
 			},
 			{
+				Config: testAccGroupConfig_InstanceRefresh_MinHealthyPercentage(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.strategy", "Rolling"),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.preferences.0.instance_warmup", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.preferences.0.min_healthy_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.preferences.0.checkpoint_delay", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_refresh.0.preferences.0.checkpoint_percentages.#", "0"),
+				),
+			},
+			{
 				Config: testAccGroupConfig_InstanceRefresh_Full(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupExists(resourceName, &group),
@@ -4474,6 +4487,49 @@ resource "aws_launch_configuration" "test" {
 `
 }
 
+func testAccGroupConfig_InstanceRefresh_MinHealthyPercentage() string {
+	return `
+resource "aws_autoscaling_group" "test" {
+  availability_zones   = [data.aws_availability_zones.current.names[0]]
+  max_size             = 2
+  min_size             = 1
+  desired_capacity     = 1
+  launch_configuration = aws_launch_configuration.test.name
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 0
+    }
+  }
+}
+
+data "aws_ami" "test" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+data "aws_availability_zones" "current" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_launch_configuration" "test" {
+  image_id      = data.aws_ami.test.id
+  instance_type = "t3.nano"
+}
+`
+}
+
 func testAccGroupConfig_InstanceRefresh_Full() string {
 	return `
 resource "aws_autoscaling_group" "test" {
@@ -4965,6 +5021,27 @@ func TestCreateAutoScalingGroupInstanceRefreshInput(t *testing.T) {
 					},
 					InstanceWarmup:       nil,
 					MinHealthyPercentage: nil,
+				},
+			},
+		},
+		{
+			name: "checkpoint_percentages empty",
+			input: []interface{}{map[string]interface{}{
+				"strategy": "Rolling",
+				"preferences": []interface{}{
+					map[string]interface{}{
+						"checkpoint_percentages": []interface{}{},
+					},
+				},
+			}},
+			expected: &autoscaling.StartInstanceRefreshInput{
+				AutoScalingGroupName: aws.String(asgName),
+				Strategy:             aws.String("Rolling"),
+				Preferences: &autoscaling.RefreshPreferences{
+					CheckpointDelay:       nil,
+					CheckpointPercentages: nil,
+					InstanceWarmup:        nil,
+					MinHealthyPercentage:  nil,
 				},
 			},
 		},


### PR DESCRIPTION
When an instance refresh is triggered, an empty `checkpoint_percentages` array is sent, causing the refresh to hang.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21656

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAutoScalingGroup_' PKG_NAME=internal/service/autoscaling

--- PASS: TestAccAutoScalingGroup_Name_generated (82.71s)
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (92.82s)
--- PASS: TestAccAutoScalingGroup_namePrefix (98.25s)
--- PASS: TestAccAutoScalingGroup_withMetrics (135.95s)
--- PASS: TestAccAutoScalingGroup_vpcUpdates (152.26s)
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (164.74s)
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (184.06s)
--- PASS: TestAccAutoScalingGroup_classicVPCZoneIdentifier (60.14s)
--- PASS: TestAccAutoScalingGroup_enablingMetrics (205.51s)
--- PASS: TestAccAutoScalingGroup_ALB_targetGroups (226.85s)
--- PASS: TestAccAutoScalingGroup_launchTemplate (83.09s)
--- PASS: TestAccAutoScalingGroup_terminationPolicies (227.02s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_iamInstanceProfile (91.73s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (84.62s)
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (94.62s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (82.09s)
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (316.11s)
--- PASS: TestAccAutoScalingGroup_targetGroupARNs (247.27s)
--- PASS: TestAccAutoScalingGroup_tags (324.58s)
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (255.66s)
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (340.38s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (252.40s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (125.79s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (68.93s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (123.95s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (285.23s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (292.85s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (236.38s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (81.55s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (67.28s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (183.85s)
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (417.13s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (125.47s)
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (69.82s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (102.93s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (120.79s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (107.33s)
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (393.42s)
--- PASS: TestAccAutoScalingGroup_basic (560.43s)
--- PASS: TestAccAutoScalingGroup_loadBalancers (385.28s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (235.15s)
--- PASS: TestAccAutoScalingGroup_warmPool (508.48s)
```
