### PR TITLE
r/aws_cloudfront_cache_policy: Fix support for 0 values of `default_ttl`, `max_ttl` and `min_ttl`

### DIFF
--- a/.changelog/21793.txt
+++ b/.changelog/21793.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_cache_policy: Fix 0 values for `default_ttl`, `max_ttl` and `min_ttl` arguments
+```

--- a/internal/service/cloudfront/cache_policy.go
+++ b/internal/service/cloudfront/cache_policy.go
@@ -161,20 +161,14 @@ func resourceCachePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	apiObject := &cloudfront.CachePolicyConfig{
-		MinTTL: aws.Int64(int64(d.Get("min_ttl").(int))),
-		Name:   aws.String(name),
+		DefaultTTL: aws.Int64(int64(d.Get("default_ttl").(int))),
+		MaxTTL:     aws.Int64(int64(d.Get("max_ttl").(int))),
+		MinTTL:     aws.Int64(int64(d.Get("min_ttl").(int))),
+		Name:       aws.String(name),
 	}
 
 	if v, ok := d.GetOk("comment"); ok {
 		apiObject.Comment = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("default_ttl"); ok {
-		apiObject.DefaultTTL = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := d.GetOk("max_ttl"); ok {
-		apiObject.MaxTTL = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -238,20 +232,14 @@ func resourceCachePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	// "When you update a cache policy configuration, all the fields are updated with the values provided in the request. You cannot update some fields independent of others."
 	//
 	apiObject := &cloudfront.CachePolicyConfig{
-		MinTTL: aws.Int64(int64(d.Get("min_ttl").(int))),
-		Name:   aws.String(d.Get("name").(string)),
+		DefaultTTL: aws.Int64(int64(d.Get("default_ttl").(int))),
+		MaxTTL:     aws.Int64(int64(d.Get("max_ttl").(int))),
+		MinTTL:     aws.Int64(int64(d.Get("min_ttl").(int))),
+		Name:       aws.String(d.Get("name").(string)),
 	}
 
 	if v, ok := d.GetOk("comment"); ok {
 		apiObject.Comment = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("default_ttl"); ok {
-		apiObject.DefaultTTL = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := d.GetOk("max_ttl"); ok {
-		apiObject.MaxTTL = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21788.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/cloudfront TESTARGS='-run=TestAccCloudFrontCachePolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run=TestAccCloudFrontCachePolicy_ -timeout 180m
=== RUN   TestAccCloudFrontCachePolicy_basic
=== PAUSE TestAccCloudFrontCachePolicy_basic
=== RUN   TestAccCloudFrontCachePolicy_disappears
=== PAUSE TestAccCloudFrontCachePolicy_disappears
=== RUN   TestAccCloudFrontCachePolicy_Items
=== PAUSE TestAccCloudFrontCachePolicy_Items
=== RUN   TestAccCloudFrontCachePolicy_ZeroTTLs
=== PAUSE TestAccCloudFrontCachePolicy_ZeroTTLs
=== CONT  TestAccCloudFrontCachePolicy_basic
=== CONT  TestAccCloudFrontCachePolicy_ZeroTTLs
=== CONT  TestAccCloudFrontCachePolicy_Items
=== CONT  TestAccCloudFrontCachePolicy_disappears
--- PASS: TestAccCloudFrontCachePolicy_disappears (11.20s)
--- PASS: TestAccCloudFrontCachePolicy_ZeroTTLs (15.62s)
--- PASS: TestAccCloudFrontCachePolicy_basic (15.67s)
--- PASS: TestAccCloudFrontCachePolicy_Items (22.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	26.090s
```
