### PR TITLE
r/aws_internet_gateway: Allow `available` as a pending state during gateway detach

### DIFF
--- a/.changelog/21794.txt
+++ b/.changelog/21794.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_internet_gateway: Allow `available` as a *pending* state during gateway detach
+```

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -714,7 +714,7 @@ func WaitInternetGatewayAttached(conn *ec2.EC2, internetGatewayID, vpcID string,
 
 func WaitInternetGatewayDetached(conn *ec2.EC2, internetGatewayID, vpcID string, timeout time.Duration) (*ec2.InternetGatewayAttachment, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.AttachmentStatusDetaching},
+		Pending: []string{InternetGatewayAttachmentStateAvailable, ec2.AttachmentStatusDetaching},
 		Target:  []string{},
 		Timeout: timeout,
 		Refresh: StatusInternetGatewayAttachmentState(conn, internetGatewayID, vpcID),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21792.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/ec2 TESTARGS='-run=TestAccEC2InternetGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run=TestAccEC2InternetGateway_ -timeout 180m
=== RUN   TestAccEC2InternetGateway_basic
=== PAUSE TestAccEC2InternetGateway_basic
=== RUN   TestAccEC2InternetGateway_disappears
=== PAUSE TestAccEC2InternetGateway_disappears
=== RUN   TestAccEC2InternetGateway_Attachment
=== PAUSE TestAccEC2InternetGateway_Attachment
=== RUN   TestAccEC2InternetGateway_Tags
=== PAUSE TestAccEC2InternetGateway_Tags
=== CONT  TestAccEC2InternetGateway_basic
=== CONT  TestAccEC2InternetGateway_Tags
=== CONT  TestAccEC2InternetGateway_Attachment
=== CONT  TestAccEC2InternetGateway_disappears
--- PASS: TestAccEC2InternetGateway_disappears (12.10s)
--- PASS: TestAccEC2InternetGateway_basic (16.27s)
--- PASS: TestAccEC2InternetGateway_Tags (34.96s)
--- PASS: TestAccEC2InternetGateway_Attachment (45.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	48.975s
```
