### PR TITLE
To ensure PSK changes are in SYnc with the AWS API

### DIFF
--- a/internal/service/ec2/vpn_connection.go
+++ b/internal/service/ec2/vpn_connection.go
@@ -1574,7 +1574,17 @@ func modifyVpnTunnels(d *schema.ResourceData, conn *ec2.EC2) error {
 		tun2Changed = true
 		options[1].StartupAction = aws.String(d.Get("tunnel2_startup_action").(string))
 	}
-
+	
+	if d.HasChange("tunnel1_preshared_key") {
+		tun1Changed = true
+		options[0].PreSharedKey = aws.String(d.Get("tunnel1_preshared_key").(string))
+	}
+	
+	if d.HasChange("tunnel2_preshared_key") {
+		tun2Changed = true
+		options[1].PreSharedKey = aws.String(d.Get("tunnel2_preshared_key").(string))
+	}
+	
 	if tun1Changed {
 		if err := modifyVpnTunnelOptions(conn, d.Get("vgw_telemetry").(*schema.Set), vpnConnectionID, vgwTelemetryTun1Index, options[0]); err != nil {
 			return err


### PR DESCRIPTION
PSK keys when updated result in a drop & create for VPN connections. This is out of Sync with the Actual AWS API and hence making changes to be in Sync with the AWS API behavior.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
