### PR TITLE
aws_route53_resolver_dnssec_config - increase config create/delete timeouts to 10 minutes

### DIFF
--- a/.changelog/21797.txt
+++ b/.changelog/21797.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_resolver_dnssec_config: Increase resource creation and deletion timeouts to 10 minutes
+```

--- a/internal/service/route53resolver/wait.go
+++ b/internal/service/route53resolver/wait.go
@@ -23,10 +23,10 @@ const (
 	QueryLogConfigDeletedTimeout = 5 * time.Minute
 
 	// Maximum amount of time to wait for a DnssecConfig to return ENABLED
-	DNSSECConfigCreatedTimeout = 5 * time.Minute
+	DNSSECConfigCreatedTimeout = 10 * time.Minute
 
 	// Maximum amount of time to wait for a DnssecConfig to return DISABLED
-	DNSSECConfigDeletedTimeout = 5 * time.Minute
+	DNSSECConfigDeletedTimeout = 10 * time.Minute
 
 	// Maximum amount of time to wait for a FirewallDomainList to be updated
 	FirewallDomainListUpdatedTimeout = 5 * time.Minute


### PR DESCRIPTION
DNSSEC config validation status takes longer than 5 minutes on initial creation

examples:
`ENABLING` exceeding 5 minutes
```
aws_route53_resolver_dnssec_config.main: Still creating... [4m40s elapsed]
aws_route53_resolver_dnssec_config.main: Still creating... [4m50s elapsed]
aws_route53_resolver_dnssec_config.main: Still creating... [5m0s elapsed]
╷
│ Error: timeout while waiting for state to become 'ENABLED' (last state: 'ENABLING', timeout: 5m0s)
│ 
│   with aws_route53_resolver_dnssec_config.main,
│   on network.tf line 16, in resource "aws_route53_resolver_dnssec_config" "main":
│   16: resource "aws_route53_resolver_dnssec_config" "main" {
│ 
```

`DISABLING` exceeding 5 minutes (due to the taint applied to the resource since creation exceeded initial timeout)
```
aws_route53_resolver_dnssec_config.main: Still destroying... [id=rdsc-5463558bd171395b, 4m40s elapsed]
aws_route53_resolver_dnssec_config.main: Still destroying... [id=rdsc-5463558bd171395b, 4m50s elapsed]
aws_route53_resolver_dnssec_config.main: Still destroying... [id=rdsc-5463558bd171395b, 5m0s elapsed]
╷
│ Error: error waiting for Route 53 Resolver DNSSEC config (rdsc-5463558bd171395b) to be disabled: timeout while waiting for state to become 'DISABLED' (last state: 'DISABLING', timeout: 5m0s)
│ 

```
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20732
