### PR TITLE
Add output S3 region to AWS SSM since it is now a supported parameter.

### DIFF
--- a/.changelog/21803.txt
+++ b/.changelog/21803.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ssm_association: Add `s3_region` argument to `output_location` configuration block
+```

--- a/internal/service/ssm/association.go
+++ b/internal/service/ssm/association.go
@@ -91,8 +91,9 @@ func ResourceAssociation() *schema.Resource {
 							Optional: true,
 						},
 						"s3_region": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(3, 20),
 						},
 					},
 				},
@@ -364,8 +365,8 @@ func expandSSMAssociationOutputLocation(config []interface{}) *ssm.InstanceAssoc
 		S3OutputLocation.OutputS3KeyPrefix = aws.String(v.(string))
 	}
 
-	if v, ok := locationConfig["s3_region"]; ok {
-		S3OutputLocation.OutputS3Region = aws.String(v.(string))
+	if v, ok := locationConfig["s3_region"].(string); ok && v != "" {
+		S3OutputLocation.OutputS3Region = aws.String(v)
 	}
 
 	return &ssm.InstanceAssociationOutputLocation{

--- a/internal/service/ssm/association.go
+++ b/internal/service/ssm/association.go
@@ -90,6 +90,10 @@ func ResourceAssociation() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"s3_region": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -360,6 +364,10 @@ func expandSSMAssociationOutputLocation(config []interface{}) *ssm.InstanceAssoc
 		S3OutputLocation.OutputS3KeyPrefix = aws.String(v.(string))
 	}
 
+	if v, ok := locationConfig["s3_region"]; ok {
+		S3OutputLocation.OutputS3Region = aws.String(v.(string))
+	}
+
 	return &ssm.InstanceAssociationOutputLocation{
 		S3Location: S3OutputLocation,
 	}
@@ -377,6 +385,10 @@ func flattenAssociationOutoutLocation(location *ssm.InstanceAssociationOutputLoc
 
 	if location.S3Location.OutputS3KeyPrefix != nil {
 		item["s3_key_prefix"] = *location.S3Location.OutputS3KeyPrefix
+	}
+
+	if location.S3Location.OutputS3Region != nil {
+		item["s3_region"] = *location.S3Location.OutputS3Region
 	}
 
 	result = append(result, item)

--- a/internal/service/ssm/association_test.go
+++ b/internal/service/ssm/association_test.go
@@ -331,6 +331,8 @@ func TestAccSSMAssociation_withOutputLocation(t *testing.T) {
 						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-%s", name)),
 					resource.TestCheckResourceAttr(
 						resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
+					resource.TestCheckResourceAttr(
+						resourceName, "output_location.0.s3_region", "us-east-1"),
 				),
 			},
 			{
@@ -346,6 +348,8 @@ func TestAccSSMAssociation_withOutputLocation(t *testing.T) {
 						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
 					resource.TestCheckResourceAttr(
 						resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
+					resource.TestCheckResourceAttr(
+						resourceName, "output_location.0.s3_region", "us-east-2"),
 				),
 			},
 			{
@@ -356,6 +360,8 @@ func TestAccSSMAssociation_withOutputLocation(t *testing.T) {
 						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
 					resource.TestCheckResourceAttr(
 						resourceName, "output_location.0.s3_key_prefix", "UpdatedAssociation"),
+					resource.TestCheckResourceAttr(
+						resourceName, "output_location.0.s3_region", "UpdatedAssociation"),
 				),
 			},
 		},
@@ -1077,6 +1083,7 @@ func testAccAssociationBasicWithOutPutLocationConfig(rName string) string {
 resource "aws_s3_bucket" "output_location" {
   bucket        = "tf-acc-test-ssmoutput-%s"
   force_destroy = true
+  region        = "us-east-1"
 }
 
 resource "aws_ssm_document" "test" {
@@ -1116,6 +1123,7 @@ resource "aws_ssm_association" "test" {
   output_location {
     s3_bucket_name = aws_s3_bucket.output_location.id
     s3_key_prefix  = "SSMAssociation"
+    s3_region      = aws_s3_bucket.output_location.region
   }
 }
 `, rName, rName)
@@ -1126,11 +1134,13 @@ func testAccAssociationBasicWithOutPutLocationUpdateBucketNameConfig(rName strin
 resource "aws_s3_bucket" "output_location" {
   bucket        = "tf-acc-test-ssmoutput-%s"
   force_destroy = true
+  region        = "us-east-1"
 }
 
 resource "aws_s3_bucket" "output_location_updated" {
   bucket        = "tf-acc-test-ssmoutput-updated-%s"
   force_destroy = true
+  region        = "us-east-2"
 }
 
 resource "aws_ssm_document" "test" {
@@ -1170,6 +1180,7 @@ resource "aws_ssm_association" "test" {
   output_location {
     s3_bucket_name = aws_s3_bucket.output_location_updated.id
     s3_key_prefix  = "SSMAssociation"
+    s3_region      = aws_s3_bucket.output_location_updated.region
   }
 }
 `, rName, rName, rName)
@@ -1180,11 +1191,13 @@ func testAccAssociationBasicWithOutPutLocationUpdateKeyPrefixConfig(rName string
 resource "aws_s3_bucket" "output_location" {
   bucket        = "tf-acc-test-ssmoutput-%s"
   force_destroy = true
+  region        = "us-east-1"
 }
 
 resource "aws_s3_bucket" "output_location_updated" {
   bucket        = "tf-acc-test-ssmoutput-updated-%s"
   force_destroy = true
+  region        = "us-east-2"
 }
 
 resource "aws_ssm_document" "test" {
@@ -1224,6 +1237,7 @@ resource "aws_ssm_association" "test" {
   output_location {
     s3_bucket_name = aws_s3_bucket.output_location_updated.id
     s3_key_prefix  = "UpdatedAssociation"
+    s3_region      = aws_s3_bucket.output_location_updated.region
   }
 }
 `, rName, rName, rName)

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -77,6 +77,7 @@ Output Location (`output_location`) is an S3 bucket where you want to store the 
 
 * `s3_bucket_name` - (Required) The S3 bucket name.
 * `s3_key_prefix` - (Optional) The S3 bucket prefix. Results stored in the root if not configured.
+* `s3_region` - (Optional) The S3 bucket region.
 
 Targets specify what instance IDs or tags to apply the document to and has these keys:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21522

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
I'm unable to run acceptance tests from my machine at this time. I will update the PR once I run them but I also don't want to block the review of the PR.
