### PR TITLE
Add description: lb_target_group_attachment for target type alb

### DIFF
--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -63,7 +63,7 @@ resource "aws_lb_target_group_attachment" "test" {
 The following arguments are supported:
 
 * `target_group_arn` - (Required) The ARN of the target group with which to register targets
-* `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container. If the target type is ip, specify an IP address. If the target type is lambda, specify the arn of lambda.
+* `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container. If the target type is ip, specify an IP address. If the target type is lambda, specify the arn of lambda. If the target type is alb, specify the arn of alb.
 * `port` - (Optional) The port on which targets receive traffic.
 * `availability_zone` - (Optional) The Availability Zone where the IP address of the target is to be registered. If the private ip address is outside of the VPC scope, this value must be set to 'all'.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Information
Thanks to https://github.com/hashicorp/terraform-provider-aws/issues/21069, we can target an ALB.
But in [the current document of target_group_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment), there is no explanation of how to attach ALB in a target_id.


Output from acceptance testing: NA, docs
