### PR TITLE
d/aws_imagebuilder_image_recipes - new data source

### DIFF
--- a/.changelog/21814.txt
+++ b/.changelog/21814.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_imagebuilder_image_recipes
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -551,6 +551,7 @@ func Provider() *schema.Provider {
 			"aws_imagebuilder_image":                        imagebuilder.DataSourceImage(),
 			"aws_imagebuilder_image_pipeline":               imagebuilder.DataSourceImagePipeline(),
 			"aws_imagebuilder_image_recipe":                 imagebuilder.DataSourceImageRecipe(),
+			"aws_imagebuilder_image_recipes":                imagebuilder.DataSourceImageRecipes(),
 			"aws_imagebuilder_infrastructure_configuration": imagebuilder.DataSourceInfrastructureConfiguration(),
 
 			"aws_inspector_rules_packages": inspector.DataSourceRulesPackages(),

--- a/internal/service/imagebuilder/filters.go
+++ b/internal/service/imagebuilder/filters.go
@@ -1,0 +1,44 @@
+package imagebuilder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func buildFiltersDataSource(set *schema.Set) []*imagebuilder.Filter {
+	var filters []*imagebuilder.Filter
+	for _, v := range set.List() {
+		m := v.(map[string]interface{})
+		var filterValues []*string
+		for _, e := range m["values"].([]interface{}) {
+			filterValues = append(filterValues, aws.String(e.(string)))
+		}
+		filters = append(filters, &imagebuilder.Filter{
+			Name:   aws.String(m["name"].(string)),
+			Values: filterValues,
+		})
+	}
+	return filters
+}
+
+func dataSourceFiltersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+
+				"values": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}

--- a/internal/service/imagebuilder/image_recipes_data_source.go
+++ b/internal/service/imagebuilder/image_recipes_data_source.go
@@ -1,0 +1,84 @@
+package imagebuilder
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceImageRecipes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceImageRecipesRead,
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": dataSourceFiltersSchema(),
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Self", "Shared", "Amazon"}, false),
+			},
+		},
+	}
+}
+
+func dataSourceImageRecipesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ImageBuilderConn
+
+	input := &imagebuilder.ListImageRecipesInput{}
+
+	if v, ok := d.GetOk("owner"); ok {
+		input.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = buildFiltersDataSource(v.(*schema.Set))
+	}
+
+	var results []*imagebuilder.ImageRecipeSummary
+
+	err := conn.ListImageRecipesPages(input, func(page *imagebuilder.ListImageRecipesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, imageRecipeSummary := range page.ImageRecipeSummaryList {
+			if imageRecipeSummary == nil {
+				continue
+			}
+
+			results = append(results, imageRecipeSummary)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Image Builder Image Recipes: %w", err)
+	}
+
+	var arns, names []string
+
+	for _, r := range results {
+		arns = append(arns, aws.StringValue(r.Arn))
+		names = append(names, aws.StringValue(r.Name))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/imagebuilder/image_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/image_recipes_data_source_test.go
@@ -1,0 +1,143 @@
+package imagebuilder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccImageBuilderImageRecipesDataSource_owner(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceNameOwnerAmazon := "data.aws_imagebuilder_image_recipes.amazon"
+	dataSourceNameOwnerSelf := "data.aws_imagebuilder_image_recipes.self"
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageRecipesOwnerDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceNameOwnerAmazon, "arns.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceNameOwnerAmazon, "names.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceNameOwnerSelf, "arns.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceNameOwnerSelf, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceNameOwnerSelf, "arns.0", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceNameOwnerSelf, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderImageRecipesDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_imagebuilder_image_recipes.test"
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageRecipesFilterDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccImageRecipeDataSourceBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_imagebuilder_component" "test" {
+  data = yamlencode({
+    phases = [{
+      name = "build"
+      steps = [{
+        action = "ExecuteBash"
+        inputs = {
+          commands = ["echo 'hello world'"]
+        }
+        name      = "example"
+        onFailure = "Continue"
+      }]
+    }]
+    schemaVersion = 1.0
+  })
+  name     = %[1]q
+  platform = "Linux"
+  version  = "1.0.0"
+}
+`, rName)
+}
+
+func testAccImageRecipesOwnerDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccImageRecipeDataSourceBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_image_recipe" "test" {
+  component {
+    component_arn = aws_imagebuilder_component.test.arn
+  }
+
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
+}
+
+data "aws_imagebuilder_image_recipes" "amazon" {
+  owner = "Amazon"
+
+  depends_on = [
+    aws_imagebuilder_image_recipe.test
+  ]
+}
+
+data "aws_imagebuilder_image_recipes" "self" {
+  owner = "Self"
+
+  depends_on = [
+    aws_imagebuilder_image_recipe.test
+  ]
+}
+`, rName))
+}
+
+func testAccImageRecipesFilterDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccImageRecipeDataSourceBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_image_recipe" "test" {
+  component {
+    component_arn = aws_imagebuilder_component.test.arn
+  }
+
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
+}
+
+data "aws_imagebuilder_image_recipes" "test" {
+  filter {
+    name   = "name"
+	values = [aws_imagebuilder_image_recipe.test.name]
+  }
+}
+`, rName))
+}

--- a/internal/service/imagebuilder/image_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/image_recipes_data_source_test.go
@@ -136,7 +136,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
 data "aws_imagebuilder_image_recipes" "test" {
   filter {
     name   = "name"
-	values = [aws_imagebuilder_image_recipe.test.name]
+    values = [aws_imagebuilder_image_recipe.test.name]
   }
 }
 `, rName))

--- a/website/docs/d/imagebuilder_image_recipes.html.markdown
+++ b/website/docs/d/imagebuilder_image_recipes.html.markdown
@@ -26,7 +26,6 @@ data "aws_imagebuilder_image_recipes" "example" {
 ## Argument Reference
 
 * `owner` - (Optional) The owner of the image recipes. Valid values are `Self`, `Shared` and `Amazon`. Defaults to `Self`.
-
 * `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
 
 ### filter Configuration Block

--- a/website/docs/d/imagebuilder_image_recipes.html.markdown
+++ b/website/docs/d/imagebuilder_image_recipes.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Image Builder"
+layout: "aws"
+page_title: "AWS: aws_imagebuilder_image_recipes"
+description: |-
+    Get information on Image Builder Image Recipes.
+---
+
+# Data Source: aws_imagebuilder_image_recipes
+
+Use this data source to get the ARNs and names of Image Builder Image Recipes matching the specified criteria.
+
+## Example Usage
+
+```terraform
+data "aws_imagebuilder_image_recipes" "example" {
+  owner = "Self"
+
+  filter {
+    name   = "platform"
+    values = ["Linux"]
+  }
+}
+```
+
+## Argument Reference
+
+* `owner` - (Optional) The owner of the image recipes. Valid values are `Self`, `Shared` and `Amazon`. Defaults to `Self`.
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListImageRecipes API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListImageRecipes.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `arns` - Set of ARNs of the matched Image Builder Image Recipes.
+* `names` - Set of names of the matched Image Builder Image Recipes.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17035.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccImageBuilderImageRecipesDataSource_owner PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipesDataSource_owner' -timeout 180m
=== RUN   TestAccImageBuilderImageRecipesDataSource_owner
=== PAUSE TestAccImageBuilderImageRecipesDataSource_owner
=== CONT  TestAccImageBuilderImageRecipesDataSource_owner
--- PASS: TestAccImageBuilderImageRecipesDataSource_owner (37.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	44.718s
```
```
make testacc TESTS=TestAccImageBuilderImageRecipesDataSource_filter PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipesDataSource_filter' -timeout 180m
=== RUN   TestAccImageBuilderImageRecipesDataSource_filter
=== PAUSE TestAccImageBuilderImageRecipesDataSource_filter
=== CONT  TestAccImageBuilderImageRecipesDataSource_filter
--- PASS: TestAccImageBuilderImageRecipesDataSource_filter (34.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	41.994s
```