### PR TITLE
Update quicksight_user documentation example to include a valid example

### DIFF
--- a/website/docs/r/quicksight_user.html.markdown
+++ b/website/docs/r/quicksight_user.html.markdown
@@ -14,7 +14,7 @@ Resource for managing QuickSight User
 
 ```terraform
 resource "aws_quicksight_user" "example" {
-  session_name     = "an-author"
+  session_name  = "an-author"
   email         = "author@example.com"
   identity_type = "IAM"
   user_role     = "AUTHOR"

--- a/website/docs/r/quicksight_user.html.markdown
+++ b/website/docs/r/quicksight_user.html.markdown
@@ -14,7 +14,7 @@ Resource for managing QuickSight User
 
 ```terraform
 resource "aws_quicksight_user" "example" {
-  user_name     = "an-author"
+  session_name     = "an-author"
   email         = "author@example.com"
   identity_type = "IAM"
   user_role     = "AUTHOR"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

As stated here:
https://github.com/hashicorp/terraform-provider-aws/issues/17406#issuecomment-969486618

And confirmed by documentation, `user_name` is not valid for a identity type of "IAM" its only for use for Quicksight managed users. This changes the example to use `session_name`