### PR TITLE
[WIP] Rename CloudWatch Log Groups KMS Key ID to ARN

### DIFF
--- a/internal/service/cloudwatchlogs/group.go
+++ b/internal/service/cloudwatchlogs/group.go
@@ -48,7 +48,7 @@ func ResourceGroup() *schema.Resource {
 				ValidateFunc: validation.IntInSlice([]int{0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653}),
 			},
 
-			"kms_key_id": {
+			"kms_key_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -86,7 +86,7 @@ func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		LogGroupName: aws.String(logGroupName),
 	}
 
-	if v, ok := d.GetOk("kms_key_id"); ok {
+	if v, ok := d.GetOk("kms_key_arn"); ok {
 		params.KmsKeyId = aws.String(v.(string))
 	}
 
@@ -141,7 +141,7 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("arn", TrimLogGroupARNWildcardSuffix(aws.StringValue(lg.Arn)))
 	d.Set("name", lg.LogGroupName)
-	d.Set("kms_key_id", lg.KmsKeyId)
+	d.Set("kms_key_arn", lg.KmsKeyArn)
 	d.Set("retention_in_days", lg.RetentionInDays)
 
 	tags, err := ListTags(conn, d.Id())
@@ -221,8 +221,8 @@ func resourceGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("kms_key_id") && !d.IsNewResource() {
-		_, newKey := d.GetChange("kms_key_id")
+	if d.HasChange("kms_key_arn") && !d.IsNewResource() {
+		_, newKey := d.GetChange("kms_key_arn")
 
 		if newKey.(string) == "" {
 			_, err := conn.DisassociateKmsKey(&cloudwatchlogs.DisassociateKmsKeyInput{

--- a/internal/service/cloudwatchlogs/group_data_source.go
+++ b/internal/service/cloudwatchlogs/group_data_source.go
@@ -29,7 +29,7 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"kms_key_id": {
+			"kms_key_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -55,7 +55,7 @@ func dataSourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", logGroup.Arn)
 	d.Set("creation_time", logGroup.CreationTime)
 	d.Set("retention_in_days", logGroup.RetentionInDays)
-	d.Set("kms_key_id", logGroup.KmsKeyId)
+	d.Set("kms_key_arn", logGroup.KmsKeyArn)
 
 	tags, err := ListTags(conn, name)
 

--- a/internal/service/cloudwatchlogs/group_data_source_test.go
+++ b/internal/service/cloudwatchlogs/group_data_source_test.go
@@ -72,7 +72,7 @@ func TestAccCloudWatchLogsGroupDataSource_kms(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -160,7 +160,7 @@ POLICY
 
 resource aws_cloudwatch_log_group "test" {
   name       = "%s"
-  kms_key_id = aws_kms_key.foo.arn
+  kms_key_arn = aws_kms_key.foo.arn
 }
 
 data aws_cloudwatch_log_group "test" {

--- a/internal/service/cloudwatchlogs/group_test.go
+++ b/internal/service/cloudwatchlogs/group_test.go
@@ -315,7 +315,7 @@ func TestAccCloudWatchLogsGroup_kmsKey(t *testing.T) {
 				Config: testAccGroupWithKMSKeyIDConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
 				),
 			},
 		},
@@ -491,7 +491,7 @@ POLICY
 
 resource "aws_cloudwatch_log_group" "test" {
   name       = "foo-bar-%d"
-  kms_key_id = aws_kms_key.foo.arn
+  kms_key_arn = aws_kms_key.foo.arn
 }
 `, rInt, rInt)
 }

--- a/website/docs/d/cloudwatch_log_group.html.markdown
+++ b/website/docs/d/cloudwatch_log_group.html.markdown
@@ -31,5 +31,5 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the Cloudwatch log group
 * `creation_time` - The creation time of the log group, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
 * `retention_in_days` - The number of days log events retained in the specified log group.
-* `kms_key_id` - The ARN of the KMS Key to use when encrypting log data.
+* `kms_key_arn` - The ARN of the KMS Key to use when encrypting log data.
 * `tags` - A map of tags to assign to the resource.

--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `retention_in_days` - (Optional) Specifies the number of days
   you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
   If you select 0, the events in the log group are always retained and never expire.
-* `kms_key_id` - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
+* `kms_key_arn` - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
 AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
 permissions for the CMK whenever the encrypted data is requested.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```

### Description
Currently at https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/#LogGroup if you want to encrypt log data it is necessary to input an ARN of a KMS CMK.

Due to this, it is necessary to rename `KmsKeyId` to `KmsKeyArn`  to comply with the purpose of this variable. 

### Observed behavior
```
// The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.
    KmsKeyId *string `locationName:"kmsKeyId" type:"string"`
```

### Expected behavior
```
// The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.
    KmsKeyArn *string `locationName:"kmsKeyArn" type:"string"`
```

This is a WIP and it's related to https://github.com/aws/aws-sdk-go/issues/4179. 

In order to test this PR it is necessary that the related issue is accepted.