### PR TITLE
Semgrep: Try removing restrictions

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -73,32 +73,8 @@ rules:
     languages: [go]
     message: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
     paths:
-      exclude:
-        - aws/cloudfront_distribution_configuration_structure.go
-        - aws/cloudfront_distribution_configuration_structure_test.go
-        - aws/config.go
-        - aws/data_source_aws_route*
-        - aws/ecs_task_definition_equivalency.go
-        - aws/opsworks_layers.go
-        - aws/resource_aws_d*.go
-        - aws/resource_aws_e*.go
-        - aws/resource_aws_g*.go
-        - aws/resource_aws_i*.go
-        - aws/resource_aws_k*.go
-        - aws/resource_aws_l*.go
-        - aws/resource_aws_main_route_table_association.go
-        - aws/resource_aws_n*.go
-        - aws/resource_aws_o*.go
-        - aws/resource_aws_r*.go
-        - aws/resource_aws_s*.go
-        - aws/resource*_test.go
-        - aws/structure.go
-        - aws/internal/generators/
-        - aws/internal/keyvaluetags/
-        - aws/internal/naming/
-        - providerlint/vendor/
       include:
-        - aws/
+        - internal/service
     patterns:
       - pattern-either:
         - pattern: '$LHS == *$RHS'


### PR DESCRIPTION
https://semgrep.dev/docs/semgrep-ci/overview/ appears to suggest that the Semgrep CI container will not flag existing rule violations. It may only apply when the rule is first created.

Try removing the restrictions from one existing rule to see if this will work with existing rules. If this works, it will help prevent new rule violations
