### PR TITLE
Add notes to quicksight_user documentation

### DIFF
--- a/website/docs/r/quicksight_user.html.markdown
+++ b/website/docs/r/quicksight_user.html.markdown
@@ -29,16 +29,11 @@ The following arguments are supported:
 * `email` - (Required) The email address of the user that you want to register.
 * `identity_type` - (Required) Amazon QuickSight supports several ways of managing the identity of users. This parameter accepts either  `IAM` or `QUICKSIGHT`.
 * `user_role` - (Required) The Amazon QuickSight role of the user. The user role can be one of the following: `READER`, `AUTHOR`, or `ADMIN`
-* `user_name` - (Optional) The Amazon QuickSight user name that you want to create for the user you are registering.
-
-~> **NOTE:** You should only use this argument when registering a user with `identity_type` set to `QUICKSIGHT`.
-
+* `user_name` - (Optional) The Amazon QuickSight user name that you want to create for the user you are registering. Only valid for registering a user with `identity_type` set to `QUICKSIGHT`.
 * `aws_account_id` - (Optional) The ID for the AWS account that the user is in. Currently, you use the ID for the AWS account that contains your Amazon QuickSight account.
 * `iam_arn` - (Optional) The ARN of the IAM user or role that you are registering with Amazon QuickSight.
 * `namespace`  - (Optional) The namespace. Currently, you should set this to `default`.
-* `session_name` - (Optional) The name of the IAM session to use when assuming roles that can embed QuickSight dashboards.
-
-~> **NOTE:** You should only use this argument when registering users with `identity_type` set to `IAM`. Additionally, if registering multiple users with the same IAM role, each user should have a unique session name.
+* `session_name` - (Optional) The name of the IAM session to use when assuming roles that can embed QuickSight dashboards. Only valid for registering users using an assumed IAM role. Additionally, if registering multiple users using the same IAM role, each user needs to have a unique session name.
 
 ## Attributes Reference
 

--- a/website/docs/r/quicksight_user.html.markdown
+++ b/website/docs/r/quicksight_user.html.markdown
@@ -30,10 +30,15 @@ The following arguments are supported:
 * `identity_type` - (Required) Amazon QuickSight supports several ways of managing the identity of users. This parameter accepts either  `IAM` or `QUICKSIGHT`.
 * `user_role` - (Required) The Amazon QuickSight role of the user. The user role can be one of the following: `READER`, `AUTHOR`, or `ADMIN`
 * `user_name` - (Optional) The Amazon QuickSight user name that you want to create for the user you are registering.
+
+~> **NOTE:** You should only use this argument when registering a user with `identity_type` set to `QUICKSIGHT`.
+
 * `aws_account_id` - (Optional) The ID for the AWS account that the user is in. Currently, you use the ID for the AWS account that contains your Amazon QuickSight account.
 * `iam_arn` - (Optional) The ARN of the IAM user or role that you are registering with Amazon QuickSight.
 * `namespace`  - (Optional) The namespace. Currently, you should set this to `default`.
 * `session_name` - (Optional) The name of the IAM session to use when assuming roles that can embed QuickSight dashboards.
+
+~> **NOTE:** You should only use this argument when registering users with `identity_type` set to `IAM`. Additionally, if registering multiple users with the same IAM role, each user should have a unique session name.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Adding some additional context around the documentation update made in https://github.com/hashicorp/terraform-provider-aws/pull/21819. When mutually exclusive arguments are provided, Terraform yields an `InvalidParameterValueException` during a `terraform apply` (no error occurs during a `terraform plan`). The error message is a generic `Invalid resource identifiers provided. Please check the documentation`, so the documentation should call out any possible invalid combinations of parameters until the provider is able to detect them.

See https://docs.aws.amazon.com/quicksight/latest/APIReference/API_RegisterUser.html to confirm the details around the notes I've added.