### PR TITLE
Increase aws_lambda_layer_version compatible_runtimes MaxItems value to 15

### DIFF
--- a/.changelog/21825.txt
+++ b/.changelog/21825.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_layer_version: Increase MaxItems for compatible_runtimes field to 15.
+```

--- a/internal/service/lambda/layer_version.go
+++ b/internal/service/lambda/layer_version.go
@@ -74,7 +74,7 @@ func ResourceLayerVersion() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				MinItems: 0,
-				MaxItems: 5,
+				MaxItems: 15,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(lambda.Runtime_Values(), false),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21742

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccLambdaLayerVersion' PKG_NAME=internal/service/lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run=TestAccLambdaLayerVersion -timeout 180m
=== RUN   TestAccLambdaLayerVersionDataSource_basic
=== PAUSE TestAccLambdaLayerVersionDataSource_basic
=== RUN   TestAccLambdaLayerVersionDataSource_version
=== PAUSE TestAccLambdaLayerVersionDataSource_version
=== RUN   TestAccLambdaLayerVersionDataSource_runtime
=== PAUSE TestAccLambdaLayerVersionDataSource_runtime
=== RUN   TestAccLambdaLayerVersionDataSource_architectures
=== PAUSE TestAccLambdaLayerVersionDataSource_architectures
=== RUN   TestAccLambdaLayerVersion_basic
=== PAUSE TestAccLambdaLayerVersion_basic
=== RUN   TestAccLambdaLayerVersion_update
=== PAUSE TestAccLambdaLayerVersion_update
=== RUN   TestAccLambdaLayerVersion_s3
=== PAUSE TestAccLambdaLayerVersion_s3
=== RUN   TestAccLambdaLayerVersion_compatibleRuntimes
=== PAUSE TestAccLambdaLayerVersion_compatibleRuntimes
=== RUN   TestAccLambdaLayerVersion_compatibleArchitectures
=== PAUSE TestAccLambdaLayerVersion_compatibleArchitectures
=== RUN   TestAccLambdaLayerVersion_description
=== PAUSE TestAccLambdaLayerVersion_description
=== RUN   TestAccLambdaLayerVersion_licenseInfo
=== PAUSE TestAccLambdaLayerVersion_licenseInfo
=== CONT  TestAccLambdaLayerVersionDataSource_basic
=== CONT  TestAccLambdaLayerVersion_compatibleRuntimes
=== CONT  TestAccLambdaLayerVersion_licenseInfo
=== CONT  TestAccLambdaLayerVersion_description
=== CONT  TestAccLambdaLayerVersion_compatibleArchitectures
=== CONT  TestAccLambdaLayerVersionDataSource_architectures
=== CONT  TestAccLambdaLayerVersionDataSource_runtime
=== CONT  TestAccLambdaLayerVersion_update
=== CONT  TestAccLambdaLayerVersionDataSource_version
=== CONT  TestAccLambdaLayerVersion_s3
=== CONT  TestAccLambdaLayerVersion_basic
--- PASS: TestAccLambdaLayerVersion_basic (32.52s)
--- PASS: TestAccLambdaLayerVersion_s3 (36.13s)
--- PASS: TestAccLambdaLayerVersion_licenseInfo (38.63s)
--- PASS: TestAccLambdaLayerVersion_compatibleRuntimes (46.97s)
--- PASS: TestAccLambdaLayerVersionDataSource_version (50.76s)
--- PASS: TestAccLambdaLayerVersion_description (65.88s)
--- PASS: TestAccLambdaLayerVersionDataSource_basic (67.01s)
--- PASS: TestAccLambdaLayerVersion_update (73.70s)
--- PASS: TestAccLambdaLayerVersionDataSource_runtime (77.94s)
--- PASS: TestAccLambdaLayerVersionDataSource_architectures (108.37s)
--- PASS: TestAccLambdaLayerVersion_compatibleArchitectures (118.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	118.415s
...
```
