### PR TITLE
New resource/aws_networkmanager_global_network

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -105,6 +105,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/mwaa"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/neptune"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/opsworks"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/outposts"
@@ -1356,6 +1357,8 @@ func Provider() *schema.Provider {
 			"aws_networkfirewall_logging_configuration": networkfirewall.ResourceLoggingConfiguration(),
 			"aws_networkfirewall_resource_policy":       networkfirewall.ResourceResourcePolicy(),
 			"aws_networkfirewall_rule_group":            networkfirewall.ResourceRuleGroup(),
+
+			"aws_networkmanager_global_network": networkmanager.ResourceGlobalNetwork(),
 
 			"aws_opsworks_application":      opsworks.ResourceApplication(),
 			"aws_opsworks_custom_layer":     opsworks.ResourceCustomLayer(),

--- a/internal/service/networkmanager/global_network.go
+++ b/internal/service/networkmanager/global_network.go
@@ -1,0 +1,278 @@
+package networkmanager
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceGlobalNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGlobalNetworkCreate,
+		Read:   resourceGlobalNetworkRead,
+		Update: resourceGlobalNetworkUpdate,
+		Delete: resourceGlobalNetworkDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Second),
+			Delete: schema.DefaultTimeout(30 * time.Second),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceGlobalNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).NetworkManagerConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &networkmanager.CreateGlobalNetworkInput{}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	log.Println("[DEBUG] Creating Global Network:", input)
+	output, err := conn.CreateGlobalNetwork(input)
+	if err != nil {
+		return fmt.Errorf("Error creating Global Network: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.GlobalNetwork.GlobalNetworkId))
+
+	if err := waitForNetworkManagerGlobalNetworkCreation(conn, d.Id()); err != nil {
+		return fmt.Errorf("Error waiting for Global Network: %w", err)
+	}
+
+	return resourceGlobalNetworkRead(d, meta)
+}
+
+func resourceGlobalNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).NetworkManagerConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	output, err := DescribeGlobalNetwork(conn, d.Id())
+
+	if tfawserr.ErrMessageContains(err, networkmanager.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] No Global Networks by ID (%s) found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error reading Global Network %s: %s", d.Id(), err)
+	}
+
+	if output == nil {
+		log.Printf("[WARN] No Global Networks by ID (%s) found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if aws.StringValue(output.State) != networkmanager.ConnectionStateAvailable {
+		log.Printf("[WARN] Global Networks (%s) delet(ing|ed), removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("arn", output.GlobalNetworkArn)
+	d.Set("description", output.Description)
+
+	tags := KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("Error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("Error setting tags_all: %w", err)
+	}
+
+	return nil
+
+}
+
+func resourceGlobalNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).NetworkManagerConn
+
+	if d.HasChanges("description") {
+		request := &networkmanager.UpdateGlobalNetworkInput{
+			GlobalNetworkId: aws.String(d.Id()),
+			Description:     aws.String(d.Get("description").(string)),
+		}
+
+		log.Println("[DEBUG] Update Global Network request:", request)
+		_, err := conn.UpdateGlobalNetwork(request)
+		if err != nil {
+			if tfawserr.ErrMessageContains(err, networkmanager.ErrCodeResourceNotFoundException, "") {
+				log.Printf("[WARN] No Global Network by ID (%s) found", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error updating Global Network %s: %s", d.Id(), err)
+		}
+
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("Error updating Global Network (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceGlobalNetworkRead(d, meta)
+
+}
+
+func resourceGlobalNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).NetworkManagerConn
+
+	input := &networkmanager.DeleteGlobalNetworkInput{
+		GlobalNetworkId: aws.String(d.Id()),
+	}
+
+	log.Println("[DEBUG] Delete Global Network request:", input)
+	_, err := conn.DeleteGlobalNetwork(input)
+	if err != nil {
+		return fmt.Errorf("Error deleting Global Network: %s", err)
+	}
+
+	if err := waitForNetworkManagerGlobalNetworkDeletion(conn, d.Id()); err != nil {
+		return fmt.Errorf("Error waiting for Global Network (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func networkManagerGlobalNetworkRefresh(conn *networkmanager.NetworkManager, globalNetworkId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		networkManagerGlobalNetwork, err := DescribeGlobalNetwork(conn, globalNetworkId)
+		if tfawserr.ErrMessageContains(err, networkmanager.ErrCodeResourceNotFoundException, "") {
+			return nil, networkmanager.GlobalNetworkStateDeleting, nil
+		}
+
+		if err != nil {
+			return nil, "", fmt.Errorf("Error reading Global Network (%s): %s", globalNetworkId, err)
+		}
+
+		if networkManagerGlobalNetwork == nil {
+			return nil, networkmanager.GlobalNetworkStateDeleting, nil
+		}
+
+		return networkManagerGlobalNetwork, aws.StringValue(networkManagerGlobalNetwork.State), nil
+	}
+}
+
+func DescribeGlobalNetwork(conn *networkmanager.NetworkManager, globalNetworkID string) (*networkmanager.GlobalNetwork, error) {
+	request := &networkmanager.DescribeGlobalNetworksInput{
+		GlobalNetworkIds: []*string{aws.String(globalNetworkID)},
+	}
+
+	log.Printf("[DEBUG] Reading Global Network (%s): %s", globalNetworkID, request)
+	for {
+		output, err := conn.DescribeGlobalNetworks(request)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if output == nil || len(output.GlobalNetworks) == 0 {
+			return nil, nil
+		}
+
+		for _, globalNetwork := range output.GlobalNetworks {
+			if globalNetwork == nil {
+				continue
+			}
+
+			if aws.StringValue(globalNetwork.GlobalNetworkId) == globalNetworkID {
+				return globalNetwork, nil
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		request.NextToken = output.NextToken
+	}
+
+	return nil, nil
+}
+
+func waitForNetworkManagerGlobalNetworkCreation(conn *networkmanager.NetworkManager, globalNetworkId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{networkmanager.GlobalNetworkStatePending},
+		Target:  []string{networkmanager.GlobalNetworkStateAvailable},
+		Refresh: networkManagerGlobalNetworkRefresh(conn, globalNetworkId),
+		Timeout: 10 * time.Minute,
+	}
+
+	log.Printf("[DEBUG] Waiting for Global Network (%s) creation", globalNetworkId)
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForNetworkManagerGlobalNetworkDeletion(conn *networkmanager.NetworkManager, globalNetworkId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:        []string{networkmanager.GlobalNetworkStateAvailable},
+		Target:         []string{networkmanager.GlobalNetworkStateDeleting},
+		Refresh:        networkManagerGlobalNetworkRefresh(conn, globalNetworkId),
+		Timeout:        10 * time.Minute,
+		NotFoundChecks: 1,
+	}
+
+	log.Printf("[DEBUG] Waiting for Global Network (%s) deletion", globalNetworkId)
+	_, err := stateConf.WaitForState()
+
+	if tfresource.NotFound(err) {
+		return nil
+	}
+
+	return err
+}

--- a/internal/service/networkmanager/global_network_test.go
+++ b/internal/service/networkmanager/global_network_test.go
@@ -1,0 +1,227 @@
+package networkmanager_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	nm "github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager"
+)
+
+func TestAccNetworkManagerGlobalNetwork_basic(t *testing.T) {
+	var globalNetwork nm.GlobalNetwork
+	resourceName := "aws_networkmanager_global_network.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckResourceGlobalNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceGlobalNetworkConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGlobalNetworkExists(resourceName, &globalNetwork),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexp.MustCompile(`global-network/global-network-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkManagerGlobalNetwork_tags(t *testing.T) {
+	var globalNetwork nm.GlobalNetwork
+	resourceName := "aws_networkmanager_global_network.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckResourceGlobalNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceGlobalNetworkTagsConfig(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGlobalNetworkExists(resourceName, &globalNetwork),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+			{
+				Config:            testAccresourceGlobalNetworkTagsConfig(rName, "key1", "value1"),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccresourceGlobalNetworkTags2Config(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGlobalNetworkExists(resourceName, &globalNetwork),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+				),
+			},
+			{
+				Config: testAccresourceGlobalNetworkConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGlobalNetworkExists(resourceName, &globalNetwork),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkManagerGlobalNetwork_description(t *testing.T) {
+	var globalNetwork nm.GlobalNetwork
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkmanager_global_network.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apigateway.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckResourceGlobalNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccresourceGlobalNetworkDescriptionConfig(rName, "description1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceGlobalNetworkExists(resourceName, &globalNetwork),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccresourceGlobalNetworkDescriptionConfig(rName, "description2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResourceGlobalNetworkExists(resourceName, &globalNetwork),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceGlobalNetworkDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_networkmanager_global_network" {
+			continue
+		}
+
+		output, err := networkmanager.DescribeGlobalNetwork(conn, rs.Primary.ID)
+
+		if tfawserr.ErrMessageContains(err, nm.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil {
+			continue
+		}
+
+		if aws.StringValue(output.State) != nm.GlobalNetworkStateDeleting {
+			return fmt.Errorf("Network Manager Global Network (%s) still exists in non-deleted (%s) state", rs.Primary.ID, aws.StringValue(output.State))
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckResourceGlobalNetworkExists(resourceName string, globalNetwork *nm.GlobalNetwork) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Network Manager Global Network ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn
+		globalNetwork, err := networkmanager.DescribeGlobalNetwork(conn, rs.Primary.ID)
+
+		if err != nil {
+			return nil
+		}
+
+		if globalNetwork == nil {
+			return fmt.Errorf("Network Manager Global Network not found")
+		}
+
+		if aws.StringValue(globalNetwork.State) != nm.GlobalNetworkStateAvailable {
+			return fmt.Errorf("Network Manager Global Netowrk (%s) exists in non-available (%s) state", rs.Primary.ID, aws.StringValue(globalNetwork.State))
+		}
+
+		return nil
+
+	}
+}
+
+func testAccresourceGlobalNetworkConfig() string {
+	return `
+resource "aws_networkmanager_global_network" "test" { }
+`
+}
+
+func testAccresourceGlobalNetworkDescriptionConfig(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_networkmanager_global_network" "test" {
+	description = %[2]q
+
+	tags = {
+		Name = %[1]q
+	}
+}
+`, rName, description)
+}
+
+func testAccresourceGlobalNetworkTagsConfig(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_networkmanager_global_network" "test" {
+	tags = {
+		Name = %[1]q
+		%[2]q = %[3]q
+	}
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccresourceGlobalNetworkTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_networkmanager_global_network" "test" {
+	tags = {
+		Name = %[1]q
+		%[2]q = %[3]q
+		%[4]q = %[5]q
+	}
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/website/docs/r/networkmanager_global_network.html.markdown
+++ b/website/docs/r/networkmanager_global_network.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "Transit Gateway Network Manager"
+layout: "aws"
+page_title: "AWS: aws_networkmanager_global_network"
+description: |-
+  Provides a global network resource.
+---
+
+# Resource: aws_networkmanager_global_network
+
+Provides a global network resource.
+
+## Example Usage
+
+```hcl
+resource "aws_networkmanager_global_network" "example" {
+  description = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Description of the Global Network.
+* `tags` - (Optional) Key-value tags for the Global Network.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Global Network Amazon Resource Name (ARN)
+
+## Import
+
+`aws_networkmanager_global_network` can be imported using the global network ID, e.g.
+
+```
+$ terraform import aws_networkmanager_global_network.example global-network-0d47f6t230mz46dy4
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run TestAccNetworkManagerGlobalNetwork -timeout 180m
=== RUN   TestAccNetworkManagerGlobalNetwork_basic
=== PAUSE TestAccNetworkManagerGlobalNetwork_basic
=== RUN   TestAccNetworkManagerGlobalNetwork_tags
=== PAUSE TestAccNetworkManagerGlobalNetwork_tags
=== RUN   TestAccNetworkManagerGlobalNetwork_description
=== PAUSE TestAccNetworkManagerGlobalNetwork_description
=== CONT  TestAccNetworkManagerGlobalNetwork_basic
=== CONT  TestAccNetworkManagerGlobalNetwork_description
=== CONT  TestAccNetworkManagerGlobalNetwork_tags
--- PASS: TestAccNetworkManagerGlobalNetwork_basic (29.90s)
--- PASS: TestAccNetworkManagerGlobalNetwork_description (39.95s)
--- PASS: TestAccNetworkManagerGlobalNetwork_tags (55.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     55.784s
...
```
