### PR TITLE
Add encryption-in-transit-supported attribute to aws_ec2_instance_type

### DIFF
--- a/.changelog/21837.txt
+++ b/.changelog/21837.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ec2_instance_type: Add `encryption_in_transit_supported` attribute
+```

--- a/internal/service/ec2/instance_type_data_source.go
+++ b/internal/service/ec2/instance_type_data_source.go
@@ -112,6 +112,11 @@ func DataSourceInstanceType() *schema.Resource {
 				Computed: true,
 			},
 
+			"encryption_in_transit_supported": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"fpgas": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -384,6 +389,7 @@ func dataSourceInstanceTypeRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.Set("efa_supported", v.NetworkInfo.EfaSupported)
 	d.Set("ena_support", v.NetworkInfo.EnaSupport)
+	d.Set("encryption_in_transit_supported", v.NetworkInfo.EncryptionInTransitSupported)
 	if v.FpgaInfo != nil {
 		fpgaList := make([]interface{}, len(v.FpgaInfo.Fpgas))
 		for i, fpg := range v.FpgaInfo.Fpgas {

--- a/internal/service/ec2/instance_type_data_source_test.go
+++ b/internal/service/ec2/instance_type_data_source_test.go
@@ -31,6 +31,7 @@ func TestAccEC2InstanceTypeDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceBasic, "ebs_optimized_support", "default"),
 					resource.TestCheckResourceAttr(resourceBasic, "efa_supported", "false"),
 					resource.TestCheckResourceAttr(resourceBasic, "ena_support", "required"),
+					resource.TestCheckResourceAttr(resourceBasic, "encryption_in_transit_supported", "false"),
 					resource.TestCheckResourceAttr(resourceBasic, "free_tier_eligible", "false"),
 					resource.TestCheckResourceAttr(resourceBasic, "hibernation_supported", "true"),
 					resource.TestCheckResourceAttr(resourceBasic, "hypervisor", "nitro"),

--- a/website/docs/d/ec2_instance_type.html.markdown
+++ b/website/docs/d/ec2_instance_type.html.markdown
@@ -51,6 +51,7 @@ In addition to the argument above, the following attributes are exported:
 * `ebs_performance_maximum_throughput` - The maximum throughput performance for an EBS-optimized instance type, in MBps.
 * `efa_supported` - Indicates whether Elastic Fabric Adapter (EFA) is supported.
 * `ena_support` - Indicates whether Elastic Network Adapter (ENA) is supported.
+* `encryption_in_transit_supported` - Indicates whether encryption in-transit between instances is supported.
 * `fpgas` - Describes the FPGA accelerator settings for the instance type.
     * `fpgas.#.count` - The count of FPGA accelerators for the instance type.
     * `fpgas.#.manufacturer` - The manufacturer of the FPGA accelerator.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21624

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2InstanceTypeDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceTypeDataSource' -timeout 180m
=== RUN   TestAccEC2InstanceTypeDataSource_basic
=== PAUSE TestAccEC2InstanceTypeDataSource_basic
=== RUN   TestAccEC2InstanceTypeDataSource_metal
=== PAUSE TestAccEC2InstanceTypeDataSource_metal
=== RUN   TestAccEC2InstanceTypeDataSource_gpu
=== PAUSE TestAccEC2InstanceTypeDataSource_gpu
=== RUN   TestAccEC2InstanceTypeDataSource_fpga
=== PAUSE TestAccEC2InstanceTypeDataSource_fpga
=== CONT  TestAccEC2InstanceTypeDataSource_basic
=== CONT  TestAccEC2InstanceTypeDataSource_gpu
=== CONT  TestAccEC2InstanceTypeDataSource_metal
=== CONT  TestAccEC2InstanceTypeDataSource_fpga
--- PASS: TestAccEC2InstanceTypeDataSource_basic (38.18s)
--- PASS: TestAccEC2InstanceTypeDataSource_fpga (39.79s)
--- PASS: TestAccEC2InstanceTypeDataSource_gpu (39.87s)
--- PASS: TestAccEC2InstanceTypeDataSource_metal (40.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        42.123s

...
```
