### PR TITLE
d/aws_cloudfront_response_headers_policy: Add missing `items` level in `custom_headers_config` block

### DIFF
--- a/.changelog/21838.txt
+++ b/.changelog/21838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_cloudfront_response_headers_policy: Correctly set `custom_headers_config` attribute
+```

--- a/internal/service/cloudfront/response_headers_policy_data_source.go
+++ b/internal/service/cloudfront/response_headers_policy_data_source.go
@@ -95,17 +95,25 @@ func DataSourceResponseHeadersPolicy() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"header": {
-							Type:     schema.TypeString,
+						"items": {
+							Type:     schema.TypeSet,
 							Computed: true,
-						},
-						"override": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"value": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"header": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"override": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/internal/service/cloudfront/response_headers_policy_data_source_test.go
+++ b/internal/service/cloudfront/response_headers_policy_data_source_test.go
@@ -39,10 +39,16 @@ func TestAccCloudFrontResponseHeadersPolicyDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSource1Name, "cors_config.0.access_control_max_age_sec", resourceName, "cors_config.0.access_control_max_age_sec"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "cors_config.0.origin_override", resourceName, "cors_config.0.origin_override"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "custom_headers_config.#", resourceName, "custom_headers_config.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "custom_headers_config.0.items.#", resourceName, "custom_headers_config.0.items.#"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "etag", resourceName, "etag"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.#", resourceName, "security_headers_config.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.content_security_policy.#", resourceName, "security_headers_config.0.content_security_policy.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.frame_options.#", resourceName, "security_headers_config.0.frame_options.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.referrer_policy.#", resourceName, "security_headers_config.0.referrer_policy.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.strict_transport_security.#", resourceName, "security_headers_config.0.strict_transport_security.#"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "security_headers_config.0.xss_protection.#", resourceName, "security_headers_config.0.xss_protection.#"),
 
 					resource.TestCheckResourceAttrPair(dataSource2Name, "comment", resourceName, "comment"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "cors_config.#", resourceName, "cors_config.#"),
@@ -58,10 +64,16 @@ func TestAccCloudFrontResponseHeadersPolicyDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSource2Name, "cors_config.0.access_control_max_age_sec", resourceName, "cors_config.0.access_control_max_age_sec"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "cors_config.0.origin_override", resourceName, "cors_config.0.origin_override"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "custom_headers_config.#", resourceName, "custom_headers_config.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "custom_headers_config.0.items.#", resourceName, "custom_headers_config.0.items.#"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "etag", resourceName, "etag"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.#", resourceName, "security_headers_config.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.content_security_policy.#", resourceName, "security_headers_config.0.content_security_policy.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.frame_options.#", resourceName, "security_headers_config.0.frame_options.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.referrer_policy.#", resourceName, "security_headers_config.0.referrer_policy.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.strict_transport_security.#", resourceName, "security_headers_config.0.strict_transport_security.#"),
+					resource.TestCheckResourceAttrPair(dataSource2Name, "security_headers_config.0.xss_protection.#", resourceName, "security_headers_config.0.xss_protection.#"),
 				),
 			},
 		},
@@ -98,6 +110,38 @@ resource "aws_cloudfront_response_headers_policy" "test" {
     }
 
     origin_override = true
+  }
+
+  custom_headers_config {
+    items {
+      header   = "X-Header2"
+      override = false
+      value    = "value2"
+    }
+
+    items {
+      header   = "X-Header1"
+      override = true
+      value    = "value1"
+    }
+  }
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "policy1"
+      override                = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = false
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 90
+      override                   = true
+      preload                    = true
+    }
   }
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21832.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG_NAME=internal/service/cloudfront TESTARGS='-run=TestAccCloudFrontResponseHeadersPolicyDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run=TestAccCloudFrontResponseHeadersPolicyDataSource_ -timeout 180m
=== RUN   TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== PAUSE TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== CONT  TestAccCloudFrontResponseHeadersPolicyDataSource_basic
--- PASS: TestAccCloudFrontResponseHeadersPolicyDataSource_basic (13.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	16.788s
```

Previously:

```console
% make testacc PKG_NAME=internal/service/cloudfront TESTARGS='-run=TestAccCloudFrontResponseHeadersPolicyDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run=TestAccCloudFrontResponseHeadersPolicyDataSource_ -timeout 180m
=== RUN   TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== PAUSE TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== CONT  TestAccCloudFrontResponseHeadersPolicyDataSource_basic
panic: Invalid address to set: []string{"custom_headers_config", "0", "items"}

goroutine 337 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc00203d500, 0x9d596e1, 0x15, 0x7d50120, 0xc00176bd58, 0x0, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/resource_data.go:230 +0x371
github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront.dataSourceResponseHeadersPolicyRead(0xc00203d500, 0x8a83960, 0xc0002a3600, 0xf5f2440, 0xf5c25e0)
	/Users/ewbankkit/altsrc/github.com/terraform-providers/terraform-provider-aws/internal/service/cloudfront/response_headers_policy_data_source.go:303 +0x475
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc00033f500, 0xac4a428, 0xc000710940, 0xc00203d500, 0x8a83960, 0xc0002a3600, 0x0, 0x0, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/resource.go:335 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc00033f500, 0xac4a428, 0xc000710940, 0xc00145b040, 0x8a83960, 0xc0002a3600, 0xc0002a3600, 0xc00145b040, 0x0, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/resource.go:558 +0xfd
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc00286e168, 0xac4a428, 0xc000710940, 0xc00145ada0, 0xc000710940, 0x100d725, 0x969ffc0)
	/Users/ewbankkit/go/pkg/mod/github.com/gdavison/terraform-plugin-sdk/v2@v2.7.1-0.20210913224932-c7c2dbd9e010/helper/schema/grpc_provider.go:1105 +0x4d6
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadDataSource(0xc000476140, 0xac4a4d0, 0xc000710940, 0xc001784a00, 0xc000476140, 0xc0019d6000, 0xc002016ba0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:247 +0xe5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler(0x9a644c0, 0xc000476140, 0xac4a4d0, 0xc0019d6000, 0xc002790240, 0x0, 0xac4a4d0, 0xc0019d6000, 0xc00140e580, 0xad)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00082c540, 0xac761b8, 0xc0022c8900, 0xc00003ac00, 0xc002870720, 0xf5af530, 0x0, 0x0, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00082c540, 0xac761b8, 0xc0022c8900, 0xc00003ac00, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc001708e40, 0xc00082c540, 0xac761b8, 0xc0022c8900, 0xc00003ac00)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	8.702s
FAIL
make: *** [testacc] Error 1
```