### PR TITLE
apprunner/service: Make `instance_role_arn` optional

### DIFF
--- a/.changelog/20149.txt
+++ b/.changelog/20149.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_service: Make instance_role_arn optional
+```

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -652,7 +652,7 @@ func expandAppRunnerServiceInstanceConfiguration(l []interface{}) *apprunner.Ins
 		result.Cpu = aws.String(v)
 	}
 
-	if v, ok := tfMap["instance_role_arn"].(string); ok && len(v) > 0 {
+	if v, ok := tfMap["instance_role_arn"].(string); ok && v != "" {
 		result.InstanceRoleArn = aws.String(v)
 	}
 

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -135,7 +135,7 @@ func ResourceService() *schema.Resource {
 						},
 						"instance_role_arn": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"memory": {
@@ -652,7 +652,7 @@ func expandAppRunnerServiceInstanceConfiguration(l []interface{}) *apprunner.Ins
 		result.Cpu = aws.String(v)
 	}
 
-	if v, ok := tfMap["instance_role_arn"].(string); ok {
+	if v, ok := tfMap["instance_role_arn"].(string); ok && len(v) > 0 {
 		result.InstanceRoleArn = aws.String(v)
 	}
 

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -46,6 +46,7 @@ func TestAccAppRunnerService_ImageRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.cpu"),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.memory"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.instance_role_arn", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "service_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_url"),
 					resource.TestCheckResourceAttr(resourceName, "source_configuration.#", "1"),
@@ -186,7 +187,36 @@ func TestAccAppRunnerService_ImageRepository_healthCheck(t *testing.T) {
 	})
 }
 
-func TestAccAppRunnerService_ImageRepository_instance(t *testing.T) {
+func TestAccAppRunnerService_ImageRepository_instance_NoInstanceRole(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_apprunner_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRunnerService_imageRepository_instanceConfiguration_NoInstanceRole(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.cpu", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.instance_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.memory", "3072"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAppRunnerService_ImageRepository_instance_Update(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_apprunner_service.test"
 	roleResourceName := "aws_iam_role.test"
@@ -232,8 +262,9 @@ func TestAccAppRunnerService_ImageRepository_instance(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.cpu"),
-					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.memory"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.cpu", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "instance_configuration.0.memory", "4096"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_configuration.0.instance_role_arn"), // The IAM Role is not unset
 				),
 			},
 		},
@@ -607,6 +638,30 @@ resource "aws_apprunner_service" "test" {
   }
 }
 `, rName))
+}
+
+func testAccAppRunnerService_imageRepository_instanceConfiguration_NoInstanceRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apprunner_service" "test" {
+  service_name = %[1]q
+
+  instance_configuration {
+    cpu               = "1 vCPU"
+    memory            = "3 GB"
+  }
+
+  source_configuration {
+    auto_deployments_enabled = false
+    image_repository {
+      image_configuration {
+        port = "80"
+      }
+      image_identifier      = "public.ecr.aws/nginx/nginx:latest"
+      image_repository_type = "ECR_PUBLIC"
+    }
+  }
+}
+`, rName)
 }
 
 func testAccAppRunnerService_imageRepository_updateInstanceConfiguration(rName string) string {

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -646,8 +646,8 @@ resource "aws_apprunner_service" "test" {
   service_name = %[1]q
 
   instance_configuration {
-    cpu               = "1 vCPU"
-    memory            = "3 GB"
+    cpu    = "1 vCPU"
+    memory = "3 GB"
   }
 
   source_configuration {

--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -105,7 +105,7 @@ The `health_check_configuration` block supports the following arguments:
 The `instance_configuration` block supports the following arguments:
 
 * `cpu` - (Optional) The number of CPU units reserved for each instance of your App Runner service represented as a String. Defaults to `1024`. Valid values: `1024|2048|(1|2) vCPU`.
-* `instance_role_arn` - (Required) The Amazon Resource Name (ARN) of an IAM role that provides permissions to your App Runner service. These are permissions that your code needs when it calls any AWS APIs.
+* `instance_role_arn` - (Optional) The Amazon Resource Name (ARN) of an IAM role that provides permissions to your App Runner service. These are permissions that your code needs when it calls any AWS APIs.
 * `memory` - (Optional) The amount of memory, in MB or GB, reserved for each instance of your App Runner service. Defaults to `2048`. Valid values: `2048|3072|4096|(2|3|4) GB`.
 
 ### Source Configuration


### PR DESCRIPTION
Copied from #20149 due to Git shenanigans.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20145

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppRunnerService_ PKG= apprunner

--- PASS: TestAccAppRunnerService_disappears (287.45s)
--- PASS: TestAccAppRunnerService_ImageRepository_runtimeEnvironmentVars (292.23s)
--- PASS: TestAccAppRunnerService_ImageRepository_basic (302.72s)
--- PASS: TestAccAppRunnerService_ImageRepository_instance_NoInstanceRole (304.72s)
--- PASS: TestAccAppRunnerService_tags (366.45s)
--- PASS: TestAccAppRunnerService_ImageRepository_autoScaling (436.97s)
--- PASS: TestAccAppRunnerService_ImageRepository_instance_Update (483.29s)
--- PASS: TestAccAppRunnerService_ImageRepository_encryption (528.42s)
--- PASS: TestAccAppRunnerService_ImageRepository_healthCheck (570.65s)
```
