### PR TITLE
Support for Redshift settings in DMS target endpoint

### DIFF
--- a/.changelog/21846.txt
+++ b/.changelog/21846.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Add `redshift_settings` configuration block
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -327,6 +327,44 @@ func ResourceEndpoint() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"redshift_settings": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_folder": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"encryption_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      s3SettingsEncryptionModeSseS3,
+							ValidateFunc: validation.StringInSlice(s3SettingsEncryptionMode_Values(), false),
+						},
+						"server_side_encryption_kms_key_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "",
+							ValidateFunc: verify.ValidARN,
+						},
+						"service_access_role_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "",
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
 			"s3_settings": {
 				Type:             schema.TypeList,
 				Optional:         true,
@@ -481,6 +519,20 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// Set connection info in top-level namespace as well
+		request.Username = aws.String(d.Get("username").(string))
+		request.Password = aws.String(d.Get("password").(string))
+		request.ServerName = aws.String(d.Get("server_name").(string))
+		request.Port = aws.Int64(int64(d.Get("port").(int)))
+		request.DatabaseName = aws.String(d.Get("database_name").(string))
+	case engineNameRedshift:
+		request.RedshiftSettings = &dms.RedshiftSettings{
+			BucketFolder:                 aws.String(d.Get("redshift_settings.0.bucket_folder").(string)),
+			BucketName:                   aws.String(d.Get("redshift_settings.0.bucket_name").(string)),
+			EncryptionMode:               aws.String(d.Get("redshift_settings.0.encryption_mode").(string)),
+			ServerSideEncryptionKmsKeyId: aws.String(d.Get("redshift_settings.0.server_side_encryption_kms_key_id").(string)),
+			ServiceAccessRoleArn:         aws.String(d.Get("redshift_settings.0.service_access_role_arn").(string)),
+		}
+
 		request.Username = aws.String(d.Get("username").(string))
 		request.Password = aws.String(d.Get("password").(string))
 		request.ServerName = aws.String(d.Get("server_name").(string))
@@ -719,6 +771,28 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 
 			hasChanges = true
 		}
+	case engineNameRedshift:
+		if d.HasChanges(
+			"username", "password", "server_name", "port", "database_name",
+			"redshift_settings.0.bucket_folder", "redshift_settings.0.bucket_name", "redshift_settings.0.encryption_mode",
+			"redshift_settings.0.server_side_encryption_kms_key_id", "redshift_settings.0.service_access_role_arn") {
+			request.RedshiftSettings = &dms.RedshiftSettings{
+				BucketFolder:                 aws.String(d.Get("redshift_settings.0.bucket_folder").(string)),
+				BucketName:                   aws.String(d.Get("redshift_settings.0.bucket_name").(string)),
+				EncryptionMode:               aws.String(d.Get("redshift_settings.0.encryption_mode").(string)),
+				ServerSideEncryptionKmsKeyId: aws.String(d.Get("redshift_settings.0.server_side_encryption_kms_key_id").(string)),
+				ServiceAccessRoleArn:         aws.String(d.Get("redshift_settings.0.service_access_role_arn").(string)),
+			}
+			request.EngineName = aws.String(engineName)
+
+			request.Username = aws.String(d.Get("username").(string))
+			request.Password = aws.String(d.Get("password").(string))
+			request.ServerName = aws.String(d.Get("server_name").(string))
+			request.Port = aws.Int64(int64(d.Get("port").(int)))
+			request.DatabaseName = aws.String(d.Get("database_name").(string))
+
+			hasChanges = true
+		}
 	case engineNameS3:
 		if d.HasChanges(
 			"s3_settings.0.service_access_role_arn", "s3_settings.0.external_table_definition",
@@ -888,6 +962,14 @@ func resourceEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) er
 		}
 		if err := d.Set("mongodb_settings", flattenDmsMongoDbSettings(endpoint.MongoDbSettings)); err != nil {
 			return fmt.Errorf("Error setting mongodb_settings for DMS: %s", err)
+		}
+	case "redshift":
+		d.Set("database_name", endpoint.DatabaseName)
+		d.Set("port", endpoint.Port)
+		d.Set("server_name", endpoint.ServerName)
+		d.Set("username", endpoint.Username)
+		if err := d.Set("redshift_settings", flattenDmsRedshiftSettings(endpoint.RedshiftSettings)); err != nil {
+			return fmt.Errorf("Error setting redshift_settings for DMS: %s", err)
 		}
 	case "s3":
 		if err := d.Set("s3_settings", flattenDmsS3Settings(endpoint.S3Settings)); err != nil {
@@ -1190,6 +1272,22 @@ func flattenDmsMongoDbSettings(settings *dms.MongoDbSettings) []map[string]inter
 		"extract_doc_id":      aws.StringValue(settings.ExtractDocId),
 		"docs_to_investigate": aws.StringValue(settings.DocsToInvestigate),
 		"auth_source":         aws.StringValue(settings.AuthSource),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenDmsRedshiftSettings(settings *dms.RedshiftSettings) []map[string]interface{} {
+	if settings == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"bucket_folder":                     aws.StringValue(settings.BucketFolder),
+		"bucket_name":                       aws.StringValue(settings.BucketName),
+		"encryption_mode":                   aws.StringValue(settings.EncryptionMode),
+		"server_side_encryption_kms_key_id": aws.StringValue(settings.ServerSideEncryptionKmsKeyId),
+		"service_access_role_arn":           aws.StringValue(settings.ServiceAccessRoleArn),
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -584,6 +584,47 @@ func TestAccDMSEndpoint_db2(t *testing.T) {
 	})
 }
 
+func TestAccDMSEndpoint_redshift(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	iamRoleResourceName := "aws_iam_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dms.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointRedshiftConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "redshift_settings.0.service_access_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.bucket_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.bucket_folder", ""),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.server_side_encryption_kms_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.encryption_mode", "SSE_S3"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			{
+				Config: dmsEndpointRedshiftConfigUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "redshift_settings.0.service_access_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.bucket_name", "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "redshift_settings.0.bucket_folder", "bucket_folder"),
+				),
+			},
+		},
+	})
+}
+
 // testAccCheckResourceAttrRegionalHostname ensures the Terraform state exactly matches a formatted DNS hostname with region and partition DNS suffix
 func testAccCheckResourceAttrRegionalHostname(resourceName, attributeName, serviceName, hostnamePrefix string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1491,4 +1532,131 @@ resource "aws_dms_endpoint" "dms_endpoint" {
   username = "tftestupdate"
 }
 `, randId)
+}
+
+func dmsEndpointRedshiftConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier  = "tftest"
+  database_name       = "tftest"
+  master_username     = "tftest"
+  master_password     = "tftestPassword1"
+  node_type           = "dc2.large"
+  cluster_type        = "single-node"
+  skip_final_snapshot = true
+}
+
+resource "aws_iam_role" "test" {
+  name_prefix = %[1]q
+
+  assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": "sts:AssumeRole",
+			"Principal": {
+				"Service": "dms.${data.aws_partition.current.dns_suffix}"
+			},
+			"Effect": "Allow"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name   = %[1]q
+  role   = aws_iam_role.test.name
+  policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = [
+      "s3:CreateBucket",
+      "s3:ListBucket",
+	  "s3:DeleteBucket",
+	  "s3:GetBucketLocation",
+	  "s3:GetObject",
+	  "s3:PutObject",
+	  "s3:DeleteObject",
+	  "s3:GetObjectVersion",
+	  "s3:GetBucketPolicy",
+	  "s3:PutBucketPolicy",
+	  "s3:DeleteBucketPolicy"
+    ]
+    resources = ["*"]
+  }
+}
+`, rName)
+}
+
+func dmsEndpointRedshiftConfig(rName string) string {
+	return acctest.ConfigCompose(dmsEndpointRedshiftConfigBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "target"
+  engine_name                 = "redshift"
+  server_name                 = "${aws_redshift_cluster.test.endpoint}"
+  port                        = "5439"
+  username                    = "tftest"
+  password                    = "tftestPassword1"
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  redshift_settings {
+    service_access_role_arn           = aws_iam_role.test.arn
+    bucket_name                       = ""
+    bucket_folder                     = ""
+	server_side_encryption_kms_key_id = ""
+	encryption_mode                   = "SSE_S3"
+  }
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+
+  depends_on = [aws_iam_role_policy.test, aws_redshift_cluster.test]
+}
+`, rName))
+}
+
+func dmsEndpointRedshiftConfigUpdate(rName string) string {
+	return acctest.ConfigCompose(dmsEndpointRedshiftConfigBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+  endpoint_id                 = "tf-test-dms-endpoint-%[1]s"
+  endpoint_type               = "target"
+  engine_name                 = "redshift"
+  server_name                 = "${aws_redshift_cluster.test.endpoint}"
+  port                        = 5439
+  username                    = "tftest"
+  password                    = "tftestPassword1"
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  redshift_settings {
+    service_access_role_arn           = aws_iam_role.test.arn
+    bucket_name                       = "bucket_name"
+    bucket_folder                     = "bucket_folder"
+	encryption_mode                   = "SSE_S3"
+  }
+
+  tags = {
+    Name   = "tf-test-dms-endpoint-%[1]s"
+    Update = "updated"
+    Add    = "added"
+  }
+
+  depends_on = [aws_iam_role_policy.test, aws_redshift_cluster.test]
+}
+`, rName))
 }

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 * `mongodb_settings` - (Optional) Configuration block with MongoDB settings. Detailed below.
 * `password` - (Optional) The password to be used to login to the endpoint database.
 * `port` - (Optional) The port used by the endpoint database.
+* `redshift_settings` - (Optional) Configuration block with Redshift settings. Detailed below.
 * `s3_settings` - (Optional) Configuration block with S3 settings. Detailed below.
 * `server_name` - (Optional) The host name of the server.
 * `service_access_role` - (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
@@ -153,6 +154,18 @@ The `s3_settings` configuration block supports the following arguments:
 * `parquet_version` - (Optional) The version of the .parquet file format. Defaults to `parquet-1-0`. Valid values are `parquet-1-0` and `parquet-2-0`.
 * `server_side_encryption_kms_key_id` - (Optional) If you set encryptionMode to `SSE_KMS`, set this parameter to the Amazon Resource Name (ARN) for the AWS KMS key.
 * `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to read from or write to the S3 Bucket.
+
+### redshift_settings Arguments
+
+-> Additional information can be found in the [Using Amazon Redshift as a Target for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Redshift.html).
+
+The `redshift_settings` configuration block supports the following arguments:
+
+* `bucket_folder` - (Optional) Custom S3 Bucket Object prefix for intermediate storage.
+* `bucket_name` - (Optional) Custom S3 Bucket name for intermediate storage.
+* `encryption_mode` - (Optional) The server-side encryption mode that you want to encrypt your intermediate .csv object files copied to S3. Defaults to `SSE_S3`. Valid values are `SSE_S3` and `SSE_KMS`.
+* `server_side_encryption_kms_key_id` - (Optional) If you set encryptionMode to `SSE_KMS`, set this parameter to the Amazon Resource Name (ARN) for the AWS KMS key.
+* `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to read from or write to the S3 Bucket for intermediate storage.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #13162

Output from acceptance testing:

```
$ make testacc TESTS=TestAccDMSEndpoint_redshift PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_redshift' -timeout 180m
=== RUN   TestAccDMSEndpoint_redshift
=== PAUSE TestAccDMSEndpoint_redshift
=== CONT  TestAccDMSEndpoint_redshift
2021/11/19 16:32:56 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:33:08 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:08 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:08 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:33:10 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:10 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:13 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:13 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:14 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:33:16 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:16 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:33:19 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:33:22 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:33:33 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:33:44 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:33:55 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:34:06 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:34:17 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:34:28 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:34:39 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:34:50 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:35:00 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:35:11 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:35:22 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:35:33 [INFO] Reading Redshift Cluster Information: tftest
2021/11/19 16:35:42 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:42 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:42 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:35:45 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:45 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:48 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:48 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:48 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:35:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:50 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:55 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:55 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:55 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:35:57 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:35:57 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:03 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:09 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:09 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:09 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:11 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:11 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:16 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:16 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:16 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:18 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:18 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:20 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:30 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:30 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:30 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:32 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:32 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:34 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:34 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:34 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:36 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:36 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:42 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:42 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:42 [INFO] AWS Auth provider used: "EnvProvider"
2021/11/19 16:36:43 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:43 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:47 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:47 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2021/11/19 16:36:48 [INFO] AWS Auth provider used: "EnvProvider"
--- PASS: TestAccDMSEndpoint_redshift (301.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        301.849s
```
