### PR TITLE
r/route_table: Increase the default timeout values

### DIFF
--- a/.changelog/21847.txt
+++ b/.changelog/21847.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route_table: The default aws_route_table timeouts are increased from 2m for create and update to 10m for create and 5m for update.
+```

--- a/internal/service/ec2/route_table.go
+++ b/internal/service/ec2/route_table.go
@@ -50,8 +50,8 @@ func ResourceRouteTable() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Minute),
-			Update: schema.DefaultTimeout(2 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21829

#21161 wrongly decreases the default aws_route_table timeouts from 

```
create = 10m
update = 5m
delete = 5m
```

to

```
create = 2m
update = 2m
delete = 5m
```

This PR basically reverts the default timeouts to their values before #21161.

Ref https://github.com/hashicorp/terraform-provider-aws/issues/21829#issuecomment-974055027

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
