### PR TITLE
New Data Source: aws_ec2_instance_types

### DIFF
--- a/.changelog/21850.txt
+++ b/.changelog/21850.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ec2_instance_types
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -431,6 +431,7 @@ func Provider() *schema.Provider {
 			"aws_ec2_instance_type_offering":                 ec2.DataSourceInstanceTypeOffering(),
 			"aws_ec2_instance_type_offerings":                ec2.DataSourceInstanceTypeOfferings(),
 			"aws_ec2_instance_type":                          ec2.DataSourceInstanceType(),
+			"aws_ec2_instance_types":                         ec2.DataSourceInstanceTypes(),
 			"aws_ec2_local_gateway_route_table":              ec2.DataSourceLocalGatewayRouteTable(),
 			"aws_ec2_local_gateway_route_tables":             ec2.DataSourceLocalGatewayRouteTables(),
 			"aws_ec2_local_gateway_virtual_interface":        ec2.DataSourceLocalGatewayVirtualInterface(),

--- a/internal/service/ec2/instance_types_data_source.go
+++ b/internal/service/ec2/instance_types_data_source.go
@@ -52,14 +52,11 @@ func dataSourceInstanceTypesRead(d *schema.ResourceData, meta interface{}) error
 	})
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Instance Type: %w", err)
-	}
-
-	if err := d.Set("instance_types", instanceTypes); err != nil {
-		return fmt.Errorf("error setting instance_types: %w", err)
+		return fmt.Errorf("error listing EC2 Instance Types: %w", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("instance_types", instanceTypes)
 
 	return nil
 }

--- a/internal/service/ec2/instance_types_data_source.go
+++ b/internal/service/ec2/instance_types_data_source.go
@@ -1,0 +1,65 @@
+package ec2
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceInstanceTypes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceInstanceTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": DataSourceFiltersSchema(),
+			"instance_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceInstanceTypesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	input := &ec2.DescribeInstanceTypesInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = BuildFiltersDataSource(v.(*schema.Set))
+	}
+
+	var instanceTypes []string
+
+	err := conn.DescribeInstanceTypesPages(input, func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, instanceType := range page.InstanceTypes {
+			if instanceType == nil {
+				continue
+			}
+
+			instanceTypes = append(instanceTypes, aws.StringValue(instanceType.InstanceType))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Instance Type: %w", err)
+	}
+
+	if err := d.Set("instance_types", instanceTypes); err != nil {
+		return fmt.Errorf("error setting instance_types: %w", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+
+	return nil
+}

--- a/internal/service/ec2/instance_types_data_source_test.go
+++ b/internal/service/ec2/instance_types_data_source_test.go
@@ -1,0 +1,86 @@
+package ec2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func TestAccEC2InstanceTypesDataSource_filter(t *testing.T) {
+	dataSourceName := "data.aws_ec2_instance_types.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckInstanceTypes(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypesFilterDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEc2InstanceTypes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEc2InstanceTypes(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", dataSourceName)
+		}
+
+		if v := rs.Primary.Attributes["instance_types.#"]; v == "0" {
+			return fmt.Errorf("expected at least one instance_types result, got none")
+		}
+
+		return nil
+	}
+}
+
+func testAccPreCheckInstanceTypes(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+	input := &ec2.DescribeInstanceTypesInput{
+		MaxResults: aws.Int64(5),
+	}
+
+	_, err := conn.DescribeInstanceTypes(input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccInstanceTypesFilterDataSourceConfig() string {
+	return `
+data "aws_ec2_instance_types" "test" {
+  filter {
+    name   = "auto-recovery-supported"
+    values = ["true"]
+  }
+
+  filter {
+	name = "network-info.encryption-in-transit-supported"
+	values = ["true"]
+  }
+
+  filter {
+	name = "instance-storage-supported"
+	values = ["true"]
+  }
+}
+`
+}

--- a/internal/service/ec2/instance_types_data_source_test.go
+++ b/internal/service/ec2/instance_types_data_source_test.go
@@ -73,13 +73,13 @@ data "aws_ec2_instance_types" "test" {
   }
 
   filter {
-	name = "network-info.encryption-in-transit-supported"
-	values = ["true"]
+    name   = "network-info.encryption-in-transit-supported"
+    values = ["true"]
   }
 
   filter {
-	name = "instance-storage-supported"
-	values = ["true"]
+    name   = "instance-storage-supported"
+    values = ["true"]
   }
 }
 `

--- a/website/docs/d/ec2_instance_types.html.markdown
+++ b/website/docs/d/ec2_instance_types.html.markdown
@@ -20,18 +20,18 @@ data "aws_ec2_instance_types" "test" {
   }
 
   filter {
-	name = "network-info.encryption-in-transit-supported"
-	values = ["true"]
+    name   = "network-info.encryption-in-transit-supported"
+    values = ["true"]
   }
 
   filter {
-	name = "instance-storage-supported"
-	values = ["true"]
+    name   = "instance-storage-supported"
+    values = ["true"]
   }
 
   filter {
-	name = "instance-type"
-	values = ["g5.2xlarge", "g5.4xlarge"]
+    name   = "instance-type"
+    values = ["g5.2xlarge", "g5.4xlarge"]
   }
 }
 ```
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 ### filter Argument Reference
 
-* `name` - (Required) Name of the filter. The `location` filter depends on the top-level `location_type` argument and if not specified, defaults to the current region.
+* `name` - (Required) Name of the filter.
 * `values` - (Required) List of one or more values for the filter.
 
 ## Attribute Reference

--- a/website/docs/d/ec2_instance_types.html.markdown
+++ b/website/docs/d/ec2_instance_types.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_ec2_instance_types"
+description: |-
+  Information about EC2 Instance Types.
+---
+
+# Data Source: aws_ec2_instance_types
+
+Information about EC2 Instance Types.
+
+## Example Usage
+
+```terraform
+data "aws_ec2_instance_types" "test" {
+  filter {
+    name   = "auto-recovery-supported"
+    values = ["true"]
+  }
+
+  filter {
+	name = "network-info.encryption-in-transit-supported"
+	values = ["true"]
+  }
+
+  filter {
+	name = "instance-storage-supported"
+	values = ["true"]
+  }
+
+  filter {
+	name = "instance-type"
+	values = ["g5.2xlarge", "g5.4xlarge"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Optional) One or more configuration blocks containing name-values filters. See the [EC2 API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html) for supported filters. Detailed below.
+
+### filter Argument Reference
+
+* `name` - (Required) Name of the filter. The `location` filter depends on the top-level `location_type` argument and if not specified, defaults to the current region.
+* `values` - (Required) List of one or more values for the filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - AWS Region.
+* `instance_types` - List of EC2 Instance Types.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21849

This pr uses code based on the existing `instance_type_offerings` code:
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/instance_type_offerings_data_source.go
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/instance_type_offerings_data_source_test.go

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2InstanceTypesDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceTypesDataSource' -timeout 180m
=== RUN   TestAccEC2InstanceTypesDataSource_filter
=== PAUSE TestAccEC2InstanceTypesDataSource_filter
=== CONT  TestAccEC2InstanceTypesDataSource_filter
--- PASS: TestAccEC2InstanceTypesDataSource_filter (31.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        33.793s
...
```
