### PR TITLE
aws_ecs_task_definition_data_source arn attribute

### DIFF
--- a/.changelog/21856.txt
+++ b/.changelog/21856.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data/aws_ecs_task_definition: Add `arn` attribute.
+```

--- a/.changelog/21856.txt
+++ b/.changelog/21856.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data/aws_ecs_task_definition: Add `arn` attribute.
+data-source/aws_ecs_task_definition: Add `arn` attribute.
 ```

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -20,6 +20,10 @@ func DataSourceTaskDefinition() *schema.Resource {
 				Required: true,
 			},
 			// Computed values.
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"family": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -64,6 +68,7 @@ func dataSourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) erro
 	taskDefinition := desc.TaskDefinition
 
 	d.SetId(aws.StringValue(taskDefinition.TaskDefinitionArn))
+	d.Set("arn", taskDefinition.TaskDefinitionArn)
 	d.Set("family", taskDefinition.Family)
 	d.Set("network_mode", taskDefinition.NetworkMode)
 	d.Set("revision", taskDefinition.Revision)

--- a/internal/service/ecs/task_definition_data_source_test.go
+++ b/internal/service/ecs/task_definition_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccECSTaskDefinitionDataSource_ecsTaskDefinition(t *testing.T) {
 			{
 				Config: testAccCheckTaskDefinitionDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_ecs_task_definition.mongo", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "family", rName),
 					resource.TestCheckResourceAttr(resourceName, "network_mode", "bridge"),
 					resource.TestMatchResourceAttr(resourceName, "revision", regexp.MustCompile("^[1-9][0-9]*$")),

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -51,7 +51,7 @@ resource "aws_ecs_service" "mongo" {
   desired_count = 2
 
   # Track the latest ACTIVE revision
-  task_definition = "${aws_ecs_task_definition.mongo.family}:${max(aws_ecs_task_definition.mongo.revision, data.aws_ecs_task_definition.mongo.revision)}"
+  task_definition = aws_ecs_task_definition.mongo.arn
 }
 ```
 
@@ -65,6 +65,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the task definition
 * `family` - The family of this task definition
 * `network_mode` - The Docker networking mode to use for the containers in this task.
 * `revision` - The revision of this task definition


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21841

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccECSTaskDefinitionDataSource_' PKG_NAME=internal/service/ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run=TestAccECSTaskDefinitionDataSource_ -timeout 180m
=== RUN   TestAccECSTaskDefinitionDataSource_ecsTaskDefinition
=== PAUSE TestAccECSTaskDefinitionDataSource_ecsTaskDefinition
=== CONT  TestAccECSTaskDefinitionDataSource_ecsTaskDefinition
--- PASS: TestAccECSTaskDefinitionDataSource_ecsTaskDefinition (24.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	24.096s
...
```
