### PR TITLE
Makes the headers_config parameter required in cloudfront_cache_policy.

### DIFF
--- a/internal/service/cloudfront/cache_policy.go
+++ b/internal/service/cloudfront/cache_policy.go
@@ -101,7 +101,7 @@ func ResourceCachePolicy() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"header_behavior": {
 										Type:         schema.TypeString,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validation.StringInSlice(cloudfront.CachePolicyHeaderBehavior_Values(), false),
 									},
 									"headers": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21854

I found that the schema for the `aws_cloudfront_cache_policy` resource had the `header_behavior` property as optional when it is required in both the [Terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) and [AWS](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CachePolicyHeadersConfig.html) documentation.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCloudFrontPolicy PKG=cloudfront

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontCachePolicy' -timeout 180m
=== RUN   TestAccCloudFrontCachePolicyDataSource_basic
=== PAUSE TestAccCloudFrontCachePolicyDataSource_basic
=== RUN   TestAccCloudFrontCachePolicy_basic
=== PAUSE TestAccCloudFrontCachePolicy_basic
=== RUN   TestAccCloudFrontCachePolicy_disappears
=== PAUSE TestAccCloudFrontCachePolicy_disappears
=== RUN   TestAccCloudFrontCachePolicy_Items
=== PAUSE TestAccCloudFrontCachePolicy_Items
=== RUN   TestAccCloudFrontCachePolicy_ZeroTTLs
=== PAUSE TestAccCloudFrontCachePolicy_ZeroTTLs
=== CONT  TestAccCloudFrontCachePolicyDataSource_basic
=== CONT  TestAccCloudFrontCachePolicy_Items
=== CONT  TestAccCloudFrontCachePolicy_disappears
=== CONT  TestAccCloudFrontCachePolicy_ZeroTTLs
=== CONT  TestAccCloudFrontCachePolicy_basic
--- PASS: TestAccCloudFrontCachePolicy_disappears (14.43s)
--- PASS: TestAccCloudFrontCachePolicyDataSource_basic (18.08s)
--- PASS: TestAccCloudFrontCachePolicy_basic (18.52s)
--- PASS: TestAccCloudFrontCachePolicy_ZeroTTLs (18.66s)
--- PASS: TestAccCloudFrontCachePolicy_Items (29.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 29.555s
```
