### PR TITLE
Clean up docs on aws_s3_bucket_policy

### DIFF
--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -15,24 +15,20 @@ Attaches a policy to an S3 bucket resource.
 ### Basic Usage
 
 ```terraform
-locals {
-  aws_account_b_id = "123456789012"
-}
-
 resource "aws_s3_bucket" "example" {
   bucket = "my-tf-test-bucket"
 }
 
-resource "aws_s3_bucket_policy" "allow_access_from_account_b" {
+resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
   bucket = aws_s3_bucket.example.id
-  policy = data.aws_iam_policy_document.allow_access_from_account_b.json
+  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
 }
 
-data "aws_iam_policy_document" "allow_access_from_account_b" {
+data "aws_iam_policy_document" "allow_access_from_another_account" {
   statement {
     principals {
-      type         = "AWS"
-      identitfiers = [local.aws_account_b_id]
+      type        = "AWS"
+      identifiers = ["123456789012"]
     }
 
     actions = [

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to which to apply the policy.
-* `policy` - (Required) The text of the policy. Although this isn't technically an IAM policy, you can use the [`aws_iam_policy_document`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) data source for this, so long as it specifies a principal. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy). Note: Bucket policies are limited to 20 KB in size.
+* `policy` - (Required) The text of the policy. Although this is a bucket policy rather than an IAM policy, the [`aws_iam_policy_document`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) data source may be used, so long as it specifies a principal. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy). Note: Bucket policies are limited to 20 KB in size.
 
 ## Attributes Reference
 

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -36,7 +36,10 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
       "s3:ListBucket",
     ]
 
-    resources = ["*"]
+    resources = [
+      aws_s3_bucket.example.arn,
+      "${aws_s3_bucket.example.arn}/*",
+    ]
   }
 }
 ```


### PR DESCRIPTION
Change the docs on the `aws_s3_bucket_policy` resource example so that:
- Instead of using the `jsonencode` function, it uses the `aws_iam_policy_document` data source
- Change the policy attached to be a bit simpler and easier to understand

Also, update the docs on the `policy` member of the resource to suggest using the `aws_iam_policy_document` data source.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000