### PR TITLE
Clean up Kafka/MSK funcs

### DIFF
--- a/internal/service/kafka/broker_nodes_data_source_test.go
+++ b/internal/service/kafka/broker_nodes_data_source_test.go
@@ -19,10 +19,10 @@ func TestAccKafkaBrokerNodesDataSource_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskBrokerNodesDataSourceConfig(rName),
+				Config: testAccBrokerNodesDataSourceConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "node_info_list.#", resourceName, "number_of_broker_nodes"),
@@ -34,8 +34,8 @@ func TestAccKafkaBrokerNodesDataSource_basic(t *testing.T) {
 		},
 	})
 }
-func testAccMskBrokerNodesDataSourceConfig(rName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccBrokerNodesDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.2.1"

--- a/internal/service/kafka/cluster_data_source_test.go
+++ b/internal/service/kafka/cluster_data_source_test.go
@@ -19,10 +19,10 @@ func TestAccKafkaClusterDataSource_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterDataSourceConfig(rName),
+				Config: testAccClusterDataSourceConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bootstrap_brokers", resourceName, "bootstrap_brokers"),
@@ -39,8 +39,8 @@ func TestAccKafkaClusterDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccMskClusterDataSourceConfig(rName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterDataSourceConfig(rName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.2.1"

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -50,12 +50,12 @@ func TestAccKafkaCluster_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfig_basic(rName),
+				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccCheckClusterExists(resourceName, &cluster),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kafka", regexp.MustCompile(`cluster/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.az_distribution", kafka.BrokerAZDistributionDefault),
@@ -109,12 +109,12 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName, 11),
+				Config: testAccClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName, 11),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "11"),
 				),
@@ -129,10 +129,10 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_ebsVolumeSize(t *testing.T) {
 			},
 			{
 				// BadRequestException: The minimum increase in storage size of the cluster should be atleast 100GB
-				Config: testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName, 112),
+				Config: testAccClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName, 112),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "112"),
 				),
@@ -150,12 +150,12 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigBrokerNodeGroupInfoInstanceType(rName, "kafka.t3.small"),
+				Config: testAccClusterConfigBrokerNodeGroupInfoInstanceType(rName, "kafka.t3.small"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.instance_type", "kafka.t3.small"),
 				),
@@ -171,10 +171,10 @@ func TestAccKafkaCluster_BrokerNodeGroupInfo_instanceType(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigBrokerNodeGroupInfoInstanceType(rName, "kafka.m5.large"),
+				Config: testAccClusterConfigBrokerNodeGroupInfoInstanceType(rName, "kafka.m5.large"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.instance_type", "kafka.m5.large"),
 				),
@@ -192,12 +192,12 @@ func TestAccKafkaCluster_ClientAuthenticationSASL_scram(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigClientAuthenticationSaslScram(rName, true),
+				Config: testAccClusterConfigClientAuthenticationSaslScram(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.0.scram", "true"),
@@ -216,10 +216,10 @@ func TestAccKafkaCluster_ClientAuthenticationSASL_scram(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigClientAuthenticationSaslScram(rName, false),
+				Config: testAccClusterConfigClientAuthenticationSaslScram(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.0.scram", "false"),
@@ -250,12 +250,12 @@ func TestAccKafkaCluster_ClientAuthenticationSASL_iam(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigClientAuthenticationSaslIam(rName, true),
+				Config: testAccClusterConfigClientAuthenticationSaslIam(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.0.iam", "true"),
@@ -274,10 +274,10 @@ func TestAccKafkaCluster_ClientAuthenticationSASL_iam(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigClientAuthenticationSaslIam(rName, false),
+				Config: testAccClusterConfigClientAuthenticationSaslIam(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.0.iam", "false"),
@@ -311,20 +311,20 @@ func TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs(t *tes
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			// We need to create and activate the CA before creating the MSK cluster.
 			{
-				Config: testAccMskClusterConfigRootCA(commonName),
+				Config: testAccClusterConfigRootCA(commonName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckACMPCACertificateAuthorityExists(acmCAResourceName, &ca),
 					acctest.CheckACMPCACertificateAuthorityActivateCA(&ca),
 				),
 			},
 			{
-				Config: testAccMskClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName, commonName),
+				Config: testAccClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName, commonName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.tls.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.tls.0.certificate_authority_arns.#", "1"),
@@ -340,7 +340,7 @@ func TestAccKafkaCluster_ClientAuthenticationTLS_certificateAuthorityARNs(t *tes
 				},
 			},
 			{
-				Config: testAccMskClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName, commonName),
+				Config: testAccClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName, commonName),
 				Check: resource.ComposeTestCheckFunc(
 					// CA must be DISABLED for deletion.
 					acctest.CheckACMPCACertificateAuthorityDisableCA(&ca),
@@ -363,12 +363,12 @@ func TestAccKafkaCluster_Info_revision(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigConfigurationInfoRevision1(rName),
+				Config: testAccClusterConfigConfigurationInfoRevision1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.revision", configurationResourceName, "latest_revision"),
@@ -383,10 +383,10 @@ func TestAccKafkaCluster_Info_revision(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigConfigurationInfoRevision2(rName),
+				Config: testAccClusterConfigConfigurationInfoRevision2(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName2, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.revision", configurationResourceName2, "latest_revision"),
@@ -405,12 +405,12 @@ func TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN(t *testing.T) 
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigEncryptionInfoEncryptionAtRestKmsKeyArn(rName),
+				Config: testAccClusterConfigEncryptionInfoEncryptionAtRestKmsKeyArn(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_info.0.encryption_at_rest_kms_key_arn", "aws_kms_key.example_key", "arn"),
 				),
 			},
@@ -435,12 +435,12 @@ func TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker(t *testi
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName, "PLAINTEXT"),
+				Config: testAccClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName, "PLAINTEXT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.client_broker", "PLAINTEXT"),
@@ -471,12 +471,12 @@ func TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster(t *testing.
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName, false),
+				Config: testAccClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.in_cluster", "false"),
@@ -503,12 +503,12 @@ func TestAccKafkaCluster_enhancedMonitoring(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigEnhancedMonitoring(rName, "PER_BROKER"),
+				Config: testAccClusterConfigEnhancedMonitoring(rName, "PER_BROKER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_monitoring", kafka.EnhancedMonitoringPerBroker),
 				),
 			},
@@ -521,10 +521,10 @@ func TestAccKafkaCluster_enhancedMonitoring(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigEnhancedMonitoring(rName, "PER_TOPIC_PER_BROKER"),
+				Config: testAccClusterConfigEnhancedMonitoring(rName, "PER_TOPIC_PER_BROKER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_monitoring", kafka.EnhancedMonitoringPerTopicPerBroker),
 				),
 			},
@@ -541,12 +541,12 @@ func TestAccKafkaCluster_numberOfBrokerNodes(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigNumberOfBrokerNodes(rName, 3),
+				Config: testAccClusterConfigNumberOfBrokerNodes(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers", ""),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers_sasl_scram", ""),
 					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", mskClusterBoostrapBrokersTlsRegexp),
@@ -568,10 +568,10 @@ func TestAccKafkaCluster_numberOfBrokerNodes(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigNumberOfBrokerNodes(rName, 6),
+				Config: testAccClusterConfigNumberOfBrokerNodes(rName, 6),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers", ""),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers_sasl_scram", ""),
 					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", mskClusterBoostrapBrokersTlsRegexp),
@@ -597,12 +597,12 @@ func TestAccKafkaCluster_openMonitoring(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigOpenMonitoring(rName, false, false),
+				Config: testAccClusterConfigOpenMonitoring(rName, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "open_monitoring.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "open_monitoring.0.prometheus.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "open_monitoring.0.prometheus.0.jmx_exporter.#", "1"),
@@ -620,10 +620,10 @@ func TestAccKafkaCluster_openMonitoring(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigOpenMonitoring(rName, true, false),
+				Config: testAccClusterConfigOpenMonitoring(rName, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "open_monitoring.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "open_monitoring.0.prometheus.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "open_monitoring.0.prometheus.0.jmx_exporter.#", "1"),
@@ -645,12 +645,12 @@ func TestAccKafkaCluster_loggingInfo(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigLoggingInfo(rName, false, false, false),
+				Config: testAccClusterConfigLoggingInfo(rName, false, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.cloudwatch_logs.#", "1"),
@@ -670,10 +670,10 @@ func TestAccKafkaCluster_loggingInfo(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigLoggingInfo(rName, true, true, true),
+				Config: testAccClusterConfigLoggingInfo(rName, true, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_info.0.broker_logs.0.cloudwatch_logs.#", "1"),
@@ -697,12 +697,12 @@ func TestAccKafkaCluster_kafkaVersionUpgrade(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigKafkaVersion(rName, "2.7.1"),
+				Config: testAccClusterConfigKafkaVersion(rName, "2.7.1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.7.1"),
 				),
 			},
@@ -715,10 +715,10 @@ func TestAccKafkaCluster_kafkaVersionUpgrade(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigKafkaVersion(rName, "2.8.0"),
+				Config: testAccClusterConfigKafkaVersion(rName, "2.8.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.8.0"),
 				),
 			},
@@ -735,12 +735,12 @@ func TestAccKafkaCluster_kafkaVersionDowngrade(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigKafkaVersion(rName, "2.8.0"),
+				Config: testAccClusterConfigKafkaVersion(rName, "2.8.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.8.0"),
 					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers", mskClusterBoostrapBrokersRegexp),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers_sasl_scram", ""),
@@ -758,10 +758,10 @@ func TestAccKafkaCluster_kafkaVersionDowngrade(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigKafkaVersion(rName, "2.7.1"),
+				Config: testAccClusterConfigKafkaVersion(rName, "2.7.1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.7.1"),
 					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers", mskClusterBoostrapBrokersRegexp),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers_sasl_scram", ""),
@@ -785,12 +785,12 @@ func TestAccKafkaCluster_kafkaVersionUpgradeWithInfo(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigKafkaVersionWithConfigurationInfo(rName, "2.7.1", "config1"),
+				Config: testAccClusterConfigKafkaVersionWithConfigurationInfo(rName, "2.7.1", "config1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster1),
+					testAccCheckClusterExists(resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.7.1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName1, "arn"),
@@ -806,10 +806,10 @@ func TestAccKafkaCluster_kafkaVersionUpgradeWithInfo(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigKafkaVersionWithConfigurationInfo(rName, "2.8.0", "config2"),
+				Config: testAccClusterConfigKafkaVersionWithConfigurationInfo(rName, "2.8.0", "config2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster2),
-					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.8.0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName2, "arn"),
@@ -829,12 +829,12 @@ func TestAccKafkaCluster_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskClusterDestroy,
+		CheckDestroy: testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfigTags1(rName, "key1", "value1"),
+				Config: testAccClusterConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -848,18 +848,18 @@ func TestAccKafkaCluster_tags(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccMskClusterConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccClusterConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccMskClusterConfigTags1(rName, "key2", "value2"),
+				Config: testAccClusterConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccCheckClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -889,7 +889,7 @@ func testAccCheckResourceAttrIsSortedCSV(resourceName, attributeName string) res
 	}
 }
 
-func testAccCheckMskClusterDestroy(s *terraform.State) error {
+func testAccCheckClusterDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).KafkaConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -913,7 +913,7 @@ func testAccCheckMskClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckMskClusterExists(n string, v *kafka.ClusterInfo) resource.TestCheckFunc {
+func testAccCheckClusterExists(n string, v *kafka.ClusterInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -938,7 +938,7 @@ func testAccCheckMskClusterExists(n string, v *kafka.ClusterInfo) resource.TestC
 	}
 }
 
-func testAccCheckMskClusterNotRecreated(i, j *kafka.ClusterInfo) resource.TestCheckFunc {
+func testAccCheckClusterNotRecreated(i, j *kafka.ClusterInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.ClusterArn) != aws.StringValue(j.ClusterArn) {
 			return fmt.Errorf("MSK Cluster (%s) recreated", aws.StringValue(i.ClusterArn))
@@ -948,7 +948,7 @@ func testAccCheckMskClusterNotRecreated(i, j *kafka.ClusterInfo) resource.TestCh
 	}
 }
 
-func testAccCheckMskClusterRecreated(i, j *kafka.ClusterInfo) resource.TestCheckFunc {
+func testAccCheckClusterRecreated(i, j *kafka.ClusterInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.ClusterArn) == aws.StringValue(j.ClusterArn) {
 			return fmt.Errorf("MSK Cluster (%s) was not recreated", aws.StringValue(i.ClusterArn))
@@ -974,7 +974,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccMskClusterBaseConfig(rName string) string {
+func testAccClusterBaseConfig(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "example_vpc" {
   cidr_block = "192.168.0.0/22"
@@ -1020,8 +1020,8 @@ resource "aws_security_group" "example_sg" {
 `, rName))
 }
 
-func testAccMskClusterConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1037,8 +1037,8 @@ resource "aws_msk_cluster" "test" {
 `, rName))
 }
 
-func testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName string, ebsVolumeSize int) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName string, ebsVolumeSize int) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1054,8 +1054,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, ebsVolumeSize))
 }
 
-func testAccMskClusterConfigBrokerNodeGroupInfoInstanceType(rName string, t string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigBrokerNodeGroupInfoInstanceType(rName string, t string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1071,7 +1071,7 @@ resource "aws_msk_cluster" "test" {
 `, rName, t))
 }
 
-func testAccMskClusterConfigRootCA(commonName string) string {
+func testAccClusterConfigRootCA(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
@@ -1089,10 +1089,10 @@ resource "aws_acmpca_certificate_authority" "test" {
 `, commonName)
 }
 
-func testAccMskClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName, commonName string) string {
+func testAccClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName, commonName string) string {
 	return acctest.ConfigCompose(
-		testAccMskClusterBaseConfig(rName),
-		testAccMskClusterConfigRootCA(commonName),
+		testAccClusterBaseConfig(rName),
+		testAccClusterConfigRootCA(commonName),
 		fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
@@ -1121,8 +1121,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, commonName))
 }
 
-func testAccMskClusterConfigClientAuthenticationSaslScram(rName string, enabled bool) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigClientAuthenticationSaslScram(rName string, enabled bool) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1144,8 +1144,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, enabled))
 }
 
-func testAccMskClusterConfigClientAuthenticationSaslIam(rName string, enabled bool) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigClientAuthenticationSaslIam(rName string, enabled bool) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1167,8 +1167,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, enabled))
 }
 
-func testAccMskClusterConfigConfigurationInfoRevision1(rName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigConfigurationInfoRevision1(rName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   kafka_versions = ["2.7.1"]
   name           = "%[1]s-1"
@@ -1198,8 +1198,8 @@ resource "aws_msk_cluster" "test" {
 `, rName))
 }
 
-func testAccMskClusterConfigConfigurationInfoRevision2(rName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigConfigurationInfoRevision2(rName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   kafka_versions = ["2.7.1"]
   name           = "%[1]s-1"
@@ -1238,8 +1238,8 @@ resource "aws_msk_cluster" "test" {
 `, rName))
 }
 
-func testAccMskClusterConfigEncryptionInfoEncryptionAtRestKmsKeyArn(rName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigEncryptionInfoEncryptionAtRestKmsKeyArn(rName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_key" "example_key" {
   description = %[1]q
 
@@ -1268,8 +1268,8 @@ resource "aws_msk_cluster" "test" {
 
 }
 
-func testAccMskClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName, clientBroker string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName, clientBroker string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1291,8 +1291,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, clientBroker))
 }
 
-func testAccMskClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName string, inCluster bool) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName string, inCluster bool) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1314,8 +1314,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, inCluster))
 }
 
-func testAccMskClusterConfigEnhancedMonitoring(rName, enhancedMonitoring string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigEnhancedMonitoring(rName, enhancedMonitoring string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   enhanced_monitoring    = %[2]q
@@ -1333,8 +1333,8 @@ resource "aws_msk_cluster" "test" {
 
 }
 
-func testAccMskClusterConfigNumberOfBrokerNodes(rName string, brokerCount int) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigNumberOfBrokerNodes(rName string, brokerCount int) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1351,8 +1351,8 @@ resource "aws_msk_cluster" "test" {
 
 }
 
-func testAccMskClusterConfigOpenMonitoring(rName string, jmxExporterEnabled bool, nodeExporterEnabled bool) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigOpenMonitoring(rName string, jmxExporterEnabled bool, nodeExporterEnabled bool) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1380,7 +1380,7 @@ resource "aws_msk_cluster" "test" {
 `, rName, jmxExporterEnabled, nodeExporterEnabled))
 }
 
-func testAccMskClusterConfigLoggingInfo(rName string, cloudwatchLogsEnabled bool, firehoseEnabled bool, s3Enabled bool) string {
+func testAccClusterConfigLoggingInfo(rName string, cloudwatchLogsEnabled bool, firehoseEnabled bool, s3Enabled bool) string {
 	cloudwatchLogsLogGroup := "\"\""
 	firehoseDeliveryStream := "\"\""
 	s3Bucket := "\"\""
@@ -1395,7 +1395,7 @@ func testAccMskClusterConfigLoggingInfo(rName string, cloudwatchLogsEnabled bool
 		s3Bucket = "aws_s3_bucket.bucket.id"
 	}
 
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -1482,8 +1482,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, cloudwatchLogsEnabled, cloudwatchLogsLogGroup, firehoseEnabled, firehoseDeliveryStream, s3Enabled, s3Bucket))
 }
 
-func testAccMskClusterConfigKafkaVersion(rName string, kafkaVersion string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigKafkaVersion(rName string, kafkaVersion string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = %[2]q
@@ -1505,8 +1505,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, kafkaVersion))
 }
 
-func testAccMskClusterConfigKafkaVersionWithConfigurationInfo(rName string, kafkaVersion string, configResourceName string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigKafkaVersionWithConfigurationInfo(rName string, kafkaVersion string, configResourceName string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_configuration" "config1" {
   kafka_versions    = ["2.7.1"]
   name              = "%[1]s-1"
@@ -1549,8 +1549,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, kafkaVersion, configResourceName))
 }
 
-func testAccMskClusterConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"
@@ -1570,8 +1570,8 @@ resource "aws_msk_cluster" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccMskClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccMskClusterBaseConfig(rName), fmt.Sprintf(`
+func testAccClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccClusterBaseConfig(rName), fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.7.1"

--- a/internal/service/kafka/configuration_data_source_test.go
+++ b/internal/service/kafka/configuration_data_source_test.go
@@ -19,10 +19,10 @@ func TestAccKafkaConfigurationDataSource_name(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		CheckDestroy: testAccCheckConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationDataSourceConfigName(rName),
+				Config: testAccConfigurationDataSourceNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceName, "description"),
@@ -36,7 +36,7 @@ func TestAccKafkaConfigurationDataSource_name(t *testing.T) {
 	})
 }
 
-func testAccMskConfigurationDataSourceConfigName(rName string) string {
+func testAccConfigurationDataSourceNameConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   kafka_versions = ["2.1.0"]

--- a/internal/service/kafka/configuration_test.go
+++ b/internal/service/kafka/configuration_test.go
@@ -25,12 +25,12 @@ func TestAccKafkaConfiguration_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		CheckDestroy: testAccCheckConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationConfig(rName),
+				Config: testAccConfigurationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration1),
+					testAccCheckConfigurationExists(resourceName, &configuration1),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "kafka", regexp.MustCompile(`configuration/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "kafka_versions.#", "0"),
@@ -57,12 +57,12 @@ func TestAccKafkaConfiguration_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		CheckDestroy: testAccCheckConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationConfig(rName),
+				Config: testAccConfigurationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration1),
+					testAccCheckConfigurationExists(resourceName, &configuration1),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkafka.ResourceConfiguration(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -80,12 +80,12 @@ func TestAccKafkaConfiguration_description(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		CheckDestroy: testAccCheckConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationConfigDescription(rName, "description1"),
+				Config: testAccConfigurationConfigDescription(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration1),
+					testAccCheckConfigurationExists(resourceName, &configuration1),
 					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
 				),
 			},
@@ -95,9 +95,9 @@ func TestAccKafkaConfiguration_description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMskConfigurationConfigDescription(rName, "description2"),
+				Config: testAccConfigurationConfigDescription(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration2),
+					testAccCheckConfigurationExists(resourceName, &configuration2),
 					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
 				),
@@ -115,12 +115,12 @@ func TestAccKafkaConfiguration_kafkaVersions(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		CheckDestroy: testAccCheckConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationConfigKafkaVersions(rName),
+				Config: testAccConfigurationConfigKafkaVersions(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration1),
+					testAccCheckConfigurationExists(resourceName, &configuration1),
 					resource.TestCheckResourceAttr(resourceName, "kafka_versions.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "kafka_versions.*", "2.6.0"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "kafka_versions.*", "2.7.0"),
@@ -146,12 +146,12 @@ func TestAccKafkaConfiguration_serverProperties(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		CheckDestroy: testAccCheckConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationConfigServerProperties(rName, serverProperty1),
+				Config: testAccConfigurationConfigServerProperties(rName, serverProperty1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration1),
+					testAccCheckConfigurationExists(resourceName, &configuration1),
 					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(serverProperty1)),
 				),
 			},
@@ -161,9 +161,9 @@ func TestAccKafkaConfiguration_serverProperties(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMskConfigurationConfigServerProperties(rName, serverProperty2),
+				Config: testAccConfigurationConfigServerProperties(rName, serverProperty2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskConfigurationExists(resourceName, &configuration2),
+					testAccCheckConfigurationExists(resourceName, &configuration2),
 					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
 					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(serverProperty2)),
 				),
@@ -172,7 +172,7 @@ func TestAccKafkaConfiguration_serverProperties(t *testing.T) {
 	})
 }
 
-func testAccCheckMskConfigurationDestroy(s *terraform.State) error {
+func testAccCheckConfigurationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).KafkaConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -202,7 +202,7 @@ func testAccCheckMskConfigurationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckMskConfigurationExists(resourceName string, configuration *kafka.DescribeConfigurationOutput) resource.TestCheckFunc {
+func testAccCheckConfigurationExists(resourceName string, configuration *kafka.DescribeConfigurationOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -231,7 +231,7 @@ func testAccCheckMskConfigurationExists(resourceName string, configuration *kafk
 	}
 }
 
-func testAccMskConfigurationConfig(rName string) string {
+func testAccConfigurationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   name = %[1]q
@@ -244,7 +244,7 @@ PROPERTIES
 `, rName)
 }
 
-func testAccMskConfigurationConfigDescription(rName, description string) string {
+func testAccConfigurationConfigDescription(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   description = %[2]q
@@ -257,7 +257,7 @@ PROPERTIES
 `, rName, description)
 }
 
-func testAccMskConfigurationConfigKafkaVersions(rName string) string {
+func testAccConfigurationConfigKafkaVersions(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   kafka_versions = ["2.6.0", "2.7.0"]
@@ -270,7 +270,7 @@ PROPERTIES
 `, rName)
 }
 
-func testAccMskConfigurationConfigServerProperties(rName string, serverProperty string) string {
+func testAccConfigurationConfigServerProperties(rName string, serverProperty string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   name = %[1]q

--- a/internal/service/kafka/kafka_version_data_source.go
+++ b/internal/service/kafka/kafka_version_data_source.go
@@ -34,7 +34,7 @@ func DataSourceVersion() *schema.Resource {
 	}
 }
 
-func findMskKafkaVersion(preferredVersions []interface{}, versions []*kafka.KafkaVersion) *kafka.KafkaVersion {
+func findKafkaVersion(preferredVersions []interface{}, versions []*kafka.KafkaVersion) *kafka.KafkaVersion {
 	var found *kafka.KafkaVersion
 
 	for _, v := range preferredVersions {
@@ -86,9 +86,9 @@ func dataSourceVersionRead(d *schema.ResourceData, meta interface{}) error {
 	var found *kafka.KafkaVersion
 
 	if v, ok := d.GetOk("preferred_versions"); ok {
-		found = findMskKafkaVersion(v.([]interface{}), kafkaVersions)
+		found = findKafkaVersion(v.([]interface{}), kafkaVersions)
 	} else if v, ok := d.GetOk("version"); ok {
-		found = findMskKafkaVersion([]interface{}{v}, kafkaVersions)
+		found = findKafkaVersion([]interface{}{v}, kafkaVersions)
 	}
 
 	if found == nil {

--- a/internal/service/kafka/scram_secret_association_test.go
+++ b/internal/service/kafka/scram_secret_association_test.go
@@ -25,12 +25,12 @@ func TestAccKafkaScramSecretAssociation_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskScramSecretAssociationDestroy,
+		CheckDestroy: testAccCheckScramSecretAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskScramSecretAssociation_basic(rName, 1),
+				Config: testAccScramSecretAssociation_basic(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskScramSecretAssociationExists(resourceName),
+					testAccCheckScramSecretAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_arn", clusterResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "secret_arn_list.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "secret_arn_list.*", secretResourceName, "arn"),
@@ -56,18 +56,18 @@ func TestAccKafkaScramSecretAssociation_update(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskScramSecretAssociationDestroy,
+		CheckDestroy: testAccCheckScramSecretAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskScramSecretAssociation_basic(rName, 1),
+				Config: testAccScramSecretAssociation_basic(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskScramSecretAssociationExists(resourceName),
+					testAccCheckScramSecretAssociationExists(resourceName),
 				),
 			},
 			{
-				Config: testAccMskScramSecretAssociation_basic(rName, 3),
+				Config: testAccScramSecretAssociation_basic(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskScramSecretAssociationExists(resourceName),
+					testAccCheckScramSecretAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "secret_arn_list.#", "3"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "secret_arn_list.*", secretResourceName, "arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "secret_arn_list.*", secretResourceName2, "arn"),
@@ -75,9 +75,9 @@ func TestAccKafkaScramSecretAssociation_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMskScramSecretAssociation_basic(rName, 2),
+				Config: testAccScramSecretAssociation_basic(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskScramSecretAssociationExists(resourceName),
+					testAccCheckScramSecretAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "secret_arn_list.#", "2"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "secret_arn_list.*", secretResourceName, "arn"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "secret_arn_list.*", secretResourceName2, "arn"),
@@ -100,12 +100,12 @@ func TestAccKafkaScramSecretAssociation_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskScramSecretAssociationDestroy,
+		CheckDestroy: testAccCheckScramSecretAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskScramSecretAssociation_basic(rName, 1),
+				Config: testAccScramSecretAssociation_basic(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskScramSecretAssociationExists(resourceName),
+					testAccCheckScramSecretAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkafka.ResourceScramSecretAssociation(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -123,12 +123,12 @@ func TestAccKafkaScramSecretAssociation_Disappears_cluster(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, kafka.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckMskScramSecretAssociationDestroy,
+		CheckDestroy: testAccCheckScramSecretAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskScramSecretAssociation_basic(rName, 1),
+				Config: testAccScramSecretAssociation_basic(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskScramSecretAssociationExists(resourceName),
+					testAccCheckScramSecretAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfkafka.ResourceCluster(), clusterResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -137,7 +137,7 @@ func TestAccKafkaScramSecretAssociation_Disappears_cluster(t *testing.T) {
 	})
 }
 
-func testAccCheckMskScramSecretAssociationDestroy(s *terraform.State) error {
+func testAccCheckScramSecretAssociationDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_msk_scram_secret_association" {
 			continue
@@ -159,7 +159,7 @@ func testAccCheckMskScramSecretAssociationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckMskScramSecretAssociationExists(resourceName string) resource.TestCheckFunc {
+func testAccCheckScramSecretAssociationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -179,7 +179,7 @@ func testAccCheckMskScramSecretAssociationExists(resourceName string) resource.T
 	}
 }
 
-func testAccMskScramSecretAssociationBaseConfig(rName string, count int) string {
+func testAccScramSecretAssociationBaseConfig(rName string, count int) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -240,10 +240,10 @@ POLICY
 `, rName, count)
 }
 
-func testAccMskScramSecretAssociation_basic(rName string, count int) string {
+func testAccScramSecretAssociation_basic(rName string, count int) string {
 	return acctest.ConfigCompose(
-		testAccMskClusterBaseConfig(rName),
-		testAccMskScramSecretAssociationBaseConfig(rName, count), `
+		testAccClusterBaseConfig(rName),
+		testAccScramSecretAssociationBaseConfig(rName, count), `
 resource "aws_msk_scram_secret_association" "test" {
   cluster_arn     = aws_msk_cluster.test.arn
   secret_arn_list = aws_secretsmanager_secret.test[*].arn


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc PKG=kafka
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafka/... -v -count 1 -parallel 20  -timeout 180m
--- PASS: TestSortEndpointsString (0.00s)
    --- PASS: TestSortEndpointsString/empty (0.00s)
    --- PASS: TestSortEndpointsString/one_endpoint (0.00s)
    --- PASS: TestSortEndpointsString/three_endpoints (0.00s)
--- PASS: TestAccKafkaKafkaVersionDataSource_basic (16.15s)
--- PASS: TestAccKafkaKafkaVersionDataSource_preferred (16.15s)
--- PASS: TestAccKafkaConfiguration_description (42.68s)
--- PASS: TestAccKafkaConfiguration_serverProperties (45.53s)
--- PASS: TestAccKafkaConfigurationDataSource_name (46.25s)
--- PASS: TestAccKafkaConfiguration_kafkaVersions (53.50s)
--- PASS: TestAccKafkaConfiguration_disappears (40.47s)
--- PASS: TestAccKafkaConfiguration_basic (43.24s)
--- PASS: TestAccKafkaCluster_enhancedMonitoring (2129.82s)
--- PASS: TestAccKafkaBrokerNodesDataSource_basic (2130.91s)
--- PASS: TestAccKafkaScramSecretAssociation_disappears (2131.34s)
--- PASS: TestAccKafkaCluster_EncryptionInfo_encryptionAtRestKMSKeyARN (2132.12s)
--- PASS: TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_clientBroker (2132.73s)
--- PASS: TestAccKafkaScramSecretAssociation_basic (2133.93s)
--- PASS: TestAccKafkaCluster_basic (2075.35s)
--- PASS: TestAccKafkaScramSecretAssociation_update (2134.94s)
--- PASS: TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster (2136.55s)
--- PASS: TestAccKafkaCluster_tags (2093.80s)
--- PASS: TestAccKafkaScramSecretAssociation_Disappears_cluster (2141.71s)
--- PASS: TestAccKafkaCluster_openMonitoring (2277.29s)
--- PASS: TestAccKafkaCluster_loggingInfo (2308.01s)
--- PASS: TestAccKafkaCluster_Info_revision (2704.28s)
--- PASS: TestAccKafkaCluster_numberOfBrokerNodes (2713.96s)
```
