### PR TITLE
Use Ubuntu Bionic 18.04 LTS instead of unsupported 12.04 in two-tier example

### DIFF
--- a/examples/two-tier/variables.tf
+++ b/examples/two-tier/variables.tf
@@ -17,12 +17,12 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
-# Ubuntu Precise 12.04 LTS (x64)
+# Ubuntu Bionic 18.04 LTS (x64)
 variable "aws_amis" {
   default = {
-    eu-west-1 = "ami-674cbc1e"
-    us-east-1 = "ami-1d4e7a66"
-    us-west-1 = "ami-969ab1f6"
-    us-west-2 = "ami-8803e0f0"
+    eu-west-1 = "ami-0c259a97cbf621daf"
+    us-east-1 = "ami-04751c628226b9b59"
+    us-west-1 = "ami-0558dde970ca91ee5"
+    us-west-2 = "ami-0bdef2eb518663879"
   }
 }


### PR DESCRIPTION
Small fix for using Ubuntu Bionic 18.04 LTS instead of unsupported 12.04, to avoid a lot of confusing situations

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #8438