### PR TITLE
d/aws_imagebuilder_components - new data source

### DIFF
--- a/.changelog/21881.txt
+++ b/.changelog/21881.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_imagebuilder_components
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -549,6 +549,7 @@ func Provider() *schema.Provider {
 			"aws_identitystore_user":  identitystore.DataSourceUser(),
 
 			"aws_imagebuilder_component":                    imagebuilder.DataSourceComponent(),
+			"aws_imagebuilder_components":                   imagebuilder.DataSourceComponents(),
 			"aws_imagebuilder_distribution_configuration":   imagebuilder.DataSourceDistributionConfiguration(),
 			"aws_imagebuilder_image":                        imagebuilder.DataSourceImage(),
 			"aws_imagebuilder_image_pipeline":               imagebuilder.DataSourceImagePipeline(),

--- a/internal/service/imagebuilder/comonents_data_source_test.go
+++ b/internal/service/imagebuilder/comonents_data_source_test.go
@@ -1,0 +1,64 @@
+package imagebuilder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccImageBuilderComponentsDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_imagebuilder_components.test"
+	resourceName := "aws_imagebuilder_component.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentsFilterDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccComponentsFilterDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_imagebuilder_component" "test" {
+  data = yamlencode({
+    phases = [{
+      name = "build"
+      steps = [{
+        action = "ExecuteBash"
+        inputs = {
+          commands = ["echo 'hello world'"]
+        }
+        name      = "example"
+        onFailure = "Continue"
+      }]
+    }]
+    schemaVersion = 1.0
+  })
+  name     = %[1]q
+  platform = "Linux"
+  version  = "1.0.0"
+}
+
+data "aws_imagebuilder_components" "test" {
+  filter {
+    name = "name"
+    values = [aws_imagebuilder_component.test.name]
+  }
+}
+`, rName)
+}

--- a/internal/service/imagebuilder/components_data_source.go
+++ b/internal/service/imagebuilder/components_data_source.go
@@ -1,0 +1,84 @@
+package imagebuilder
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceComponents() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComponentsRead,
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": dataSourceFiltersSchema(),
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Self", "Shared", "Amazon"}, false),
+			},
+		},
+	}
+}
+
+func dataSourceComponentsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ImageBuilderConn
+
+	input := &imagebuilder.ListComponentsInput{}
+
+	if v, ok := d.GetOk("owner"); ok {
+		input.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = buildFiltersDataSource(v.(*schema.Set))
+	}
+
+	var results []*imagebuilder.ComponentVersion
+
+	err := conn.ListComponentsPages(input, func(page *imagebuilder.ListComponentsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, componentVersion := range page.ComponentVersionList {
+			if componentVersion == nil {
+				continue
+			}
+
+			results = append(results, componentVersion)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Image Builder Components: %w", err)
+	}
+
+	var arns, names []string
+
+	for _, r := range results {
+		arns = append(arns, aws.StringValue(r.Arn))
+		names = append(names, aws.StringValue(r.Name))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/imagebuilder/components_data_source_test.go
+++ b/internal/service/imagebuilder/components_data_source_test.go
@@ -64,7 +64,7 @@ func testAccConfigComponentWithDataSource(rName string) string {
 		`
 data "aws_imagebuilder_components" "test" {
   filter {
-    name = "name"
+    name   = "name"
     values = [aws_imagebuilder_component.test.name]  
   }
 }

--- a/internal/service/imagebuilder/components_data_source_test.go
+++ b/internal/service/imagebuilder/components_data_source_test.go
@@ -10,57 +10,31 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccImageBuilderComponentsDataSource_owner(t *testing.T) {
-	dataSourceName := "data.aws_imagebuilder_components.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckImageRecipeDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComponentsOwnerDataSourceConfig,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
-					resource.TestCheckResourceAttr(dataSourceName, "names.#", "0"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccImageBuilderComponentsDataSource_filter(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_imagebuilder_components.test"
-	resourceName := "aws_imagebuilder_component.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		CheckDestroy:      testAccCheckComponentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComponentsFilterDataSourceConfig(rName),
+				Config: testAccConfigComponent(rName),
+			},
+			{
+				Config: testAccConfigComponentWithDataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "arns.0", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
 				),
 			},
 		},
 	})
 }
 
-const testAccComponentsOwnerDataSourceConfig = `
-data "aws_imagebuilder_components" "test" {
-  owner = "Self"
-}
-`
-
-func testAccComponentsFilterDataSourceConfig(rName string) string {
+func testAccConfigComponent(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_imagebuilder_component" "test" {
   data = yamlencode({
@@ -79,14 +53,20 @@ resource "aws_imagebuilder_component" "test" {
   })
   name     = %[1]q
   platform = "Linux"
-  version  = "1.0.1"
-}
-
-data "aws_imagebuilder_components" "test" {
-  filter {
-    name   = "name"
-    values = [aws_imagebuilder_component.test.name]
-  }
+  version  = "1.0.0"
 }
 `, rName)
+}
+
+func testAccConfigComponentWithDataSource(rName string) string {
+	return acctest.ConfigCompose(
+		testAccConfigComponent(rName),
+		`
+data "aws_imagebuilder_components" "test" {
+  filter {
+    name = "name"
+    values = [aws_imagebuilder_component.test.name]  
+  }
+}
+`)
 }

--- a/internal/service/imagebuilder/components_data_source_test.go
+++ b/internal/service/imagebuilder/components_data_source_test.go
@@ -65,7 +65,7 @@ func testAccConfigComponentWithDataSource(rName string) string {
 data "aws_imagebuilder_components" "test" {
   filter {
     name   = "name"
-    values = [aws_imagebuilder_component.test.name]  
+    values = [aws_imagebuilder_component.test.name]
   }
 }
 `)

--- a/internal/service/imagebuilder/components_data_source_test.go
+++ b/internal/service/imagebuilder/components_data_source_test.go
@@ -84,7 +84,7 @@ resource "aws_imagebuilder_component" "test" {
 
 data "aws_imagebuilder_components" "test" {
   filter {
-    name = "name"
+    name   = "name"
     values = [aws_imagebuilder_component.test.name]
   }
 }

--- a/website/docs/d/imagebuilder_components.html.markdown
+++ b/website/docs/d/imagebuilder_components.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Image Builder"
+layout: "aws"
+page_title: "AWS: aws_imagebuilder_components"
+description: |-
+    Get information on Image Builder Components.
+---
+
+# Data Source: aws_imagebuilder_components
+
+Use this data source to get the ARNs and names of Image Builder Components matching the specified criteria.
+
+## Example Usage
+
+```terraform
+data "aws_imagebuilder_components" "example" {
+  owner = "Self"
+
+  filter {
+    name   = "platform"
+    values = ["Linux"]
+  }
+}
+```
+
+## Argument Reference
+
+* `owner` - (Optional) The owner of the image recipes. Valid values are `Self`, `Shared` and `Amazon`. Defaults to `Self`.
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListComponents API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListComponents.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `arns` - Set of ARNs of the matched Image Builder Components.
+* `names` - Set of names of the matched Image Builder Components.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17035.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderComponentsDataSource_" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run=TestAccImageBuilderComponentsDataSource_ -timeout 180m
=== RUN   TestAccImageBuilderComponentsDataSource_filter
=== PAUSE TestAccImageBuilderComponentsDataSource_filter
=== CONT  TestAccImageBuilderComponentsDataSource_filter
--- PASS: TestAccImageBuilderComponentsDataSource_filter (45.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       51.845s
```
