### PR TITLE
imagebuilder: Allow image recipe to be updated/replaced

### DIFF
--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -155,7 +155,7 @@ func resourceDistributionConfigurationCreate(d *schema.ResourceData, meta interf
 	}
 
 	if v, ok := d.GetOk("distribution"); ok && v.(*schema.Set).Len() > 0 {
-		input.Distributions = expandImageBuilderDistributions(v.(*schema.Set).List())
+		input.Distributions = expandDistributions(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("name"); ok {
@@ -212,7 +212,7 @@ func resourceDistributionConfigurationRead(d *schema.ResourceData, meta interfac
 	d.Set("date_created", distributionConfiguration.DateCreated)
 	d.Set("date_updated", distributionConfiguration.DateUpdated)
 	d.Set("description", distributionConfiguration.Description)
-	d.Set("distribution", flattenImageBuilderDistributions(distributionConfiguration.Distributions))
+	d.Set("distribution", flattenDistributions(distributionConfiguration.Distributions))
 	d.Set("name", distributionConfiguration.Name)
 	tags := KeyValueTags(distributionConfiguration.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
@@ -241,7 +241,7 @@ func resourceDistributionConfigurationUpdate(d *schema.ResourceData, meta interf
 		}
 
 		if v, ok := d.GetOk("distribution"); ok && v.(*schema.Set).Len() > 0 {
-			input.Distributions = expandImageBuilderDistributions(v.(*schema.Set).List())
+			input.Distributions = expandDistributions(v.(*schema.Set).List())
 		}
 
 		log.Printf("[DEBUG] UpdateDistributionConfiguration: %#v", input)
@@ -283,7 +283,7 @@ func resourceDistributionConfigurationDelete(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func expandImageBuilderAmiDistributionConfiguration(tfMap map[string]interface{}) *imagebuilder.AmiDistributionConfiguration {
+func expandAmiDistributionConfiguration(tfMap map[string]interface{}) *imagebuilder.AmiDistributionConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -303,7 +303,7 @@ func expandImageBuilderAmiDistributionConfiguration(tfMap map[string]interface{}
 	}
 
 	if v, ok := tfMap["launch_permission"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.LaunchPermission = expandImageBuilderLaunchPermissionConfiguration(v[0].(map[string]interface{}))
+		apiObject.LaunchPermission = expandLaunchPermissionConfiguration(v[0].(map[string]interface{}))
 	}
 
 	if v, ok := tfMap["name"].(string); ok && v != "" {
@@ -317,7 +317,7 @@ func expandImageBuilderAmiDistributionConfiguration(tfMap map[string]interface{}
 	return apiObject
 }
 
-func expandImageBuilderDistribution(tfMap map[string]interface{}) *imagebuilder.Distribution {
+func expandDistribution(tfMap map[string]interface{}) *imagebuilder.Distribution {
 	if tfMap == nil {
 		return nil
 	}
@@ -325,7 +325,7 @@ func expandImageBuilderDistribution(tfMap map[string]interface{}) *imagebuilder.
 	apiObject := &imagebuilder.Distribution{}
 
 	if v, ok := tfMap["ami_distribution_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AmiDistributionConfiguration = expandImageBuilderAmiDistributionConfiguration(v[0].(map[string]interface{}))
+		apiObject.AmiDistributionConfiguration = expandAmiDistributionConfiguration(v[0].(map[string]interface{}))
 	}
 
 	if v, ok := tfMap["license_configuration_arns"].(*schema.Set); ok && v.Len() > 0 {
@@ -339,7 +339,7 @@ func expandImageBuilderDistribution(tfMap map[string]interface{}) *imagebuilder.
 	return apiObject
 }
 
-func expandImageBuilderDistributions(tfList []interface{}) []*imagebuilder.Distribution {
+func expandDistributions(tfList []interface{}) []*imagebuilder.Distribution {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -353,7 +353,7 @@ func expandImageBuilderDistributions(tfList []interface{}) []*imagebuilder.Distr
 			continue
 		}
 
-		apiObject := expandImageBuilderDistribution(tfMap)
+		apiObject := expandDistribution(tfMap)
 
 		if apiObject == nil {
 			continue
@@ -372,7 +372,7 @@ func expandImageBuilderDistributions(tfList []interface{}) []*imagebuilder.Distr
 	return apiObjects
 }
 
-func expandImageBuilderLaunchPermissionConfiguration(tfMap map[string]interface{}) *imagebuilder.LaunchPermissionConfiguration {
+func expandLaunchPermissionConfiguration(tfMap map[string]interface{}) *imagebuilder.LaunchPermissionConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -390,7 +390,7 @@ func expandImageBuilderLaunchPermissionConfiguration(tfMap map[string]interface{
 	return apiObject
 }
 
-func flattenImageBuilderAmiDistributionConfiguration(apiObject *imagebuilder.AmiDistributionConfiguration) map[string]interface{} {
+func flattenAmiDistributionConfiguration(apiObject *imagebuilder.AmiDistributionConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -410,7 +410,7 @@ func flattenImageBuilderAmiDistributionConfiguration(apiObject *imagebuilder.Ami
 	}
 
 	if v := apiObject.LaunchPermission; v != nil {
-		tfMap["launch_permission"] = []interface{}{flattenImageBuilderLaunchPermissionConfiguration(v)}
+		tfMap["launch_permission"] = []interface{}{flattenLaunchPermissionConfiguration(v)}
 	}
 
 	if v := apiObject.Name; v != nil {
@@ -424,7 +424,7 @@ func flattenImageBuilderAmiDistributionConfiguration(apiObject *imagebuilder.Ami
 	return tfMap
 }
 
-func flattenImageBuilderDistribution(apiObject *imagebuilder.Distribution) map[string]interface{} {
+func flattenDistribution(apiObject *imagebuilder.Distribution) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -432,7 +432,7 @@ func flattenImageBuilderDistribution(apiObject *imagebuilder.Distribution) map[s
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.AmiDistributionConfiguration; v != nil {
-		tfMap["ami_distribution_configuration"] = []interface{}{flattenImageBuilderAmiDistributionConfiguration(v)}
+		tfMap["ami_distribution_configuration"] = []interface{}{flattenAmiDistributionConfiguration(v)}
 	}
 
 	if v := apiObject.LicenseConfigurationArns; v != nil {
@@ -446,7 +446,7 @@ func flattenImageBuilderDistribution(apiObject *imagebuilder.Distribution) map[s
 	return tfMap
 }
 
-func flattenImageBuilderDistributions(apiObjects []*imagebuilder.Distribution) []interface{} {
+func flattenDistributions(apiObjects []*imagebuilder.Distribution) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -458,13 +458,13 @@ func flattenImageBuilderDistributions(apiObjects []*imagebuilder.Distribution) [
 			continue
 		}
 
-		tfList = append(tfList, flattenImageBuilderDistribution(apiObject))
+		tfList = append(tfList, flattenDistribution(apiObject))
 	}
 
 	return tfList
 }
 
-func flattenImageBuilderLaunchPermissionConfiguration(apiObject *imagebuilder.LaunchPermissionConfiguration) map[string]interface{} {
+func flattenLaunchPermissionConfiguration(apiObject *imagebuilder.LaunchPermissionConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -283,7 +283,7 @@ func resourceDistributionConfigurationDelete(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func expandAmiDistributionConfiguration(tfMap map[string]interface{}) *imagebuilder.AmiDistributionConfiguration {
+func expandAMIDistributionConfiguration(tfMap map[string]interface{}) *imagebuilder.AmiDistributionConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -325,7 +325,7 @@ func expandDistribution(tfMap map[string]interface{}) *imagebuilder.Distribution
 	apiObject := &imagebuilder.Distribution{}
 
 	if v, ok := tfMap["ami_distribution_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AmiDistributionConfiguration = expandAmiDistributionConfiguration(v[0].(map[string]interface{}))
+		apiObject.AmiDistributionConfiguration = expandAMIDistributionConfiguration(v[0].(map[string]interface{}))
 	}
 
 	if v, ok := tfMap["license_configuration_arns"].(*schema.Set); ok && v.Len() > 0 {
@@ -390,7 +390,7 @@ func expandLaunchPermissionConfiguration(tfMap map[string]interface{}) *imagebui
 	return apiObject
 }
 
-func flattenAmiDistributionConfiguration(apiObject *imagebuilder.AmiDistributionConfiguration) map[string]interface{} {
+func flattenAMIDistributionConfiguration(apiObject *imagebuilder.AmiDistributionConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -432,7 +432,7 @@ func flattenDistribution(apiObject *imagebuilder.Distribution) map[string]interf
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.AmiDistributionConfiguration; v != nil {
-		tfMap["ami_distribution_configuration"] = []interface{}{flattenAmiDistributionConfiguration(v)}
+		tfMap["ami_distribution_configuration"] = []interface{}{flattenAMIDistributionConfiguration(v)}
 	}
 
 	if v := apiObject.LicenseConfigurationArns; v != nil {

--- a/internal/service/imagebuilder/distribution_configuration_data_source.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source.go
@@ -138,7 +138,7 @@ func dataSourceDistributionConfigurationRead(d *schema.ResourceData, meta interf
 	d.Set("date_created", distributionConfiguration.DateCreated)
 	d.Set("date_updated", distributionConfiguration.DateUpdated)
 	d.Set("description", distributionConfiguration.Description)
-	d.Set("distribution", flattenImageBuilderDistributions(distributionConfiguration.Distributions))
+	d.Set("distribution", flattenDistributions(distributionConfiguration.Distributions))
 	d.Set("name", distributionConfiguration.Name)
 	d.Set("tags", KeyValueTags(distributionConfiguration.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -142,7 +142,7 @@ func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_am
 		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDistributionConfigurationDistributionAMIDistributionConfigurationAmiTagsConfig(rName, "key1", "value1"),
+				Config: testAccDistributionConfigurationDistributionAMIDistributionConfigurationAMITagsConfig(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
@@ -159,7 +159,7 @@ func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_am
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccDistributionConfigurationDistributionAMIDistributionConfigurationAmiTagsConfig(rName, "key2", "value2"),
+				Config: testAccDistributionConfigurationDistributionAMIDistributionConfigurationAMITagsConfig(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionConfigurationExists(resourceName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
@@ -582,7 +582,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
 `, rName))
 }
 
-func testAccDistributionConfigurationDistributionAMIDistributionConfigurationAmiTagsConfig(rName string, amiTagKey string, amiTagValue string) string {
+func testAccDistributionConfigurationDistributionAMIDistributionConfigurationAMITagsConfig(rName string, amiTagKey string, amiTagValue string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 

--- a/internal/service/imagebuilder/image.go
+++ b/internal/service/imagebuilder/image.go
@@ -166,7 +166,7 @@ func resourceImageCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("image_tests_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ImageTestsConfiguration = expandImageBuilderImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		input.ImageTestsConfiguration = expandImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("infrastructure_configuration_arn"); ok {
@@ -237,7 +237,7 @@ func resourceImageRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if image.ImageTestsConfiguration != nil {
-		d.Set("image_tests_configuration", []interface{}{flattenImageBuilderImageTestsConfiguration(image.ImageTestsConfiguration)})
+		d.Set("image_tests_configuration", []interface{}{flattenImageTestsConfiguration(image.ImageTestsConfiguration)})
 	} else {
 		d.Set("image_tests_configuration", nil)
 	}
@@ -251,7 +251,7 @@ func resourceImageRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("os_version", image.OsVersion)
 
 	if image.OutputResources != nil {
-		d.Set("output_resources", []interface{}{flattenImageBuilderOutputResources(image.OutputResources)})
+		d.Set("output_resources", []interface{}{flattenOutputResources(image.OutputResources)})
 	} else {
 		d.Set("output_resources", nil)
 	}
@@ -306,7 +306,7 @@ func resourceImageDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func flattenImageBuilderOutputResources(apiObject *imagebuilder.OutputResources) map[string]interface{} {
+func flattenOutputResources(apiObject *imagebuilder.OutputResources) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -314,13 +314,13 @@ func flattenImageBuilderOutputResources(apiObject *imagebuilder.OutputResources)
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Amis; v != nil {
-		tfMap["amis"] = flattenImageBuilderAmis(v)
+		tfMap["amis"] = flattenAmis(v)
 	}
 
 	return tfMap
 }
 
-func flattenImageBuilderAmi(apiObject *imagebuilder.Ami) map[string]interface{} {
+func flattenAmi(apiObject *imagebuilder.Ami) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -350,7 +350,7 @@ func flattenImageBuilderAmi(apiObject *imagebuilder.Ami) map[string]interface{} 
 	return tfMap
 }
 
-func flattenImageBuilderAmis(apiObjects []*imagebuilder.Ami) []interface{} {
+func flattenAmis(apiObjects []*imagebuilder.Ami) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -362,7 +362,7 @@ func flattenImageBuilderAmis(apiObjects []*imagebuilder.Ami) []interface{} {
 			continue
 		}
 
-		tfList = append(tfList, flattenImageBuilderAmi(apiObject))
+		tfList = append(tfList, flattenAmi(apiObject))
 	}
 
 	return tfList

--- a/internal/service/imagebuilder/image.go
+++ b/internal/service/imagebuilder/image.go
@@ -314,13 +314,13 @@ func flattenOutputResources(apiObject *imagebuilder.OutputResources) map[string]
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Amis; v != nil {
-		tfMap["amis"] = flattenAmis(v)
+		tfMap["amis"] = flattenAMIs(v)
 	}
 
 	return tfMap
 }
 
-func flattenAmi(apiObject *imagebuilder.Ami) map[string]interface{} {
+func flattenAMI(apiObject *imagebuilder.Ami) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -350,7 +350,7 @@ func flattenAmi(apiObject *imagebuilder.Ami) map[string]interface{} {
 	return tfMap
 }
 
-func flattenAmis(apiObjects []*imagebuilder.Ami) []interface{} {
+func flattenAMIs(apiObjects []*imagebuilder.Ami) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -362,7 +362,7 @@ func flattenAmis(apiObjects []*imagebuilder.Ami) []interface{} {
 			continue
 		}
 
-		tfList = append(tfList, flattenAmi(apiObject))
+		tfList = append(tfList, flattenAMI(apiObject))
 	}
 
 	return tfList

--- a/internal/service/imagebuilder/image_data_source.go
+++ b/internal/service/imagebuilder/image_data_source.go
@@ -162,7 +162,7 @@ func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if image.ImageTestsConfiguration != nil {
-		d.Set("image_tests_configuration", []interface{}{flattenImageBuilderImageTestsConfiguration(image.ImageTestsConfiguration)})
+		d.Set("image_tests_configuration", []interface{}{flattenImageTestsConfiguration(image.ImageTestsConfiguration)})
 	} else {
 		d.Set("image_tests_configuration", nil)
 	}
@@ -176,7 +176,7 @@ func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("os_version", image.OsVersion)
 
 	if image.OutputResources != nil {
-		d.Set("output_resources", []interface{}{flattenImageBuilderOutputResources(image.OutputResources)})
+		d.Set("output_resources", []interface{}{flattenOutputResources(image.OutputResources)})
 	} else {
 		d.Set("output_resources", nil)
 	}

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -294,6 +294,10 @@ func resourceImagePipelineUpdate(d *schema.ResourceData, meta interface{}) error
 			input.DistributionConfigurationArn = aws.String(v.(string))
 		}
 
+		if v, ok := d.GetOk("image_recipe_arn"); ok {
+			input.ImageRecipeArn = aws.String(v.(string))
+		}
+
 		if v, ok := d.GetOk("image_tests_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.ImageTestsConfiguration = expandImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
 		}

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -161,7 +161,7 @@ func resourceImagePipelineCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("image_tests_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ImageTestsConfiguration = expandImageBuilderImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		input.ImageTestsConfiguration = expandImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("infrastructure_configuration_arn"); ok {
@@ -173,7 +173,7 @@ func resourceImagePipelineCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("schedule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Schedule = expandImageBuilderPipelineSchedule(v.([]interface{})[0].(map[string]interface{}))
+		input.Schedule = expandPipelineSchedule(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("status"); ok {
@@ -237,7 +237,7 @@ func resourceImagePipelineRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("image_recipe_arn", imagePipeline.ImageRecipeArn)
 
 	if imagePipeline.ImageTestsConfiguration != nil {
-		d.Set("image_tests_configuration", []interface{}{flattenImageBuilderImageTestsConfiguration(imagePipeline.ImageTestsConfiguration)})
+		d.Set("image_tests_configuration", []interface{}{flattenImageTestsConfiguration(imagePipeline.ImageTestsConfiguration)})
 	} else {
 		d.Set("image_tests_configuration", nil)
 	}
@@ -247,7 +247,7 @@ func resourceImagePipelineRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("platform", imagePipeline.Platform)
 
 	if imagePipeline.Schedule != nil {
-		d.Set("schedule", []interface{}{flattenImageBuilderSchedule(imagePipeline.Schedule)})
+		d.Set("schedule", []interface{}{flattenSchedule(imagePipeline.Schedule)})
 	} else {
 		d.Set("schedule", nil)
 	}
@@ -295,7 +295,7 @@ func resourceImagePipelineUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if v, ok := d.GetOk("image_tests_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.ImageTestsConfiguration = expandImageBuilderImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
+			input.ImageTestsConfiguration = expandImageTestConfiguration(v.([]interface{})[0].(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("infrastructure_configuration_arn"); ok {
@@ -303,7 +303,7 @@ func resourceImagePipelineUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if v, ok := d.GetOk("schedule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Schedule = expandImageBuilderPipelineSchedule(v.([]interface{})[0].(map[string]interface{}))
+			input.Schedule = expandPipelineSchedule(v.([]interface{})[0].(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("status"); ok {
@@ -348,7 +348,7 @@ func resourceImagePipelineDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func expandImageBuilderImageTestConfiguration(tfMap map[string]interface{}) *imagebuilder.ImageTestsConfiguration {
+func expandImageTestConfiguration(tfMap map[string]interface{}) *imagebuilder.ImageTestsConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -366,7 +366,7 @@ func expandImageBuilderImageTestConfiguration(tfMap map[string]interface{}) *ima
 	return apiObject
 }
 
-func expandImageBuilderPipelineSchedule(tfMap map[string]interface{}) *imagebuilder.Schedule {
+func expandPipelineSchedule(tfMap map[string]interface{}) *imagebuilder.Schedule {
 	if tfMap == nil {
 		return nil
 	}
@@ -384,7 +384,7 @@ func expandImageBuilderPipelineSchedule(tfMap map[string]interface{}) *imagebuil
 	return apiObject
 }
 
-func flattenImageBuilderImageTestsConfiguration(apiObject *imagebuilder.ImageTestsConfiguration) map[string]interface{} {
+func flattenImageTestsConfiguration(apiObject *imagebuilder.ImageTestsConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -402,7 +402,7 @@ func flattenImageBuilderImageTestsConfiguration(apiObject *imagebuilder.ImageTes
 	return tfMap
 }
 
-func flattenImageBuilderSchedule(apiObject *imagebuilder.Schedule) map[string]interface{} {
+func flattenSchedule(apiObject *imagebuilder.Schedule) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -65,6 +65,7 @@ func ResourceImagePipeline() *schema.Resource {
 			"image_recipe_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^arn:aws[^:]*:imagebuilder:[^:]+:(?:\d{12}|aws):image-recipe/[a-z0-9-_]+/\d+\.\d+\.\d+$`), "valid image recipe ARN must be provided"),
 			},
 			"image_tests_configuration": {
@@ -274,7 +275,6 @@ func resourceImagePipelineUpdate(d *schema.ResourceData, meta interface{}) error
 		"description",
 		"distribution_configuration_arn",
 		"enhanced_image_metadata_enabled",
-		"image_recipe_arn",
 		"image_tests_configuration",
 		"infrastructure_configuration_arn",
 		"schedule",
@@ -292,10 +292,6 @@ func resourceImagePipelineUpdate(d *schema.ResourceData, meta interface{}) error
 
 		if v, ok := d.GetOk("distribution_configuration_arn"); ok {
 			input.DistributionConfigurationArn = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("image_recipe_arn"); ok {
-			input.ImageRecipeArn = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("image_tests_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {

--- a/internal/service/imagebuilder/image_pipeline_data_source.go
+++ b/internal/service/imagebuilder/image_pipeline_data_source.go
@@ -139,7 +139,7 @@ func dataSourceImagePipelineRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("image_recipe_arn", imagePipeline.ImageRecipeArn)
 
 	if imagePipeline.ImageTestsConfiguration != nil {
-		d.Set("image_tests_configuration", []interface{}{flattenImageBuilderImageTestsConfiguration(imagePipeline.ImageTestsConfiguration)})
+		d.Set("image_tests_configuration", []interface{}{flattenImageTestsConfiguration(imagePipeline.ImageTestsConfiguration)})
 	} else {
 		d.Set("image_tests_configuration", nil)
 	}
@@ -149,7 +149,7 @@ func dataSourceImagePipelineRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("platform", imagePipeline.Platform)
 
 	if imagePipeline.Schedule != nil {
-		d.Set("schedule", []interface{}{flattenImageBuilderSchedule(imagePipeline.Schedule)})
+		d.Set("schedule", []interface{}{flattenSchedule(imagePipeline.Schedule)})
 	} else {
 		d.Set("schedule", nil)
 	}

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -367,7 +367,7 @@ func expandComponentConfigurations(tfList []interface{}) []*imagebuilder.Compone
 	return apiObjects
 }
 
-func expandEbsInstanceBlockDeviceSpecification(tfMap map[string]interface{}) *imagebuilder.EbsInstanceBlockDeviceSpecification {
+func expandEBSInstanceBlockDeviceSpecification(tfMap map[string]interface{}) *imagebuilder.EbsInstanceBlockDeviceSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -419,7 +419,7 @@ func expandInstanceBlockDeviceMapping(tfMap map[string]interface{}) *imagebuilde
 	}
 
 	if v, ok := tfMap["ebs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Ebs = expandEbsInstanceBlockDeviceSpecification(v[0].(map[string]interface{}))
+		apiObject.Ebs = expandEBSInstanceBlockDeviceSpecification(v[0].(map[string]interface{}))
 	}
 
 	if v, ok := tfMap["no_device"].(bool); ok && v {
@@ -491,7 +491,7 @@ func flattenComponentConfigurations(apiObjects []*imagebuilder.ComponentConfigur
 	return tfList
 }
 
-func flattenEbsInstanceBlockDeviceSpecification(apiObject *imagebuilder.EbsInstanceBlockDeviceSpecification) map[string]interface{} {
+func flattenEBSInstanceBlockDeviceSpecification(apiObject *imagebuilder.EbsInstanceBlockDeviceSpecification) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -541,7 +541,7 @@ func flattenInstanceBlockDeviceMapping(apiObject *imagebuilder.InstanceBlockDevi
 	}
 
 	if v := apiObject.Ebs; v != nil {
-		tfMap["ebs"] = []interface{}{flattenEbsInstanceBlockDeviceSpecification(v)}
+		tfMap["ebs"] = []interface{}{flattenEBSInstanceBlockDeviceSpecification(v)}
 	}
 
 	if v := apiObject.NoDevice; v != nil {

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -196,11 +196,11 @@ func resourceImageRecipeCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("block_device_mapping"); ok && v.(*schema.Set).Len() > 0 {
-		input.BlockDeviceMappings = expandImageBuilderInstanceBlockDeviceMappings(v.(*schema.Set).List())
+		input.BlockDeviceMappings = expandInstanceBlockDeviceMappings(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("component"); ok && len(v.([]interface{})) > 0 {
-		input.Components = expandImageBuilderComponentConfigurations(v.([]interface{}))
+		input.Components = expandComponentConfigurations(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -269,8 +269,8 @@ func resourceImageRecipeRead(d *schema.ResourceData, meta interface{}) error {
 	imageRecipe := output.ImageRecipe
 
 	d.Set("arn", imageRecipe.Arn)
-	d.Set("block_device_mapping", flattenImageBuilderInstanceBlockDeviceMappings(imageRecipe.BlockDeviceMappings))
-	d.Set("component", flattenImageBuilderComponentConfigurations(imageRecipe.Components))
+	d.Set("block_device_mapping", flattenInstanceBlockDeviceMappings(imageRecipe.BlockDeviceMappings))
+	d.Set("component", flattenComponentConfigurations(imageRecipe.Components))
 	d.Set("date_created", imageRecipe.DateCreated)
 	d.Set("description", imageRecipe.Description)
 	d.Set("name", imageRecipe.Name)
@@ -327,7 +327,7 @@ func resourceImageRecipeDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandImageBuilderComponentConfiguration(tfMap map[string]interface{}) *imagebuilder.ComponentConfiguration {
+func expandComponentConfiguration(tfMap map[string]interface{}) *imagebuilder.ComponentConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -341,7 +341,7 @@ func expandImageBuilderComponentConfiguration(tfMap map[string]interface{}) *ima
 	return apiObject
 }
 
-func expandImageBuilderComponentConfigurations(tfList []interface{}) []*imagebuilder.ComponentConfiguration {
+func expandComponentConfigurations(tfList []interface{}) []*imagebuilder.ComponentConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -355,7 +355,7 @@ func expandImageBuilderComponentConfigurations(tfList []interface{}) []*imagebui
 			continue
 		}
 
-		apiObject := expandImageBuilderComponentConfiguration(tfMap)
+		apiObject := expandComponentConfiguration(tfMap)
 
 		if apiObject == nil {
 			continue
@@ -367,7 +367,7 @@ func expandImageBuilderComponentConfigurations(tfList []interface{}) []*imagebui
 	return apiObjects
 }
 
-func expandImageBuilderEbsInstanceBlockDeviceSpecification(tfMap map[string]interface{}) *imagebuilder.EbsInstanceBlockDeviceSpecification {
+func expandEbsInstanceBlockDeviceSpecification(tfMap map[string]interface{}) *imagebuilder.EbsInstanceBlockDeviceSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -407,7 +407,7 @@ func expandImageBuilderEbsInstanceBlockDeviceSpecification(tfMap map[string]inte
 	return apiObject
 }
 
-func expandImageBuilderInstanceBlockDeviceMapping(tfMap map[string]interface{}) *imagebuilder.InstanceBlockDeviceMapping {
+func expandInstanceBlockDeviceMapping(tfMap map[string]interface{}) *imagebuilder.InstanceBlockDeviceMapping {
 	if tfMap == nil {
 		return nil
 	}
@@ -419,7 +419,7 @@ func expandImageBuilderInstanceBlockDeviceMapping(tfMap map[string]interface{}) 
 	}
 
 	if v, ok := tfMap["ebs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Ebs = expandImageBuilderEbsInstanceBlockDeviceSpecification(v[0].(map[string]interface{}))
+		apiObject.Ebs = expandEbsInstanceBlockDeviceSpecification(v[0].(map[string]interface{}))
 	}
 
 	if v, ok := tfMap["no_device"].(bool); ok && v {
@@ -433,7 +433,7 @@ func expandImageBuilderInstanceBlockDeviceMapping(tfMap map[string]interface{}) 
 	return apiObject
 }
 
-func expandImageBuilderInstanceBlockDeviceMappings(tfList []interface{}) []*imagebuilder.InstanceBlockDeviceMapping {
+func expandInstanceBlockDeviceMappings(tfList []interface{}) []*imagebuilder.InstanceBlockDeviceMapping {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -447,7 +447,7 @@ func expandImageBuilderInstanceBlockDeviceMappings(tfList []interface{}) []*imag
 			continue
 		}
 
-		apiObject := expandImageBuilderInstanceBlockDeviceMapping(tfMap)
+		apiObject := expandInstanceBlockDeviceMapping(tfMap)
 
 		if apiObject == nil {
 			continue
@@ -459,7 +459,7 @@ func expandImageBuilderInstanceBlockDeviceMappings(tfList []interface{}) []*imag
 	return apiObjects
 }
 
-func flattenImageBuilderComponentConfiguration(apiObject *imagebuilder.ComponentConfiguration) map[string]interface{} {
+func flattenComponentConfiguration(apiObject *imagebuilder.ComponentConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -473,7 +473,7 @@ func flattenImageBuilderComponentConfiguration(apiObject *imagebuilder.Component
 	return tfMap
 }
 
-func flattenImageBuilderComponentConfigurations(apiObjects []*imagebuilder.ComponentConfiguration) []interface{} {
+func flattenComponentConfigurations(apiObjects []*imagebuilder.ComponentConfiguration) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -485,13 +485,13 @@ func flattenImageBuilderComponentConfigurations(apiObjects []*imagebuilder.Compo
 			continue
 		}
 
-		tfList = append(tfList, flattenImageBuilderComponentConfiguration(apiObject))
+		tfList = append(tfList, flattenComponentConfiguration(apiObject))
 	}
 
 	return tfList
 }
 
-func flattenImageBuilderEbsInstanceBlockDeviceSpecification(apiObject *imagebuilder.EbsInstanceBlockDeviceSpecification) map[string]interface{} {
+func flattenEbsInstanceBlockDeviceSpecification(apiObject *imagebuilder.EbsInstanceBlockDeviceSpecification) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -529,7 +529,7 @@ func flattenImageBuilderEbsInstanceBlockDeviceSpecification(apiObject *imagebuil
 	return tfMap
 }
 
-func flattenImageBuilderInstanceBlockDeviceMapping(apiObject *imagebuilder.InstanceBlockDeviceMapping) map[string]interface{} {
+func flattenInstanceBlockDeviceMapping(apiObject *imagebuilder.InstanceBlockDeviceMapping) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -541,7 +541,7 @@ func flattenImageBuilderInstanceBlockDeviceMapping(apiObject *imagebuilder.Insta
 	}
 
 	if v := apiObject.Ebs; v != nil {
-		tfMap["ebs"] = []interface{}{flattenImageBuilderEbsInstanceBlockDeviceSpecification(v)}
+		tfMap["ebs"] = []interface{}{flattenEbsInstanceBlockDeviceSpecification(v)}
 	}
 
 	if v := apiObject.NoDevice; v != nil {
@@ -555,7 +555,7 @@ func flattenImageBuilderInstanceBlockDeviceMapping(apiObject *imagebuilder.Insta
 	return tfMap
 }
 
-func flattenImageBuilderInstanceBlockDeviceMappings(apiObjects []*imagebuilder.InstanceBlockDeviceMapping) []interface{} {
+func flattenInstanceBlockDeviceMappings(apiObjects []*imagebuilder.InstanceBlockDeviceMapping) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -567,7 +567,7 @@ func flattenImageBuilderInstanceBlockDeviceMappings(apiObjects []*imagebuilder.I
 			continue
 		}
 
-		tfList = append(tfList, flattenImageBuilderInstanceBlockDeviceMapping(apiObject))
+		tfList = append(tfList, flattenInstanceBlockDeviceMapping(apiObject))
 	}
 
 	return tfList

--- a/internal/service/imagebuilder/image_recipe_data_source.go
+++ b/internal/service/imagebuilder/image_recipe_data_source.go
@@ -150,8 +150,8 @@ func dataSourceImageRecipeRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(aws.StringValue(imageRecipe.Arn))
 	d.Set("arn", imageRecipe.Arn)
-	d.Set("block_device_mapping", flattenImageBuilderInstanceBlockDeviceMappings(imageRecipe.BlockDeviceMappings))
-	d.Set("component", flattenImageBuilderComponentConfigurations(imageRecipe.Components))
+	d.Set("block_device_mapping", flattenInstanceBlockDeviceMappings(imageRecipe.BlockDeviceMappings))
+	d.Set("component", flattenComponentConfigurations(imageRecipe.Components))
 	d.Set("date_created", imageRecipe.DateCreated)
 	d.Set("description", imageRecipe.Description)
 	d.Set("name", imageRecipe.Name)

--- a/internal/service/imagebuilder/image_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/image_recipes_data_source_test.go
@@ -16,7 +16,9 @@ func TestAccImageBuilderImageRecipesDataSource_owner(t *testing.T) {
 	dataSourceNameOwnerSelf := "data.aws_imagebuilder_image_recipes.self"
 	resourceName := "aws_imagebuilder_image_recipe.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Not a good test since it is susceptible to fail with parallel tests or if anything else
+	// ImageBuilder is going on in the account
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/imagebuilder/infrastructure_configuration.go
+++ b/internal/service/imagebuilder/infrastructure_configuration.go
@@ -157,7 +157,7 @@ func resourceInfrastructureConfigurationCreate(d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("logging"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Logging = expandImageBuilderLogging(v.([]interface{})[0].(map[string]interface{}))
+		input.Logging = expandLogging(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("resource_tags"); ok && len(v.(map[string]interface{})) > 0 {
@@ -249,7 +249,7 @@ func resourceInfrastructureConfigurationRead(d *schema.ResourceData, meta interf
 	d.Set("instance_types", aws.StringValueSlice(infrastructureConfiguration.InstanceTypes))
 	d.Set("key_pair", infrastructureConfiguration.KeyPair)
 	if infrastructureConfiguration.Logging != nil {
-		d.Set("logging", []interface{}{flattenImageBuilderLogging(infrastructureConfiguration.Logging)})
+		d.Set("logging", []interface{}{flattenLogging(infrastructureConfiguration.Logging)})
 	} else {
 		d.Set("logging", nil)
 	}
@@ -310,7 +310,7 @@ func resourceInfrastructureConfigurationUpdate(d *schema.ResourceData, meta inte
 		}
 
 		if v, ok := d.GetOk("logging"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Logging = expandImageBuilderLogging(v.([]interface{})[0].(map[string]interface{}))
+			input.Logging = expandLogging(v.([]interface{})[0].(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("resource_tags"); ok && len(v.(map[string]interface{})) > 0 {
@@ -383,7 +383,7 @@ func resourceInfrastructureConfigurationDelete(d *schema.ResourceData, meta inte
 	return nil
 }
 
-func expandImageBuilderLogging(tfMap map[string]interface{}) *imagebuilder.Logging {
+func expandLogging(tfMap map[string]interface{}) *imagebuilder.Logging {
 	if tfMap == nil {
 		return nil
 	}
@@ -391,13 +391,13 @@ func expandImageBuilderLogging(tfMap map[string]interface{}) *imagebuilder.Loggi
 	apiObject := &imagebuilder.Logging{}
 
 	if v, ok := tfMap["s3_logs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.S3Logs = expandImageBuilderS3Logs(v[0].(map[string]interface{}))
+		apiObject.S3Logs = expandS3Logs(v[0].(map[string]interface{}))
 	}
 
 	return apiObject
 }
 
-func expandImageBuilderS3Logs(tfMap map[string]interface{}) *imagebuilder.S3Logs {
+func expandS3Logs(tfMap map[string]interface{}) *imagebuilder.S3Logs {
 	if tfMap == nil {
 		return nil
 	}
@@ -415,7 +415,7 @@ func expandImageBuilderS3Logs(tfMap map[string]interface{}) *imagebuilder.S3Logs
 	return apiObject
 }
 
-func flattenImageBuilderLogging(apiObject *imagebuilder.Logging) map[string]interface{} {
+func flattenLogging(apiObject *imagebuilder.Logging) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -423,13 +423,13 @@ func flattenImageBuilderLogging(apiObject *imagebuilder.Logging) map[string]inte
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.S3Logs; v != nil {
-		tfMap["s3_logs"] = []interface{}{flattenImageBuilderS3Logs(v)}
+		tfMap["s3_logs"] = []interface{}{flattenS3Logs(v)}
 	}
 
 	return tfMap
 }
 
-func flattenImageBuilderS3Logs(apiObject *imagebuilder.S3Logs) map[string]interface{} {
+func flattenS3Logs(apiObject *imagebuilder.S3Logs) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source.go
@@ -128,7 +128,7 @@ func dataSourceInfrastructureConfigurationRead(d *schema.ResourceData, meta inte
 	d.Set("instance_types", aws.StringValueSlice(infrastructureConfiguration.InstanceTypes))
 	d.Set("key_pair", infrastructureConfiguration.KeyPair)
 	if infrastructureConfiguration.Logging != nil {
-		d.Set("logging", []interface{}{flattenImageBuilderLogging(infrastructureConfiguration.Logging)})
+		d.Set("logging", []interface{}{flattenLogging(infrastructureConfiguration.Logging)})
 	} else {
 		d.Set("logging", nil)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19642
Relates #17137

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
--- PASS: TestAccImageBuilderComponent_basic (21.37s)
--- PASS: TestAccImageBuilderComponent_changeDescription (23.79s)
--- PASS: TestAccImageBuilderComponent_description (23.02s)
--- PASS: TestAccImageBuilderComponent_disappears (17.76s)
--- PASS: TestAccImageBuilderComponent_kmsKeyID (28.42s)
--- PASS: TestAccImageBuilderComponent_Platform_windows (22.53s)
--- PASS: TestAccImageBuilderComponent_supportedOsVersions (18.70s)
--- PASS: TestAccImageBuilderComponent_tags (100.51s)
--- PASS: TestAccImageBuilderComponent_uri (41.03s)
--- PASS: TestAccImageBuilderComponentDataSource_arn (28.77s)
--- PASS: TestAccImageBuilderDistributionConfiguration_basic (27.20s)
--- PASS: TestAccImageBuilderDistributionConfiguration_description (40.19s)
--- PASS: TestAccImageBuilderDistributionConfiguration_disappears (16.49s)
--- PASS: TestAccImageBuilderDistributionConfiguration_distribution (28.34s)
--- PASS: TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs (40.70s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_amiTags (40.37s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_description (50.01s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_kmsKeyID (46.93s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_name (53.62s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_targetAccountIDs (49.91s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userGroups (23.46s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionAMIDistributionLaunchPermission_userIDs (55.00s)
--- PASS: TestAccImageBuilderDistributionConfiguration_tags (57.28s)
--- PASS: TestAccImageBuilderDistributionConfigurationDataSource_arn (22.35s)
--- PASS: TestAccImageBuilderImage_basic (1453.20s)
--- PASS: TestAccImageBuilderImage_disappears (1197.38s)
--- PASS: TestAccImageBuilderImage_distributionARN (1705.86s)
--- PASS: TestAccImageBuilderImage_enhancedImageMetadataEnabled (1187.08s)
--- PASS: TestAccImageBuilderImage_ImageTests_imageTestsEnabled (1067.64s)
--- PASS: TestAccImageBuilderImage_ImageTests_timeoutMinutes (1445.54s)
--- PASS: TestAccImageBuilderImage_tags (1489.89s)
--- PASS: TestAccImageBuilderImageDataSource_ARN_aws (19.31s)
--- PASS: TestAccImageBuilderImageDataSource_ARN_self (1443.78s)
--- PASS: TestAccImageBuilderImagePipeline_basic (52.42s)
--- PASS: TestAccImageBuilderImagePipeline_description (71.10s)
--- PASS: TestAccImageBuilderImagePipeline_disappears (36.83s)
--- PASS: TestAccImageBuilderImagePipeline_distributionARN (80.59s)
--- PASS: TestAccImageBuilderImagePipeline_enhancedImageMetadataEnabled (74.71s)
--- PASS: TestAccImageBuilderImagePipeline_imageRecipeARN (75.79s)
--- PASS: TestAccImageBuilderImagePipeline_ImageTests_imageTestsEnabled (59.99s)
--- PASS: TestAccImageBuilderImagePipeline_ImageTests_timeoutMinutes (66.84s)
--- PASS: TestAccImageBuilderImagePipeline_infrastructureARN (71.12s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_pipelineExecutionStartCondition (66.04s)
--- PASS: TestAccImageBuilderImagePipeline_Schedule_scheduleExpression (73.72s)
--- PASS: TestAccImageBuilderImagePipeline_status (73.55s)
--- PASS: TestAccImageBuilderImagePipeline_tags (101.55s)
--- PASS: TestAccImageBuilderImagePipelineDataSource_arn (49.69s)
--- PASS: TestAccImageBuilderImageRecipe_basic (33.89s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (24.74s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (33.68s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (28.50s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (27.28s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (26.86s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (26.96s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (28.87s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (54.57s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (26.94s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (26.77s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (51.24s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (27.26s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (49.23s)
--- PASS: TestAccImageBuilderImageRecipe_component (32.58s)
--- PASS: TestAccImageBuilderImageRecipe_description (31.76s)
--- PASS: TestAccImageBuilderImageRecipe_disappears (29.26s)
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (64.27s)
--- PASS: TestAccImageBuilderImageRecipe_tags (115.28s)
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (33.17s)
--- PASS: TestAccImageBuilderImageRecipeDataSource_arn (37.35s)
--- PASS: TestAccImageBuilderImageRecipesDataSource_filter (32.53s)
--- PASS: TestAccImageBuilderImageRecipesDataSource_owner (21.81s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_basic (46.74s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_description (70.09s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_disappears (45.64s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceProfileName (81.32s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceTypes (75.16s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_keyPair (67.68s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName (112.57s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName (92.20s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix (115.88s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix (85.97s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_resourceTags (70.38s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs (114.51s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_snsTopicARN (75.28s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_subnetID (112.79s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_tags (134.68s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure (70.31s)
--- PASS: TestAccImageBuilderInfrastructureConfigurationDataSource_arn (43.20s)
```
