### PR TITLE
Add account_id for aws_account_alternate_contact to manage member accounts in an AWS organization

### DIFF
--- a/.changelog/21888.txt
+++ b/.changelog/21888.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_account_alternate_contact: Add `account_id` argument
+```

--- a/internal/service/account/alternate_contact_test.go
+++ b/internal/service/account/alternate_contact_test.go
@@ -93,7 +93,13 @@ func testAccountAlternateContactDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, "", rs.Primary.ID)
+		accountID, contactType, err := tfaccount.AlternateContactParseResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		_, err = tfaccount.FindAlternateContactByAccountIDAndContactType(ctx, conn, accountID, contactType)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -121,10 +127,16 @@ func testAccCheckAccountAlternateContactExists(n string) resource.TestCheckFunc 
 			return fmt.Errorf("No Account Alternate Contact ID is set")
 		}
 
+		accountID, contactType, err := tfaccount.AlternateContactParseResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
 		ctx := context.TODO()
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AccountConn
 
-		_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, "", rs.Primary.ID)
+		_, err = tfaccount.FindAlternateContactByAccountIDAndContactType(ctx, conn, accountID, contactType)
 
 		if err != nil {
 			return err
@@ -151,7 +163,7 @@ func testAccPreCheck(t *testing.T) {
 	ctx := context.TODO()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AccountConn
 
-	_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, "", account.AlternateContactTypeOperations)
+	_, err := tfaccount.FindAlternateContactByAccountIDAndContactType(ctx, conn, "", account.AlternateContactTypeOperations)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/account/alternate_contact_test.go
+++ b/internal/service/account/alternate_contact_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/account"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -33,6 +34,7 @@ func TestAccAccountAlternateContact_basic(t *testing.T) {
 				Config: testAccountAlternateContactConfig(rName1, emailAddress1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAccountAlternateContactExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "alternate_contact_type", "OPERATIONS"),
 					resource.TestCheckResourceAttr(resourceName, "email_address", emailAddress1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
@@ -49,6 +51,7 @@ func TestAccAccountAlternateContact_basic(t *testing.T) {
 				Config: testAccountAlternateContactConfig(rName2, emailAddress2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAccountAlternateContactExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "alternate_contact_type", "OPERATIONS"),
 					resource.TestCheckResourceAttr(resourceName, "email_address", emailAddress2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
@@ -79,6 +82,59 @@ func TestAccAccountAlternateContact_disappears(t *testing.T) {
 					acctest.CheckResourceDisappears(acctest.Provider, tfaccount.ResourceAlternateContact(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAccountAlternateContact_accountID(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_account_alternate_contact.test"
+	domain := acctest.RandomDomainName()
+	emailAddress1 := acctest.RandomEmailAddress(domain)
+	emailAddress2 := acctest.RandomEmailAddress(domain)
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckOrganizationManagementAccount(t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:        acctest.ErrorCheck(t, account.EndpointsID),
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      testAccountAlternateContactDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccountAlternateContactOrganizationConfig(rName1, emailAddress1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountAlternateContactExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "alternate_contact_type", "OPERATIONS"),
+					resource.TestCheckResourceAttr(resourceName, "email_address", emailAddress1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "phone_number", "+17031235555"),
+					resource.TestCheckResourceAttr(resourceName, "title", rName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccountAlternateContactOrganizationConfig(rName2, emailAddress2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountAlternateContactExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "alternate_contact_type", "OPERATIONS"),
+					resource.TestCheckResourceAttr(resourceName, "email_address", emailAddress2),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "phone_number", "+17031235555"),
+					resource.TestCheckResourceAttr(resourceName, "title", rName2),
+				),
 			},
 		},
 	})
@@ -157,6 +213,24 @@ resource "aws_account_alternate_contact" "test" {
   title         = %[1]q
 }
 `, rName, emailAddress)
+}
+
+func testAccountAlternateContactOrganizationConfig(rName, emailAddress string) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider(), fmt.Sprintf(`
+data "aws_caller_identity" "test" {
+  provider = "awsalternate"
+}
+
+resource "aws_account_alternate_contact" "test" {
+  account_id             = data.aws_caller_identity.test.account_id
+  alternate_contact_type = "OPERATIONS"
+
+  email_address = %[2]q
+  name          = %[1]q
+  phone_number  = "+17031235555"
+  title         = %[1]q
+}
+`, rName, emailAddress))
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/internal/service/account/alternate_contact_test.go
+++ b/internal/service/account/alternate_contact_test.go
@@ -93,7 +93,7 @@ func testAccountAlternateContactDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, rs.Primary.ID)
+		_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, "", rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -124,7 +124,7 @@ func testAccCheckAccountAlternateContactExists(n string) resource.TestCheckFunc 
 		ctx := context.TODO()
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AccountConn
 
-		_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, rs.Primary.ID)
+		_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, "", rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -151,7 +151,7 @@ func testAccPreCheck(t *testing.T) {
 	ctx := context.TODO()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AccountConn
 
-	_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, account.AlternateContactTypeOperations)
+	_, err := tfaccount.FindAlternateContactByContactType(ctx, conn, "", account.AlternateContactTypeOperations)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/website/docs/r/account_alternate_contact.html.markdown
+++ b/website/docs/r/account_alternate_contact.html.markdown
@@ -14,6 +14,7 @@ Manages the specified alternate contact attached to an AWS Account.
 
 ```terraform
 resource "aws_account_alternate_contact" "operations" {
+
   alternate_contact_type = "OPERATIONS"
 
   name          = "Example"
@@ -27,6 +28,7 @@ resource "aws_account_alternate_contact" "operations" {
 
 The following arguments are supported:
 
+* `account_id` - (Optional) The ID of the target account when managing member accounts. Will manage current user's account by default if omitted.
 * `alternate_contact_type` - (Required) The type of the alternate contact. Allowed values are: `BILLING`, `OPERATIONS`, `SECURITY`.
 * `email_address` - (Required) An email address for the alternate contact.
 * `name` - (Required) The name of the alternate contact.


### PR DESCRIPTION
Thank to @shedimon for previous PR: https://github.com/hashicorp/terraform-provider-aws/pull/21789, this is my change to add support for managing member accounts in an AWS organization.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #21118

Output from acceptance testing:
```
make testacc TESTARGS='-run=TestAccAccountAlternateContact' PKG_NAME="internal/service/account"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/account/... -v -count 1 -parallel 20 -run=TestAccAccountAlternateContact -timeout 180m
=== RUN   TestAccAccountAlternateContact_basic
--- PASS: TestAccAccountAlternateContact_basic (83.90s)
=== RUN   TestAccAccountAlternateContact_disappears
--- PASS: TestAccAccountAlternateContact_disappears (34.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account    117.976s
```
