### PR TITLE
r/s3_bucket_replication_configuration: make `event_threshold` optional in `destination` `metrics` config block

### DIFF
--- a/.changelog/21901.txt
+++ b/.changelog/21901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_replication_configuration: Mark `event_threshold` in `destination` `metrics` configuration block as `Optional`
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -2426,8 +2426,10 @@ func flattenBucketReplicationConfiguration(r *s3.ReplicationConfiguration) []map
 			}
 			if v.Destination.Metrics != nil {
 				metrics := map[string]interface{}{
-					"minutes": int(aws.Int64Value(v.Destination.Metrics.EventThreshold.Minutes)),
-					"status":  aws.StringValue(v.Destination.Metrics.Status),
+					"status": aws.StringValue(v.Destination.Metrics.Status),
+				}
+				if v.Destination.Metrics.EventThreshold != nil {
+					metrics["minutes"] = int(aws.Int64Value(v.Destination.Metrics.EventThreshold.Minutes))
 				}
 				rd["metrics"] = []interface{}{metrics}
 			}

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -111,7 +111,7 @@ func ResourceBucketReplicationConfiguration() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"event_threshold": {
 													Type:     schema.TypeList,
-													Required: true,
+													Optional: true,
 													MaxItems: 1,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{

--- a/website/docs/r/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_replication_configuration.html.markdown
@@ -313,7 +313,7 @@ metrics {
 
 The `metrics` configuration block supports the following arguments:
 
-* `event_threshold` - (Required) A configuration block that specifies the time threshold for emitting the `s3:Replication:OperationMissedThreshold` event [documented below](#event_threshold).
+* `event_threshold` - (Optional) A configuration block that specifies the time threshold for emitting the `s3:Replication:OperationMissedThreshold` event [documented below](#event_threshold).
 * `status` - (Required) The status of the Destination Metrics. Either `"Enabled"` or `"Disabled"`.
 
 ### event_threshold


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21895

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (269.32s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (269.11s)
```
