### PR TITLE
New Resource: aws_eks_cluster_registration

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1125,7 +1125,7 @@ func Provider() *schema.Provider {
 
 			"aws_eks_addon":                    eks.ResourceAddon(),
 			"aws_eks_cluster":                  eks.ResourceCluster(),
-			"aws_eks_cluster_registration"      eks.ResourceClusterRegistration(),
+			"aws_eks_cluster_registration":     eks.ResourceClusterRegistration(),
 			"aws_eks_fargate_profile":          eks.ResourceFargateProfile(),
 			"aws_eks_identity_provider_config": eks.ResourceIdentityProviderConfig(),
 			"aws_eks_node_group":               eks.ResourceNodeGroup(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1125,6 +1125,7 @@ func Provider() *schema.Provider {
 
 			"aws_eks_addon":                    eks.ResourceAddon(),
 			"aws_eks_cluster":                  eks.ResourceCluster(),
+			"aws_eks_cluster_registration"      eks.ResourceClusterRegistration(),
 			"aws_eks_fargate_profile":          eks.ResourceFargateProfile(),
 			"aws_eks_identity_provider_config": eks.ResourceIdentityProviderConfig(),
 			"aws_eks_node_group":               eks.ResourceNodeGroup(),

--- a/internal/service/eks/cluster_registration.go
+++ b/internal/service/eks/cluster_registration.go
@@ -164,7 +164,6 @@ func resourceClusterRegistrationRead(ctx context.Context, d *schema.ResourceData
 	d.Set("created_at", aws.TimeValue(cluster.CreatedAt).String())
 
 	d.Set("name", cluster.Name)
-	d.Set("role_arn", cluster.RoleArn)
 	d.Set("status", cluster.Status)
 
 	tags := KeyValueTags(cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/eks/cluster_registration.go
+++ b/internal/service/eks/cluster_registration.go
@@ -1,0 +1,125 @@
+package eks
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceClusterRegistration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceClusterRegistrationCreate,
+		Read:   resourceClusterRegistrationRead,
+		Update: resourceClusterRegistrionUpdate,
+		Delete: resourceClusterRegistrationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"client_request_token": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validClusterName,
+			},
+			"connector_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(eks.ConnectorConfigProvider_Values(), false),
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func resourceClusterRegistrationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EKSConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+	name := d.Get("name").(string)
+
+	input := &eks.RegisterClusterInput{
+		ClientRequestToken: aws.String(d.Get("client_request_token").(string)),
+		Name:               aws.String(name),
+		ConnectorConfig:    expandConnectorConfigRequest(d.Get("connector_config").([]interface{})),
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	log.Printf("[DEBUG] Creating EKS Cluster Registration: %s", input)
+	var output *eks.RegisterClusterOutput
+	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.RegisterCluster(input)
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.RegisterCluster(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error registering EKS Cluster (%s): %w", name, err)
+	}
+
+	d.SetId(aws.StringValue(output.Cluster.Name))
+
+	return resourceClusterRead(d, meta)
+}
+
+func expandConnectorConfigRequest(tfList []interface{}) *eks.ConnectorConfigRequest {
+	tfMap, ok := tfList[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	apiObject := &eks.ConnectorConfigRequest{}
+
+	if v, ok := tfMap["provider"].(string); ok && v != "" {
+		apiObject.Provider = aws.String(v)
+	}
+
+	if v, ok := tfMap["role_arn"].(string); ok && v != "" {
+		apiObject.RoleArn = aws.String(v)
+	}
+
+	return apiObject
+}

--- a/internal/service/eks/cluster_registration.go
+++ b/internal/service/eks/cluster_registration.go
@@ -295,6 +295,26 @@ func resourceClusterRegistrationRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("error setting connector config: %w", err))
 	}
 
+	if err := d.Set("identity", flattenEksIdentity(cluster.Identity)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting identity: %w", err))
+	}
+
+	if err := d.Set("certificate_authority", flattenEksCertificate(cluster.CertificateAuthority)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting certificate_authority: %w", err))
+	}
+
+	if err := d.Set("encryption_config", flattenEksEncryptionConfig(cluster.EncryptionConfig)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting encryption_config: %w", err))
+	}
+
+	if err := d.Set("kubernetes_network_config", flattenEksNetworkConfig(cluster.KubernetesNetworkConfig)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting kubernetes_network_config: %w", err))
+	}
+
+	if err := d.Set("vpc_config", flattenEksVpcConfigResponse(cluster.ResourcesVpcConfig)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting vpc_config: %w", err))
+	}
+
 	tags := KeyValueTags(cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002

--- a/internal/service/eks/cluster_registration_test.go
+++ b/internal/service/eks/cluster_registration_test.go
@@ -139,62 +139,63 @@ func testAccCheckClusterRegistrationDestroy(s *terraform.State) error {
 func testAccClusterRegistrationBaseIAMConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-	name = "%[1]s-role"
-	
-	assume_role_policy = jsonencode({
-		"Version": "2012-10-17",
-		"Statement": [
-			{
-				"Sid": "SSMAccess",
-				"Effect": "Allow",
-				"Principal": {
-					"Service": [
-						"ssm.amazonaws.com"
-					]
-				},
-				"Action": "sts:AssumeRole"
-			}
-		]
-	})
+  name = "%[1]s-role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "SSMAccess",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : [
+            "ssm.amazonaws.com"
+          ]
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
 }
 
 data aws_iam_policy_document test {
-	statement {
-		sid = "SsmControlChannel"
+  statement {
+    sid = "SsmControlChannel"
 
-		actions = [
-			"ssmmessages:CreateControlChannel"
-		]
+    actions = [
+      "ssmmessages:CreateControlChannel"
+    ]
 
-		resources = [
-			"arn:aws:eks:*:*:cluster/*"
-		] 
-	}
+    resources = [
+      "arn:aws:eks:*:*:cluster/*"
+    ]
+  }
 
-	statement {
-		sid = "ssmDataplaneOperations"
+  statement {
+    sid = "ssmDataplaneOperations"
 
-		actions = [
-			"ssmmessages:CreateDataChannel",
-			"ssmmessages:OpenDataChannel",
-			"ssmmessages:OpenControlChannel"		]
+    actions = [
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenDataChannel",
+    "ssmmessages:OpenControlChannel"]
 
-		resources = [
-			"*"
-		] 
-	}
+    resources = [
+      "*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "test" {
-	name   = "%[1]s-test"
-	path   = "/"
-	policy = data.aws_iam_policy_document.test.json
-  }
+  name   = "%[1]s-test"
+  path   = "/"
+  policy = data.aws_iam_policy_document.test.json
+}
 
 resource "aws_iam_role_policy_attachment" "test" {
-	role       = aws_iam_role.test.name
-	policy_arn = aws_iam_policy.test.arn
-  }
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
   
 `, rName)
 }
@@ -204,15 +205,15 @@ func testAccClusterRegistrationBaseConfig(rName string) string {
 		testAccClusterRegistrationBaseIAMConfig(rName),
 		fmt.Sprintf(`
 resource "aws_eks_cluster_registration" "test" {
-  name     = %[1]q
+  name = %[1]q
 
   connector_config {
-	provider    = "OTHER"
-	role_arn    = aws_iam_role.test.arn
+    provider = "OTHER"
+    role_arn = aws_iam_role.test.arn
   }
 
   depends_on = [
-	"aws_iam_role_policy_attachment.test",
+    "aws_iam_role_policy_attachment.test",
   ]
 }
 `, rName))
@@ -221,19 +222,19 @@ resource "aws_eks_cluster_registration" "test" {
 func testAccClusterRegistrationTags1Config(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccClusterRegistrationBaseIAMConfig(rName), fmt.Sprintf(`
 resource "aws_eks_cluster_registration" "test" {
-  name     = %[1]q
+  name = %[1]q
 
   tags = {
     %[2]q = %[3]q
   }
 
   connector_config {
-	provider    = "OTHER"
-	role_arn    = aws_iam_role.test.arn
+    provider = "OTHER"
+    role_arn = aws_iam_role.test.arn
   }
 
   depends_on = [
-	"aws_iam_role_policy_attachment.test",
+    "aws_iam_role_policy_attachment.test",
   ]
 }
 `, rName, tagKey1, tagValue1))
@@ -242,7 +243,7 @@ resource "aws_eks_cluster_registration" "test" {
 func testAccClusterRegistrationTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccClusterRegistrationBaseIAMConfig(rName), fmt.Sprintf(`
 resource "aws_eks_cluster_registration" "test" {
-  name     = %[1]q
+  name = %[1]q
 
   tags = {
     %[2]q = %[3]q
@@ -250,12 +251,12 @@ resource "aws_eks_cluster_registration" "test" {
   }
 
   connector_config {
-	provider    = "OTHER"
-	role_arn    = aws_iam_role.test.arn
+    provider = "OTHER"
+    role_arn = aws_iam_role.test.arn
   }
 
   depends_on = [
-	"aws_iam_role_policy_attachment.test",
+    "aws_iam_role_policy_attachment.test",
   ]
 }
   `, rName, tagKey1, tagValue1, tagKey2, tagValue2))

--- a/internal/service/eks/cluster_registration_test.go
+++ b/internal/service/eks/cluster_registration_test.go
@@ -2,6 +2,7 @@ package eks_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -107,6 +108,34 @@ func TestAccEKSClusterRegistration_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccEKSClusterRegistration_InvalidClusterProvider(t *testing.T) {
+	cluName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	regName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_eks_cluster_registration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, eks.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckClusterRegistrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_Required(cluName),
+			},
+			{
+				Config: testAccClusterRegistrationBaseConfig(regName),
+			},
+			{
+				ResourceName:  resourceName,
+				ImportState:   true,
+				ImportStateId: cluName,
+				ExpectError:   regexp.MustCompile(`has not been registered`),
 			},
 		},
 	})

--- a/internal/service/eks/cluster_registration_test.go
+++ b/internal/service/eks/cluster_registration_test.go
@@ -177,7 +177,8 @@ data aws_iam_policy_document test {
     actions = [
       "ssmmessages:CreateDataChannel",
       "ssmmessages:OpenDataChannel",
-    "ssmmessages:OpenControlChannel"]
+      "ssmmessages:OpenControlChannel"
+    ]
 
     resources = [
       "*"
@@ -195,10 +196,6 @@ resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
   policy_arn = aws_iam_policy.test.arn
 }
-
-
-
-  
 `, rName)
 }
 

--- a/internal/service/eks/cluster_registration_test.go
+++ b/internal/service/eks/cluster_registration_test.go
@@ -139,7 +139,7 @@ func testAccCheckClusterRegistrationDestroy(s *terraform.State) error {
 func testAccClusterRegistrationBaseIAMConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%[1]s-role"
+  name = %[1]q
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -186,7 +186,7 @@ data aws_iam_policy_document test {
 }
 
 resource "aws_iam_policy" "test" {
-  name   = "%[1]s-test"
+  name   = %[1]q
   path   = "/"
   policy = data.aws_iam_policy_document.test.json
 }
@@ -195,6 +195,8 @@ resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
   policy_arn = aws_iam_policy.test.arn
 }
+
+
 
   
 `, rName)

--- a/internal/service/eks/cluster_registration_test.go
+++ b/internal/service/eks/cluster_registration_test.go
@@ -138,6 +138,8 @@ func testAccCheckClusterRegistrationDestroy(s *terraform.State) error {
 
 func testAccClusterRegistrationBaseIAMConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -149,7 +151,7 @@ resource "aws_iam_role" "test" {
         "Effect" : "Allow",
         "Principal" : {
           "Service" : [
-            "ssm.amazonaws.com"
+            "ssm.${data.aws_partition.current.dns_suffix}"
           ]
         },
         "Action" : "sts:AssumeRole"
@@ -167,7 +169,7 @@ data aws_iam_policy_document test {
     ]
 
     resources = [
-      "arn:aws:eks:*:*:cluster/*"
+      "arn:${data.aws_partition.current.partition}:eks:*:*:cluster/*"
     ]
   }
 

--- a/internal/service/eks/cluster_registration_test.go
+++ b/internal/service/eks/cluster_registration_test.go
@@ -1,0 +1,140 @@
+package eks_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(eks.EndpointsID, testAccErrorCheckSkipEKS)
+
+}
+
+func TestAccEKSClusterRegistration_basic(t *testing.T) {
+	var cluster eks.Cluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster_registration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, eks.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterRegistrationBaseConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccClusterRegistrationBasicConfig(rName string) string {
+	return acctest.ConfigCompose(testAccNodeGroupBaseConfig(rName), fmt.Sprintf(`
+	resource "aws_eks_node_group" "test" {
+	  cluster_name    = aws_eks_cluster.test.name
+	  node_group_name = %[1]q
+	  node_role_arn   = aws_iam_role.node.arn
+	  subnet_ids      = aws_subnet.test[*].id
+	
+	  scaling_config {
+		desired_size = 1
+		max_size     = 1
+		min_size     = 1
+	  }
+	
+	  depends_on = [
+		aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy,
+		aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy,
+		aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly,
+	  ]
+	}
+	`, rName))
+}
+
+func testAccClusterRegistrationBaseIAMConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "cluster_registration" {
+	name = "%[1]s-role"
+	
+	assume_role_policy = jsonencode({
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Sid": "SSMAccess",
+				"Effect": "Allow",
+				"Principal": {
+					"Service": [
+						"ssm.amazonaws.com"
+					]
+				},
+				"Action": "sts:AssumeRole"
+			}
+		]
+	})
+}
+
+data aws_iam_policy_document policy_document {
+	statement {
+		actions = [
+			"ssmmessages:CreateControlChannel"
+		]
+
+		resources = [
+			"arn:aws:eks:*:*:cluster/*"
+		] 
+	}
+
+	statement {
+		actions = [
+			"ssmmessages:CreateDataChannel",
+			"ssmmessages:OpenDataChannel",
+			"ssmmessages:OpenControlChannel"		]
+
+		resources = [
+			"*"
+		] 
+	}
+}
+
+resource "aws_iam_policy" "agent_policy" {
+	name   = "agent_policy"
+	path   = "/"
+	policy = data.aws_iam_policy_document.policy_document.json
+  }
+
+resource "aws_iam_role_policy_attachment" "test-attach" {
+	role       = aws_iam_role.cluster_registration.name
+	policy_arn = aws_iam_policy.agent_policy.arn
+  }
+  
+`, rName)
+}
+
+func testAccClusterRegistrationBaseConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterRegistrationBaseIAMConfig(rName),
+		fmt.Sprintf(`
+resource "aws_eks_cluster_registration" "test" {
+  name     = %[1]q
+
+  connector_config {
+	provider    = "OTHER"
+	role_arm    = aws_iam_role.cluster_registration.arn
+  }
+}
+`, rName))
+}

--- a/internal/service/eks/wait.go
+++ b/internal/service/eks/wait.go
@@ -113,6 +113,23 @@ func waitClusterDeleted(conn *eks.EKS, name string, timeout time.Duration) (*eks
 	return nil, err
 }
 
+func waitClusterRegistrationPending(conn *eks.EKS, name string, timeout time.Duration) (*eks.Cluster, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{eks.ClusterStatusCreating},
+		Target:  []string{eks.ClusterStatusPending},
+		Refresh: statusCluster(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*eks.Cluster); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitClusterUpdateSuccessful(conn *eks.EKS, name, id string, timeout time.Duration) (*eks.Update, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{eks.UpdateStatusInProgress},

--- a/website/docs/r/eks_cluster_registration.html.markdown
+++ b/website/docs/r/eks_cluster_registration.html.markdown
@@ -1,0 +1,193 @@
+---
+subcategory: "EKS"
+layout: "aws"
+page_title: "AWS: aws_eks_cluster_registration"
+description: |-
+  Registers an external Kubernetes Cluster with EKS
+---
+
+# Resource: aws_eks_cluster_registration
+
+Registers an external Kubernetes Cluster with EKS
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_eks_cluster" "example" {
+  name     = "example"
+  role_arn = aws_iam_role.example.arn
+
+  vpc_config {
+    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKSVPCResourceController,
+  ]
+}
+
+output "endpoint" {
+  value = aws_eks_cluster.example.endpoint
+}
+
+output "kubeconfig-certificate-authority-data" {
+  value = aws_eks_cluster.example.certificate_authority[0].data
+}
+```
+
+### Example IAM Role for EKS Cluster
+
+```terraform
+resource "aws_iam_role" "example" {
+  name = "eks-cluster-example"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.example.name
+}
+
+# Optionally, enable Security Groups for Pods
+# Reference: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceController" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.example.name
+}
+```
+
+### Enabling Control Plane Logging
+
+[EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) can be enabled via the `enabled_cluster_log_types` argument. To manage the CloudWatch Log Group retention period, the [`aws_cloudwatch_log_group` resource](/docs/providers/aws/r/cloudwatch_log_group.html) can be used.
+
+-> The below configuration uses [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html) to prevent ordering issues with EKS automatically creating the log group first and a variable for naming consistency. Other ordering and naming methodologies may be more appropriate for your environment.
+
+```terraform
+variable "cluster_name" {
+  default = "example"
+  type    = string
+}
+
+resource "aws_eks_cluster" "example" {
+  depends_on = [aws_cloudwatch_log_group.example]
+
+  enabled_cluster_log_types = ["api", "audit"]
+  name                      = var.cluster_name
+
+  # ... other configuration ...
+}
+
+resource "aws_cloudwatch_log_group" "example" {
+  # The log group name format is /aws/eks/<cluster-name>/cluster
+  # Reference: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = 7
+
+  # ... potentially other configuration ...
+}
+```
+
+### Enabling IAM Roles for Service Accounts
+
+Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. For more information about this feature, see the [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+
+```terraform
+resource "aws_eks_cluster" "example" {
+  # ... other configuration ...
+}
+
+data "tls_certificate" "example" {
+  url = aws_eks_cluster.example.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "example" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.example.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.example.identity[0].oidc[0].issuer
+}
+
+data "aws_iam_policy_document" "example_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.example.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-node"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.example.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "example" {
+  assume_role_policy = data.aws_iam_policy_document.example_assume_role_policy.json
+  name               = "example"
+}
+```
+
+After adding inline IAM Policies (e.g., [`aws_iam_role_policy` resource](/docs/providers/aws/r/iam_role_policy.html)) or attaching IAM Policies (e.g., [`aws_iam_policy` resource](/docs/providers/aws/r/iam_policy.html) and [`aws_iam_role_policy_attachment` resource](/docs/providers/aws/r/iam_role_policy_attachment.html)) with the desired permissions to the IAM Role, annotate the Kubernetes service account (e.g., [`kubernetes_service_account` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account)) and recreate any pods.
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` – (Required) Name of the cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
+* `connector_config` - (Required) The configuration settings required to connect the Kubernetes cluster to the Amazon EKS control plane.
+
+The following arguments are optional:
+
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### connector_config
+
+The following arguments are supported in the `encryption_config` configuration block:
+
+* `provider` - (Required) The cloud provider for the target cluster to connect.
+* `role_arn` - (Required) The Amazon Resource Name (ARN) of the role that is authorized to request the connector configuration.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the cluster.
+* `connector_config` - (Required) The configuration settings required to connect the Kubernetes cluster to the Amazon EKS control plane.
+* `created_at` - Unix epoch timestamp in seconds for when the cluster was created.
+* `status` - Status of the EKS cluster. One of `ACTIVE`, `FAILED`, `PENDING`.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
+
+### connector_config
+
+* `activation_id` - A unique code associated with the cluster for registration purposes.
+* `activation_expiry` - The expiration time of the connected cluster. The cluster's YAML file must be applied through the native provider.
+
+## Import
+
+EKS Clusters can be imported using the `name`, e.g.,
+
+```
+$ terraform import aws_eks_cluster_registration.my_cluster my_cluster
+```

--- a/website/docs/r/eks_cluster_registration.html.markdown
+++ b/website/docs/r/eks_cluster_registration.html.markdown
@@ -3,153 +3,25 @@ subcategory: "EKS"
 layout: "aws"
 page_title: "AWS: aws_eks_cluster_registration"
 description: |-
-  Registers an external Kubernetes Cluster with EKS
+  Connects a Kubernetes cluster to the Amazon EKS control plane.
 ---
 
 # Resource: aws_eks_cluster_registration
 
-Registers an external Kubernetes Cluster with EKS
+Connects a Kubernetes cluster to the Amazon EKS control plane.
 
 ## Example Usage
 
-### Basic Usage
-
 ```terraform
-resource "aws_eks_cluster" "example" {
-  name     = "example"
-  role_arn = aws_iam_role.example.arn
+resource "aws_eks_cluster_registration" "example" {
+  name = "example"
 
-  vpc_config {
-    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
-  }
-
-  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
-  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
-  depends_on = [
-    aws_iam_role_policy_attachment.example-AmazonEKSClusterPolicy,
-    aws_iam_role_policy_attachment.example-AmazonEKSVPCResourceController,
-  ]
-}
-
-output "endpoint" {
-  value = aws_eks_cluster.example.endpoint
-}
-
-output "kubeconfig-certificate-authority-data" {
-  value = aws_eks_cluster.example.certificate_authority[0].data
-}
-```
-
-### Example IAM Role for EKS Cluster
-
-```terraform
-resource "aws_iam_role" "example" {
-  name = "eks-cluster-example"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "eks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_iam_role_policy_attachment" "example-AmazonEKSClusterPolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-  role       = aws_iam_role.example.name
-}
-
-# Optionally, enable Security Groups for Pods
-# Reference: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
-resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceController" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
-  role       = aws_iam_role.example.name
-}
-```
-
-### Enabling Control Plane Logging
-
-[EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) can be enabled via the `enabled_cluster_log_types` argument. To manage the CloudWatch Log Group retention period, the [`aws_cloudwatch_log_group` resource](/docs/providers/aws/r/cloudwatch_log_group.html) can be used.
-
--> The below configuration uses [`depends_on`](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html) to prevent ordering issues with EKS automatically creating the log group first and a variable for naming consistency. Other ordering and naming methodologies may be more appropriate for your environment.
-
-```terraform
-variable "cluster_name" {
-  default = "example"
-  type    = string
-}
-
-resource "aws_eks_cluster" "example" {
-  depends_on = [aws_cloudwatch_log_group.example]
-
-  enabled_cluster_log_types = ["api", "audit"]
-  name                      = var.cluster_name
-
-  # ... other configuration ...
-}
-
-resource "aws_cloudwatch_log_group" "example" {
-  # The log group name format is /aws/eks/<cluster-name>/cluster
-  # Reference: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
-  name              = "/aws/eks/${var.cluster_name}/cluster"
-  retention_in_days = 7
-
-  # ... potentially other configuration ...
-}
-```
-
-### Enabling IAM Roles for Service Accounts
-
-Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. For more information about this feature, see the [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
-
-```terraform
-resource "aws_eks_cluster" "example" {
-  # ... other configuration ...
-}
-
-data "tls_certificate" "example" {
-  url = aws_eks_cluster.example.identity[0].oidc[0].issuer
-}
-
-resource "aws_iam_openid_connect_provider" "example" {
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.example.certificates[0].sha1_fingerprint]
-  url             = aws_eks_cluster.example.identity[0].oidc[0].issuer
-}
-
-data "aws_iam_policy_document" "example_assume_role_policy" {
-  statement {
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    effect  = "Allow"
-
-    condition {
-      test     = "StringEquals"
-      variable = "${replace(aws_iam_openid_connect_provider.example.url, "https://", "")}:sub"
-      values   = ["system:serviceaccount:kube-system:aws-node"]
-    }
-
-    principals {
-      identifiers = [aws_iam_openid_connect_provider.example.arn]
-      type        = "Federated"
-    }
+  connector_config {
+    provider = "EKS_ANYWHERE"
+    role_arn = aws_iam_role.example.arn
   }
 }
-
-resource "aws_iam_role" "example" {
-  assume_role_policy = data.aws_iam_policy_document.example_assume_role_policy.json
-  name               = "example"
-}
 ```
-
-After adding inline IAM Policies (e.g., [`aws_iam_role_policy` resource](/docs/providers/aws/r/iam_role_policy.html)) or attaching IAM Policies (e.g., [`aws_iam_policy` resource](/docs/providers/aws/r/iam_policy.html) and [`aws_iam_role_policy_attachment` resource](/docs/providers/aws/r/iam_role_policy_attachment.html)) with the desired permissions to the IAM Role, annotate the Kubernetes service account (e.g., [`kubernetes_service_account` resource](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account)) and recreate any pods.
 
 ## Argument Reference
 
@@ -164,7 +36,7 @@ The following arguments are optional:
 
 ### connector_config
 
-The following arguments are supported in the `encryption_config` configuration block:
+The following arguments are supported in the `connector_config` configuration block:
 
 * `provider` - (Required) The cloud provider for the target cluster to connect.
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the role that is authorized to request the connector configuration.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21909

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
make testacc TESTARGS='-run=TestAccEKSClusterRegistration_*' PKG_NAME=internal/service/eks
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 20 -run=TestAccEKSClusterRegistration_* -timeout 180m
=== RUN   TestAccEKSClusterRegistration_basic
=== PAUSE TestAccEKSClusterRegistration_basic
=== RUN   TestAccEKSClusterRegistration_disappears
=== PAUSE TestAccEKSClusterRegistration_disappears
=== RUN   TestAccEKSClusterRegistration_tags
=== PAUSE TestAccEKSClusterRegistration_tags
=== CONT  TestAccEKSClusterRegistration_basic
=== CONT  TestAccEKSClusterRegistration_tags
=== CONT  TestAccEKSClusterRegistration_disappears
--- PASS: TestAccEKSClusterRegistration_disappears (29.26s)
--- PASS: TestAccEKSClusterRegistration_basic (31.73s)
--- PASS: TestAccEKSClusterRegistration_tags (60.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	63.411s
```
