### PR TITLE
Add sweepers for `aws_fsx_ontap_storage_virtual_machine ` and `aws_fsx_ontap_volume`

### DIFF
--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -182,7 +182,6 @@ func init() {
 			"aws_emr_cluster",
 			"aws_fsx_lustre_file_system",
 			"aws_fsx_ontap_file_system",
-			"aws_fsx_ontap_storage_virtual_machine",
 			"aws_fsx_windows_file_system",
 			"aws_lambda_function",
 			"aws_lb",

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -460,7 +460,7 @@ func testAccCheckFsxOntapFileSystemExists(resourceName string, fs *fsx.FileSyste
 		}
 
 		if filesystem == nil {
-			return fmt.Errorf("FSx Ontap File System (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("FSx ONTAP File System (%s) not found", rs.Primary.ID)
 		}
 
 		*fs = *filesystem
@@ -483,7 +483,7 @@ func testAccCheckFsxOntapFileSystemDestroy(s *terraform.State) error {
 		}
 
 		if filesystem != nil {
-			return fmt.Errorf("FSx Ontap File System (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("FSx ONTAP File System (%s) still exists", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -492,7 +492,7 @@ func testAccCheckFsxOntapFileSystemDestroy(s *terraform.State) error {
 func testAccCheckFsxOntapFileSystemNotRecreated(i, j *fsx.FileSystem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.FileSystemId) != aws.StringValue(j.FileSystemId) {
-			return fmt.Errorf("FSx File System (%s) recreated", aws.StringValue(i.FileSystemId))
+			return fmt.Errorf("FSx ONTAP File System (%s) recreated", aws.StringValue(i.FileSystemId))
 		}
 
 		return nil
@@ -502,7 +502,7 @@ func testAccCheckFsxOntapFileSystemNotRecreated(i, j *fsx.FileSystem) resource.T
 func testAccCheckFsxOntapFileSystemRecreated(i, j *fsx.FileSystem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.FileSystemId) == aws.StringValue(j.FileSystemId) {
-			return fmt.Errorf("FSx File System (%s) not recreated", aws.StringValue(i.FileSystemId))
+			return fmt.Errorf("FSx ONTAP File System (%s) not recreated", aws.StringValue(i.FileSystemId))
 		}
 
 		return nil

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -291,7 +291,7 @@ func testAccCheckFsxOntapStorageVirtualMachineExists(resourceName string, svm *f
 		}
 
 		if storageVirtualMachine == nil {
-			return fmt.Errorf("FSx Ontap Storage Virtual Machine (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("FSx ONTAP Storage Virtual Machine (%s) not found", rs.Primary.ID)
 		}
 
 		*svm = *storageVirtualMachine
@@ -314,7 +314,7 @@ func testAccCheckFsxOntapStorageVirtualMachineDestroy(s *terraform.State) error 
 		}
 
 		if storageVirtualMachine != nil {
-			return fmt.Errorf("FSx Ontap Storage Virtual Machine (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("FSx ONTAP Storage Virtual Machine (%s) still exists", rs.Primary.ID)
 		}
 	}
 	return nil

--- a/internal/service/fsx/ontap_volume_test.go
+++ b/internal/service/fsx/ontap_volume_test.go
@@ -393,7 +393,7 @@ func testAccCheckFsxOntapVolumeExists(resourceName string, volume *fsx.Volume) r
 		}
 
 		if volume == nil {
-			return fmt.Errorf("FSx Ontap Volume (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("FSx ONTAP Volume (%s) not found", rs.Primary.ID)
 		}
 
 		*volume = *volume1
@@ -416,7 +416,7 @@ func testAccCheckFsxOntapVolumeDestroy(s *terraform.State) error {
 		}
 
 		if volume != nil {
-			return fmt.Errorf("FSx Ontap Volume (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("FSx ONTAP Volume (%s) still exists", rs.Primary.ID)
 		}
 	}
 	return nil

--- a/internal/service/fsx/sweep.go
+++ b/internal/service/fsx/sweep.go
@@ -167,15 +167,15 @@ func sweepFSXOntapFileSystems(region string) error {
 	})
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error listing FSx Ontap File Systems for %s: %w", region, err))
+		errs = multierror.Append(errs, fmt.Errorf("error listing FSx ONTAP File Systems for %s: %w", region, err))
 	}
 
 	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping FSx Ontap File Systems for %s: %w", region, err))
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping FSx ONTAP File Systems for %s: %w", region, err))
 	}
 
 	if sweep.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping FSx Ontap File System sweep for %s: %s", region, errs)
+		log.Printf("[WARN] Skipping FSx ONTAP File System sweep for %s: %s", region, errs)
 		return nil
 	}
 

--- a/internal/service/fsx/sweep.go
+++ b/internal/service/fsx/sweep.go
@@ -27,13 +27,20 @@ func init() {
 	})
 
 	resource.AddTestSweepers("aws_fsx_ontap_file_system", &resource.Sweeper{
-		Name: "aws_fsx_ontap_file_system",
-		F:    sweepFSXOntapFileSystems,
+		Name:         "aws_fsx_ontap_file_system",
+		F:            sweepFSXOntapFileSystems,
+		Dependencies: []string{"aws_fsx_ontap_storage_virtual_machine"},
 	})
 
 	resource.AddTestSweepers("aws_fsx_ontap_storage_virtual_machine", &resource.Sweeper{
-		Name: "aws_fsx_ontap_storage_virtual_machine",
-		F:    sweepFSXOntapStorageVirtualMachine,
+		Name:         "aws_fsx_ontap_storage_virtual_machine",
+		F:            sweepFSXOntapStorageVirtualMachine,
+		Dependencies: []string{"aws_fsx_ontap_volume"},
+	})
+
+	resource.AddTestSweepers("aws_fsx_ontap_volume", &resource.Sweeper{
+		Name: "aws_fsx_ontap_volume",
+		F:    sweepFSXOntapVolume,
 	})
 
 	resource.AddTestSweepers("aws_fsx_windows_file_system", &resource.Sweeper{
@@ -46,7 +53,7 @@ func sweepFSXBackups(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
@@ -90,7 +97,7 @@ func sweepFSXLustreFileSystems(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
@@ -138,7 +145,7 @@ func sweepFSXOntapFileSystems(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
 	conn := client.(*conns.AWSClient).FSxConn
@@ -176,6 +183,101 @@ func sweepFSXOntapFileSystems(region string) error {
 
 	if sweep.SkipSweepError(errs.ErrorOrNil()) {
 		log.Printf("[WARN] Skipping FSx ONTAP File System sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepFSXOntapStorageVirtualMachine(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).FSxConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+	input := &fsx.DescribeStorageVirtualMachinesInput{}
+
+	err = conn.DescribeStorageVirtualMachinesPages(input, func(page *fsx.DescribeStorageVirtualMachinesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, vm := range page.StorageVirtualMachines {
+			r := ResourceOntapStorageVirtualMachine()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(vm.StorageVirtualMachineId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing FSx ONTAP Storage Virtual Machine for %s: %w", region, err))
+	}
+
+	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping FSx ONTAP Storage Virtual Machine for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping FSx ONTAP Storage Virtual Machine sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepFSXOntapVolume(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).FSxConn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+	input := &fsx.DescribeVolumesInput{}
+
+	err = conn.DescribeVolumesPages(input, func(page *fsx.DescribeVolumesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Volumes {
+			if aws.StringValue(v.VolumeType) != fsx.VolumeTypeOntap {
+				continue
+			}
+			if v.OntapConfiguration != nil && aws.BoolValue(v.OntapConfiguration.StorageVirtualMachineRoot) {
+				continue
+			}
+
+			r := ResourceOntapVolume()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.VolumeId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error listing FSx ONTAP Volume for %s: %w", region, err))
+	}
+
+	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping FSx ONTAP Volume for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping FSx ONTAP Volume sweep for %s: %s", region, errs)
 		return nil
 	}
 


### PR DESCRIPTION
Adds sweepers missed in #21780 and #21889

Before

```console
$ make sweep SWEEPARGS=-sweep-run= aws_fsx_ontap_file_system
# github.com/hashicorp/terraform-provider-aws/internal/service/fsx
internal/service/fsx/sweep.go:36:9: undefined: sweepFSXOntapStorageVirtualMachine
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep [build failed]
FAIL
make: *** [sweep] Error 2
```

After

```console
$ make sweep SWEEPARGS=-sweep-run= aws_fsx_ontap_file_system
[DEBUG] Running Sweepers for region (us-east-1):
[DEBUG] Sweeper (aws_fsx_ontap_file_system) has dependency (aws_fsx_ontap_storage_virtual_machine), running..
[DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) has dependency (aws_fsx_ontap_volume), running..
[DEBUG] Running Sweeper (aws_fsx_ontap_volume) in region (us-east-1)
[DEBUG] Deleting FSx ONTAP Volume: fsvol-0a837de36b8cdc44b
...
[DEBUG] Completed Sweeper (aws_fsx_ontap_volume) in region (us-east-1) in 3m58.210912167s
[DEBUG] Running Sweeper (aws_fsx_ontap_storage_virtual_machine) in region (us-east-1)
[DEBUG] Deleting FSx ONTAP Storage Virtual Machine: svm-086af9676c40ef591
[DEBUG] Deleting FSx ONTAP Storage Virtual Machine: svm-0c54e58619e98c5ff
[DEBUG] Waiting for state to become: []
[DEBUG] Waiting for state to become: []
...
[DEBUG] Completed Sweeper (aws_fsx_ontap_storage_virtual_machine) in region (us-east-1) in 3m25.15600739s
[DEBUG] Running Sweeper (aws_fsx_ontap_file_system) in region (us-east-1)
[DEBUG] Waiting for state to become: [success]
[DEBUG] Deleting FSx ONTAP File System: fs-0fd68223d2b870111
[DEBUG] Waiting for state to become: []
...
[DEBUG] Completed Sweeper (aws_fsx_ontap_file_system) in region (us-east-1) in 8m43.452879166s
[DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) has dependency (aws_fsx_ontap_volume), running..
[DEBUG] Sweeper (aws_fsx_ontap_volume) already ran in region (us-east-1)
[DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) already ran in region (us-east-1)
[DEBUG] Sweeper (aws_fsx_ontap_volume) already ran in region (us-east-1)
Completed Sweepers for region (us-east-1) in 16m6.819875022s
Sweeper Tests for region (us-east-1) ran successfully:
	- aws_fsx_ontap_volume
	- aws_fsx_ontap_storage_virtual_machine
	- aws_fsx_ontap_file_system
```