### PR TITLE
docs: iam statement Resource, NotResource conflict

### DIFF
--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -441,9 +441,9 @@ The following arguments are optional:
 * `effect` (Optional) - Whether this statement allows or denies the given actions. Valid values are `Allow` and `Deny`. Defaults to `Allow`.
 * `not_actions` (Optional) - List of actions that this statement does *not* apply to. Use to apply a policy statement to all actions *except* those listed.
 * `not_principals` (Optional) - Like `principals` except these are principals that the statement does *not* apply to.
-* `not_resources` (Optional) - List of resource ARNs that this statement does *not* apply to. Use to apply a policy statement to all resources *except* those listed.
+* `not_resources` (Optional) - List of resource ARNs that this statement does *not* apply to. Use to apply a policy statement to all resources *except* those listed. Conflicts with `resources`.
 * `principals` (Optional) - Configuration block for principals. Detailed below.
-* `resources` (Optional) - List of resource ARNs that this statement applies to. This is required by AWS if used for an IAM policy.
+* `resources` (Optional) - List of resource ARNs that this statement applies to. This is required by AWS if used for an IAM policy. Conflicts with `not_resources`.
 * `sid` (Optional) - Sid (statement ID) is an identifier for a policy statement.
 
 ### `condition`


### PR DESCRIPTION
iam statements must include either Resource or NotResource element as specified [AWS docs: IAM JSON policy elements: Resource](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html) which mentions "Statements must include either a Resource or a NotResource element. You specify a resource using an ARN."

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21836