### PR TITLE
r/aws_lambda_event_source_mapping: add filter_criteria attribute

### DIFF
--- a/.changelog/21937.txt
+++ b/.changelog/21937.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lambda_event_source_mapping: Add `filter_criteria` attribute
+resource/aws_lambda_event_source_mapping: Add `filter_criteria` argument
 ```

--- a/.changelog/21937.txt
+++ b/.changelog/21937.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: Add `filter_criteria` attribute
+```

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -112,6 +112,30 @@ func ResourceEventSourceMapping() *schema.Resource {
 				ExactlyOneOf: []string{"event_source_arn", "self_managed_event_source"},
 			},
 
+			"filter_criteria": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"filters": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 5,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"pattern": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(0, 4096),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"function_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -315,6 +339,10 @@ func resourceEventSourceMappingCreate(d *schema.ResourceData, meta interface{}) 
 		target = v
 	}
 
+	if v, ok := d.GetOk("filter_criteria"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.FilterCriteria = expandLambdaFilterCriteria(v.([]interface{})[0].(map[string]interface{}))
+	}
+
 	if v, ok := d.GetOk("function_response_types"); ok && v.(*schema.Set).Len() > 0 {
 		input.FunctionResponseTypes = flex.ExpandStringSet(v.(*schema.Set))
 	}
@@ -442,6 +470,13 @@ func resourceEventSourceMappingRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("destination_config", nil)
 	}
 	d.Set("event_source_arn", eventSourceMappingConfiguration.EventSourceArn)
+	if v := eventSourceMappingConfiguration.FilterCriteria; v != nil {
+		if err := d.Set("filter_criteria", []interface{}{flattenLambdaFilterCriteria(v)}); err != nil {
+			return fmt.Errorf("error setting filter criteria: %w", err)
+		}
+	} else {
+		d.Set("filter_criteria", nil)
+	}
 	d.Set("function_arn", eventSourceMappingConfiguration.FunctionArn)
 	d.Set("function_name", eventSourceMappingConfiguration.FunctionArn)
 	d.Set("function_response_types", aws.StringValueSlice(eventSourceMappingConfiguration.FunctionResponseTypes))
@@ -516,6 +551,15 @@ func resourceEventSourceMappingUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("enabled") {
 		input.Enabled = aws.Bool(d.Get("enabled").(bool))
+	}
+
+	if d.HasChange("filter_criteria") {
+		if v, ok := d.GetOk("filter_criteria"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			input.FilterCriteria = expandLambdaFilterCriteria(v.([]interface{})[0].(map[string]interface{}))
+		} else {
+			// AWS ignores the removal if this is left as nil.
+			input.FilterCriteria = &lambda.FilterCriteria{}
+		}
 	}
 
 	if d.HasChange("function_name") {
@@ -797,4 +841,117 @@ func flattenLambdaSourceAccessConfigurations(apiObjects []*lambda.SourceAccessCo
 	}
 
 	return tfList
+}
+
+func expandLambdaFilterCriteria(tfMap map[string]interface{}) *lambda.FilterCriteria {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &lambda.FilterCriteria{}
+
+	if v, ok := tfMap["filters"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.Filters = expandLambdaFilters(v.List())
+	}
+
+	return apiObject
+}
+
+func flattenLambdaFilterCriteria(apiObject *lambda.FilterCriteria) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Filters; len(v) > 0 {
+		tfMap["filters"] = flattenLambdaFilters(v)
+	}
+
+	return tfMap
+}
+
+func expandLambdaFilters(tfList []interface{}) []*lambda.Filter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*lambda.Filter
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandLambdaFilter(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func flattenLambdaFilters(apiObjects []*lambda.Filter) *schema.Set {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenLambdaFilter(apiObject))
+	}
+
+	filterResource := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"pattern": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 4096),
+			},
+		},
+	}
+
+	tfSet := schema.NewSet(schema.HashResource(filterResource), tfList)
+
+	return tfSet
+}
+
+func expandLambdaFilter(tfMap map[string]interface{}) *lambda.Filter {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &lambda.Filter{}
+
+	if v, ok := tfMap["pattern"].(string); ok {
+		// The API permits patterns of length >= 0, so accept the empty string.
+		apiObject.Pattern = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenLambdaFilter(apiObject *lambda.Filter) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Pattern; v != nil {
+		tfMap["pattern"] = aws.StringValue(v)
+	}
+
+	return tfMap
 }

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -897,7 +897,7 @@ func expandLambdaFilters(tfList []interface{}) []*lambda.Filter {
 	return apiObjects
 }
 
-func flattenLambdaFilters(apiObjects []*lambda.Filter) *schema.Set {
+func flattenLambdaFilters(apiObjects []*lambda.Filter) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -912,19 +912,7 @@ func flattenLambdaFilters(apiObjects []*lambda.Filter) *schema.Set {
 		tfList = append(tfList, flattenLambdaFilter(apiObject))
 	}
 
-	filterResource := &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"pattern": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 4096),
-			},
-		},
-	}
-
-	tfSet := schema.NewSet(schema.HashResource(filterResource), tfList)
-
-	return tfSet
+	return tfList
 }
 
 func expandLambdaFilter(tfMap map[string]interface{}) *lambda.Filter {

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -118,7 +118,7 @@ func ResourceEventSourceMapping() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"filters": {
+						"filter": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							MaxItems: 5,
@@ -850,7 +850,7 @@ func expandLambdaFilterCriteria(tfMap map[string]interface{}) *lambda.FilterCrit
 
 	apiObject := &lambda.FilterCriteria{}
 
-	if v, ok := tfMap["filters"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := tfMap["filter"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.Filters = expandLambdaFilters(v.List())
 	}
 
@@ -865,7 +865,7 @@ func flattenLambdaFilterCriteria(apiObject *lambda.FilterCriteria) map[string]in
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Filters; len(v) > 0 {
-		tfMap["filters"] = flattenLambdaFilters(v)
+		tfMap["filter"] = flattenLambdaFilters(v)
 	}
 
 	return tfMap

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -101,6 +101,7 @@ func TestAccLambdaEventSourceMapping_SQS_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "function_arn", functionResourceName, "arn"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "last_modified"),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "0"),
 				),
 			},
 			// batch_size became optional.  Ensure that if the user supplies the default
@@ -871,6 +872,76 @@ func TestAccLambdaEventSourceMapping_rabbitMQ(t *testing.T) {
 			{
 				PlanOnly: true,
 				Config:   testAccEventSourceMappingRabbitMQConfig(rName, "null"),
+			},
+		},
+	})
+}
+
+func TestAccLambdaEventSourceMapping_SQS_filterCriteria(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_event_source_mapping.test"
+	pattern1 := "{\"Region\": [{\"prefix\": \"us-\"}]}"
+	pattern2 := "{\"Location\": [\"New York\"], \"Day\": [\"Monday\"]}"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, lambda.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventSourceMappingSQSFilterCriteria_1(rName, pattern1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filters.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern1}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+			{
+				Config: testAccEventSourceMappingSQSFilterCriteria_2(rName, pattern1, pattern2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filters.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern1}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern2}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+			{
+				Config: testAccEventSourceMappingSQSFilterCriteria_3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+			{
+				Config: testAccEventSourceMappingSQSFilterCriteria_1(rName, pattern1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filters.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern1}),
+				),
 			},
 		},
 	})
@@ -1831,4 +1902,47 @@ func testAccPreCheckSecretsManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
+}
+
+func testAccEventSourceMappingSQSFilterCriteria_1(rName string, pattern1 string) string {
+	return acctest.ConfigCompose(testAccEventSourceMappingSQSBaseConfig(rName), fmt.Sprintf(`
+resource "aws_lambda_event_source_mapping" "test" {
+  event_source_arn = aws_sqs_queue.test.arn
+  function_name    = aws_lambda_function.test.arn
+
+  filter_criteria {
+    filters {
+      pattern = %q
+    }
+  }
+}
+`, pattern1))
+}
+
+func testAccEventSourceMappingSQSFilterCriteria_2(rName string, pattern1, pattern2 string) string {
+	return acctest.ConfigCompose(testAccEventSourceMappingSQSBaseConfig(rName), fmt.Sprintf(`
+resource "aws_lambda_event_source_mapping" "test" {
+  event_source_arn = aws_sqs_queue.test.arn
+  function_name    = aws_lambda_function.test.arn
+
+  filter_criteria {
+    filters {
+      pattern = %q
+    }
+
+    filters {
+      pattern = %q
+    }
+  }
+}
+`, pattern1, pattern2))
+}
+
+func testAccEventSourceMappingSQSFilterCriteria_3(rName string) string {
+	return acctest.ConfigCompose(testAccEventSourceMappingSQSBaseConfig(rName), fmt.Sprintf(`
+resource "aws_lambda_event_source_mapping" "test" {
+  event_source_arn = aws_sqs_queue.test.arn
+  function_name    = aws_lambda_function.test.arn
+}
+`))
 }

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -895,8 +895,8 @@ func TestAccLambdaEventSourceMapping_SQS_filterCriteria(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filters.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern1}),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filter.*", map[string]string{"pattern": pattern1}),
 				),
 			},
 			{
@@ -910,9 +910,9 @@ func TestAccLambdaEventSourceMapping_SQS_filterCriteria(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filters.#", "2"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern1}),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern2}),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filter.*", map[string]string{"pattern": pattern1}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filter.*", map[string]string{"pattern": pattern2}),
 				),
 			},
 			{
@@ -939,8 +939,8 @@ func TestAccLambdaEventSourceMapping_SQS_filterCriteria(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "filter_criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filters.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filters.*", map[string]string{"pattern": pattern1}),
+					resource.TestCheckResourceAttr(resourceName, "filter_criteria.0.filter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_criteria.0.filter.*", map[string]string{"pattern": pattern1}),
 				),
 			},
 		},
@@ -1911,7 +1911,7 @@ resource "aws_lambda_event_source_mapping" "test" {
   function_name    = aws_lambda_function.test.arn
 
   filter_criteria {
-    filters {
+    filter {
       pattern = %q
     }
   }
@@ -1926,11 +1926,11 @@ resource "aws_lambda_event_source_mapping" "test" {
   function_name    = aws_lambda_function.test.arn
 
   filter_criteria {
-    filters {
+    filter {
       pattern = %q
     }
 
-    filters {
+    filter {
       pattern = %q
     }
   }

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1939,10 +1939,10 @@ resource "aws_lambda_event_source_mapping" "test" {
 }
 
 func testAccEventSourceMappingSQSFilterCriteria_3(rName string) string {
-	return acctest.ConfigCompose(testAccEventSourceMappingSQSBaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEventSourceMappingSQSBaseConfig(rName), `
 resource "aws_lambda_event_source_mapping" "test" {
   event_source_arn = aws_sqs_queue.test.arn
   function_name    = aws_lambda_function.test.arn
 }
-`))
+`)
 }

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -92,13 +92,13 @@ resource "aws_lambda_event_source_mapping" "example" {
 resource "aws_lambda_event_source_mapping" "example" {
   event_source_arn = aws_sqs_queue.sqs_queue_test.arn
   function_name    = aws_lambda_function.example.arn
-  
+
   filter_criteria {
     filters {
       pattern = jsonencode({
         body = {
-          Temperature: [{numeric: [">", 0, "<=", 100]}]
-          Location:    ["New York"]
+          Temperature : [{ numeric : [">", 0, "<=", 100] }]
+          Location : ["New York"]
         }
       })
     }

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -86,6 +86,26 @@ resource "aws_lambda_event_source_mapping" "example" {
 }
 ```
 
+### SQS with event filter
+
+```terraform
+resource "aws_lambda_event_source_mapping" "example" {
+  event_source_arn = aws_sqs_queue.sqs_queue_test.arn
+  function_name    = aws_lambda_function.example.arn
+  
+  filter_criteria {
+    filters {
+      pattern = jsonencode({
+        body = {
+          Temperature: [{numeric: [">", 0, "<=", 100]}]
+          Location:    ["New York"]
+        }
+      })
+    }
+  }
+}
+```
+
 ### Amazon MQ (ActiveMQ)
 
 ```terraform
@@ -132,6 +152,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 * `destination_config`: - (Optional) An Amazon SQS queue or Amazon SNS topic destination for failed records. Only available for stream sources (DynamoDB and Kinesis). Detailed below.
 * `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
 * `event_source_arn` - (Optional) The event source ARN - this is required for Kinesis stream, DynamoDB stream, SQS queue, MQ broker or MSK cluster.  It is incompatible with a Self Managed Kafka source.
+* `filter_criteria` - (Optional) The criteria to use for [event filtering](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html) Kinesis stream, DynamoDB stream, SQS queue event sources. Detailed below.
 * `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.
 * `function_response_types` - (Optional) A list of current response type enums applied to the event source mapping for [AWS Lambda checkpointing](https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting). Only available for stream sources (DynamoDB and Kinesis). Valid values: `ReportBatchItemFailures`.
 * `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds (between 0 and 300). Records will continue to buffer (or accumulate in the case of an SQS queue event source) until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. For streaming event sources, defaults to as soon as records are available in the stream. If the batch it reads from the stream/queue only has one record in it, Lambda only sends one record to the function. Only available for stream sources (DynamoDB and Kinesis) and SQS standard queues.
@@ -153,6 +174,14 @@ resource "aws_lambda_event_source_mapping" "example" {
 #### destination_config on_failure Configuration Block
 
 * `destination_arn` - (Required) The Amazon Resource Name (ARN) of the destination resource.
+
+### filter_criteria Configuration Block
+
+* `filters` - (Optional) A set of up to 5 filters. If an event satisfies at least one, Lambda sends the event to the function or adds it to the next batch. Detailed below.
+
+#### filter_criteria filter Configuration Block
+
+* `pattern` - (Optional) A filter pattern up to 4096 characters. See [Filter Rule Syntax](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-syntax).
 
 ### self_managed_event_source Configuration Block
 

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -94,7 +94,7 @@ resource "aws_lambda_event_source_mapping" "example" {
   function_name    = aws_lambda_function.example.arn
 
   filter_criteria {
-    filters {
+    filter {
       pattern = jsonencode({
         body = {
           Temperature : [{ numeric : [">", 0, "<=", 100] }]
@@ -177,7 +177,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 
 ### filter_criteria Configuration Block
 
-* `filters` - (Optional) A set of up to 5 filters. If an event satisfies at least one, Lambda sends the event to the function or adds it to the next batch. Detailed below.
+* `filter` - (Optional) A set of up to 5 filter. If an event satisfies at least one, Lambda sends the event to the function or adds it to the next batch. Detailed below.
 
 #### filter_criteria filter Configuration Block
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21921

The AWS SDK commit will be rebased over once that's been merged to main.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccLambdaEventSourceMapping_Kinesis_ PKG=lambda && make testacc TESTS=TestAccLambdaEventSourceMapping_SQS_ PKG=lambda && make testacc TESTS=TestAccLambdaEventSourceMapping_DynamoDB_ PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping_Kinesis_' -timeout 180m
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_destination
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_destination
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_destination
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_batchWindow
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_destination (89.36s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts (94.70s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds (100.10s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp (102.81s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne (105.69s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne (107.56s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_bisectBatch (114.26s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero (114.64s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_batchWindow (127.67s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor (141.18s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds (147.99s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_basic (154.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     156.053s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping_SQS_' -timeout 180m
=== RUN   TestAccLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccLambdaEventSourceMapping_SQS_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_SQS_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== RUN   TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== PAUSE TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== CONT  TestAccLambdaEventSourceMapping_SQS_basic
=== CONT  TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccLambdaEventSourceMapping_SQS_batchWindow
=== CONT  TestAccLambdaEventSourceMapping_SQS_filterCriteria
--- PASS: TestAccLambdaEventSourceMapping_SQS_batchWindow (58.77s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (84.46s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_basic (143.37s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_filterCriteria (249.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     251.729s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping_DynamoDB_' -timeout 180m
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_basic
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_basic
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_basic (74.16s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes (83.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     84.836s
```
