### PR TITLE
fix: Error - expected idle_disconnect_timeout_in_seconds to be in the range (60 - 3600), got 15

### DIFF
--- a/website/docs/r/appstream_fleet.html.markdown
+++ b/website/docs/r/appstream_fleet.html.markdown
@@ -21,7 +21,7 @@ resource "aws_appstream_fleet" "test_fleet" {
   }
 
   description                        = "test fleet"
-  idle_disconnect_timeout_in_seconds = 15
+  idle_disconnect_timeout_in_seconds = 60
   display_name                       = "test-fleet"
   enable_default_internet_access     = false
   fleet_type                         = "ON_DEMAND"


### PR DESCRIPTION
The default values as listed in the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appstream_fleet) produce the following error:

`"Error - expected idle_disconnect_timeout_in_seconds to be in the range (60 - 3600), got 15"`

**Given** idle_disconnect_timeout_in_seconds
**When** value is 15
**Then** minimum value should be 60

**Otherwise error:** "Error - expected idle_disconnect_timeout_in_seconds to be in the range (60 - 3600), got 15"

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
