### PR TITLE
add support for SQS-managed SSE

### DIFF
--- a/.changelog/21954.txt
+++ b/.changelog/21954.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sqs_queue: Add `sqs_managed_sse_enabled` argument
+```

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -75,6 +75,11 @@ var (
 			Optional: true,
 		},
 
+		"sqs_managed_sse_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+
 		"max_message_size": {
 			Type:         schema.TypeInt,
 			Optional:     true,
@@ -158,6 +163,7 @@ var (
 		"content_based_deduplication":       sqs.QueueAttributeNameContentBasedDeduplication,
 		"kms_master_key_id":                 sqs.QueueAttributeNameKmsMasterKeyId,
 		"kms_data_key_reuse_period_seconds": sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds,
+		"sqs_managed_sse_enabled":           sqs.QueueAttributeNameSqsManagedSseEnabled,
 		"deduplication_scope":               sqs.QueueAttributeNameDeduplicationScope,
 		"fifo_throughput_limit":             sqs.QueueAttributeNameFifoThroughputLimit,
 	}, sqsQueueSchema)

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -71,13 +71,15 @@ var (
 		},
 
 		"kms_master_key_id": {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:          schema.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{"sqs_managed_sse_enabled"},
 		},
 
 		"sqs_managed_sse_enabled": {
-			Type:     schema.TypeBool,
-			Optional: true,
+			Type:          schema.TypeBool,
+			Optional:      true,
+			ConflictsWith: []string{"kms_master_key_id"},
 		},
 
 		"max_message_size": {

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -559,6 +559,13 @@ func TestAccSQSQueue_encryption(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", "alias/aws/sqs"),
 				),
 			},
+			{
+				Config: testAccManagedEncryptionConfig(rName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "sqs_managed_sse_enabled", "true"),
+				),
+			},
 		},
 	})
 }
@@ -910,6 +917,15 @@ resource "aws_sqs_queue" "test" {
   kms_data_key_reuse_period_seconds = %[2]s
 }
 `, rName, kmsDataKeyReusePeriodSeconds)
+}
+
+func testAccManagedEncryptionConfig(rName, sqsManagedSseEnabled string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name                    = %[1]q
+  sqs_managed_sse_enabled = %[2]s
+}
+`, rName, sqsManagedSseEnabled)
 }
 
 func testAccZeroVisibilityTimeoutSecondsConfig(rName string) string {

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -51,6 +51,15 @@ resource "aws_sqs_queue" "terraform_queue" {
 
 ## Server-side encryption (SSE)
 
+Using [SSE-SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sqs-sse-queue.html):
+```terraform
+resource "aws_sqs_queue" "terraform_queue" {
+  name                    = "terraform-example-queue"
+  sqs_managed_sse_enabled = true
+}
+```
+
+Using [SSE-KMS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sse-existing-queue.html):
 ```terraform
 resource "aws_sqs_queue" "terraform_queue" {
   name                              = "terraform-example-queue"
@@ -74,6 +83,7 @@ The following arguments are supported:
 * `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html). **Note:** when specifying `maxReceiveCount`, you must specify it as an integer (`5`), and not a string (`"5"`).
 * `fifo_queue` - (Optional) Boolean designating a FIFO queue. If not set, it defaults to `false` making it standard.
 * `content_based_deduplication` - (Optional) Enables content-based deduplication for FIFO queues. For more information, see the [related documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
+* `sqs_managed_sse_enabled` - (Optional) Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys. Defaults to `false`. See [Encryption at rest](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html).
 * `kms_master_key_id` - (Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see [Key Terms](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms).
 * `kms_data_key_reuse_period_seconds` - (Optional) The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes).
 * `deduplication_scope` - (Optional) Specifies whether message deduplication occurs at the message group or queue level. Valid values are `messageGroup` and `queue` (default).

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -52,6 +52,7 @@ resource "aws_sqs_queue" "terraform_queue" {
 ## Server-side encryption (SSE)
 
 Using [SSE-SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sqs-sse-queue.html):
+
 ```terraform
 resource "aws_sqs_queue" "terraform_queue" {
   name                    = "terraform-example-queue"
@@ -60,6 +61,7 @@ resource "aws_sqs_queue" "terraform_queue" {
 ```
 
 Using [SSE-KMS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sse-existing-queue.html):
+
 ```terraform
 resource "aws_sqs_queue" "terraform_queue" {
   name                              = "terraform-example-queue"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21948 -- add support for SSE-SQS for the `aws_sqs_queue` resource.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSQSQueue_encryption PKG=sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue_encryption' -timeout 180m
=== RUN   TestAccSQSQueue_encryption
=== PAUSE TestAccSQSQueue_encryption
=== CONT  TestAccSQSQueue_encryption
--- PASS: TestAccSQSQueue_encryption (116.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	119.555s
...
```
