### PR TITLE
FSx Backup Volume addition

### DIFF
--- a/.changelog/21960.txt
+++ b/.changelog/21960.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_fsx_backup: Add `volume` attribute to support Amazon FSx for NetApp ONTAP backup
+resource/aws_fsx_backup: Add `volume_id` argument to support Amazon FSx for NetApp ONTAP backup
 ```

--- a/.changelog/21960.txt
+++ b/.changelog/21960.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_backup: Add `volume` attribute to support Amazon FSx for NetApp ONTAP backup
+```

--- a/internal/service/fsx/backup.go
+++ b/internal/service/fsx/backup.go
@@ -39,7 +39,7 @@ func ResourceBackup() *schema.Resource {
 			},
 			"file_system_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"kms_key_id": {
@@ -56,6 +56,11 @@ func ResourceBackup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -71,7 +76,22 @@ func resourceBackupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	input := &fsx.CreateBackupInput{
 		ClientRequestToken: aws.String(resource.UniqueId()),
-		FileSystemId:       aws.String(d.Get("file_system_id").(string)),
+	}
+
+	if v, ok := d.GetOk("file_system_id"); ok {
+		input.FileSystemId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("volume_id"); ok {
+		input.VolumeId = aws.String(v.(string))
+	}
+
+	if input.FileSystemId == nil && input.VolumeId == nil {
+		return fmt.Errorf("error creating FSx Backup: %s", "must specify either file_system_id or volume_id")
+	}
+
+	if input.FileSystemId != nil && input.VolumeId != nil {
+		return fmt.Errorf("error creating FSx Backup: %s", "can only specify either file_system_id or volume_id")
 	}
 
 	if len(tags) > 0 {
@@ -126,12 +146,18 @@ func resourceBackupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", backup.ResourceARN)
 	d.Set("type", backup.Type)
 
-	fs := backup.FileSystem
-	d.Set("file_system_id", fs.FileSystemId)
+	if backup.FileSystem != nil {
+		fs := backup.FileSystem
+		d.Set("file_system_id", fs.FileSystemId)
+	}
 
 	d.Set("kms_key_id", backup.KmsKeyId)
 
 	d.Set("owner_id", backup.OwnerId)
+
+	if backup.Volume != nil {
+		d.Set("volume_id", backup.Volume.VolumeId)
+	}
 
 	tags := KeyValueTags(backup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/fsx/backup_test.go
+++ b/internal/service/fsx/backup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/fsx"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -17,6 +18,7 @@ import (
 func TestAccFSxBackup_basic(t *testing.T) {
 	var backup fsx.Backup
 	resourceName := "aws_fsx_backup.test"
+	rName := fmt.Sprintf("tf_acc_test_%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
@@ -25,7 +27,65 @@ func TestAccFSxBackup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckFsxBackupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupBasicConfig(),
+				Config: testAccBackupBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxBackupExists(resourceName, &backup),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`backup/.+`)),
+					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccFSxBackup_ontapBasic(t *testing.T) {
+	var backup fsx.Backup
+	resourceName := "aws_fsx_backup.test"
+	rName := fmt.Sprintf("tf_acc_test_%d", sdkacctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, fsx.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFsxBackupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupONTAPBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxBackupExists(resourceName, &backup),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`backup/.+`)),
+					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccFSxBackup_windowsBasic(t *testing.T) {
+	var backup fsx.Backup
+	resourceName := "aws_fsx_backup.test"
+	rName := fmt.Sprintf("tf_acc_test_%d", sdkacctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, fsx.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFsxBackupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupWindowsBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`backup/.+`)),
@@ -45,6 +105,7 @@ func TestAccFSxBackup_basic(t *testing.T) {
 func TestAccFSxBackup_disappears(t *testing.T) {
 	var backup fsx.Backup
 	resourceName := "aws_fsx_backup.test"
+	rName := fmt.Sprintf("tf_acc_test_%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
@@ -53,7 +114,7 @@ func TestAccFSxBackup_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckFsxBackupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupBasicConfig(),
+				Config: testAccBackupBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					acctest.CheckResourceDisappears(acctest.Provider, tffsx.ResourceBackup(), resourceName),
@@ -67,6 +128,7 @@ func TestAccFSxBackup_disappears(t *testing.T) {
 func TestAccFSxBackup_Disappears_filesystem(t *testing.T) {
 	var backup fsx.Backup
 	resourceName := "aws_fsx_backup.test"
+	rName := fmt.Sprintf("tf_acc_test_%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
@@ -75,7 +137,7 @@ func TestAccFSxBackup_Disappears_filesystem(t *testing.T) {
 		CheckDestroy: testAccCheckFsxBackupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupBasicConfig(),
+				Config: testAccBackupBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					acctest.CheckResourceDisappears(acctest.Provider, tffsx.ResourceLustreFileSystem(), "aws_fsx_lustre_file_system.test"),
@@ -89,6 +151,7 @@ func TestAccFSxBackup_Disappears_filesystem(t *testing.T) {
 func TestAccFSxBackup_tags(t *testing.T) {
 	var backup fsx.Backup
 	resourceName := "aws_fsx_backup.test"
+	rName := fmt.Sprintf("tf_acc_test_%d", sdkacctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
@@ -97,7 +160,7 @@ func TestAccFSxBackup_tags(t *testing.T) {
 		CheckDestroy: testAccCheckFsxBackupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupTags1Config("key1", "value1"),
+				Config: testAccBackupTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -110,7 +173,7 @@ func TestAccFSxBackup_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupTags2Config("key1", "value1updated", "key2", "value2"),
+				Config: testAccBackupTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -119,7 +182,7 @@ func TestAccFSxBackup_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupTags1Config("key2", "value2"),
+				Config: testAccBackupTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -215,25 +278,124 @@ resource "aws_subnet" "test1" {
   availability_zone = data.aws_availability_zones.available.names[0]
 }
 
-resource "aws_fsx_lustre_file_system" "test" {
-  storage_capacity            = 1200
-  subnet_ids                  = [aws_subnet.test1.id]
-  deployment_type             = "PERSISTENT_1"
-  per_unit_storage_throughput = 50
-}
+resource "aws_subnet" "test2" {
+	vpc_id            = aws_vpc.test.id
+	cidr_block        = "10.0.2.0/24"
+	availability_zone = data.aws_availability_zones.available.names[1]
+  }
 `)
 }
 
-func testAccBackupBasicConfig() string {
-	return acctest.ConfigCompose(testAccBackupBaseConfig(), `
+func testAccBackupLustreBaseConfig(rName string) string {
+	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
+	resource "aws_fsx_lustre_file_system" "test" {
+		storage_capacity            = 1200
+		subnet_ids                  = [aws_subnet.test1.id]
+		deployment_type             = "PERSISTENT_1"
+		per_unit_storage_throughput = 50
+
+		tags = {
+			Name = %[1]q
+		  }
+	  }
+`, rName))
+}
+
+func testAccBackupONTAPBaseConfig(rName string) string {
+	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
+	resource "aws_fsx_ontap_file_system" "test" {
+		storage_capacity    = 1024
+		subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
+		deployment_type     = "MULTI_AZ_1"
+		throughput_capacity = 512
+		preferred_subnet_id = aws_subnet.test1.id
+
+		tags = {
+			Name = %[1]q
+		  }
+	  }
+	  
+	  resource "aws_fsx_ontap_storage_virtual_machine" "test" {
+		file_system_id = aws_fsx_ontap_file_system.test.id
+		name           = %[1]q
+	  }
+
+	  resource "aws_fsx_ontap_volume" "test" {
+		name                       = %[1]q
+		junction_path              = "/%[1]s"
+		size_in_megabytes          = 1024
+		storage_efficiency_enabled = true
+		storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.test.id
+	  }
+`, rName))
+}
+
+func testAccBackupWindowsBaseConfig(rName string) string {
+	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
+	resource "aws_directory_service_directory" "test" {
+		edition  = "Standard"
+		name     = "corp.notexample.com"
+		password = "SuperSecretPassw0rd"
+		type     = "MicrosoftAD"
+	  
+		vpc_settings {
+		  subnet_ids = [aws_subnet.test1.id, aws_subnet.test2.id]
+		  vpc_id     = aws_vpc.test.id
+		}
+	  }
+
+	resource "aws_fsx_windows_file_system" "test" {
+		active_directory_id             = aws_directory_service_directory.test.id
+		skip_final_backup               = true
+		storage_capacity                = 32
+		subnet_ids                      = [aws_subnet.test1.id]
+		throughput_capacity             = 8
+
+		tags = {
+			Name = %[1]q
+		  }
+	  }	  
+`, rName))
+}
+
+func testAccBackupBasicConfig(rName string) string {
+	return acctest.ConfigCompose(testAccBackupLustreBaseConfig(rName), fmt.Sprintf(`
 resource "aws_fsx_backup" "test" {
   file_system_id = aws_fsx_lustre_file_system.test.id
+
+  tags = {
+	Name = %[1]q
+  }
 }
-`)
+`, rName))
 }
 
-func testAccBackupTags1Config(tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
+func testAccBackupONTAPBasicConfig(rName string) string {
+	return acctest.ConfigCompose(testAccBackupONTAPBaseConfig(rName), fmt.Sprintf(`
+resource "aws_fsx_backup" "test" {
+  volume_id = aws_fsx_ontap_volume.test.id
+
+  tags = {
+	Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccBackupWindowsBasicConfig(rName string) string {
+	return acctest.ConfigCompose(testAccBackupWindowsBaseConfig(rName), fmt.Sprintf(`
+resource "aws_fsx_backup" "test" {
+  volume_id = aws_fsx_windows_file_system.test.id
+
+  tags = {
+	Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccBackupTags1Config(rName string, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccBackupLustreBaseConfig(rName), fmt.Sprintf(`
 resource "aws_fsx_backup" "test" {
   file_system_id = aws_fsx_lustre_file_system.test.id
 
@@ -244,8 +406,8 @@ resource "aws_fsx_backup" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccBackupTags2Config(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
+func testAccBackupTags2Config(rName string, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccBackupLustreBaseConfig(rName), fmt.Sprintf(`
 resource "aws_fsx_backup" "test" {
   file_system_id = aws_fsx_lustre_file_system.test.id
 

--- a/internal/service/fsx/backup_test.go
+++ b/internal/service/fsx/backup_test.go
@@ -32,7 +32,7 @@ func TestAccFSxBackup_basic(t *testing.T) {
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`backup/.+`)),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 			{
@@ -61,7 +61,7 @@ func TestAccFSxBackup_ontapBasic(t *testing.T) {
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`backup/.+`)),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 			{
@@ -90,7 +90,7 @@ func TestAccFSxBackup_windowsBasic(t *testing.T) {
 					testAccCheckFsxBackupExists(resourceName, &backup),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "fsx", regexp.MustCompile(`backup/.+`)),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 			{
@@ -345,11 +345,12 @@ resource "aws_directory_service_directory" "test" {
 }
 
 resource "aws_fsx_windows_file_system" "test" {
-  active_directory_id = aws_directory_service_directory.test.id
-  skip_final_backup   = true
-  storage_capacity    = 32
-  subnet_ids          = [aws_subnet.test1.id]
-  throughput_capacity = 8
+  active_directory_id             = aws_directory_service_directory.test.id
+  automatic_backup_retention_days = 0
+  skip_final_backup               = true
+  storage_capacity                = 32
+  subnet_ids                      = [aws_subnet.test1.id]
+  throughput_capacity             = 8
 
   tags = {
     Name = %[1]q

--- a/internal/service/fsx/backup_test.go
+++ b/internal/service/fsx/backup_test.go
@@ -279,82 +279,82 @@ resource "aws_subnet" "test1" {
 }
 
 resource "aws_subnet" "test2" {
-	vpc_id            = aws_vpc.test.id
-	cidr_block        = "10.0.2.0/24"
-	availability_zone = data.aws_availability_zones.available.names[1]
-  }
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+}
 `)
 }
 
 func testAccBackupLustreBaseConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
-	resource "aws_fsx_lustre_file_system" "test" {
-		storage_capacity            = 1200
-		subnet_ids                  = [aws_subnet.test1.id]
-		deployment_type             = "PERSISTENT_1"
-		per_unit_storage_throughput = 50
+resource "aws_fsx_lustre_file_system" "test" {
+  storage_capacity            = 1200
+  subnet_ids                  = [aws_subnet.test1.id]
+  deployment_type             = "PERSISTENT_1"
+  per_unit_storage_throughput = 50
 
-		tags = {
-			Name = %[1]q
-		  }
-	  }
+  tags = {
+    Name = %[1]q
+  }
+}
 `, rName))
 }
 
 func testAccBackupONTAPBaseConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
-	resource "aws_fsx_ontap_file_system" "test" {
-		storage_capacity    = 1024
-		subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
-		deployment_type     = "MULTI_AZ_1"
-		throughput_capacity = 512
-		preferred_subnet_id = aws_subnet.test1.id
+resource "aws_fsx_ontap_file_system" "test" {
+  storage_capacity    = 1024
+  subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
+  deployment_type     = "MULTI_AZ_1"
+  throughput_capacity = 512
+  preferred_subnet_id = aws_subnet.test1.id
 
-		tags = {
-			Name = %[1]q
-		  }
-	  }
-	  
-	  resource "aws_fsx_ontap_storage_virtual_machine" "test" {
-		file_system_id = aws_fsx_ontap_file_system.test.id
-		name           = %[1]q
-	  }
+  tags = {
+    Name = %[1]q
+  }
+}
 
-	  resource "aws_fsx_ontap_volume" "test" {
-		name                       = %[1]q
-		junction_path              = "/%[1]s"
-		size_in_megabytes          = 1024
-		storage_efficiency_enabled = true
-		storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.test.id
-	  }
+resource "aws_fsx_ontap_storage_virtual_machine" "test" {
+  file_system_id = aws_fsx_ontap_file_system.test.id
+  name           = %[1]q
+}
+
+resource "aws_fsx_ontap_volume" "test" {
+  name                       = %[1]q
+  junction_path              = "/%[1]s"
+  size_in_megabytes          = 1024
+  storage_efficiency_enabled = true
+  storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.test.id
+}
 `, rName))
 }
 
 func testAccBackupWindowsBaseConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBackupBaseConfig(), fmt.Sprintf(`
-	resource "aws_directory_service_directory" "test" {
-		edition  = "Standard"
-		name     = "corp.notexample.com"
-		password = "SuperSecretPassw0rd"
-		type     = "MicrosoftAD"
-	  
-		vpc_settings {
-		  subnet_ids = [aws_subnet.test1.id, aws_subnet.test2.id]
-		  vpc_id     = aws_vpc.test.id
-		}
-	  }
+resource "aws_directory_service_directory" "test" {
+  edition  = "Standard"
+  name     = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  type     = "MicrosoftAD"
 
-	resource "aws_fsx_windows_file_system" "test" {
-		active_directory_id             = aws_directory_service_directory.test.id
-		skip_final_backup               = true
-		storage_capacity                = 32
-		subnet_ids                      = [aws_subnet.test1.id]
-		throughput_capacity             = 8
+  vpc_settings {
+    subnet_ids = [aws_subnet.test1.id, aws_subnet.test2.id]
+    vpc_id     = aws_vpc.test.id
+  }
+}
 
-		tags = {
-			Name = %[1]q
-		  }
-	  }	  
+resource "aws_fsx_windows_file_system" "test" {
+  active_directory_id = aws_directory_service_directory.test.id
+  skip_final_backup   = true
+  storage_capacity    = 32
+  subnet_ids          = [aws_subnet.test1.id]
+  throughput_capacity = 8
+
+  tags = {
+    Name = %[1]q
+  }
+}
 `, rName))
 }
 
@@ -364,7 +364,7 @@ resource "aws_fsx_backup" "test" {
   file_system_id = aws_fsx_lustre_file_system.test.id
 
   tags = {
-	Name = %[1]q
+    Name = %[1]q
   }
 }
 `, rName))
@@ -376,7 +376,7 @@ resource "aws_fsx_backup" "test" {
   volume_id = aws_fsx_ontap_volume.test.id
 
   tags = {
-	Name = %[1]q
+    Name = %[1]q
   }
 }
 `, rName))
@@ -385,10 +385,10 @@ resource "aws_fsx_backup" "test" {
 func testAccBackupWindowsBasicConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBackupWindowsBaseConfig(rName), fmt.Sprintf(`
 resource "aws_fsx_backup" "test" {
-  volume_id = aws_fsx_windows_file_system.test.id
+  file_system_id = aws_fsx_windows_file_system.test.id
 
   tags = {
-	Name = %[1]q
+    Name = %[1]q
   }
 }
 `, rName))

--- a/website/docs/r/fsx_backup.html.markdown
+++ b/website/docs/r/fsx_backup.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a FSx Backup resource.
 
-## Example Usage
+## Lustre Example Usage
 
 ```terraform
 resource "aws_fsx_backup" "example" {
@@ -25,12 +25,47 @@ resource "aws_fsx_lustre_file_system" "example" {
 }
 ```
 
+## Windows Example Usage
+
+```terraform
+resource "aws_fsx_backup" "example" {
+  file_system_id = aws_fsx_windows_file_system.example.id
+}
+
+resource "aws_fsx_windows_file_system" "example" {
+  active_directory_id = aws_directory_service_directory.eample.id
+  skip_final_backup   = true
+  storage_capacity    = 32
+  subnet_ids          = [aws_subnet.example1.id]
+  throughput_capacity = 8
+}
+```
+
+## ONTAP Example Usage
+
+```terraform
+resource "aws_fsx_backup" "example" {
+  volume_id = aws_fsx_ontap_volume.example.id
+}
+
+resource "aws_fsx_ontap_volume" "example" {
+  name                       = "example"
+  junction_path              = "/example"
+  size_in_megabytes          = 1024
+  storage_efficiency_enabled = true
+  storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.test.id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `file_system_id` - (Required) The ID of the file system to back up.
+Note - Only file_system_id or volume_id can be specified. file_system_id is used for Lustre and Windows, volume_id is used for ONTAP. 
+
+* `file_system_id` - (Optional) The ID of the file system to back up. Required if backing up Lustre or Windows file systems.
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. If you have set `copy_tags_to_backups` to true, and you specify one or more tags, no existing file system tags are copied from the file system to the backup.
+* `volume_id` - (Optional) The ID of the volume to back up. Required if backing up a ONTAP Volume.
 
 ## Attributes Reference
 

--- a/website/docs/r/fsx_backup.html.markdown
+++ b/website/docs/r/fsx_backup.html.markdown
@@ -10,7 +10,9 @@ description: |-
 
 Provides a FSx Backup resource.
 
-## Lustre Example Usage
+## Example Usage
+
+## Lustre Example 
 
 ```terraform
 resource "aws_fsx_backup" "example" {
@@ -25,7 +27,7 @@ resource "aws_fsx_lustre_file_system" "example" {
 }
 ```
 
-## Windows Example Usage
+## Windows Example 
 
 ```terraform
 resource "aws_fsx_backup" "example" {
@@ -41,7 +43,7 @@ resource "aws_fsx_windows_file_system" "example" {
 }
 ```
 
-## ONTAP Example Usage
+## ONTAP Example 
 
 ```terraform
 resource "aws_fsx_backup" "example" {
@@ -61,7 +63,7 @@ resource "aws_fsx_ontap_volume" "example" {
 
 The following arguments are supported:
 
-Note - Only file_system_id or volume_id can be specified. file_system_id is used for Lustre and Windows, volume_id is used for ONTAP. 
+Note - Only file_system_id or volume_id can be specified. file_system_id is used for Lustre and Windows, volume_id is used for ONTAP.
 
 * `file_system_id` - (Optional) The ID of the file system to back up. Required if backing up Lustre or Windows file systems.
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. If you have set `copy_tags_to_backups` to true, and you specify one or more tags, no existing file system tags are copied from the file system to the backup.

--- a/website/docs/r/fsx_backup.html.markdown
+++ b/website/docs/r/fsx_backup.html.markdown
@@ -12,7 +12,7 @@ Provides a FSx Backup resource.
 
 ## Example Usage
 
-## Lustre Example 
+## Lustre Example
 
 ```terraform
 resource "aws_fsx_backup" "example" {
@@ -27,7 +27,7 @@ resource "aws_fsx_lustre_file_system" "example" {
 }
 ```
 
-## Windows Example 
+## Windows Example
 
 ```terraform
 resource "aws_fsx_backup" "example" {
@@ -43,7 +43,7 @@ resource "aws_fsx_windows_file_system" "example" {
 }
 ```
 
-## ONTAP Example 
+## ONTAP Example
 
 ```terraform
 resource "aws_fsx_backup" "example" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20778

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccFSxBackup' PKG_NAME=internal/service/fsx

--- PASS: TestAccFSxBackup_disappears (539.93s)
--- PASS: TestAccFSxBackup_basic (555.49s)
--- PASS: TestAccFSxBackup_Disappears_filesystem (558.67s)
--- PASS: TestAccFSxBackup_implicitTags (777.16s)
--- PASS: TestAccFSxBackup_tags (818.30s)
--- PASS: TestAccFSxBackup_ontapBasic (1845.21s)
--- PASS: TestAccFSxBackup_windowsBasic (3119.09s)
...
```
