### PR TITLE
r/synthetics_canary - add `artifact_config` + make `artifact_s3_location` updateble

### DIFF
--- a/.changelog/21963.txt
+++ b/.changelog/21963.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_synthetics_canary: Add `artifact_config` argument.
+```
+
+```release-note:enhancement
+resource/aws_synthetics_canary: Make `artifact_s3_location` updateable.
+```

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -40,10 +40,37 @@ func ResourceCanary() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"artifact_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"s3_encryption": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"encryption_mode": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(synthetics.EncryptionMode_Values(), false),
+									},
+									"kms_key_arn": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidARN,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"artifact_s3_location": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.TrimPrefix(new, "s3://") == old
 				},
@@ -238,16 +265,18 @@ func resourceCanaryCreate(d *schema.ResourceData, meta interface{}) error {
 		RuntimeVersion:     aws.String(d.Get("runtime_version").(string)),
 	}
 
-	code, err := expandCanaryCode(d)
-
-	if err != nil {
+	if code, err := expandCanaryCode(d); err != nil {
 		return err
+	} else {
+		input.Code = code
 	}
-
-	input.Code = code
 
 	if v, ok := d.GetOk("run_config"); ok {
 		input.RunConfig = expandCanaryRunConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("artifact_config"); ok {
+		input.ArtifactConfig = expandCanaryArtifactConfig(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("schedule"); ok {
@@ -368,6 +397,10 @@ func resourceCanaryRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting schedule: %w", err)
 	}
 
+	if err := d.Set("artifact_config", flattenCanaryArtifactConfig(canary.ArtifactConfig)); err != nil {
+		return fmt.Errorf("error setting artifact_config: %w", err)
+	}
+
 	tags := KeyValueTags(canary.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
@@ -394,20 +427,28 @@ func resourceCanaryUpdate(d *schema.ResourceData, meta interface{}) error {
 			input.VpcConfig = expandCanaryVPCConfig(d.Get("vpc_config").([]interface{}))
 		}
 
+		if d.HasChange("artifact_config") {
+			input.ArtifactConfig = expandCanaryArtifactConfig(d.Get("artifact_config").([]interface{}))
+		}
+
 		if d.HasChange("runtime_version") {
 			input.RuntimeVersion = aws.String(d.Get("runtime_version").(string))
 		}
 
 		if d.HasChanges("handler", "zip_file", "s3_bucket", "s3_key", "s3_version") {
-			code, err := expandCanaryCode(d)
-			if err != nil {
+			if code, err := expandCanaryCode(d); err != nil {
 				return err
+			} else {
+				input.Code = code
 			}
-			input.Code = code
 		}
 
 		if d.HasChange("run_config") {
 			input.RunConfig = expandCanaryRunConfig(d.Get("run_config").([]interface{}))
+		}
+
+		if d.HasChange("artifact_s3_location") {
+			input.ArtifactS3Location = aws.String(d.Get("artifact_s3_location").(string))
 		}
 
 		if d.HasChange("schedule") {
@@ -542,6 +583,74 @@ func expandCanaryCode(d *schema.ResourceData) (*synthetics.CanaryCodeInput, erro
 	}
 
 	return codeConfig, nil
+}
+
+func expandCanaryArtifactConfig(l []interface{}) *synthetics.ArtifactConfigInput_ {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &synthetics.ArtifactConfigInput_{}
+
+	if v, ok := m["s3_encryption"].([]interface{}); ok && len(v) > 0 {
+		config.S3Encryption = expandCanaryS3EncryptionConfig(v)
+	}
+
+	return config
+}
+
+func flattenCanaryArtifactConfig(config *synthetics.ArtifactConfigOutput_) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.S3Encryption != nil {
+		m["s3_encryption"] = flattenCanaryS3EncryptionConfig(config.S3Encryption)
+	}
+
+	return []interface{}{m}
+}
+
+func expandCanaryS3EncryptionConfig(l []interface{}) *synthetics.S3EncryptionConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &synthetics.S3EncryptionConfig{}
+
+	if v, ok := m["encryption_mode"].(string); ok && v != "" {
+		config.EncryptionMode = aws.String(v)
+	}
+
+	if v, ok := m["kms_key_arn"].(string); ok && v != "" {
+		config.KmsKeyArn = aws.String(v)
+	}
+
+	return config
+}
+
+func flattenCanaryS3EncryptionConfig(config *synthetics.S3EncryptionConfig) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.EncryptionMode != nil {
+		m["encryption_mode"] = aws.StringValue(config.EncryptionMode)
+	}
+
+	if config.KmsKeyArn != nil {
+		m["kms_key_arn"] = aws.StringValue(config.KmsKeyArn)
+	}
+
+	return []interface{}{m}
 }
 
 func expandCanarySchedule(l []interface{}) *synthetics.CanaryScheduleInput {

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -830,7 +830,7 @@ resource "aws_synthetics_canary" "test" {
   artifact_config {
     s3_encryption {
       encryption_mode = "SSE_S3"
-	}
+    }
   }
 
   schedule {
@@ -858,8 +858,8 @@ resource "aws_synthetics_canary" "test" {
   artifact_config {
     s3_encryption {
       encryption_mode = "SSE_KMS"
-	  kms_key_arn     = aws_kms_key.test.arn
-	}
+      kms_key_arn     = aws_kms_key.test.arn
+    }
   }
 
   schedule {

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -53,6 +53,7 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.created"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.#", "0"),
 				),
 			},
 			{
@@ -80,12 +81,52 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "engine_arn", "lambda", regexp.MustCompile(fmt.Sprintf(`function:cwsyn-%s.+`, rName))),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "source_location_arn", "lambda", regexp.MustCompile(fmt.Sprintf(`layer:cwsyn-%s.+`, rName))),
 					resource.TestCheckResourceAttrPair(resourceName, "execution_role_arn", "aws_iam_role.test", "arn"),
-					resource.TestCheckResourceAttr(resourceName, "artifact_s3_location", fmt.Sprintf("%s/", rName)),
+					resource.TestCheckResourceAttr(resourceName, "artifact_s3_location", fmt.Sprintf("%s/test/", rName)),
 					resource.TestCheckResourceAttr(resourceName, "timeline.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.created"),
 					resource.TestCheckResourceAttrSet(resourceName, "timeline.0.last_modified"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
 					testAccCheckCanaryIsUpdated(&conf1, &conf2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSyntheticsCanary_artifactEncryption(t *testing.T) {
+	var conf synthetics.Canary
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
+	resourceName := "aws_synthetics_canary.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, synthetics.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckCanaryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCanaryArtifactEncryptionConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.0.s3_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.0.s3_encryption.0.encryption_mode", "SSE_S3"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zip_file", "start_canary"},
+			},
+			{
+				Config: testAccCanaryArtifactEncryptionKMSConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCanaryExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.0.s3_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifact_config.0.s3_encryption.0.encryption_mode", "SSE_KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "artifact_config.0.s3_encryption.0.kms_key_arn", "aws_kms_key.test", "arn"),
 				),
 			},
 		},
@@ -459,6 +500,7 @@ func TestAccSyntheticsCanary_disappears(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(resourceName, &conf),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsynthetics.ResourceCanary(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsynthetics.ResourceCanary(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -775,6 +817,58 @@ resource "aws_synthetics_canary" "test" {
 `, rName))
 }
 
+func testAccCanaryArtifactEncryptionConfig(rName string) string {
+	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
+resource "aws_synthetics_canary" "test" {
+  name                 = %[1]q
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  execution_role_arn   = aws_iam_role.test.arn
+  handler              = "exports.handler"
+  zip_file             = "test-fixtures/lambdatest.zip"
+  runtime_version      = "syn-nodejs-puppeteer-3.3"
+
+  artifact_config {
+    s3_encryption {
+      encryption_mode = "SSE_S3"
+	}
+  }
+
+  schedule {
+    expression = "rate(0 minute)"
+  }
+}
+`, rName))
+}
+
+func testAccCanaryArtifactEncryptionKMSConfig(rName string) string {
+	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_synthetics_canary" "test" {
+  name                 = %[1]q
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  execution_role_arn   = aws_iam_role.test.arn
+  handler              = "exports.handler"
+  zip_file             = "test-fixtures/lambdatest.zip"
+  runtime_version      = "syn-nodejs-puppeteer-3.3"
+
+  artifact_config {
+    s3_encryption {
+      encryption_mode = "SSE_KMS"
+	  kms_key_arn     = aws_kms_key.test.arn
+	}
+  }
+
+  schedule {
+    expression = "rate(0 minute)"
+  }
+}
+`, rName))
+}
+
 func testAccCanaryRuntimeVersionConfig(rName, version string) string {
 	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
 resource "aws_synthetics_canary" "test" {
@@ -796,7 +890,7 @@ func testAccCanaryZipUpdatedConfig(rName string) string {
 	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
 resource "aws_synthetics_canary" "test" {
   name                 = %[1]q
-  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
+  artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/test/"
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest_modified.zip"

--- a/internal/service/synthetics/find.go
+++ b/internal/service/synthetics/find.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func FindCanaryByName(conn *synthetics.Synthetics, name string) (*synthetics.Canary, error) {
@@ -26,10 +27,7 @@ func FindCanaryByName(conn *synthetics.Synthetics, name string) (*synthetics.Can
 	}
 
 	if output == nil || output.Canary == nil || output.Canary.Status == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output.Canary, nil

--- a/website/docs/r/synthetics_canary.html.markdown
+++ b/website/docs/r/synthetics_canary.html.markdown
@@ -42,6 +42,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `vpc_config` - (Optional) Configuration block. Detailed below.
 * `failure_retention_period` - (Optional) Number of days to retain data about failed runs of this canary. If you omit this field, the default of 31 days is used. The valid range is 1 to 455 days.
 * `run_config` - (Optional) Configuration block for individual canary runs. Detailed below.
 * `s3_bucket` - (Optional) Full bucket name which is used if your canary script is located in S3. The bucket must already exist. Specify the full bucket name including s3:// as the start of the bucket name. **Conflicts with `zip_file`.**
@@ -50,8 +51,17 @@ The following arguments are optional:
 * `start_canary` - (Optional) Whether to run or stop the canary.
 * `success_retention_period` - (Optional) Number of days to retain data about successful runs of this canary. If you omit this field, the default of 31 days is used. The valid range is 1 to 455 days.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `vpc_config` - (Optional) Configuration block. Detailed below.
+* `artifact_config` - (Optional) configuration for canary artifacts, including the encryption-at-rest settings for artifacts that the canary uploads to Amazon S3. See [Artifact Config](#artifact_config).
 * `zip_file` - (Optional) ZIP file that contains the script, if you input your canary script directly into the canary instead of referring to an S3 location. It can be up to 5 MB. **Conflicts with `s3_bucket`, `s3_key`, and `s3_version`.**
+
+### artifact_config
+
+* `s3_encryption` - (Optional) Configuration of the encryption-at-rest settings for artifacts that the canary uploads to Amazon S3. See [S3 Encryption](#s3_encryption).
+
+### s3_encryption
+
+* `encryption_mode` - (Optional) The encryption method to use for artifacts created by this canary. Valid values are: `SSE-S3` and `SSE-KMS`.
+* `kms_key_arn` - (Optional) The ARN of the customer-managed KMS key to use, if you specify `SSE-KMS` for `encryption_mode`.
 
 ### schedule
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSyntheticsCanary_ PKG=synthetics
--- PASS: TestAccSyntheticsCanary_disappears (151.63s)
--- PASS: TestAccSyntheticsCanary_s3 (167.12s)
--- PASS: TestAccSyntheticsCanary_artifactEncryption (225.27s)
--- PASS: TestAccSyntheticsCanary_basic (240.57s)
--- PASS: TestAccSyntheticsCanary_StartCanary_codeChanges (249.96s)
--- PASS: TestAccSyntheticsCanary_runtimeVersion (250.73s)
--- PASS: TestAccSyntheticsCanary_runTracing (269.59s)
--- PASS: TestAccSyntheticsCanary_startCanary (279.54s)
--- PASS: TestAccSyntheticsCanary_tags (281.43s)
--- PASS: TestAccSyntheticsCanary_run (282.26s)
```
