### PR TITLE
Add Hugging Face DLC images to sagemaker pre-built ecr image

### DIFF
--- a/.changelog/21983.txt
+++ b/.changelog/21983.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data/aws_sagemaker_prebuilt_ecr_image: Add Hugging Face DLCs
+```

--- a/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
+++ b/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
@@ -70,6 +70,14 @@ const (
 	sageMakerRepositoryTensorFlowInferenceEIA = "tensorflow-inference-eia"
 	// SageMaker Repo TensorFlow Training
 	sageMakerRepositoryTensorFlowTraining = "tensorflow-training"
+	// SageMaker Repo HuggingFace TensorFlow Training
+	sageMakerRepositoryHuggingFaceTensorFlowTraining = "huggingface-tensorflow-training"
+	// SageMaker Repo HuggingFace TensorFlow Inference
+	sageMakerRepositoryHuggingFaceTensorFlowInference = "huggingface-tensorflow-inference"
+	// SageMaker Repo HuggingFace PyTorch Training
+	sageMakerRepositoryHuggingFacePyTorchTraining = "huggingface-pytorch-training"
+	// SageMaker Repo HuggingFace PyTorch Inference
+	sageMakerRepositoryHuggingFacePyTorchInference = "huggingface-pytorch-inference"
 )
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
@@ -295,6 +303,10 @@ func DataSourcePrebuiltECRImage() *schema.Resource {
 					sageMakerRepositoryTensorFlowServing,
 					sageMakerRepositoryTensorFlowServingEIA,
 					sageMakerRepositoryTensorFlowTraining,
+					sageMakerRepositoryHuggingFaceTensorFlowTraining,
+					sageMakerRepositoryHuggingFaceTensorFlowInference,
+					sageMakerRepositoryHuggingFacePyTorchTraining,
+					sageMakerRepositoryHuggingFacePyTorchInference,
 					sageMakerRepositoryXGBoost,
 				}, false),
 			},
@@ -367,7 +379,11 @@ func dataSourcePrebuiltECRImageRead(d *schema.ResourceData, meta interface{}) er
 		sageMakerRepositoryPyTorchTraining,
 		sageMakerRepositoryTensorFlowInference,
 		sageMakerRepositoryTensorFlowInferenceEIA,
-		sageMakerRepositoryTensorFlowTraining:
+		sageMakerRepositoryTensorFlowTraining,
+		sageMakerRepositoryHuggingFaceTensorFlowTraining,
+		sageMakerRepositoryHuggingFaceTensorFlowInference,
+		sageMakerRepositoryHuggingFacePyTorchTraining,
+		sageMakerRepositoryHuggingFacePyTorchInference:
 		id = sageMakerPrebuiltECRImageIDByRegion_DeepLearning[region]
 	default:
 		id = PrebuiltECRImageIDByRegion_FactorMachines[region]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->
### What does this PR do? 

This PR adds the [Hugging Face DLCs](https://github.com/aws/deep-learning-containers/tree/master/huggingface) to the `aws_sagemaker_prebuilt_ecr_image` data source. The Hugging Face DLCs include flavors for TensorFlow and PyTorch with Training and Inference Containers. I checked the region account mapping. 

example
```hcl
data "aws_sagemaker_prebuilt_ecr_image" "test" {
  repository_name = "huggingface-pytorch-inference"
  image_tag       = "1.7.1-transformers4.6.1-gpu-py36-cu110-ubuntu18.04"
}
```

I hope the `.changelog` is correct. 


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_PROFILE=hf-sm make testacc TESTS=TestAccSageMakerPrebuiltECRImageDataSource_basic PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerPrebuiltECRImageDataSource_basic' -timeout 180m
=== RUN   TestAccSageMakerPrebuiltECRImageDataSource_basic
=== PAUSE TestAccSageMakerPrebuiltECRImageDataSource_basic
=== CONT  TestAccSageMakerPrebuiltECRImageDataSource_basic
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_basic (15.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  17.434s```

```bash
$ AWS_PROFILE=hf-sm make testacc TESTS=TestAccSageMakerPrebuiltECRImageDataSource_region PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerPrebuiltECRImageDataSource_region' -timeout 180m
=== RUN   TestAccSageMakerPrebuiltECRImageDataSource_region
=== PAUSE TestAccSageMakerPrebuiltECRImageDataSource_region
=== CONT  TestAccSageMakerPrebuiltECRImageDataSource_region
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_region (15.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  17.370s
```
