### PR TITLE
Restore bfe20a96cd31cc296ae657cbcd3bdc308a01922b (#21970)

### DIFF
--- a/.changelog/21970.txt
+++ b/.changelog/21970.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_elasticache_user_group: Fix TestAccElastiCacheUserGroup_tags user_id reference
-```

--- a/internal/service/elasticache/user_group_test.go
+++ b/internal/service/elasticache/user_group_test.go
@@ -98,29 +98,28 @@ func TestAccElastiCacheUserGroup_tags(t *testing.T) {
 		CheckDestroy: testAccCheckUserGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserGroupTagsConfig(rName, "tagKey", "tagVal"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(resourceName, &userGroup),
-					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
-					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.tagKey", "tagVal"),
-				),
-			},
-			{
-				Config: testAccUserGroupTagsConfig(rName, "tagKey", "tagVal2"),
+				Config: testAccUserGroupConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserGroupExists(resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.tagKey", "tagVal2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				Config: testAccUserGroupBasicConfig(rName),
+				Config: testAccUserGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserGroupExists(resourceName, &userGroup),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccUserGroupConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupExists(resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -255,7 +254,7 @@ resource "aws_elasticache_user_group" "test" {
 `, rName))
 }
 
-func testAccUserGroupTagsConfig(rName, tagKey, tagValue string) string {
+func testAccUserGroupConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_elasticache_user" "test1" {
   user_id       = "%[1]s-1"
@@ -264,15 +263,34 @@ resource "aws_elasticache_user" "test1" {
   engine        = "REDIS"
   passwords     = ["password123456789"]
 }
-
 resource "aws_elasticache_user_group" "test" {
   user_group_id = %[1]q
   engine        = "REDIS"
   user_ids      = [aws_elasticache_user.test1.user_id]
-
   tags = {
     %[2]s = %[3]q
   }
 }
-`, rName, tagKey, tagValue))
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccUserGroupConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_elasticache_user" "test1" {
+  user_id       = "%[1]s-1"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = %[1]q
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test1.user_id]
+  tags = {
+    %[2]s = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21970.

Restores bfe20a96cd31cc296ae657cbcd3bdc308a01922b which was overwritten before merge.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccElastiCacheUserGroup_tags PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroup_tags' -timeout 180m
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== CONT  TestAccElastiCacheUserGroup_tags
--- PASS: TestAccElastiCacheUserGroup_tags (174.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	181.359s
```
