### PR TITLE
s3: Preserve order in JSON/policy arrays

### DIFF
--- a/.changelog/21997.txt
+++ b/.changelog/21997.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_s3_bucket: Fix order-related diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_s3_bucket_policy: Fix order-related diffs in `policy`
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -915,7 +915,14 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 				if err != nil {
 					return fmt.Errorf("policy contains an invalid JSON: %s", err)
 				}
-				d.Set("policy", policy)
+
+				policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+
+				if err != nil {
+					return fmt.Errorf("while setting policy (%s), encountered: %w", policy, err)
+				}
+
+				d.Set("policy", policyToSet)
 			}
 		}
 	}

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -911,15 +911,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 					return err
 				}
 			} else {
-				policy, err := structure.NormalizeJsonString(aws.StringValue(v))
+				policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.StringValue(v))
+
 				if err != nil {
-					return fmt.Errorf("policy contains an invalid JSON: %s", err)
+					return fmt.Errorf("while setting policy (%s), encountered: %w", aws.StringValue(v), err)
 				}
 
-				policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+				policyToSet, err = structure.NormalizeJsonString(policyToSet)
 
 				if err != nil {
-					return fmt.Errorf("while setting policy (%s), encountered: %w", policy, err)
+					return fmt.Errorf("policy (%s) contains invalid JSON: %w", d.Get("policy").(string), err)
 				}
 
 				d.Set("policy", policyToSet)
@@ -1451,7 +1452,12 @@ func resourceBucketDelete(d *schema.ResourceData, meta interface{}) error {
 
 func resourceBucketPolicyUpdate(conn *s3.S3, d *schema.ResourceData) error {
 	bucket := d.Get("bucket").(string)
-	policy := d.Get("policy").(string)
+
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policy, err)
+	}
 
 	if policy != "" {
 		log.Printf("[DEBUG] S3 bucket: %s, put policy: %s", bucket, policy)

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -483,7 +483,7 @@ resource "aws_s3_bucket_policy" "bucket" {
       ]
     }]
     Version = "2012-10-17"
-  })  
+  })
 }
 `, rName))
 }
@@ -520,7 +520,7 @@ resource "aws_s3_bucket_policy" "bucket" {
       ]
     }]
     Version = "2012-10-17"
-  })  
+  })
 }
 `, rName))
 }
@@ -557,7 +557,7 @@ resource "aws_s3_bucket_policy" "bucket" {
       ]
     }]
     Version = "2012-10-17"
-  })  
+  })
 }
 `, rName))
 }

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -133,6 +133,86 @@ func TestAccS3BucketPolicy_policyUpdate(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11801
+func TestAccS3BucketPolicy_IAMRoleOrder_policyDoc(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyIAMRoleOrderIAMPolicyDocConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+				),
+			},
+			{
+				Config:   testAccBucketPolicyIAMRoleOrderIAMPolicyDocConfig(rName),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccBucketPolicyIAMRoleOrderIAMPolicyDocConfig(rName),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccBucketPolicyIAMRoleOrderIAMPolicyDocConfig(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11801
+func TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPolicyIAMRoleOrderJSONEncodeConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+				),
+			},
+			{
+				Config:   testAccBucketPolicyIAMRoleOrderJSONEncodeConfig(rName),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccBucketPolicyIAMRoleOrderJSONEncodeOrder2Config(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+				),
+			},
+			{
+				Config:   testAccBucketPolicyIAMRoleOrderJSONEncodeConfig(rName2),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccBucketPolicyIAMRoleOrderJSONEncodeOrder3Config(rName3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+				),
+			},
+			{
+				Config:   testAccBucketPolicyIAMRoleOrderJSONEncodeConfig(rName3),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBucketHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -171,7 +251,7 @@ func testAccCheckBucketHasPolicy(n string, expectedPolicyText string) resource.T
 func testAccBucketPolicyConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
+  bucket = %[1]q
 
   tags = {
     TestName = "TestAccS3BucketPolicy_basic"
@@ -208,7 +288,7 @@ data "aws_iam_policy_document" "policy" {
 func testAccBucketPolicyConfig_updated(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
+  bucket = %[1]q
 
   tags = {
     TestName = "TestAccS3BucketPolicy_basic"
@@ -242,4 +322,242 @@ data "aws_iam_policy_document" "policy" {
   }
 }
 `, bucketName)
+}
+
+func testAccBucketPolicyIAMRoleOrderBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test1" {
+  name = "%[1]s-sultan"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "s3.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test2" {
+  name = "%[1]s-shepard"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "s3.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test3" {
+  name = "%[1]s-tritonal"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "s3.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test4" {
+  name = "%[1]s-artlec"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "s3.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test5" {
+  name = "%[1]s-cazzette"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "s3.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  tags = {
+    TestName = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccBucketPolicyIAMRoleOrderIAMPolicyDocConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBucketPolicyIAMRoleOrderBaseConfig(rName),
+		fmt.Sprintf(`
+data "aws_iam_policy_document" "test" {
+  policy_id = %[1]q
+
+  statement {
+    actions = [
+      "s3:DeleteBucket",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+    ]
+    effect = "Allow"
+    principals {
+      identifiers = [
+        aws_iam_role.test2.arn,
+        aws_iam_role.test1.arn,
+        aws_iam_role.test4.arn,
+        aws_iam_role.test3.arn,
+        aws_iam_role.test5.arn,
+      ]
+      type = "AWS"
+    }
+    resources = [
+      aws_s3_bucket.test.arn,
+      "${aws_s3_bucket.test.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket" {
+  bucket = aws_s3_bucket.test.bucket
+  policy = data.aws_iam_policy_document.test.json
+}
+`, rName))
+}
+
+func testAccBucketPolicyIAMRoleOrderJSONEncodeConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBucketPolicyIAMRoleOrderBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_s3_bucket_policy" "bucket" {
+  bucket = aws_s3_bucket.test.bucket
+
+  policy = jsonencode({
+    Id = %[1]q
+    Statement = [{
+      Action = [
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+      ]
+      Effect = "Allow"
+      Principal = {
+        AWS = [
+          aws_iam_role.test2.arn,
+          aws_iam_role.test1.arn,
+          aws_iam_role.test4.arn,
+          aws_iam_role.test3.arn,
+          aws_iam_role.test5.arn,
+        ]
+      }
+
+      Resource = [
+        aws_s3_bucket.test.arn,
+        "${aws_s3_bucket.test.arn}/*",
+      ]
+    }]
+    Version = "2012-10-17"
+  })  
+}
+`, rName))
+}
+
+func testAccBucketPolicyIAMRoleOrderJSONEncodeOrder2Config(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBucketPolicyIAMRoleOrderBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_s3_bucket_policy" "bucket" {
+  bucket = aws_s3_bucket.test.bucket
+
+  policy = jsonencode({
+    Id = %[1]q
+    Statement = [{
+      Action = [
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+      ]
+      Effect = "Allow"
+      Principal = {
+        AWS = [
+          aws_iam_role.test2.arn,
+          aws_iam_role.test3.arn,
+          aws_iam_role.test5.arn,
+          aws_iam_role.test1.arn,
+          aws_iam_role.test4.arn,
+        ]
+      }
+
+      Resource = [
+        aws_s3_bucket.test.arn,
+        "${aws_s3_bucket.test.arn}/*",
+      ]
+    }]
+    Version = "2012-10-17"
+  })  
+}
+`, rName))
+}
+
+func testAccBucketPolicyIAMRoleOrderJSONEncodeOrder3Config(rName string) string {
+	return acctest.ConfigCompose(
+		testAccBucketPolicyIAMRoleOrderBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_s3_bucket_policy" "bucket" {
+  bucket = aws_s3_bucket.test.bucket
+
+  policy = jsonencode({
+    Id = %[1]q
+    Statement = [{
+      Action = [
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+      ]
+      Effect = "Allow"
+      Principal = {
+        AWS = [
+          aws_iam_role.test4.arn,
+          aws_iam_role.test1.arn,
+          aws_iam_role.test3.arn,
+          aws_iam_role.test5.arn,
+          aws_iam_role.test2.arn,
+        ]
+      }
+
+      Resource = [
+        aws_s3_bucket.test.arn,
+        "${aws_s3_bucket.test.arn}/*",
+      ]
+    }]
+    Version = "2012-10-17"
+  })  
+}
+`, rName))
 }

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -618,7 +618,7 @@ data "aws_iam_policy_document" "test" {
         aws_iam_role.test4.arn,
         aws_iam_role.test1.arn,
         aws_iam_role.test5.arn,
-		data.aws_caller_identity.current.arn,
+        data.aws_caller_identity.current.arn,
       ]
       type = "AWS"
     }

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -167,6 +167,7 @@ func TestAccS3BucketPolicy_IAMRoleOrder_policyDoc(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13144
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/20456
 func TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket.test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Related #21968
Related #11801
Fixes #13144
Closes #20456

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccS3Bucket_Security_policy (78.33s)

--- PASS: TestAccS3BucketPolicy_basic (28.25s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (46.54s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (75.62s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (80.42s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (142.76s)

% make testacc TESTS=TestAccS3Bucket_ PKG=s3               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_' -timeout 180m
--- PASS: TestAccS3Bucket_Basic_namePrefix (45.66s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (45.99s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (51.51s)
--- PASS: TestAccS3Bucket_Basic_basic (53.51s)
--- PASS: TestAccS3Bucket_Basic_generatedName (53.94s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (55.53s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (69.21s)
--- PASS: TestAccS3Bucket_Security_grantToACL (79.58s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (82.44s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (38.66s)
--- PASS: TestAccS3Bucket_Security_updateACL (88.05s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (88.56s)
--- PASS: TestAccS3Bucket_Web_routingRules (93.84s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (93.84s)
--- PASS: TestAccS3Bucket_Basic_acceleration (94.71s)
--- PASS: TestAccS3Bucket_Security_logging (58.30s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (29.48s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (52.52s)
--- PASS: TestAccS3Bucket_Security_policy (122.50s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (129.98s)
--- PASS: TestAccS3Bucket_Web_simple (130.65s)
--- PASS: TestAccS3Bucket_Manage_objectLock (85.88s)
--- PASS: TestAccS3Bucket_Manage_versioning (138.37s)
--- PASS: TestAccS3Bucket_Security_updateGrant (138.38s)
--- PASS: TestAccS3Bucket_Web_redirect (138.73s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (59.46s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (30.04s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (88.50s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (78.79s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (43.09s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (75.24s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (81.92s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (82.03s)
--- PASS: TestAccS3Bucket_Security_corsDelete (39.49s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (49.08s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (48.08s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (69.74s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (128.61s)
--- PASS: TestAccS3Bucket_Basic_emptyString (44.07s)
--- PASS: TestAccS3Bucket_Tags_basic (50.45s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (76.36s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (68.57s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (96.87s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (182.58s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (121.16s)
--- PASS: TestAccS3Bucket_Replication_basic (169.65s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (153.54s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (201.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	297.403s
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccS3BucketPolicy_basic (38.99s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (63.20s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (95.78s)
--- PASS: TestAccS3Bucket_Security_policy (99.23s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (102.92s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (162.31s)
```
