### PR TITLE
Fixes initial setup for Service Quota resource and data source

### DIFF
--- a/internal/service/servicequotas/acc_test.go
+++ b/internal/service/servicequotas/acc_test.go
@@ -1,0 +1,61 @@
+package servicequotas_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func testAccPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn
+
+	input := &servicequotas.ListServicesInput{}
+
+	_, err := conn.ListServices(input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func preCheckServiceQuotaSet(serviceCode, quotaCode string, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn
+
+	input := &servicequotas.GetServiceQuotaInput{
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	_, err := conn.GetServiceQuota(input)
+	if tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
+		t.Fatalf("The Service Quota (%s/%s) has never been set. This test can only be run with a quota that has previously been set. Please update the test to check a new quota.", serviceCode, quotaCode)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error getting Service Quota (%s/%s) : %s", serviceCode, quotaCode, err)
+	}
+}
+
+func preCheckServiceQuotaUnset(serviceCode, quotaCode string, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn
+
+	input := &servicequotas.GetServiceQuotaInput{
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	_, err := conn.GetServiceQuota(input)
+	if err == nil {
+		t.Fatalf("The Service Quota (%s/%s) has been set. This test can only be run with a quota that has never been set. Please update the test to check a new quota.", serviceCode, quotaCode)
+	}
+	if !tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
+		t.Fatalf("unexpected PreCheck error getting Service Quota (%s/%s) : %s", serviceCode, quotaCode, err)
+	}
+}

--- a/internal/service/servicequotas/acc_test.go
+++ b/internal/service/servicequotas/acc_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+const (
+	setQuotaServiceCode = "vpc"
+	setQuotaQuotaCode   = "L-F678F1CE"
+	setQuotaQuotaName   = "VPCs per Region"
+
+	unsetQuotaServiceCode = "s3"
+	unsetQuotaQuotaCode   = "L-FAABEEBA"
+	unsetQuotaQuotaName   = "Access Points"
+)
+
 func testAccPreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn
 

--- a/internal/service/servicequotas/find.go
+++ b/internal/service/servicequotas/find.go
@@ -1,0 +1,98 @@
+package servicequotas
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func findServiceQuotaDefaultByID(conn *servicequotas.ServiceQuotas, serviceCode, quotaCode string) (*servicequotas.ServiceQuota, error) {
+	input := &servicequotas.GetAWSDefaultServiceQuotaInput{
+		ServiceCode: aws.String(serviceCode),
+		QuotaCode:   aws.String(quotaCode),
+	}
+
+	output, err := conn.GetAWSDefaultServiceQuota(input)
+
+	if err != nil {
+		return nil, err
+	}
+	if output == nil || output.Quota == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Quota, nil
+}
+
+func findServiceQuotaDefaultByName(conn *servicequotas.ServiceQuotas, serviceCode, quotaName string) (*servicequotas.ServiceQuota, error) {
+	input := &servicequotas.ListAWSDefaultServiceQuotasInput{
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	var defaultQuota *servicequotas.ServiceQuota
+	err := conn.ListAWSDefaultServiceQuotasPages(input, func(page *servicequotas.ListAWSDefaultServiceQuotasOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, q := range page.Quotas {
+			if aws.StringValue(q.QuotaName) == quotaName {
+				defaultQuota = q
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+	if err != nil {
+		return nil, err
+	}
+	if defaultQuota == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return defaultQuota, nil
+}
+
+func findServiceQuotaByID(conn *servicequotas.ServiceQuotas, serviceCode, quotaCode string) (*servicequotas.ServiceQuota, error) {
+	input := &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String(serviceCode),
+		QuotaCode:   aws.String(quotaCode),
+	}
+
+	output, err := conn.GetServiceQuota(input)
+
+	if tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Quota == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if output.Quota.ErrorReason != nil {
+		return nil, &resource.NotFoundError{
+			Message:     fmt.Sprintf("%s: %s", aws.StringValue(output.Quota.ErrorReason.ErrorCode), aws.StringValue(output.Quota.ErrorReason.ErrorMessage)),
+			LastRequest: input,
+		}
+	}
+
+	if output.Quota.Value == nil {
+		return nil, &resource.NotFoundError{
+			Message:     "empty value",
+			LastRequest: input,
+		}
+	}
+
+	return output.Quota, nil
+}

--- a/internal/service/servicequotas/service_quota.go
+++ b/internal/service/servicequotas/service_quota.go
@@ -2,7 +2,6 @@ package servicequotas
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func ResourceServiceQuota() *schema.Resource {
@@ -90,30 +90,23 @@ func resourceServiceQuotaCreate(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(fmt.Sprintf("%s/%s", serviceCode, quotaCode))
 
-	input := &servicequotas.GetServiceQuotaInput{
-		QuotaCode:   aws.String(quotaCode),
-		ServiceCode: aws.String(serviceCode),
-	}
-
-	output, err := conn.GetServiceQuota(input)
-
+	// A Service Quota will always have a default value, but will only have a current value if it has been set.
+	// If it is not set, `GetServiceQuota` will return "NoSuchResourceException"
+	defaultQuota, err := findServiceQuotaDefaultByID(conn, serviceCode, quotaCode)
 	if err != nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting Default Service Quota for (%s/%s): %w", serviceCode, quotaCode, err)
+	}
+	quotaValue := aws.Float64Value(defaultQuota.Value)
+
+	serviceQuota, err := findServiceQuotaByID(conn, serviceCode, quotaCode)
+	if err != nil && !tfresource.NotFound(err) {
+		return fmt.Errorf("error getting Service Quota for (%s/%s): %w", serviceCode, quotaCode, err)
+	}
+	if serviceQuota != nil {
+		quotaValue = aws.Float64Value(serviceQuota.Value)
 	}
 
-	if output == nil || output.Quota == nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty result", d.Id())
-	}
-
-	if output.Quota.ErrorReason != nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s: %s", d.Id(), aws.StringValue(output.Quota.ErrorReason.ErrorCode), aws.StringValue(output.Quota.ErrorReason.ErrorMessage))
-	}
-
-	if output.Quota.Value == nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty value", d.Id())
-	}
-
-	if value > aws.Float64Value(output.Quota.Value) {
+	if value > quotaValue {
 		input := &servicequotas.RequestServiceQuotaIncreaseInput{
 			DesiredValue: aws.Float64(value),
 			QuotaCode:    aws.String(quotaCode),
@@ -123,7 +116,7 @@ func resourceServiceQuotaCreate(d *schema.ResourceData, meta interface{}) error 
 		output, err := conn.RequestServiceQuotaIncrease(input)
 
 		if err != nil {
-			return fmt.Errorf("error requesting Service Quota (%s) increase: %s", d.Id(), err)
+			return fmt.Errorf("error requesting Service Quota (%s) increase: %w", d.Id(), err)
 		}
 
 		if output == nil || output.RequestedQuota == nil {
@@ -145,58 +138,31 @@ func resourceServiceQuotaRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	input := &servicequotas.GetServiceQuotaInput{
-		QuotaCode:   aws.String(quotaCode),
-		ServiceCode: aws.String(serviceCode),
-	}
-
-	output, err := conn.GetServiceQuota(input)
-
-	if tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
-		log.Printf("[WARN] Service Quotas Service Quota (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
+	// A Service Quota will always have a default value, but will only have a current value if it has been set.
+	// If it is not set, `GetServiceQuota` will return "NoSuchResourceException"
+	defaultQuota, err := findServiceQuotaDefaultByID(conn, serviceCode, quotaCode)
 	if err != nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting Default Service Quota for (%s/%s): %w", serviceCode, quotaCode, err)
 	}
 
-	if output == nil || output.Quota == nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty result", d.Id())
+	d.Set("adjustable", defaultQuota.Adjustable)
+	d.Set("arn", defaultQuota.QuotaArn)
+	d.Set("default_value", defaultQuota.Value)
+	d.Set("quota_code", defaultQuota.QuotaCode)
+	d.Set("quota_name", defaultQuota.QuotaName)
+	d.Set("service_code", defaultQuota.ServiceCode)
+	d.Set("service_name", defaultQuota.ServiceName)
+	d.Set("value", defaultQuota.Value)
+
+	serviceQuota, err := findServiceQuotaByID(conn, serviceCode, quotaCode)
+	if err != nil && !tfresource.NotFound(err) {
+		return fmt.Errorf("error getting Service Quota for (%s/%s): %w", serviceCode, quotaCode, err)
 	}
 
-	if output.Quota.ErrorReason != nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s: %s", d.Id(), aws.StringValue(output.Quota.ErrorReason.ErrorCode), aws.StringValue(output.Quota.ErrorReason.ErrorMessage))
+	if err == nil {
+		d.Set("arn", serviceQuota.QuotaArn)
+		d.Set("value", serviceQuota.Value)
 	}
-
-	if output.Quota.Value == nil {
-		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty value", d.Id())
-	}
-
-	defaultInput := &servicequotas.GetAWSDefaultServiceQuotaInput{
-		QuotaCode:   aws.String(quotaCode),
-		ServiceCode: aws.String(serviceCode),
-	}
-
-	defaultOutput, err := conn.GetAWSDefaultServiceQuota(defaultInput)
-
-	if err != nil {
-		return fmt.Errorf("error getting Service Quotas Default Service Quota (%s): %s", d.Id(), err)
-	}
-
-	if defaultOutput == nil {
-		return fmt.Errorf("error getting Service Quotas Default Service Quota (%s): empty result", d.Id())
-	}
-
-	d.Set("adjustable", output.Quota.Adjustable)
-	d.Set("arn", output.Quota.QuotaArn)
-	d.Set("default_value", defaultOutput.Quota.Value)
-	d.Set("quota_code", output.Quota.QuotaCode)
-	d.Set("quota_name", output.Quota.QuotaName)
-	d.Set("service_code", output.Quota.ServiceCode)
-	d.Set("service_name", output.Quota.ServiceName)
-	d.Set("value", output.Quota.Value)
 
 	requestID := d.Get("request_id").(string)
 
@@ -214,7 +180,7 @@ func resourceServiceQuotaRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("error getting Service Quotas Requested Service Quota Change (%s): %s", requestID, err)
+			return fmt.Errorf("error getting Service Quotas Requested Service Quota Change (%s): %w", requestID, err)
 		}
 
 		if output == nil || output.RequestedQuota == nil {
@@ -254,7 +220,7 @@ func resourceServiceQuotaUpdate(d *schema.ResourceData, meta interface{}) error 
 	output, err := conn.RequestServiceQuotaIncrease(input)
 
 	if err != nil {
-		return fmt.Errorf("error requesting Service Quota (%s) increase: %s", d.Id(), err)
+		return fmt.Errorf("error requesting Service Quota (%s) increase: %w", d.Id(), err)
 	}
 
 	if output == nil || output.RequestedQuota == nil {

--- a/internal/service/servicequotas/service_quota.go
+++ b/internal/service/servicequotas/service_quota.go
@@ -152,7 +152,7 @@ func resourceServiceQuotaRead(d *schema.ResourceData, meta interface{}) error {
 
 	output, err := conn.GetServiceQuota(input)
 
-	if tfawserr.ErrMessageContains(err, servicequotas.ErrCodeNoSuchResourceException, "") {
+	if tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
 		log.Printf("[WARN] Service Quotas Service Quota (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -207,7 +207,7 @@ func resourceServiceQuotaRead(d *schema.ResourceData, meta interface{}) error {
 
 		output, err := conn.GetRequestedServiceQuotaChange(input)
 
-		if tfawserr.ErrMessageContains(err, servicequotas.ErrCodeNoSuchResourceException, "") {
+		if tfawserr.ErrCodeEquals(err, servicequotas.ErrCodeNoSuchResourceException) {
 			d.Set("request_id", "")
 			d.Set("request_status", "")
 			return nil

--- a/internal/service/servicequotas/service_quota_data_source.go
+++ b/internal/service/servicequotas/service_quota_data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func DataSourceServiceQuota() *schema.Resource {
@@ -31,16 +32,16 @@ func DataSourceServiceQuota() *schema.Resource {
 				Computed: true,
 			},
 			"quota_code": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"quota_name"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"quota_code", "quota_name"},
 			},
 			"quota_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"quota_code"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"quota_code", "quota_name"},
 			},
 			"service_code": {
 				Type:     schema.TypeString,
@@ -65,89 +66,46 @@ func dataSourceServiceQuotaRead(d *schema.ResourceData, meta interface{}) error 
 	quotaName := d.Get("quota_name").(string)
 	serviceCode := d.Get("service_code").(string)
 
-	if quotaCode == "" && quotaName == "" {
-		return fmt.Errorf("either quota_code or quota_name must be configured")
-	}
+	var err error
+	var defaultQuota *servicequotas.ServiceQuota
 
-	var serviceQuota *servicequotas.ServiceQuota
-
-	if quotaCode == "" {
-		input := &servicequotas.ListServiceQuotasInput{
-			ServiceCode: aws.String(serviceCode),
-		}
-
-		err := conn.ListServiceQuotasPages(input, func(page *servicequotas.ListServiceQuotasOutput, lastPage bool) bool {
-			for _, q := range page.Quotas {
-				if aws.StringValue(q.QuotaName) == quotaName {
-					serviceQuota = q
-					break
-				}
-			}
-
-			return !lastPage
-		})
-
+	// A Service Quota will always have a default value, but will only have a current value if it has been set.
+	// If it is not set, `GetServiceQuota` will return "NoSuchResourceException"
+	if quotaName != "" {
+		defaultQuota, err = findServiceQuotaDefaultByName(conn, serviceCode, quotaName)
 		if err != nil {
-			return fmt.Errorf("error listing Service (%s) Quotas: %w", serviceCode, err)
+			return fmt.Errorf("error getting Default Service Quota for (%s/%s): %w", serviceCode, quotaName, err)
 		}
 
-		if serviceQuota == nil {
-			return fmt.Errorf("error finding Service (%s) Quota (%s): no results found", serviceCode, quotaName)
-		}
+		quotaCode = aws.StringValue(defaultQuota.QuotaCode)
 	} else {
-		input := &servicequotas.GetServiceQuotaInput{
-			QuotaCode:   aws.String(quotaCode),
-			ServiceCode: aws.String(serviceCode),
-		}
-
-		output, err := conn.GetServiceQuota(input)
-
+		defaultQuota, err = findServiceQuotaDefaultByID(conn, serviceCode, quotaCode)
 		if err != nil {
-			return fmt.Errorf("error getting Service (%s) Quota (%s): %w", serviceCode, quotaCode, err)
+			return fmt.Errorf("error getting Default Service Quota for (%s/%s): %w", serviceCode, quotaCode, err)
 		}
-
-		if output == nil || output.Quota == nil {
-			return fmt.Errorf("error getting Service (%s) Quota (%s): empty result", serviceCode, quotaCode)
-		}
-
-		serviceQuota = output.Quota
 	}
 
-	if serviceQuota.ErrorReason != nil {
-		return fmt.Errorf("error getting Service (%s) Quota (%s): %s: %s", serviceCode, quotaCode, aws.StringValue(serviceQuota.ErrorReason.ErrorCode), aws.StringValue(serviceQuota.ErrorReason.ErrorMessage))
-	}
-
-	if serviceQuota.Value == nil {
-		return fmt.Errorf("error getting Service (%s) Quota (%s): empty value", serviceCode, quotaCode)
-	}
-
-	input := &servicequotas.GetAWSDefaultServiceQuotaInput{
-		QuotaCode:   serviceQuota.QuotaCode,
-		ServiceCode: serviceQuota.ServiceCode,
-	}
-
-	output, err := conn.GetAWSDefaultServiceQuota(input)
-
-	if err != nil {
-		return fmt.Errorf("error getting Service (%s) Default Quota (%s): %w", serviceCode, aws.StringValue(serviceQuota.QuotaCode), err)
-	}
-
-	if output == nil {
-		return fmt.Errorf("error getting Service (%s) Default Quota (%s): empty result", serviceCode, aws.StringValue(serviceQuota.QuotaCode))
-	}
-
-	defaultQuota := output.Quota
-
-	d.Set("adjustable", serviceQuota.Adjustable)
-	d.Set("arn", serviceQuota.QuotaArn)
+	d.SetId(aws.StringValue(defaultQuota.QuotaArn))
+	d.Set("adjustable", defaultQuota.Adjustable)
+	d.Set("arn", defaultQuota.QuotaArn)
 	d.Set("default_value", defaultQuota.Value)
-	d.Set("global_quota", serviceQuota.GlobalQuota)
-	d.Set("quota_code", serviceQuota.QuotaCode)
-	d.Set("quota_name", serviceQuota.QuotaName)
-	d.Set("service_code", serviceQuota.ServiceCode)
-	d.Set("service_name", serviceQuota.ServiceName)
+	d.Set("global_quota", defaultQuota.GlobalQuota)
+	d.Set("quota_code", defaultQuota.QuotaCode)
+	d.Set("quota_name", defaultQuota.QuotaName)
+	d.Set("service_code", defaultQuota.ServiceCode)
+	d.Set("service_name", defaultQuota.ServiceName)
+	d.Set("value", defaultQuota.Value)
+
+	serviceQuota, err := findServiceQuotaByID(conn, serviceCode, quotaCode)
+	if tfresource.NotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error getting Service Quota for (%s/%s): %w", serviceCode, quotaCode, err)
+	}
+
+	d.Set("arn", serviceQuota.QuotaArn)
 	d.Set("value", serviceQuota.Value)
-	d.SetId(aws.StringValue(serviceQuota.QuotaArn))
 
 	return nil
 }

--- a/internal/service/servicequotas/service_quota_data_source_test.go
+++ b/internal/service/servicequotas/service_quota_data_source_test.go
@@ -13,28 +13,25 @@ import (
 func TestAccServiceQuotasServiceQuotaDataSource_quotaCode(t *testing.T) {
 	const dataSourceName = "data.aws_servicequotas_service_quota.test"
 
-	const serviceCode = "vpc"
-	const quotaCode = "L-F678F1CE"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
-			preCheckServiceQuotaSet(serviceCode, quotaCode, t)
+			preCheckServiceQuotaSet(setQuotaServiceCode, setQuotaQuotaCode, t)
 		},
 		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaQuotaCodeDataSourceConfig(serviceCode, quotaCode),
+				Config: testAccServiceQuotaQuotaCodeDataSourceConfig(setQuotaServiceCode, setQuotaQuotaCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
-					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
+					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", setQuotaServiceCode, setQuotaQuotaCode)),
 					resource.TestCheckResourceAttr(dataSourceName, "default_value", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", setQuotaQuotaCode),
 					resource.TestCheckResourceAttr(dataSourceName, "quota_name", "VPCs per Region"),
-					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", setQuotaServiceCode),
 					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Virtual Private Cloud (Amazon VPC)"),
 					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
 				),
@@ -46,29 +43,25 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaCode(t *testing.T) {
 func TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset(t *testing.T) {
 	const dataSourceName = "data.aws_servicequotas_service_quota.test"
 
-	const serviceCode = "s3"
-	const quotaCode = "L-DC2B2D3D"
-	const quotaName = "Buckets"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
-			preCheckServiceQuotaUnset(serviceCode, quotaCode, t)
+			preCheckServiceQuotaUnset(unsetQuotaServiceCode, unsetQuotaQuotaCode, t)
 		},
 		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaQuotaCodeDataSourceConfig(serviceCode, quotaCode),
+				Config: testAccServiceQuotaQuotaCodeDataSourceConfig(unsetQuotaServiceCode, unsetQuotaQuotaCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acctest.CheckResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", unsetQuotaServiceCode, unsetQuotaQuotaCode)),
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
 					resource.TestMatchResourceAttr(dataSourceName, "default_value", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_name", quotaName),
-					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", unsetQuotaQuotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_name", unsetQuotaQuotaName),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", unsetQuotaServiceCode),
 					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Simple Storage Service (Amazon S3)"),
 					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttrPair(dataSourceName, "value", dataSourceName, "default_value"),
@@ -100,29 +93,25 @@ func TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode(t *tes
 func TestAccServiceQuotasServiceQuotaDataSource_quotaName(t *testing.T) {
 	dataSourceName := "data.aws_servicequotas_service_quota.test"
 
-	const serviceCode = "vpc"
-	const quotaCode = "L-F678F1CE"
-	const quotaName = "VPCs per Region"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
-			preCheckServiceQuotaSet(serviceCode, quotaCode, t)
+			preCheckServiceQuotaSet(setQuotaServiceCode, setQuotaQuotaCode, t)
 		},
 		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaQuotaNameDataSourceConfig("vpc", quotaName),
+				Config: testAccServiceQuotaQuotaNameDataSourceConfig("vpc", setQuotaQuotaName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
-					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
+					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", setQuotaServiceCode, setQuotaQuotaCode)),
 					resource.TestCheckResourceAttr(dataSourceName, "default_value", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_name", quotaName),
-					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", setQuotaQuotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_name", setQuotaQuotaName),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", setQuotaServiceCode),
 					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Virtual Private Cloud (Amazon VPC)"),
 					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
 				),
@@ -134,29 +123,25 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaName(t *testing.T) {
 func TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset(t *testing.T) {
 	const dataSourceName = "data.aws_servicequotas_service_quota.test"
 
-	const serviceCode = "s3"
-	const quotaCode = "L-DC2B2D3D"
-	const quotaName = "Buckets"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
-			preCheckServiceQuotaUnset(serviceCode, quotaCode, t)
+			preCheckServiceQuotaUnset(unsetQuotaServiceCode, unsetQuotaQuotaCode, t)
 		},
 		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaQuotaNameDataSourceConfig(serviceCode, quotaName),
+				Config: testAccServiceQuotaQuotaNameDataSourceConfig(unsetQuotaServiceCode, unsetQuotaQuotaName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acctest.CheckResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", unsetQuotaServiceCode, unsetQuotaQuotaCode)),
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
 					resource.TestMatchResourceAttr(dataSourceName, "default_value", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_name", quotaName),
-					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", unsetQuotaQuotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_name", unsetQuotaQuotaName),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", unsetQuotaServiceCode),
 					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Simple Storage Service (Amazon S3)"),
 					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttrPair(dataSourceName, "value", dataSourceName, "default_value"),

--- a/internal/service/servicequotas/service_quota_data_source_test.go
+++ b/internal/service/servicequotas/service_quota_data_source_test.go
@@ -11,23 +11,30 @@ import (
 )
 
 func TestAccServiceQuotasServiceQuotaDataSource_quotaCode(t *testing.T) {
-	dataSourceName := "data.aws_servicequotas_service_quota.test"
+	const dataSourceName = "data.aws_servicequotas_service_quota.test"
+
+	const serviceCode = "vpc"
+	const quotaCode = "L-F678F1CE"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
+			preCheckServiceQuotaSet(serviceCode, quotaCode, t)
+		},
 		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaQuotaCodeDataSourceConfig("vpc", "L-F678F1CE"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccServiceQuotaQuotaCodeDataSourceConfig(serviceCode, quotaCode),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
-					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", "vpc/L-F678F1CE"),
+					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
 					resource.TestCheckResourceAttr(dataSourceName, "default_value", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_code", "L-F678F1CE"),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(dataSourceName, "quota_name", "VPCs per Region"),
-					resource.TestCheckResourceAttr(dataSourceName, "service_code", "vpc"),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
 					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Virtual Private Cloud (Amazon VPC)"),
 					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
 				),
@@ -36,9 +43,48 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaCode(t *testing.T) {
 	})
 }
 
+func TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset(t *testing.T) {
+	const dataSourceName = "data.aws_servicequotas_service_quota.test"
+
+	const serviceCode = "s3"
+	const quotaCode = "L-DC2B2D3D"
+	const quotaName = "Buckets"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
+			preCheckServiceQuotaUnset(serviceCode, quotaCode, t)
+		},
+		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceQuotaQuotaCodeDataSourceConfig(serviceCode, quotaCode),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
+					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
+					resource.TestMatchResourceAttr(dataSourceName, "default_value", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_name", quotaName),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Simple Storage Service (Amazon S3)"),
+					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "value", dataSourceName, "default_value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t); acctest.PreCheckAssumeRoleARN(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			acctest.PreCheckAssumeRoleARN(t)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: nil,
@@ -54,21 +100,29 @@ func TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode(t *tes
 func TestAccServiceQuotasServiceQuotaDataSource_quotaName(t *testing.T) {
 	dataSourceName := "data.aws_servicequotas_service_quota.test"
 
+	const serviceCode = "vpc"
+	const quotaCode = "L-F678F1CE"
+	const quotaName = "VPCs per Region"
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
+			preCheckServiceQuotaSet(serviceCode, quotaCode, t)
+		},
 		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaQuotaNameDataSourceConfig("vpc", "VPCs per Region"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccServiceQuotaQuotaNameDataSourceConfig("vpc", quotaName),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
-					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", "vpc/L-F678F1CE"),
+					acctest.CheckResourceAttrRegionalARN(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
 					resource.TestCheckResourceAttr(dataSourceName, "default_value", "5"),
 					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_code", "L-F678F1CE"),
-					resource.TestCheckResourceAttr(dataSourceName, "quota_name", "VPCs per Region"),
-					resource.TestCheckResourceAttr(dataSourceName, "service_code", "vpc"),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_name", quotaName),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
 					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Virtual Private Cloud (Amazon VPC)"),
 					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
 				),
@@ -77,9 +131,48 @@ func TestAccServiceQuotasServiceQuotaDataSource_quotaName(t *testing.T) {
 	})
 }
 
+func TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset(t *testing.T) {
+	const dataSourceName = "data.aws_servicequotas_service_quota.test"
+
+	const serviceCode = "s3"
+	const quotaCode = "L-DC2B2D3D"
+	const quotaName = "Buckets"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(servicequotas.EndpointsID, t)
+			preCheckServiceQuotaUnset(serviceCode, quotaCode, t)
+		},
+		ErrorCheck: acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceQuotaQuotaNameDataSourceConfig(serviceCode, quotaName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNNoAccount(dataSourceName, "arn", "servicequotas", fmt.Sprintf("%s/%s", serviceCode, quotaCode)),
+					resource.TestCheckResourceAttr(dataSourceName, "adjustable", "true"),
+					resource.TestMatchResourceAttr(dataSourceName, "default_value", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr(dataSourceName, "global_quota", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(dataSourceName, "quota_name", quotaName),
+					resource.TestCheckResourceAttr(dataSourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(dataSourceName, "service_name", "Amazon Simple Storage Service (Amazon S3)"),
+					resource.TestMatchResourceAttr(dataSourceName, "value", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "value", dataSourceName, "default_value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t); acctest.PreCheckAssumeRoleARN(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			acctest.PreCheckAssumeRoleARN(t)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: nil,

--- a/internal/service/servicequotas/service_quota_test.go
+++ b/internal/service/servicequotas/service_quota_test.go
@@ -19,21 +19,18 @@ func TestAccServiceQuotasServiceQuota_basic(t *testing.T) {
 	const dataSourceName = "data.aws_servicequotas_service_quota.test"
 	const resourceName = "aws_servicequotas_service_quota.test"
 
-	const serviceCode = "vpc"
-	const quotaCode = "L-F678F1CE"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			testAccPreCheck(t)
-			preCheckServiceQuotaSet(serviceCode, quotaCode, t)
+			preCheckServiceQuotaSet(setQuotaServiceCode, setQuotaQuotaCode, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaSameValueConfig(quotaCode, serviceCode),
+				Config: testAccServiceQuotaSameValueConfig(setQuotaQuotaCode, setQuotaServiceCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -59,21 +56,18 @@ func TestAccServiceQuotasServiceQuota_basic_Unset(t *testing.T) {
 	const dataSourceName = "data.aws_servicequotas_service_quota.test"
 	const resourceName = "aws_servicequotas_service_quota.test"
 
-	const serviceCode = "s3"
-	const quotaCode = "L-DC2B2D3D"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			testAccPreCheck(t)
-			preCheckServiceQuotaUnset(serviceCode, quotaCode, t)
+			preCheckServiceQuotaUnset(unsetQuotaServiceCode, unsetQuotaQuotaCode, t)
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaSameValueConfig(quotaCode, serviceCode),
+				Config: testAccServiceQuotaSameValueConfig(unsetQuotaQuotaCode, unsetQuotaServiceCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -206,6 +200,7 @@ func TestAccServiceQuotasServiceQuota_permissionError(t *testing.T) {
 	})
 }
 
+// TODO: Reorder this!
 func testAccServiceQuotaSameValueConfig(quotaCode, serviceCode string) string {
 	return fmt.Sprintf(`
 data "aws_servicequotas_service_quota" "test" {

--- a/internal/service/servicequotas/service_quota_test.go
+++ b/internal/service/servicequotas/service_quota_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 // This resource is different than many since quotas are pre-existing
@@ -17,18 +16,25 @@ import (
 // In the basic case, we test that the resource can match the existing quota
 // without unexpected changes.
 func TestAccServiceQuotasServiceQuota_basic(t *testing.T) {
-	dataSourceName := "data.aws_servicequotas_service_quota.test"
-	resourceName := "aws_servicequotas_service_quota.test"
+	const dataSourceName = "data.aws_servicequotas_service_quota.test"
+	const resourceName = "aws_servicequotas_service_quota.test"
+
+	const serviceCode = "vpc"
+	const quotaCode = "L-F678F1CE"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			preCheckServiceQuotaSet(serviceCode, quotaCode, t)
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, servicequotas.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaSameValueConfig("L-F678F1CE", "vpc"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccServiceQuotaSameValueConfig(quotaCode, serviceCode),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_value", dataSourceName, "default_value"),
@@ -37,6 +43,47 @@ func TestAccServiceQuotasServiceQuota_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "service_code", dataSourceName, "service_code"),
 					resource.TestCheckResourceAttrPair(resourceName, "service_name", dataSourceName, "service_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "value", dataSourceName, "value"),
+					resource.TestCheckNoResourceAttr(resourceName, "request_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceQuotasServiceQuota_basic_Unset(t *testing.T) {
+	const dataSourceName = "data.aws_servicequotas_service_quota.test"
+	const resourceName = "aws_servicequotas_service_quota.test"
+
+	const serviceCode = "s3"
+	const quotaCode = "L-DC2B2D3D"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			preCheckServiceQuotaUnset(serviceCode, quotaCode, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, servicequotas.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceQuotaSameValueConfig(quotaCode, serviceCode),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_value", dataSourceName, "default_value"),
+					resource.TestCheckResourceAttrPair(resourceName, "quota_code", dataSourceName, "quota_code"),
+					resource.TestCheckResourceAttrPair(resourceName, "quota_name", dataSourceName, "quota_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_code", dataSourceName, "service_code"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_name", dataSourceName, "service_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "value", dataSourceName, "value"),
+					resource.TestCheckNoResourceAttr(resourceName, "request_id"),
 				),
 			},
 			{
@@ -80,10 +127,11 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnCreate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceQuotaValueConfig(quotaCode, serviceCode, value),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
 					resource.TestCheckResourceAttr(resourceName, "value", value),
+					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
 				),
 			},
 		},
@@ -123,18 +171,20 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceQuotaSameValueConfig(quotaCode, serviceCode),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
 					resource.TestCheckResourceAttrPair(resourceName, "value", dataSourceName, "value"),
+					resource.TestCheckNoResourceAttr(resourceName, "request_id"),
 				),
 			},
 			{
 				Config: testAccServiceQuotaValueConfig(quotaCode, serviceCode, value),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
 					resource.TestCheckResourceAttr(resourceName, "value", value),
+					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
 				),
 			},
 		},
@@ -154,22 +204,6 @@ func TestAccServiceQuotasServiceQuota_permissionError(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccPreCheck(t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ServiceQuotasConn
-
-	input := &servicequotas.ListServicesInput{}
-
-	_, err := conn.ListServices(input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
 }
 
 func testAccServiceQuotaSameValueConfig(quotaCode, serviceCode string) string {

--- a/internal/service/servicequotas/service_quota_test.go
+++ b/internal/service/servicequotas/service_quota_test.go
@@ -30,7 +30,7 @@ func TestAccServiceQuotasServiceQuota_basic(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaSameValueConfig(setQuotaQuotaCode, setQuotaServiceCode),
+				Config: testAccServiceQuotaSameValueConfig(setQuotaServiceCode, setQuotaQuotaCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -67,7 +67,7 @@ func TestAccServiceQuotasServiceQuota_basic_Unset(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaSameValueConfig(unsetQuotaQuotaCode, unsetQuotaServiceCode),
+				Config: testAccServiceQuotaSameValueConfig(unsetQuotaServiceCode, unsetQuotaQuotaCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
@@ -120,7 +120,7 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnCreate(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaValueConfig(quotaCode, serviceCode, value),
+				Config: testAccServiceQuotaValueConfig(serviceCode, quotaCode, value),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
@@ -164,7 +164,7 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceQuotaSameValueConfig(quotaCode, serviceCode),
+				Config: testAccServiceQuotaSameValueConfig(serviceCode, quotaCode),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
@@ -173,7 +173,7 @@ func TestAccServiceQuotasServiceQuota_Value_increaseOnUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceQuotaValueConfig(quotaCode, serviceCode, value),
+				Config: testAccServiceQuotaValueConfig(serviceCode, quotaCode, value),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
 					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
@@ -200,8 +200,7 @@ func TestAccServiceQuotasServiceQuota_permissionError(t *testing.T) {
 	})
 }
 
-// TODO: Reorder this!
-func testAccServiceQuotaSameValueConfig(quotaCode, serviceCode string) string {
+func testAccServiceQuotaSameValueConfig(serviceCode, quotaCode string) string {
 	return fmt.Sprintf(`
 data "aws_servicequotas_service_quota" "test" {
   quota_code   = %[1]q
@@ -216,7 +215,7 @@ resource "aws_servicequotas_service_quota" "test" {
 `, quotaCode, serviceCode)
 }
 
-func testAccServiceQuotaValueConfig(quotaCode, serviceCode, value string) string {
+func testAccServiceQuotaValueConfig(serviceCode, quotaCode, value string) string {
 	return fmt.Sprintf(`
 resource "aws_servicequotas_service_quota" "test" {
   quota_code   = %[1]q

--- a/website/docs/d/servicequotas_service_quota.html.markdown
+++ b/website/docs/d/servicequotas_service_quota.html.markdown
@@ -31,8 +31,8 @@ data "aws_servicequotas_service_quota" "by_quota_name" {
 ~> *NOTE:* Either `quota_code` or `quota_name` must be configured.
 
 * `service_code` - (Required) Service code for the quota. Available values can be found with the [`aws_servicequotas_service` data source](/docs/providers/aws/d/servicequotas_service.html) or [AWS CLI service-quotas list-services command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-services.html).
-* `quota_code` - (Optional) Quota code within the service. When configured, the data source directly looks up the service quota. Available values can be found with the [AWS CLI service-quotas list-service-quotas command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-service-quotas.html).
-* `quota_name` - (Optional) Quota name within the service. When configured, the data source searches through all service quotas to find the matching quota name. Available values can be found with the [AWS CLI service-quotas list-service-quotas command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-service-quotas.html).
+* `quota_code` - (Optional) Quota code within the service. When configured, the data source directly looks up the service quota. Available values can be found with the [AWS CLI service-quotas list-service-quotas command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-service-quotas.html). One of `quota_code` or `quota_name` must be specified.
+* `quota_name` - (Optional) Quota name within the service. When configured, the data source searches through all service quotas to find the matching quota name. Available values can be found with the [AWS CLI service-quotas list-service-quotas command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-service-quotas.html). One of `quota_name` or `quota_code` must be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
When a Service Quota has not been set, the API call `GetServiceQuota` returns a not found error. The default value can be retrieved using `GetAWSDefaultServiceQuota` or `ListAWSDefaultServiceQuotas`. This PR updates the resource and data source to retrieve the default value first and not fail when the quota has not been set.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19745
Closes #10929

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS='TestAccServiceQuotasServiceQuotaDataSource_\|TestAccServiceQuotasServiceQuota_basic' PKG=servicequotas
--- SKIP: TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaName (1.57s)
--- SKIP: TestAccServiceQuotasServiceQuotaDataSource_PermissionError_quotaCode (1.71s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode_Unset (67.23s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName_Unset (67.44s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaCode (70.68s)
--- PASS: TestAccServiceQuotasServiceQuotaDataSource_quotaName (72.27s)
--- PASS: TestAccServiceQuotasServiceQuota_basic_Unset (90.82s)
--- PASS: TestAccServiceQuotasServiceQuota_basic (90.91s)
```
