### PR TITLE
ecr: Preserve/ignore order in JSON/policy

### DIFF
--- a/.changelog/22004.txt
+++ b/.changelog/22004.txt
@@ -7,5 +7,5 @@ resource/aws_ecr_registry_policy: Fix order-related diffs in `policy`
 ```
 
 ```release-note:bug
-resource/aws_iam_role: Prevent `arn` from ever containing a unique ID immediately after role creation
+resource/aws_iam_role: Prevent `arn` attribute from ever containing a unique ID immediately after role creation
 ```

--- a/.changelog/22004.txt
+++ b/.changelog/22004.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecr_repository_policy: Fix order-related diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_ecr_registry_policy: Fix order-related diffs in `policy`
+```

--- a/.changelog/22004.txt
+++ b/.changelog/22004.txt
@@ -5,3 +5,7 @@ resource/aws_ecr_repository_policy: Fix order-related diffs in `policy`
 ```release-note:bug
 resource/aws_ecr_registry_policy: Fix order-related diffs in `policy`
 ```
+
+```release-note:bug
+resource/aws_iam_role: Prevent `arn` from ever containing a unique ID immediately after role creation
+```

--- a/internal/service/ecr/errorcheck_test.go
+++ b/internal/service/ecr/errorcheck_test.go
@@ -1,0 +1,20 @@
+package ecr_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(ecr.EndpointsID, testAccErrorCheckSkip)
+}
+
+// testAccErrorCheckSkip skips tests that have error messages indicating unsupported features
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"This feature is disabled",
+	)
+}

--- a/internal/service/ecr/registry_policy.go
+++ b/internal/service/ecr/registry_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -41,8 +42,14 @@ func ResourceRegistryPolicy() *schema.Resource {
 func resourceRegistryPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ECRConn
 
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
+
 	input := ecr.PutRegistryPolicyInput{
-		PolicyText: aws.String(d.Get("policy").(string)),
+		PolicyText: aws.String(policy),
 	}
 
 	out, err := conn.PutRegistryPolicy(&input)
@@ -72,7 +79,20 @@ func resourceRegistryPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("registry_id", out.RegistryId)
-	d.Set("policy", out.PolicyText)
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.StringValue(out.PolicyText))
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
+	}
+
+	policyToSet, err = structure.NormalizeJsonString(policyToSet)
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policyToSet, err)
+	}
+
+	d.Set("policy", policyToSet)
 
 	return nil
 }

--- a/internal/service/ecr/registry_policy_test.go
+++ b/internal/service/ecr/registry_policy_test.go
@@ -152,12 +152,8 @@ resource "aws_ecr_registry_policy" "test" {
         "Principal" : {
           "AWS" : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
         },
-        "Action" : [
-          "ecr:ReplicateImage"
-        ],
-        "Resource" : [
-          "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"
-        ]
+        "Action" : "ecr:ReplicateImage",
+        "Resource" : "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*",
       }
     ]
   })

--- a/internal/service/ecr/repository_policy_test.go
+++ b/internal/service/ecr/repository_policy_test.go
@@ -54,7 +54,7 @@ func TestAccECRRepositoryPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccECRRepositoryPolicy_iam(t *testing.T) {
+func TestAccECRRepositoryPolicy_IAM_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecr_repository_policy.test"
 
@@ -65,7 +65,7 @@ func TestAccECRRepositoryPolicy_iam(t *testing.T) {
 		CheckDestroy: testAccCheckRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRepositoryPolicyWithIAMRoleConfig(rName),
+				Config: testAccRepositoryPolicyIAMRoleConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRepositoryPolicyExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(rName)),
@@ -76,6 +76,39 @@ func TestAccECRRepositoryPolicy_iam(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19365
+func TestAccECRRepositoryPolicy_IAM_principalOrder(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecr_repository_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckRepositoryPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryPolicyIAMRoleOrderJSONEncodeConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRepositoryPolicyExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(rName)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile("iam")),
+				),
+			},
+			{
+				Config: testAccRepositoryPolicyIAMRoleNewOrderJSONEncodeConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRepositoryPolicyExists(resourceName),
+				),
+			},
+			{
+				Config:   testAccRepositoryPolicyIAMRoleOrderJSONEncodeConfig(rName),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -169,21 +202,15 @@ resource "aws_ecr_repository" "test" {
 resource "aws_ecr_repository_policy" "test" {
   repository = aws_ecr_repository.test.name
 
-  policy = <<EOF
-{
-    "Version": "2008-10-17",
-    "Statement": [
-        {
-            "Sid": "%[1]s",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": [
-                "ecr:ListImages"
-            ]
-        }
-    ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [{
+      Sid       = %[1]q
+      Effect    = "Allow"
+      Principal = "*"
+      Action = "ecr:ListImages"
+    }]
+  })
 }
 `, rName)
 }
@@ -197,31 +224,27 @@ resource "aws_ecr_repository" "test" {
 resource "aws_ecr_repository_policy" "test" {
   repository = aws_ecr_repository.test.name
 
-  policy = <<EOF
-{
-    "Version": "2008-10-17",
-    "Statement": [
-        {
-            "Sid": "%[1]s",
-            "Effect": "Allow",
-            "Principal": "*",
-            "Action": [
-                "ecr:ListImages",
-                "ecr:DescribeImages"
-            ]
-        }
-    ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [{
+      Sid       = %[1]q
+      Effect    = "Allow"
+      Principal = "*"
+      Action = [
+        "ecr:ListImages",
+        "ecr:DescribeImages",
+      ]
+    }]
+  })
 }
 `, rName)
 }
 
-// testAccRepositoryPolicyWithIAMRoleConfig creates a new IAM Role and tries
+// testAccRepositoryPolicyIAMRoleConfig creates a new IAM Role and tries
 // to use it's ARN in an ECR Repository Policy. IAM changes need some time to
 // be propagated to other services - like ECR. So the following code should
 // exercise our retry logic, since we try to use the new resource instantly.
-func testAccRepositoryPolicyWithIAMRoleConfig(rName string) string {
+func testAccRepositoryPolicyIAMRoleConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_repository" "test" {
   name = %[1]q
@@ -230,42 +253,177 @@ resource "aws_ecr_repository" "test" {
 resource "aws_iam_role" "test" {
   name = %[1]q
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
       }
-    }
-  ]
-}
-EOF
+    }]
+  })
 }
 
 resource "aws_ecr_repository_policy" "test" {
   repository = aws_ecr_repository.test.name
 
-  policy = <<EOF
-{
-    "Version": "2008-10-17",
-    "Statement": [
-        {
-            "Sid": "%[1]s",
-            "Effect": "Allow",
-            "Principal": {
-              "AWS": "${aws_iam_role.test.arn}"
-            },
-            "Action": [
-                "ecr:ListImages"
-            ]
-        }
-    ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [{
+      Sid = %[1]q
+      Effect = "Allow",
+      Principal = {
+        AWS = aws_iam_role.test.arn
+      }
+      Action = "ecr:ListImages"
+    }]
+  })
 }
 `, rName)
+}
+
+func testAccRepositoryPolicyIAMRoleOrderBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test1" {
+  name = "%[1]s-mercedes"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test2" {
+  name = "%[1]s-redbull"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test3" {
+  name = "%[1]s-mclaren"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test4" {
+  name = "%[1]s-ferrari"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role" "test5" {
+  name = "%[1]s-astonmartin"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+`, rName)
+}
+
+func testAccRepositoryPolicyIAMRoleOrderJSONEncodeConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccRepositoryPolicyIAMRoleOrderBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_ecr_repository_policy" "test" {
+  repository = aws_ecr_repository.test.name
+
+  policy = jsonencode({
+    Statement = [{
+      Sid = %[1]q
+      Action = "ecr:ListImages"
+      Effect = "Allow"
+      Principal = {
+        AWS = [
+          aws_iam_role.test1.arn,
+          aws_iam_role.test3.arn,
+          aws_iam_role.test2.arn,
+          aws_iam_role.test4.arn,
+          aws_iam_role.test5.arn,
+		]
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+`, rName))
+}
+
+func testAccRepositoryPolicyIAMRoleNewOrderJSONEncodeConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccRepositoryPolicyIAMRoleOrderBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_ecr_repository_policy" "test" {
+  repository = aws_ecr_repository.test.name
+
+  policy = jsonencode({
+    Statement = [{
+      Sid = %[1]q
+      Action = "ecr:ListImages"
+      Effect = "Allow"
+      Principal = {
+        AWS = [
+          aws_iam_role.test1.arn,
+          aws_iam_role.test5.arn,
+          aws_iam_role.test4.arn,
+          aws_iam_role.test2.arn,
+          aws_iam_role.test3.arn,
+        ]
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+`, rName))
 }

--- a/internal/service/ecr/repository_policy_test.go
+++ b/internal/service/ecr/repository_policy_test.go
@@ -208,7 +208,7 @@ resource "aws_ecr_repository_policy" "test" {
       Sid       = %[1]q
       Effect    = "Allow"
       Principal = "*"
-      Action = "ecr:ListImages"
+      Action    = "ecr:ListImages"
     }]
   })
 }
@@ -271,7 +271,7 @@ resource "aws_ecr_repository_policy" "test" {
   policy = jsonencode({
     Version = "2008-10-17"
     Statement = [{
-      Sid = %[1]q
+      Sid    = %[1]q
       Effect = "Allow",
       Principal = {
         AWS = aws_iam_role.test.arn
@@ -381,7 +381,7 @@ resource "aws_ecr_repository_policy" "test" {
 
   policy = jsonencode({
     Statement = [{
-      Sid = %[1]q
+      Sid    = %[1]q
       Action = "ecr:ListImages"
       Effect = "Allow"
       Principal = {
@@ -409,7 +409,7 @@ resource "aws_ecr_repository_policy" "test" {
 
   policy = jsonencode({
     Statement = [{
-      Sid = %[1]q
+      Sid    = %[1]q
       Action = "ecr:ListImages"
       Effect = "Allow"
       Principal = {

--- a/internal/service/ecr/repository_policy_test.go
+++ b/internal/service/ecr/repository_policy_test.go
@@ -285,10 +285,6 @@ resource "aws_ecr_repository_policy" "test" {
 
 func testAccRepositoryPolicyIAMRoleOrderBaseConfig(rName string) string {
 	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {}
-
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test1" {

--- a/internal/service/ecr/repository_policy_test.go
+++ b/internal/service/ecr/repository_policy_test.go
@@ -391,7 +391,7 @@ resource "aws_ecr_repository_policy" "test" {
           aws_iam_role.test2.arn,
           aws_iam_role.test4.arn,
           aws_iam_role.test5.arn,
-		]
+        ]
       }
     }]
     Version = "2012-10-17"

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -250,6 +250,11 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	role := outputRaw.(*iam.Role)
 
+	// occasionally, immediately after a role is created, AWS will give an ARN like AROAQ7SSZBKHRKPWRZUN6 (unique ID)
+	if role, err = waitRoleARNIsNotUniqueID(conn, d.Id(), role); err != nil {
+		return fmt.Errorf("error waiting for IAM role (%s) read: %w", d.Id(), err)
+	}
+
 	d.Set("arn", role.Arn)
 	if err := d.Set("create_date", role.CreateDate.Format(time.RFC3339)); err != nil {
 		return err

--- a/internal/service/iam/wait.go
+++ b/internal/service/iam/wait.go
@@ -1,7 +1,13 @@
 package iam
 
 import (
+	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 const (
@@ -11,4 +17,49 @@ const (
 	// have incorrect references or permissions.
 	// Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency
 	PropagationTimeout = 2 * time.Minute
+
+	RoleStatusARNIsUniqueID = "uniqueid"
+	RoleStatusARNIsARN      = "arn"
+	RoleStatusNotFound      = "notfound"
 )
+
+func waitRoleARNIsNotUniqueID(conn *iam.IAM, id string, role *iam.Role) (*iam.Role, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{RoleStatusARNIsUniqueID, RoleStatusNotFound},
+		Target:  []string{RoleStatusARNIsARN},
+		Refresh: statusRoleCreate(conn, id, role),
+		Timeout: PropagationTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*iam.Role); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func statusRoleCreate(conn *iam.IAM, id string, role *iam.Role) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		if strings.HasPrefix(aws.StringValue(role.Arn), "arn:") {
+			return role, RoleStatusARNIsARN, nil
+		}
+
+		output, err := FindRoleByName(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, RoleStatusNotFound, nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if strings.HasPrefix(aws.StringValue(output.Arn), "arn:") {
+			return output, RoleStatusARNIsARN, nil
+		}
+
+		return output, RoleStatusARNIsUniqueID, nil
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19365
Closes #8905
Closes #22018
Related #21968
Related #11801

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccECRRepositoryPolicy_Disappears_repository (12.51s)
--- PASS: TestAccECRRepositoryPolicy_disappears (14.07s)
--- PASS: TestAccECRRepositoryPolicy_IAM_basic (26.41s)
--- PASS: TestAccECRRepositoryPolicy_basic (27.86s)
--- PASS: TestAccECRRepositoryPolicy_IAM_principalOrder (40.62s)

--- PASS: TestAccECRRegistryPolicy_serial (32.32s)
    --- PASS: TestAccECRRegistryPolicy_serial/basic (22.42s)
    --- PASS: TestAccECRRegistryPolicy_serial/disappears (9.90s)

% make testacc TESTS=TestAccIAMRole PKG=iam                  
 ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole' -timeout 180m
--- PASS: TestAccIAMRolePolicy_invalidJSON (4.15s)
--- PASS: TestAccIAMRole_badJSON (5.75s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (15.82s)
--- PASS: TestAccIAMRolesDataSource_nonExistentPathPrefix (18.70s)
--- PASS: TestAccIAMRole_disappears (23.76s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (24.55s)
--- PASS: TestAccIAMRolesDataSource_basic (21.60s)
--- PASS: TestAccIAMRolesDataSource_pathPrefix (27.55s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (27.68s)
--- PASS: TestAccIAMRolePolicy_disappears (27.71s)
--- PASS: TestAccIAMRolesDataSource_nameRegexAndPathPrefix (28.13s)
--- PASS: TestAccIAMRolesDataSource_nameRegex (28.27s)
--- PASS: TestAccIAMRoleDataSource_basic (28.35s)
--- PASS: TestAccIAMRole_nameGenerated (32.09s)
--- PASS: TestAccIAMRole_namePrefix (32.72s)
--- PASS: TestAccIAMRole_ForceDetach_policies (33.18s)
--- PASS: TestAccIAMRolePolicy_generatedName (54.68s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedEmpty (49.03s)
--- PASS: TestAccIAMRole_policyBasicInlineEmpty (27.39s)
--- PASS: TestAccIAMRolePolicy_namePrefix (55.96s)
--- PASS: TestAccIAMRolePolicy_basic (56.03s)
--- PASS: TestAccIAMRole_testNameChange (56.35s)
--- PASS: TestAccIAMRole_maxSessionDuration (58.98s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineEmpty (45.88s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionIgnored_managedNonExistent (43.04s)
--- PASS: TestAccIAMRole_basic (28.68s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineNonEmpty (44.25s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedNonEmpty (43.55s)
--- PASS: TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_inlineNonEmpty (43.37s)
--- PASS: TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_managedNonEmpty (43.90s)
--- PASS: TestAccIAMRole_tags (44.01s)
--- PASS: TestAccIAMRoleDataSource_tags (17.98s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionIgnored_inlineNonExistent (50.78s)
--- PASS: TestAccIAMRole_basicWithDescription (50.64s)
--- PASS: TestAccIAMRole_policyBasicInline (55.58s)
--- PASS: TestAccIAMRole_policyBasicManaged (56.36s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (30.44s)
--- PASS: TestAccIAMRole_permissionsBoundary (67.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	100.929s
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccECRRepositoryPolicy_Disappears_repository (15.49s)
--- PASS: TestAccECRRepositoryPolicy_disappears (17.88s)
--- PASS: TestAccECRRepositoryPolicy_IAM_basic (30.57s)
--- PASS: TestAccECRRepositoryPolicy_basic (34.02s)
--- PASS: TestAccECRRepositoryPolicy_IAM_principalOrder (52.57s)

--- PASS: TestAccECRRegistryPolicy_serial (16.05s)
    --- SKIP: TestAccECRRegistryPolicy_serial/basic (8.66s)
    --- SKIP: TestAccECRRegistryPolicy_serial/disappears (7.39s)

% make testacc TESTS=TestAccIAMRole PKG=iam            
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole' -timeout 180m
--- PASS: TestAccIAMRole_badJSON (8.70s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (24.90s)
--- PASS: TestAccIAMRolesDataSource_nonExistentPathPrefix (28.16s)
--- PASS: TestAccIAMRole_disappears (37.76s)
--- PASS: TestAccIAMRolesDataSource_nameRegexAndPathPrefix (42.82s)
--- PASS: TestAccIAMRoleDataSource_basic (42.84s)
--- PASS: TestAccIAMRolesDataSource_pathPrefix (42.92s)
--- PASS: TestAccIAMRolePolicy_invalidJSON (3.28s)
--- PASS: TestAccIAMRole_nameGenerated (49.62s)
--- PASS: TestAccIAMRole_basic (49.77s)
--- PASS: TestAccIAMRole_namePrefix (49.91s)
--- PASS: TestAccIAMRolesDataSource_nameRegex (51.35s)
--- PASS: TestAccIAMRole_ForceDetach_policies (52.34s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionIgnored_managedNonExistent (69.44s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineEmpty (71.55s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedEmpty (72.20s)
--- PASS: TestAccIAMRolePolicy_basic (74.80s)
--- PASS: TestAccIAMRole_maxSessionDuration (84.41s)
--- PASS: TestAccIAMRole_policyBasicInlineEmpty (36.74s)
--- PASS: TestAccIAMRole_testNameChange (88.28s)
--- PASS: TestAccIAMRolesDataSource_basic (88.59s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineNonEmpty (67.63s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionIgnored_inlineNonExistent (96.18s)
--- PASS: TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedNonEmpty (70.05s)
--- PASS: TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_inlineNonEmpty (63.22s)
--- PASS: TestAccIAMRole_basicWithDescription (105.05s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (32.86s)
--- PASS: TestAccIAMRolePolicy_disappears (35.63s)
--- PASS: TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_managedNonEmpty (65.27s)
--- PASS: TestAccIAMRole_tags (62.15s)
--- PASS: TestAccIAMRoleDataSource_tags (28.77s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (27.90s)
--- PASS: TestAccIAMRolePolicy_generatedName (66.67s)
--- PASS: TestAccIAMRolePolicy_namePrefix (63.76s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (58.67s)
--- PASS: TestAccIAMRole_policyBasicManaged (91.09s)
--- PASS: TestAccIAMRole_policyBasicInline (87.14s)
--- PASS: TestAccIAMRole_permissionsBoundary (110.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	164.127s
```
