### PR TITLE
r/ecs - Add support for FARGATE Windows Containers and ARM based Containers

### DIFF
--- a/.changelog/22016.txt
+++ b/.changelog/22016.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/ecs: Add `runtime_platform` object
+resource/ecs: Add `runtime_platform` argument in support of Fargate for ECS Windows containers
 ```

--- a/.changelog/22016.txt
+++ b/.changelog/22016.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/ecs: Add `runtime_platform` object
+```

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -197,6 +197,34 @@ TASK_DEFINITION
 }
 ```
 
+### Example Using `runtime_platform` and `fargate`
+
+```terraform
+resource "aws_ecs_task_definition" "test" {
+  family                   = "test"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
+  container_definitions    = <<TASK_DEFINITION
+[
+  {
+    "name": "iis",
+    "image": "mcr.microsoft.com/windows/servercore/iis",
+    "cpu": 1024,
+    "memory": 2048,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  runtime_platform {
+    operating_system_family = "WINDOWS_SERVER_2019_CORE"
+    cpu_architecture        = "X86_64"
+  }
+}
+```
+
 ## Argument Reference
 
 ~> **NOTE**: Proper escaping is required for JSON field values containing quotes (`"`) such as `environment` values. If directly setting the JSON, they should be escaped as `\"` in the JSON,  e.g., `"value": "I \"love\" escaped quotes"`. If using a Terraform variable value, they should be escaped as `\\\"` in the variable, e.g., `value = "I \\\"love\\\" escaped quotes"` in the variable and `"value": "${var.myvariable}"` in the JSON.
@@ -214,6 +242,7 @@ The following arguments are optional:
 * `ipc_mode` - (Optional) IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
 * `memory` - (Optional) Amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `network_mode` - (Optional) Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
+* `runtime_platform` - (Optional) Configuration block for [runtime_platform](#runtime_platform) that containers in your task may use.
 * `pid_mode` - (Optional) Process namespace to use for the containers in the task. The valid values are `host` and `task`.
 * `placement_constraints` - (Optional) Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. [Detailed below](#placement_constraints).
 * `proxy_configuration` - (Optional) Configuration block for the App Mesh proxy. [Detailed below.](#proxy_configuration)
@@ -251,6 +280,11 @@ For more information, see [Specifying an EFS volume in your Task Definition Deve
 * `transit_encryption` - (Optional) Whether or not to enable encryption for Amazon EFS data in transit between the Amazon ECS host and the Amazon EFS server. Transit encryption must be enabled if Amazon EFS IAM authorization is used. Valid values: `ENABLED`, `DISABLED`. If this parameter is omitted, the default value of `DISABLED` is used.
 * `transit_encryption_port` - (Optional) Port to use for transit encryption. If you do not specify a transit encryption port, it will use the port selection strategy that the Amazon EFS mount helper uses.
 * `authorization_config` - (Optional) Configuration block for [authorization](#authorization_config) for the Amazon EFS file system. Detailed below.
+
+### runtime_platform
+
+* `operating_system_family` - (Optional) If the `requires_compatibilities` is `FARGATE` this field is required; must be set to a valid option from the [operating system family in the runtime platform](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform) setting
+* `cpu_architecture` - (Optional) Must be set to either `X86_64` or `ARM64`; see [cpu architecture](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform)
 
 #### authorization_config
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -163,30 +163,30 @@ resource "aws_ecs_task_definition" "test" {
   family                = "test"
   container_definitions = <<TASK_DEFINITION
 [
-	{
-		"cpu": 10,
-		"command": ["sleep", "10"],
-		"entryPoint": ["/"],
-		"environment": [
-			{"name": "VARNAME", "value": "VARVAL"}
-		],
-		"essential": true,
-		"image": "jenkins",
-		"memory": 128,
-		"name": "jenkins",
-		"portMappings": [
-			{
-				"containerPort": 80,
-				"hostPort": 8080
-			}
-		],
+  {
+    "cpu": 10,
+    "command": ["sleep", "10"],
+    "entryPoint": ["/"],
+    "environment": [
+      {"name": "VARNAME", "value": "VARVAL"}
+    ],
+    "essential": true,
+    "image": "jenkins",
+    "memory": 128,
+    "name": "jenkins",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 8080
+      }
+    ],
         "resourceRequirements":[
             {
                 "type":"InferenceAccelerator",
                 "value":"device_1"
             }
         ]
-	}
+  }
 ]
 TASK_DEFINITION
 


### PR DESCRIPTION
Adds platform runtime properties and validation based on https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

```
  runtime_platform {
    operating_system_family = "WINDOWS_SERVER_2019_CORE"
    cpu_architecture = "X86_64"
  }
```

Adds documentation for new fields (but no new examples; I'd happily add examples for windows fargate if its wanted, I didn't want to bloat the document)


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #21706
Closes #22033

Output from acceptance testing:

```
make testacc TESTS=TestAccECSTaskDefinition_withRuntimePlatform PKG=ecs
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_withRuntimePlatform' -timeout 180m
=== RUN   TestAccECSTaskDefinition_withRuntimePlatform
=== PAUSE TestAccECSTaskDefinition_withRuntimePlatform
=== CONT  TestAccECSTaskDefinition_withRuntimePlatform
--- PASS: TestAccECSTaskDefinition_withRuntimePlatform (14.22s)
PASS
ok  


make testacc TESTS=TestAccECSTaskDefinition_Fargate_withRuntimePlatform PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_Fargate_withRuntimePlatform' -timeout 180m
=== RUN   TestAccECSTaskDefinition_Fargate_withRuntimePlatform
=== PAUSE TestAccECSTaskDefinition_Fargate_withRuntimePlatform
=== CONT  TestAccECSTaskDefinition_Fargate_withRuntimePlatform
--- PASS: TestAccECSTaskDefinition_Fargate_withRuntimePlatform (14.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        14.620s
...
```
