### PR TITLE
r/aws_backup_region_settings: Add `ResourceTypeManagementPreference`

### DIFF
--- a/.changelog/22021.txt
+++ b/.changelog/22021.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_backup_region_settings: Add `resource_type_management_preference` argument
+```

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -38,6 +38,15 @@ func ExpandStringMap(m map[string]interface{}) map[string]*string {
 	return stringMap
 }
 
+// Expands a map of string to interface to a map of string to *bool
+func ExpandBoolMap(m map[string]interface{}) map[string]*bool {
+	boolMap := make(map[string]*bool, len(m))
+	for k, v := range m {
+		boolMap[k] = aws.Bool(v.(bool))
+	}
+	return boolMap
+}
+
 // Takes the result of schema.Set of strings and returns a []*string
 func ExpandStringSet(configured *schema.Set) []*string {
 	return ExpandStringList(configured.List()) // nosemgrep: helper-schema-Set-extraneous-ExpandStringList-with-List

--- a/internal/service/backup/region_settings.go
+++ b/internal/service/backup/region_settings.go
@@ -25,6 +25,11 @@ func ResourceRegionSettings() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeBool},
 			},
+			"resource_type_management_preference": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
 		},
 	}
 }
@@ -32,14 +37,21 @@ func ResourceRegionSettings() *schema.Resource {
 func resourceRegionSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).BackupConn
 
-	prefrences := d.Get("resource_type_opt_in_preference").(map[string]interface{})
-	list := make(map[string]*bool, len(prefrences))
-	for i, v := range prefrences {
-		list[i] = aws.Bool(v.(bool))
+	optInPrefs := d.Get("resource_type_opt_in_preference").(map[string]interface{})
+	optInList := make(map[string]*bool, len(optInPrefs))
+	for i, v := range optInPrefs {
+		optInList[i] = aws.Bool(v.(bool))
+	}
+
+	mgmtPrefs := d.Get("resource_type_management_preference").(map[string]interface{})
+	mgmtList := make(map[string]*bool, len(mgmtPrefs))
+	for i, v := range mgmtPrefs {
+		mgmtList[i] = aws.Bool(v.(bool))
 	}
 
 	input := &backup.UpdateRegionSettingsInput{
-		ResourceTypeOptInPreference: list,
+		ResourceTypeOptInPreference:      optInList,
+		ResourceTypeManagementPreference: mgmtList,
 	}
 
 	_, err := conn.UpdateRegionSettings(input)
@@ -61,6 +73,7 @@ func resourceRegionSettingsRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("resource_type_opt_in_preference", aws.BoolValueMap(resp.ResourceTypeOptInPreference))
+	d.Set("resource_type_management_preference", aws.BoolValueMap(resp.ResourceTypeManagementPreference))
 
 	return nil
 }

--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/aws/aws-sdk-go/service/fsx"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -14,9 +13,8 @@ import (
 
 func TestAccBackupRegionSettings_basic(t *testing.T) {
 	var settings backup.DescribeRegionSettingsOutput
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_backup_region_settings.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
@@ -28,7 +26,7 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupRegionSettingsConfig1(rName),
+				Config: testAccBackupRegionSettingsConfig1(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
@@ -44,8 +42,8 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.DynamoDB", "true"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.EFS", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_type_management_preference.DynamoDB"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_type_management_preference.EFS"),
 				),
 			},
 			{
@@ -54,7 +52,7 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBackupRegionSettingsConfig2(rName),
+				Config: testAccBackupRegionSettingsConfig2(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
@@ -75,11 +73,11 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupRegionSettingsConfig1(rName),
+				Config: testAccBackupRegionSettingsConfig3(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "false"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
@@ -89,9 +87,9 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "false"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.DynamoDB", "false"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.EFS", "true"),
 				),
 			},
@@ -114,11 +112,31 @@ func testAccCheckRegionSettingsExists(settings *backup.DescribeRegionSettingsOut
 	}
 }
 
-func testAccBackupRegionSettingsConfig1(rName string) string {
+func testAccBackupRegionSettingsConfig1() string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
     "Aurora"          = true
+    "DocumentDB"      = true
+    "DynamoDB"        = true
+    "EBS"             = true
+    "EC2"             = true
+    "EFS"             = true
+    "FSx"             = true
+    "Neptune"         = true
+    "RDS"             = true
+    "Storage Gateway" = true
+    "VirtualMachine"  = true
+  }
+}
+`
+}
+
+func testAccBackupRegionSettingsConfig2() string {
+	return `
+resource "aws_backup_region_settings" "test" {
+  resource_type_opt_in_preference = {
+    "Aurora"          = false
     "DocumentDB"      = true
     "DynamoDB"        = true
     "EBS"             = true
@@ -139,7 +157,7 @@ resource "aws_backup_region_settings" "test" {
 `
 }
 
-func testAccBackupRegionSettingsConfig2(rName string) string {
+func testAccBackupRegionSettingsConfig3() string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
@@ -153,11 +171,11 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"         = true
     "RDS"             = true
     "Storage Gateway" = true
-    "VirtualMachine"  = true
+    "VirtualMachine"  = false
   }
 
   resource_type_management_preference = {
-    "DynamoDB" = true
+    "DynamoDB" = false
     "EFS"      = true
   }
 }

--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -132,8 +132,8 @@ resource "aws_backup_region_settings" "test" {
   }
 
   resource_type_management_preference = {
-    "DynamoDB"        = true
-    "EFS"             = true
+    "DynamoDB" = true
+    "EFS"      = true
   }
 }
 `
@@ -157,8 +157,8 @@ resource "aws_backup_region_settings" "test" {
   }
 
   resource_type_management_preference = {
-    "DynamoDB"        = true
-    "EFS"             = true
+    "DynamoDB" = true
+    "EFS"      = true
   }
 }
 `

--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -31,15 +31,21 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 				Config: testAccBackupRegionSettingsConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "8"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.EFS", "true"),
 				),
 			},
 			{
@@ -51,30 +57,42 @@ func TestAccBackupRegionSettings_basic(t *testing.T) {
 				Config: testAccBackupRegionSettingsConfig2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "8"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "false"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.EFS", "true"),
 				),
 			},
 			{
 				Config: testAccBackupRegionSettingsConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionSettingsExists(&settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "8"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "11"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EBS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EC2", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.EFS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", "true"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.DynamoDB", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_management_preference.EFS", "true"),
 				),
 			},
 		},
@@ -100,14 +118,22 @@ func testAccBackupRegionSettingsConfig1(rName string) string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-    "DynamoDB"        = true
     "Aurora"          = true
+    "DocumentDB"      = true
+    "DynamoDB"        = true
     "EBS"             = true
     "EC2"             = true
     "EFS"             = true
     "FSx"             = true
+    "Neptune"         = true
     "RDS"             = true
     "Storage Gateway" = true
+    "VirtualMachine"  = true
+  }
+
+  resource_type_management_preference = {
+    "DynamoDB"        = true
+    "EFS"             = true
   }
 }
 `
@@ -117,14 +143,22 @@ func testAccBackupRegionSettingsConfig2(rName string) string {
 	return `
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-    "DynamoDB"        = true
     "Aurora"          = false
+    "DocumentDB"      = true
+    "DynamoDB"        = true
     "EBS"             = true
     "EC2"             = true
     "EFS"             = true
     "FSx"             = true
+    "Neptune"         = true
     "RDS"             = true
     "Storage Gateway" = true
+    "VirtualMachine"  = true
+  }
+
+  resource_type_management_preference = {
+    "DynamoDB"        = true
+    "EFS"             = true
   }
 }
 `

--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -15,14 +15,22 @@ Provides an AWS Backup Region Settings resource.
 ```terraform
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-    "DynamoDB"        = true
     "Aurora"          = true
+    "DocumentDB"      = true
+    "DynamoDB"        = true
     "EBS"             = true
     "EC2"             = true
     "EFS"             = true
     "FSx"             = true
+    "Neptune"         = true
     "RDS"             = true
     "Storage Gateway" = true
+    "VirtualMachine"  = true
+  }
+
+  resource_type_management_preference = {
+    "DynamoDB"        = true
+    "EFS"             = true
   }
 }
 ```
@@ -32,6 +40,7 @@ resource "aws_backup_region_settings" "test" {
 The following arguments are supported:
 
 * `resource_type_opt_in_preference` - (Required) A map of services along with the opt-in preferences for the Region.
+* `resource_type_management_preference` - (Required A map of services along with the management preferences for the Region.
 
 ## Attributes Reference
 

--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -29,8 +29,8 @@ resource "aws_backup_region_settings" "test" {
   }
 
   resource_type_management_preference = {
-    "DynamoDB"        = true
-    "EFS"             = true
+    "DynamoDB" = true
+    "EFS"      = true
   }
 }
 ```

--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -40,7 +40,7 @@ resource "aws_backup_region_settings" "test" {
 The following arguments are supported:
 
 * `resource_type_opt_in_preference` - (Required) A map of services along with the opt-in preferences for the Region.
-* `resource_type_management_preference` - (Required A map of services along with the management preferences for the Region.
+* `resource_type_management_preference` - (Optional) A map of services along with the management preferences for the Region.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #22012

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md):

```release-note:enhancement
resource/aws_backup_region_settings: Add resource_type_management_preference argument
```

Output from acceptance testing:

```
$ make testacc TESTS=TestAccBackupRegionSettings PKG=backup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 20 -run='TestAccBackupRegionSettings' -timeout 180m
=== RUN   TestAccBackupRegionSettings_basic
=== PAUSE TestAccBackupRegionSettings_basic
=== CONT  TestAccBackupRegionSettings_basic
--- PASS: TestAccBackupRegionSettings_basic (31.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	33.840s
```
