### PR TITLE
Update `securityhub_standards_control` example with idiomatic quoted label syntax

### DIFF
--- a/website/docs/r/securityhub_standards_control.markdown
+++ b/website/docs/r/securityhub_standards_control.markdown
@@ -17,14 +17,14 @@ into management. When you _delete_ this resource configuration, Terraform "aband
 ## Example Usage
 
 ```terraform
-resource aws_securityhub_account example {}
+resource "aws_securityhub_account" "example" {}
 
-resource aws_securityhub_standards_subscription cis_aws_foundations_benchmark {
+resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark" {
   standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
   depends_on    = [aws_securityhub_account.example]
 }
 
-resource aws_securityhub_standards_control ensure_iam_password_policy_prevents_password_reuse {
+resource "aws_securityhub_standards_control" "ensure_iam_password_policy_prevents_password_reuse" {
   standards_control_arn = "arn:aws:securityhub:us-east-1:111111111111:control/cis-aws-foundations-benchmark/v/1.2.0/1.10"
   control_status        = "DISABLED"
   disabled_reason       = "We handle password policies within Okta"


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

The example for this resource is using deprecated syntax. It should be updated to use the idiomatic quoted label syntax like all other resource types.