### PR TITLE
resource/aws_directory_service_directory: Adds retry when directory still has authorized applications

### DIFF
--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -3,10 +3,12 @@ package ds
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -14,6 +16,10 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+const (
+	directoryApplicationDeauthorizedPropagationTimeout = 2 * time.Minute
 )
 
 func ResourceDirectory() *schema.Resource {
@@ -517,10 +523,23 @@ func resourceDirectoryDelete(d *schema.ResourceData, meta interface{}) error {
 		DirectoryId: aws.String(d.Id()),
 	}
 
-	_, err := conn.DeleteDirectory(input)
+	err := resource.Retry(directoryApplicationDeauthorizedPropagationTimeout, func() *resource.RetryError {
+		_, err := conn.DeleteDirectory(input)
 
-	if tfawserr.ErrCodeEquals(err, directoryservice.ErrCodeEntityDoesNotExistException) {
+		if tfawserr.ErrCodeEquals(err, directoryservice.ErrCodeEntityDoesNotExistException) {
+			return nil
+		}
+		if tfawserr.ErrMessageContains(err, directoryservice.ErrCodeClientException, "authorized applications") {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
 		return nil
+	})
+	if tfresource.TimedOut(err) {
+		_, err = conn.DeleteDirectory(input)
 	}
 
 	if err != nil {


### PR DESCRIPTION
There is a propagation delay for unregistering applications from the Directory Service directory. This PR adds a retry when `aws_directory_service_directory` still has authorized applications.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20556

Before the change

```console
$ make testacc TESTS='TestAccConnectInstance_serial/directory' PKG=connect TEST_COUNT=3

=== RUN   TestAccConnectInstance_serial
=== RUN   TestAccConnectInstance_serial/directory
--- PASS: TestAccConnectInstance_serial (913.19s)
    --- PASS: TestAccConnectInstance_serial/directory (913.19s)
=== RUN   TestAccConnectInstance_serial
=== RUN   TestAccConnectInstance_serial/directory
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting Directory Service Directory (d-9267770990): ClientException: Cannot delete the directory because it still has authorized applications. : RequestId: 382f7159-d266-4fc7-9555-40a2fc9fdf14
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "382f7159-d266-4fc7-9555-40a2fc9fdf14"
          },
          Message_: "Cannot delete the directory because it still has authorized applications. : RequestId: 382f7159-d266-4fc7-9555-40a2fc9fdf14",
          RequestId: "382f7159-d266-4fc7-9555-40a2fc9fdf14"
        }
        
--- FAIL: TestAccConnectInstance_serial (467.35s)
    --- FAIL: TestAccConnectInstance_serial/directory (467.35s)
=== RUN   TestAccConnectInstance_serial
=== RUN   TestAccConnectInstance_serial/directory
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting Directory Service Directory (d-92677709e2): ClientException: Cannot delete the directory because it still has authorized applications. : RequestId: 21f190be-008d-45cc-b08d-d3e0b1e341dc
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "21f190be-008d-45cc-b08d-d3e0b1e341dc"
          },
          Message_: "Cannot delete the directory because it still has authorized applications. : RequestId: 21f190be-008d-45cc-b08d-d3e0b1e341dc",
          RequestId: "21f190be-008d-45cc-b08d-d3e0b1e341dc"
        }
        
--- FAIL: TestAccConnectInstance_serial (454.25s)
    --- FAIL: TestAccConnectInstance_serial/directory (454.25s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/connect	1836.891s
FAIL
```

After change

```console
$ make testacc TESTS=TestAccConnectInstance_serial/directory PKG=connect TEST_COUNT=3

=== RUN   TestAccConnectInstance_serial
=== RUN   TestAccConnectInstance_serial/directory
--- PASS: TestAccConnectInstance_serial (850.52s)
    --- PASS: TestAccConnectInstance_serial/directory (850.51s)
=== RUN   TestAccConnectInstance_serial
=== RUN   TestAccConnectInstance_serial/directory
--- PASS: TestAccConnectInstance_serial (858.79s)
    --- PASS: TestAccConnectInstance_serial/directory (858.79s)
=== RUN   TestAccConnectInstance_serial
=== RUN   TestAccConnectInstance_serial/directory
--- PASS: TestAccConnectInstance_serial (1001.44s)
    --- PASS: TestAccConnectInstance_serial/directory (1001.44s)
PASS
```