### PR TITLE
R/ecs service update with bg deployment

### DIFF
--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -3881,11 +3881,11 @@ resource "aws_ecs_cluster" "test" {
 resource "aws_ecs_task_definition" "test" {
   family                   = %[1]q
   requires_compatibilities = ["FARGATE"]
-  network_mode = "awsvpc"
+  network_mode             = "awsvpc"
   cpu                      = "256"
   memory                   = "512"
 
-  container_definitions    = <<DEFINITION
+  container_definitions = <<DEFINITION
 [
   {
     "essential": true,
@@ -3903,10 +3903,10 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "test" {
-  cluster         = aws_ecs_cluster.test.id
-  desired_count   = %[2]d
-  name            = %[1]q
-  task_definition = aws_ecs_task_definition.test.arn
+  cluster                           = aws_ecs_cluster.test.id
+  desired_count                     = %[2]d
+  name                              = %[1]q
+  task_definition                   = aws_ecs_task_definition.test.arn
   health_check_grace_period_seconds = %[3]d
 
   deployment_controller {
@@ -3915,8 +3915,8 @@ resource "aws_ecs_service" "test" {
 
   capacity_provider_strategy {
     capacity_provider = "FARGATE"
-    base = 1
-    weight = 1
+    base              = 1
+    weight            = 1
   }
 
   load_balancer {
@@ -3926,8 +3926,8 @@ resource "aws_ecs_service" "test" {
   }
 
   network_configuration {
-    subnets         = aws_subnet.test[*].id
-    security_groups = [aws_security_group.test.id]
+    subnets          = aws_subnet.test[*].id
+    security_groups  = [aws_security_group.test.id]
     assign_public_ip = true
   }
 }

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -407,6 +407,37 @@ func TestAccECSService_DeploymentControllerType_codeDeploy(t *testing.T) {
 	})
 }
 
+func TestAccECSService_WithDeploymentControllerType_codeDeployUpdate(t *testing.T) {
+	var service ecs.Service
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ecs.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDeploymentControllerTypeCodeDeployConfigUpdate(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_controller.0.type", ecs.DeploymentControllerTypeCodeDeploy),
+					resource.TestCheckResourceAttr(resourceName, "desired_count", "1"),
+				),
+			},
+			{
+				Config: testAccServiceDeploymentControllerTypeCodeDeployConfigUpdate(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "desired_count", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSService_DeploymentControllerType_external(t *testing.T) {
 	var service ecs.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -3736,6 +3767,163 @@ resource "aws_ecs_service" "test" {
   }
 }
 `, rName)
+}
+
+func testAccServiceDeploymentControllerTypeCodeDeployConfigUpdate(rName string, desiredReplicas int) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = "Allow traffic"
+  vpc_id      = aws_vpc.test.id
+
+  ingress {
+    protocol    = "6"
+    from_port   = 80
+    to_port     = 8000
+    cidr_blocks = [aws_vpc.test.cidr_block]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+}
+
+resource "aws_route_table_association" "test" {
+  count          = 2
+  subnet_id      = element(aws_subnet.test.*.id, count.index)
+  route_table_id = aws_route_table.test.id
+}
+
+resource "aws_lb" "test" {
+  internal = true
+  name     = %[1]q
+  subnets  = aws_subnet.test[*].id
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.id
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  target_type = "ip"
+  name        = aws_lb.test.name
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.test.id
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family                   = %[1]q
+  requires_compatibilities = ["FARGATE"]
+  network_mode = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+
+  container_definitions    = <<DEFINITION
+[
+  {
+    "essential": true,
+    "image": "nginx:latest",
+    "name": "test",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "protocol": "tcp"
+      }
+    ]
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "test" {
+  cluster         = aws_ecs_cluster.test.id
+  desired_count   = %[2]d
+  name            = %[1]q
+  task_definition = aws_ecs_task_definition.test.arn
+
+  deployment_controller {
+    type = "CODE_DEPLOY"
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    base = 1
+    weight = 1
+  }
+
+  load_balancer {
+    container_name   = "test"
+    container_port   = "80"
+    target_group_arn = aws_lb_target_group.test.id
+  }
+
+  network_configuration {
+    subnets         = aws_subnet.test[*].id
+    security_groups = [aws_security_group.test.id]
+    assign_public_ip = true
+  }
+}
+`, rName, desiredReplicas)
 }
 
 func testAccServiceDeploymentControllerTypeExternalConfig(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13658.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccECSService_DeploymentControllerType_codeDeployUpdate' PKG_NAME=internal/service/ecs

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run=TestAccECSService_DeploymentControllerType_codeDeployUpdate -timeout 180m
=== RUN   TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== PAUSE TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
=== CONT  TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (366.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	366.564s
```
