### PR TITLE
remove :* suffix on cloudwatchlog group datasource

### DIFF
--- a/.changelog/22043.txt
+++ b/.changelog/22043.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_cloudwatch_log_group: Automatically trim `:*` suffix from `arn` attribute
+```

--- a/internal/service/cloudwatchlogs/group_data_source.go
+++ b/internal/service/cloudwatchlogs/group_data_source.go
@@ -52,7 +52,7 @@ func dataSourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(name)
-	d.Set("arn", logGroup.Arn)
+	d.Set("arn", TrimLogGroupARNWildcardSuffix(aws.StringValue(logGroup.Arn)))
 	d.Set("creation_time", logGroup.CreationTime)
 	d.Set("retention_in_days", logGroup.RetentionInDays)
 	d.Set("kms_key_id", logGroup.KmsKeyId)

--- a/internal/service/cloudwatchlogs/group_data_source.go
+++ b/internal/service/cloudwatchlogs/group_data_source.go
@@ -3,6 +3,7 @@ package cloudwatchlogs
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"

--- a/internal/service/cloudwatchlogs/group_data_source_test.go
+++ b/internal/service/cloudwatchlogs/group_data_source_test.go
@@ -22,10 +22,10 @@ func TestAccCloudWatchLogsGroupDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckGroupDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_cloudwatch_log_group.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_cloudwatch_log_group.test", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", "aws_cloudwatch_log_group.test", "tags"),
 				),
 			},
 		},
@@ -44,13 +44,10 @@ func TestAccCloudWatchLogsGroupDataSource_tags(t *testing.T) {
 			{
 				Config: testAccCheckGroupTagsDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_cloudwatch_log_group.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_cloudwatch_log_group.test", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "Production"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "Bar"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Empty", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", "aws_cloudwatch_log_group.test", "tags"),
 				),
 			},
 		},
@@ -69,11 +66,11 @@ func TestAccCloudWatchLogsGroupDataSource_kms(t *testing.T) {
 			{
 				Config: testAccCheckGroupKMSDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_cloudwatch_log_group.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_cloudwatch_log_group.test", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_cloudwatch_log_group.test", "kms_key_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", "aws_cloudwatch_log_group.test", "tags"),
 				),
 			},
 		},
@@ -92,11 +89,11 @@ func TestAccCloudWatchLogsGroupDataSource_retention(t *testing.T) {
 			{
 				Config: testAccCheckGroupRetentionDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_cloudwatch_log_group.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_cloudwatch_log_group.test", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "365"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", "aws_cloudwatch_log_group.test", "tags"),
+					resource.TestCheckResourceAttrPair(resourceName, "retention_in_days", "aws_cloudwatch_log_group.test", "retention_in_days"),
 				),
 			},
 		},


### PR DESCRIPTION
Closes #15073.

To match what we have on the resource create/read in https://github.com/hashicorp/terraform-provider-aws/blob/187f1659a4fef11ac314567273b5470afe6b662f/internal/service/cloudwatchlogs/group.go#L142

Potential breaking change since we don't know what string manipulation clients do on their end :/

I'll add acctest output and changelog if that makes since to merge this PR.

Potential refactor : reuse what we do after https://github.com/hashicorp/terraform-provider-aws/blob/187f1659a4fef11ac314567273b5470afe6b662f/internal/service/cloudwatchlogs/group.go#L131 in https://github.com/hashicorp/terraform-provider-aws/blame/187f1659a4fef11ac314567273b5470afe6b662f/internal/service/cloudwatchlogs/group_data_source.go#L46 - out of scope of this PR however.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

