### PR TITLE
Re-enables Semgrep rule `prefer-aws-go-sdk-pointer-conversion-conditional`

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -16,13 +16,13 @@ rules:
     languages: [go]
     message: Resources should not implement multiple AWS service functionality
     paths:
+      include:
+        - internal/
       exclude:
         - "internal/service/**/*_test.go"
         - "internal/service/**/sweep.go"
         - "internal/acctest/acctest.go"
         - "internal/conns/conns.go"
-      include:
-        - internal/
     patterns:
       - pattern: |
           import ("$X")
@@ -70,32 +70,19 @@ rules:
     languages: [go]
     message: Prefer AWS Go SDK pointer conversion functions for dereferencing during conditionals, e.g. aws.StringValue()
     paths:
-      exclude:
-        - aws/cloudfront_distribution_configuration_structure.go
-        - aws/cloudfront_distribution_configuration_structure_test.go
-        - aws/config.go
-        - aws/data_source_aws_route*
-        - aws/ecs_task_definition_equivalency.go
-        - aws/opsworks_layers.go
-        - aws/resource_aws_d*.go
-        - aws/resource_aws_e*.go
-        - aws/resource_aws_g*.go
-        - aws/resource_aws_i*.go
-        - aws/resource_aws_k*.go
-        - aws/resource_aws_l*.go
-        - aws/resource_aws_main_route_table_association.go
-        - aws/resource_aws_n*.go
-        - aws/resource_aws_o*.go
-        - aws/resource_aws_r*.go
-        - aws/resource_aws_s*.go
-        - aws/resource*_test.go
-        - aws/structure.go
-        - aws/internal/generators/
-        - aws/internal/keyvaluetags/
-        - aws/internal/naming/
-        - providerlint/vendor/
       include:
-        - aws/
+        - internal/service
+      exclude:
+        - internal/service/**/*_test.go
+        - internal/service/dax
+        - internal/service/docdb
+        - internal/service/ec2
+        - internal/service/ecs
+        - internal/service/elasticache
+        - internal/service/elasticbeanstalk
+        - internal/service/elb
+        - internal/service/rds
+        - internal/service/redshift
     patterns:
       - pattern-either:
         - pattern: '$LHS == *$RHS'

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -558,7 +558,7 @@ func resourceLaunchConfigurationCreate(d *schema.ResourceData, meta interface{})
 		_, err = autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 	}
 	if err != nil {
-		return fmt.Errorf("Error creating launch configuration: %s", err)
+		return fmt.Errorf("Error creating launch configuration: %w", err)
 	}
 
 	d.SetId(lcName)
@@ -586,10 +586,8 @@ func resourceLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Verify AWS returned our launch configuration
-	if *describConfs.LaunchConfigurations[0].LaunchConfigurationName != d.Id() {
-		return fmt.Errorf(
-			"Unable to find launch configuration: %#v",
-			describConfs.LaunchConfigurations)
+	if aws.StringValue(describConfs.LaunchConfigurations[0].LaunchConfigurationName) != d.Id() {
+		return fmt.Errorf("Unable to find launch configuration: %#v", describConfs.LaunchConfigurations)
 	}
 
 	lc := describConfs.LaunchConfigurations[0]
@@ -608,7 +606,7 @@ func resourceLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("enable_monitoring", lc.InstanceMonitoring.Enabled)
 	d.Set("associate_public_ip_address", lc.AssociatePublicIpAddress)
 	if err := d.Set("security_groups", flex.FlattenStringList(lc.SecurityGroups)); err != nil {
-		return fmt.Errorf("error setting security_groups: %s", err)
+		return fmt.Errorf("error setting security_groups: %w", err)
 	}
 	if v := aws.StringValue(lc.UserData); v != "" {
 		_, b64 := d.GetOk("user_data_base64")

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -105,7 +105,7 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 		d.Set("caller_reference", distributionConfig.CallerReference)
 	}
 	if distributionConfig.Comment != nil {
-		if *distributionConfig.Comment != "" {
+		if aws.StringValue(distributionConfig.Comment) != "" {
 			d.Set("comment", distributionConfig.Comment)
 		}
 	}
@@ -152,13 +152,13 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 			return err
 		}
 	}
-	if *distributionConfig.Origins.Quantity > 0 {
+	if aws.Int64Value(distributionConfig.Origins.Quantity) > 0 {
 		err = d.Set("origin", FlattenOrigins(distributionConfig.Origins))
 		if err != nil {
 			return err
 		}
 	}
-	if *distributionConfig.OriginGroups.Quantity > 0 {
+	if aws.Int64Value(distributionConfig.OriginGroups.Quantity) > 0 {
 		err = d.Set("origin_group", FlattenOriginGroups(distributionConfig.OriginGroups))
 		if err != nil {
 			return err

--- a/internal/service/dms/certificate.go
+++ b/internal/service/dms/certificate.go
@@ -202,7 +202,7 @@ func resourceCertificateSetState(d *schema.ResourceData, cert *dms.Certificate) 
 	d.Set("certificate_id", cert.CertificateIdentifier)
 	d.Set("certificate_arn", cert.CertificateArn)
 
-	if cert.CertificatePem != nil && *cert.CertificatePem != "" {
+	if aws.StringValue(cert.CertificatePem) != "" {
 		d.Set("certificate_pem", cert.CertificatePem)
 	}
 	if cert.CertificateWallet != nil && len(cert.CertificateWallet) != 0 {

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -463,7 +463,7 @@ func resourceDirectoryRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("alias", dir.Alias)
 	d.Set("description", dir.Description)
 
-	if *dir.Type == directoryservice.DirectoryTypeAdconnector {
+	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {
 		d.Set("dns_ip_addresses", flex.FlattenStringSet(dir.ConnectSettings.ConnectIps))
 	} else {
 		d.Set("dns_ip_addresses", flex.FlattenStringSet(dir.DnsIpAddrs))

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1380,7 +1380,7 @@ func flattenDynamoDbPitr(pitrDesc *dynamodb.DescribeContinuousBackupsOutput) []i
 	if pitrDesc.ContinuousBackupsDescription != nil {
 		pitr := pitrDesc.ContinuousBackupsDescription.PointInTimeRecoveryDescription
 		if pitr != nil {
-			m["enabled"] = (*pitr.PointInTimeRecoveryStatus == dynamodb.PointInTimeRecoveryStatusEnabled)
+			m["enabled"] = (aws.StringValue(pitr.PointInTimeRecoveryStatus) == dynamodb.PointInTimeRecoveryStatusEnabled)
 		}
 	}
 

--- a/internal/service/elastictranscoder/pipeline.go
+++ b/internal/service/elastictranscoder/pipeline.go
@@ -304,7 +304,7 @@ func flattenETNotifications(n *elastictranscoder.Notifications) []map[string]int
 
 	allEmpty := func(s ...*string) bool {
 		for _, s := range s {
-			if s != nil && *s != "" {
+			if aws.StringValue(s) != "" {
 				return false
 			}
 		}

--- a/internal/service/elastictranscoder/preset.go
+++ b/internal/service/elastictranscoder/preset.go
@@ -346,8 +346,8 @@ func resourcePresetCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating Elastic Transcoder Preset: %s", err)
 	}
 
-	if resp.Warning != nil && *resp.Warning != "" {
-		log.Printf("[WARN] Elastic Transcoder Preset: %s", *resp.Warning)
+	if aws.StringValue(resp.Warning) != "" {
+		log.Printf("[WARN] Elastic Transcoder Preset: %s", aws.StringValue(resp.Warning))
 	}
 
 	d.SetId(aws.StringValue(resp.Preset.Id))

--- a/internal/service/fsx/ontap_volume.go
+++ b/internal/service/fsx/ontap_volume.go
@@ -328,7 +328,7 @@ func flattenFsxOntapVolumeTieringPolicy(rs *fsx.TieringPolicy) []interface{} {
 	minCoolingPeriod := 2
 
 	m := make(map[string]interface{})
-	if rs.CoolingPeriod != nil && *rs.CoolingPeriod >= int64(minCoolingPeriod) {
+	if aws.Int64Value(rs.CoolingPeriod) >= int64(minCoolingPeriod) {
 		m["cooling_period"] = aws.Int64Value(rs.CoolingPeriod)
 	}
 

--- a/internal/service/gamelift/fleet.go
+++ b/internal/service/gamelift/fleet.go
@@ -653,7 +653,7 @@ func isGameliftEventFailure(event *gamelift.Event) bool {
 		gamelift.EventCodeServerProcessTerminatedUnhealthy,
 	}
 	for _, fc := range failureCodes {
-		if *event.EventCode == fc {
+		if aws.StringValue(event.EventCode) == fc {
 			return true
 		}
 	}

--- a/internal/service/glue/resource_policy.go
+++ b/internal/service/glue/resource_policy.go
@@ -74,7 +74,7 @@ func resourceResourcePolicyRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error reading policy request: %w", err)
 	}
 
-	if *resourcePolicy.PolicyInJson == "" {
+	if aws.StringValue(resourcePolicy.PolicyInJson) == "" {
 		//Since the glue resource policy is global we expect it to be deleted when the policy is empty
 		d.SetId("")
 	} else {

--- a/internal/service/guardduty/ipset.go
+++ b/internal/service/guardduty/ipset.go
@@ -150,7 +150,7 @@ func resourceIPSetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("format", resp.Format)
 	d.Set("location", resp.Location)
 	d.Set("name", resp.Name)
-	d.Set("activate", *resp.Status == guardduty.IpSetStatusActive)
+	d.Set("activate", aws.StringValue(resp.Status) == guardduty.IpSetStatusActive)
 
 	tags := KeyValueTags(resp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/guardduty/threatintelset.go
+++ b/internal/service/guardduty/threatintelset.go
@@ -151,7 +151,7 @@ func resourceThreatintelsetRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("format", resp.Format)
 	d.Set("location", resp.Location)
 	d.Set("name", resp.Name)
-	d.Set("activate", *resp.Status == guardduty.ThreatIntelSetStatusActive)
+	d.Set("activate", aws.StringValue(resp.Status) == guardduty.ThreatIntelSetStatusActive)
 
 	tags := KeyValueTags(resp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/iam/access_key.go
+++ b/internal/service/iam/access_key.go
@@ -195,7 +195,7 @@ func resourceAccessKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for _, key := range getResp.AccessKeyMetadata {
-		if key.AccessKeyId != nil && *key.AccessKeyId == d.Id() {
+		if aws.StringValue(key.AccessKeyId) == d.Id() {
 			return resourceAccessKeyReadResult(d, key)
 		}
 	}

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -353,7 +353,7 @@ func DeleteUserVirtualMFADevices(svc *iam.IAM, username string) error {
 	pageOfVirtualMFADevices := func(page *iam.ListVirtualMFADevicesOutput, lastPage bool) (shouldContinue bool) {
 		for _, m := range page.VirtualMFADevices {
 			// UserName is `nil` for the root user
-			if m.User.UserName != nil && *m.User.UserName == username {
+			if aws.StringValue(m.User.UserName) == username {
 				VirtualMFADevices = append(VirtualMFADevices, *m.SerialNumber)
 			}
 		}

--- a/internal/service/iot/certificate.go
+++ b/internal/service/iot/certificate.go
@@ -92,7 +92,7 @@ func resourceCertificateRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading certificate details: %v", err)
 	}
 
-	d.Set("active", aws.Bool(*out.CertificateDescription.Status == iot.CertificateStatusActive))
+	d.Set("active", aws.Bool(aws.StringValue(out.CertificateDescription.Status) == iot.CertificateStatusActive))
 	d.Set("arn", out.CertificateDescription.CertificateArn)
 	d.Set("certificate_pem", out.CertificateDescription.CertificatePem)
 

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -289,7 +289,7 @@ func resourceGrantDelete(d *schema.ResourceData, meta interface{}) error {
 
 func getKmsGrantById(grants []*kms.GrantListEntry, grantIdentifier string) *kms.GrantListEntry {
 	for _, grant := range grants {
-		if *grant.GrantId == grantIdentifier {
+		if aws.StringValue(grant.GrantId) == grantIdentifier {
 			return grant
 		}
 	}

--- a/internal/service/lambda/flex.go
+++ b/internal/service/lambda/flex.go
@@ -34,7 +34,7 @@ func flattenVPCConfigResponse(s *lambda.VpcConfigResponse) []map[string]interfac
 	}
 
 	var emptyVpc bool
-	if s.VpcId == nil || *s.VpcId == "" {
+	if aws.StringValue(s.VpcId) == "" {
 		emptyVpc = true
 	}
 	if len(s.SubnetIds) == 0 && len(s.SecurityGroupIds) == 0 && emptyVpc {

--- a/internal/service/neptune/parameter_group.go
+++ b/internal/service/neptune/parameter_group.go
@@ -137,7 +137,7 @@ func resourceParameterGroupRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if len(describeResp.DBParameterGroups) != 1 ||
-		*describeResp.DBParameterGroups[0].DBParameterGroupName != d.Id() {
+		aws.StringValue(describeResp.DBParameterGroups[0].DBParameterGroupName) != d.Id() {
 		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.DBParameterGroups)
 	}
 

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -418,8 +418,8 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, meta interface{}) er
 	d.SetId(layerId)
 
 	loadBalancer := aws.String(d.Get("elastic_load_balancer").(string))
-	if loadBalancer != nil && *loadBalancer != "" {
-		log.Printf("[DEBUG] Attaching load balancer: %s", *loadBalancer)
+	if aws.StringValue(loadBalancer) != "" {
+		log.Printf("[DEBUG] Attaching load balancer: %s", aws.StringValue(loadBalancer))
 		_, err := conn.AttachElasticLoadBalancer(&opsworks.AttachElasticLoadBalancerInput{
 			ElasticLoadBalancerName: loadBalancer,
 			LayerId:                 &layerId,
@@ -486,7 +486,7 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, meta interface{}) er
 		loadBalancerOld := aws.String(lbo.(string))
 		loadBalancerNew := aws.String(lbn.(string))
 
-		if loadBalancerOld != nil && *loadBalancerOld != "" {
+		if aws.StringValue(loadBalancerOld) != "" {
 			log.Printf("[DEBUG] Dettaching load balancer: %s", *loadBalancerOld)
 			_, err := conn.DetachElasticLoadBalancer(&opsworks.DetachElasticLoadBalancerInput{
 				ElasticLoadBalancerName: loadBalancerOld,
@@ -497,7 +497,7 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 
-		if loadBalancerNew != nil && *loadBalancerNew != "" {
+		if aws.StringValue(loadBalancerNew) != "" {
 			log.Printf("[DEBUG] Attaching load balancer: %s", *loadBalancerNew)
 			_, err := conn.AttachElasticLoadBalancer(&opsworks.AttachElasticLoadBalancerInput{
 				ElasticLoadBalancerName: loadBalancerNew,

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -248,7 +248,7 @@ func resourceStackCustomCookbooksSource(d *schema.ResourceData) *opsworks.Source
 
 func resourceSetStackCustomCookbooksSource(d *schema.ResourceData, v *opsworks.Source) error {
 	nv := make([]interface{}, 0, 1)
-	if v != nil && v.Type != nil && *v.Type != "" {
+	if v != nil && aws.StringValue(v.Type) != "" {
 		m := make(map[string]interface{})
 		if v.Type != nil {
 			m["type"] = *v.Type
@@ -417,7 +417,7 @@ func opsworksConnForRegion(region string, meta interface{}) (*opsworks.OpsWorks,
 	originalConn := meta.(*conns.AWSClient).OpsWorksConn
 
 	// Regions are the same, no need to reconfigure
-	if originalConn.Config.Region != nil && *originalConn.Config.Region == region {
+	if aws.StringValue(originalConn.Config.Region) == region {
 		return originalConn, nil
 	}
 

--- a/internal/service/securityhub/invite_accepter.go
+++ b/internal/service/securityhub/invite_accepter.go
@@ -70,7 +70,7 @@ func resourceInviteAccepterGetInvitationID(conn *securityhub.SecurityHub, master
 
 	for _, invitation := range resp.Invitations {
 		log.Printf("[DEBUG] Invitation: %s", invitation)
-		if *invitation.AccountId == masterId {
+		if aws.StringValue(invitation.AccountId) == masterId {
 			return *invitation.InvitationId, nil
 		}
 	}

--- a/internal/service/ssm/resource_data_sync.go
+++ b/internal/service/ssm/resource_data_sync.go
@@ -142,7 +142,7 @@ func FindResourceDataSyncItem(conn *ssm.SSM, name string) (*ssm.ResourceDataSync
 			return nil, err
 		}
 		for _, v := range resp.ResourceDataSyncItems {
-			if *v.SyncName == name {
+			if aws.StringValue(v.SyncName) == name {
 				return v, nil
 			}
 		}


### PR DESCRIPTION
Re-enables Semgrep rule `prefer-aws-go-sdk-pointer-conversion-conditional`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSSMResourceDataSync|TestAccOpsWorksStack|TestAccDynamoDBTable|TestAccAutoScalingLaunchConfiguration|TestAccDMSCertificate|TestAccElasticTranscoderPipeline|TestAccKMSGrant|TestAccElasticTranscoderPreset|TestAccFSxOntapVolume|TestAccIAMAccessKey|TestAccNeptuneParameterGroup|TestAccDirectoryServiceDirectory|TestAccGameLiftFleet|TestAccIAMUser|TestAccIoTCertificate

--- SKIP: TestAccAutoScalingLaunchConfiguration_withVPCClassicLink (2.69s)
--- PASS: TestAccAutoScalingLaunchConfigurationDataSource_ebsNoDevice (122.52s)
--- PASS: TestAccAutoScalingLaunchConfigurationDataSource_basic (123.89s)
--- PASS: TestAccAutoScalingLaunchConfigurationDataSource_metadataOptions (124.00s)
--- PASS: TestAccAutoScalingLaunchConfiguration_namePrefix (125.54s)
--- PASS: TestAccAutoScalingLaunchConfigurationDataSource_securityGroups (125.91s)
--- PASS: TestAccAutoScalingLaunchConfiguration_withEncryption (128.84s)
--- PASS: TestAccAutoScalingLaunchConfiguration_EBS_noDevice (130.00s)
--- PASS: TestAccAutoScalingLaunchConfiguration_withSpotPrice (130.21s)
--- PASS: TestAccAutoScalingLaunchConfiguration_metadataOptions (130.23s)
--- PASS: TestAccAutoScalingLaunchConfiguration_Name_generated (131.25s)
--- PASS: TestAccAutoScalingLaunchConfiguration_basic (132.57s)
--- PASS: TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior (0.00s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.00s)
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.00s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.00s)
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.00s)
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.00s)
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.00s)
--- PASS: TestCloudFrontStructure_expandFunctionAssociations (0.00s)
--- PASS: TestCloudFrontStructure_flattenFunctionAssociations (0.00s)
--- PASS: TestCloudFrontStructure_expandFunctionAssociations_empty (0.00s)
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.00s)
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.00s)
--- PASS: TestCloudFrontStructure_expandHeaders (0.00s)
--- PASS: TestCloudFrontStructure_flattenHeaders (0.00s)
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.00s)
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.00s)
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.00s)
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.00s)
--- PASS: TestCloudFrontStructure_expandCookieNames (0.00s)
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.00s)
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.00s)
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.00s)
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.00s)
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.00s)
--- PASS: TestCloudFrontStructure_expandOrigins (0.00s)
--- PASS: TestCloudFrontStructure_flattenOrigins (0.00s)
--- PASS: TestCloudFrontStructure_expandOriginGroups (0.00s)
--- PASS: TestCloudFrontStructure_flattenOriginGroups (0.00s)
--- PASS: TestCloudFrontStructure_expandOrigin (0.00s)
--- PASS: TestCloudFrontStructure_flattenOrigin (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.00s)
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.00s)
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.00s)
--- PASS: TestCloudFrontStructure_expandOriginShield (0.00s)
--- PASS: TestCloudFrontStructure_flattenOriginShield (0.00s)
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.00s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.00s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.00s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.00s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.00s)
--- PASS: TestCloudFrontStructure_expandAliases (0.00s)
--- PASS: TestCloudFrontStructure_flattenAliases (0.00s)
--- PASS: TestCloudFrontStructure_expandRestrictions (0.00s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.00s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.00s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.00s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.00s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.00s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.00s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.00s)
--- PASS: TestAccAutoScalingLaunchConfiguration_withInstanceStoreAMI (130.16s)
--- PASS: TestAccAutoScalingLaunchConfiguration_encryptedRootBlockDevice (133.15s)
--- PASS: TestAccAutoScalingLaunchConfiguration_withBlockDevices (133.20s)
--- PASS: TestAccAutoScalingLaunchConfiguration_withGP3 (133.22s)
--- PASS: TestAccAutoScalingLaunchConfiguration_withIAMProfile (134.70s)
--- PASS: TestAccAutoScalingLaunchConfiguration_userData (156.50s)
--- PASS: TestAccAutoScalingLaunchConfiguration_updateEBSBlockDevices (158.68s)
--- PASS: TestAccAutoScalingLaunchConfiguration_RootBlockDevice_volumeSize (160.00s)
--- PASS: TestAccDMSCertificate_disappears (26.13s)
--- PASS: TestUpdateDynamoDbDiffGSI (0.00s)
--- PASS: TestAccDMSCertificate_basic (38.63s)
--- PASS: TestAccDMSCertificate_certificateWallet (38.86s)
--- PASS: TestAccDirectoryServiceDirectoryDataSource_nonExistent (19.00s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (34.72s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (55.18s)
--- PASS: TestAccDMSCertificate_tags (93.99s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (117.56s)
--- PASS: TestAccAutoScalingLaunchConfiguration_RootBlockDevice_amiDisappears (430.70s)
--- PASS: TestAccDynamoDBTable_tags (133.32s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (173.95s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (176.23s)
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (142.86s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (181.53s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (183.76s)
--- PASS: TestAccDynamoDBTable_disappears (77.21s)
--- PASS: TestAccDynamoDBTable_enablePITR (201.56s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (203.80s)
--- PASS: TestAccDynamoDBTable_streamSpecification (205.04s)
--- PASS: TestAccDynamoDBTable_basic (85.16s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (167.42s)
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (61.76s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (64.51s)
--- PASS: TestAccDynamoDBTableItem_rangeKey (57.68s)
--- PASS: TestAccDynamoDBTableItem_basic (48.35s)
--- PASS: TestAccDynamoDBTableItem_update (76.17s)
--- PASS: TestAccDynamoDBTableDataSource_basic (58.33s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (76.23s)
--- PASS: TestAccDynamoDBTable_encryption (281.78s)
--- PASS: TestAccElasticTranscoderPreset_disappears (48.55s)
--- PASS: TestAccElasticTranscoderPreset_Video_frameRate (60.58s)
--- PASS: TestAccElasticTranscoderPreset_description (60.61s)
--- PASS: TestAccElasticTranscoderPipeline_disappears (61.51s)
--- PASS: TestAccElasticTranscoderPreset_basic (61.74s)
--- PASS: TestAccElasticTranscoderPreset_AudioCodecOptions_empty (62.24s)
--- PASS: TestAccElasticTranscoderPipeline_withPermissions (65.74s)
--- PASS: TestAccElasticTranscoderPipeline_basic (65.81s)
--- PASS: TestAccElasticTranscoderPreset_full (79.42s)
--- PASS: TestAccElasticTranscoderPipeline_withContent (81.52s)
--- PASS: TestAccElasticTranscoderPipeline_notifications (82.13s)
--- PASS: TestAccElasticTranscoderPipeline_kmsKey (90.75s)
--- PASS: TestDiffGameliftPortSettings (0.00s)
--- PASS: TestAccDynamoDBTable_extended (445.17s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (445.20s)
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (504.73s)
--- PASS: TestAccDirectoryServiceDirectory_basic (769.30s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (825.00s)
--- PASS: TestAccDirectoryServiceDirectory_disappears (844.78s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (655.12s)
--- PASS: TestAccDirectoryServiceDirectoryDataSource_simpleAD (884.46s)
--- PASS: TestAccDirectoryServiceDirectory_withAliasAndSSO (917.98s)
--- PASS: TestAccDirectoryServiceDirectory_tags (938.59s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1185.41s)
--- PASS: TestAccDynamoDBTable_Replica_single (1348.67s)
--- PASS: TestAccDirectoryServiceDirectory_connector (1440.15s)
--- PASS: TestAccDirectoryServiceDirectoryDataSource_connector (1478.83s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (1480.49s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (1537.23s)
--- PASS: TestAccDirectoryServiceDirectoryDataSource_microsoftAD (1583.67s)
--- PASS: TestSesSmtpPasswordFromSecretKeySigV4 (0.00s)
--- PASS: TestAccDirectoryServiceDirectory_microsoftStandard (1650.24s)
--- PASS: TestAccIAMUsersDataSource_nonExistentNameRegex (61.16s)
--- PASS: TestAccIAMUserLoginProfile_notAKey (61.41s)
--- PASS: TestAccIAMUsersDataSource_nonExistentPathPrefix (62.12s)
--- PASS: TestAccIAMUsersDataSource_nameRegex (67.18s)
--- PASS: TestAccIAMUser_disappears (67.82s)
--- PASS: TestAccIAMUsersDataSource_pathPrefix (78.93s)
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (86.05s)
--- PASS: TestAccIAMUserSSHKeyDataSource_basic (86.61s)
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (94.18s)
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (95.28s)
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (95.59s)
--- PASS: TestAccIAMAccessKey_basic (96.82s)
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (101.16s)
--- PASS: TestAccIAMUserSSHKey_pemEncoding (105.44s)
--- PASS: TestAccIAMUserPolicy_disappears (109.45s)
--- PASS: TestAccIAMUserSSHKey_basic (110.05s)
--- FAIL: TestAccIAMUserLoginProfile_keybase (51.58s)
--- PASS: TestAccIAMUserLoginProfile_keybaseDoesntExist (53.10s)
--- PASS: TestAccIAMUser_basic (146.65s)
--- PASS: TestAccIAMUser_nameChange (147.48s)
--- PASS: TestAccIAMUserPolicy_basic (155.86s)
--- PASS: TestAccIAMUserDataSource_basic (76.96s)
--- PASS: TestAccIAMUserLoginProfile_passwordLength (92.78s)
--- PASS: TestAccIAMUserDataSource_tags (67.31s)
--- PASS: TestAccIAMAccessKey_encrypted (74.06s)
--- PASS: TestAccIAMUserPolicy_namePrefix (122.21s)
--- PASS: TestAccIAMUserPolicyAttachment_basic (123.79s)
--- PASS: TestAccIAMUserPolicy_generatedName (124.82s)
--- PASS: TestAccIAMUserLoginProfile_basic (97.11s)
--- PASS: TestAccIAMUser_pathChange (93.04s)
--- PASS: TestAccIAMUser_tags (91.15s)
--- PASS: TestAccIAMUserPolicy_multiplePolicies (205.47s)
--- PASS: TestAccIAMAccessKey_status (116.49s)
--- PASS: TestAccIAMUser_permissionsBoundary (137.10s)
--- PASS: TestAccIAMUserGroupMembership_basic (181.04s)
--- PASS: TestAccDirectoryServiceDirectory_microsoft (1896.02s)
--- PASS: TestAccIoTCertificate_csr (19.14s)
--- PASS: TestAccIoTCertificate_Keys_certificate (19.58s)
--- PASS: TestAccKMSGrant_asymmetricKey (52.14s)
--- PASS: TestAccKMSGrant_withRetiringPrincipal (52.38s)
--- PASS: TestAccKMSGrant_bare (53.35s)
--- PASS: TestAccKMSGrant_basic (53.51s)
--- PASS: TestAccKMSGrant_arn (53.58s)
--- PASS: TestAccKMSGrant_withConstraints (66.26s)
--- PASS: TestAccNeptuneParameterGroup_description (21.25s)
--- PASS: TestAccNeptuneParameterGroup_basic (21.53s)
--- PASS: TestAccKMSGrant_disappears (221.48s)
--- PASS: TestAccNeptuneParameterGroup_parameter (38.15s)
--- PASS: TestAccNeptuneParameterGroup_tags (45.44s)
--- PASS: TestAccOpsWorksStack_classicEndpoints (55.12s)
--- PASS: TestAccOpsWorksStack_CustomCookbooks_setPrivateProperties (44.31s)
--- PASS: TestAccOpsWorksStack_noVPCBasic (47.36s)
--- PASS: TestAccOpsWorksStack_noVPCCreateTags (65.65s)
--- PASS: TestAccOpsWorksStack_vpc (65.67s)
--- PASS: TestAccOpsWorksStack_noVPCChangeServiceRoleForceNew (80.99s)
--- PASS: TestAccGameLiftFleet_tags (2041.98s)
--- PASS: TestAccGameLiftFleet_disappears (2067.91s)
--- PASS: TestAccGameLiftFleet_basic (2118.34s)
--- PASS: TestAccSSMResourceDataSync_basic (40.00s)
--- PASS: TestAccSSMResourceDataSync_update (72.00s)
--- PASS: TestAccGameLiftFleet_allFields (2557.84s)
--- PASS: TestAccFSxOntapVolume_basic (2987.54s)
--- PASS: TestAccFSxOntapVolume_disappears (3078.27s)
--- PASS: TestAccFSxOntapVolume_tags (3079.74s)
--- PASS: TestAccFSxOntapVolume_junctionPath (3169.07s)
--- PASS: TestAccFSxOntapVolume_storageEfficiency (3246.69s)
--- PASS: TestAccFSxOntapVolume_size (3305.04s)
--- PASS: TestAccFSxOntapVolume_securityStyle (3448.39s)
--- PASS: TestAccFSxOntapVolume_tieringPolicy (3572.92s)
--- PASS: TestAccFSxOntapVolume_name (3576.18s)
```

Test `TestAccIAMUserLoginProfile_keybase` is a pre-existing failure