### PR TITLE
Added a boolean eventbridge attribute to s3/bucket_notification

### DIFF
--- a/.changelog/22045.txt
+++ b/.changelog/22045.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_s3_bucket_notification: Add `eventbridge` attribute
+resource/aws_s3_bucket_notification: Add `eventbridge` argument
 ```

--- a/.changelog/22045.txt
+++ b/.changelog/22045.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_notification: Add `eventbridge` attribute
+```

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -130,7 +130,7 @@ func TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter(t *
 			acctest.PreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
-		ErrorCheck:        testAccErrorCheckSkipS3(t),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckReplicationConfigDestroy, &providers),
 		Steps: []resource.TestStep{
@@ -189,7 +189,7 @@ func TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter(
 			acctest.PreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
-		ErrorCheck:        testAccErrorCheckSkipS3(t),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckReplicationConfigDestroy, &providers),
 		Steps: []resource.TestStep{
@@ -240,7 +240,7 @@ func TestAccS3BucketReplicationConfiguration_twoDestination(t *testing.T) {
 			acctest.PreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
-		ErrorCheck:        testAccErrorCheckSkipS3(t),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckReplicationConfigDestroy, &providers),
 		Steps: []resource.TestStep{

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -31,6 +31,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(s3.EndpointsID, testAccErrorCheckSkip)
+}
+
+// testAccErrorCheckSkip skips tests that have error messages indicating unsupported features
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"Number of distinct destination bucket ARNs cannot exceed",
+		"destination is not allowed",
+	)
+}
+
 func TestAccS3Bucket_Basic_basic(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	region := acctest.Region()
@@ -1493,7 +1505,7 @@ func TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter(t *testing.T) {
 			acctest.PreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
-		ErrorCheck:        testAccErrorCheckSkipS3(t),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckBucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
@@ -1560,7 +1572,7 @@ func TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter(t *testing.T
 			acctest.PreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
-		ErrorCheck:        testAccErrorCheckSkipS3(t),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckBucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
@@ -1631,7 +1643,7 @@ func TestAccS3Bucket_Replication_twoDestination(t *testing.T) {
 			acctest.PreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
-		ErrorCheck:        testAccErrorCheckSkipS3(t),
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
 		ProviderFactories: acctest.FactoriesAlternate(&providers),
 		CheckDestroy:      acctest.CheckWithProviders(testAccCheckBucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
@@ -2795,13 +2807,6 @@ func TestWebsiteEndpoint(t *testing.T) {
 			t.Errorf("WebsiteEndpointUrl(\"bucket-name\", %q) => %q, want %q", testCase.LocationConstraint, got.Endpoint, testCase.Expected)
 		}
 	}
-}
-
-// testAccErrorCheckSkipS3 skips tests that have error messages indicating unsupported features
-func testAccErrorCheckSkipS3(t *testing.T) resource.ErrorCheckFunc {
-	return acctest.ErrorCheckSkipMessagesContaining(t,
-		"Number of distinct destination bucket ARNs cannot exceed",
-	)
 }
 
 func testAccCheckBucketDestroy(s *terraform.State) error {

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -302,20 +302,20 @@ The following arguments are required:
 
 * `bucket` - (Required) Name of the bucket for notification configuration.
 
-The following arguments are supported:
+The following arguments are optional:
 
 * `eventbridge` - (Optional) Whether to enable Amazon EventBridge notifications.
 * `lambda_function` - (Optional, Multiple) Used to configure notifications to a Lambda Function. See below.
 * `queue` - (Optional) Notification configuration to SQS Queue. See below.
 * `topic` - (Optional) Notification configuration to SNS Topic. See below.
 
-### `topic`
+### `lambda_function`
 
 * `events` - (Required) [Event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
 * `filter_prefix` - (Optional) Object key name prefix.
 * `filter_suffix` - (Optional) Object key name suffix.
 * `id` - (Optional) Unique identifier for each of the notification configurations.
-* `topic_arn` - (Required) SNS topic ARN.
+* `lambda_function_arn` - (Required) Lambda function ARN.
 
 ### `queue`
 
@@ -325,13 +325,13 @@ The following arguments are supported:
 * `id` - (Optional) Unique identifier for each of the notification configurations.
 * `queue_arn` - (Required) SQS queue ARN.
 
-### `lambda_function`
+### `topic`
 
 * `events` - (Required) [Event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
 * `filter_prefix` - (Optional) Object key name prefix.
 * `filter_suffix` - (Optional) Object key name suffix.
 * `id` - (Optional) Unique identifier for each of the notification configurations.
-* `lambda_function_arn` - (Required) Lambda function ARN.
+* `topic_arn` - (Required) SNS topic ARN.
 
 ## Attributes Reference
 

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -304,6 +304,7 @@ The following arguments are supported:
 * `topic` - (Optional) The notification configuration to SNS Topic (documented below).
 * `queue` - (Optional) The notification configuration to SQS Queue (documented below).
 * `lambda_function` - (Optional, Multiple) Used to configure notifications to a Lambda Function (documented below).
+* `eventbridge` - (Optional) Set to true to enable Amazon EventBridge notifications.
 
 The `topic` notification configuration supports the following:
 

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -298,37 +298,40 @@ For Terraform's [JSON syntax](https://www.terraform.io/docs/configuration/syntax
 
 ## Argument Reference
 
+The following arguments are required:
+
+* `bucket` - (Required) Name of the bucket for notification configuration.
+
 The following arguments are supported:
 
-* `bucket` - (Required) The name of the bucket to put notification configuration.
-* `topic` - (Optional) The notification configuration to SNS Topic (documented below).
-* `queue` - (Optional) The notification configuration to SQS Queue (documented below).
-* `lambda_function` - (Optional, Multiple) Used to configure notifications to a Lambda Function (documented below).
-* `eventbridge` - (Optional) Set to true to enable Amazon EventBridge notifications.
+* `eventbridge` - (Optional) Whether to enable Amazon EventBridge notifications.
+* `lambda_function` - (Optional, Multiple) Used to configure notifications to a Lambda Function. See below.
+* `queue` - (Optional) Notification configuration to SQS Queue. See below.
+* `topic` - (Optional) Notification configuration to SNS Topic. See below.
 
-The `topic` notification configuration supports the following:
+### `topic`
 
-* `id` - (Optional) Specifies unique identifier for each of the notification configurations.
-* `topic_arn` - (Required) Specifies Amazon SNS topic ARN.
+* `events` - (Required) [Event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
+* `filter_prefix` - (Optional) Object key name prefix.
+* `filter_suffix` - (Optional) Object key name suffix.
+* `id` - (Optional) Unique identifier for each of the notification configurations.
+* `topic_arn` - (Required) SNS topic ARN.
+
+### `queue`
+
 * `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
-* `filter_prefix` - (Optional) Specifies object key name prefix.
-* `filter_suffix` - (Optional) Specifies object key name suffix.
+* `filter_prefix` - (Optional) Object key name prefix.
+* `filter_suffix` - (Optional) Object key name suffix.
+* `id` - (Optional) Unique identifier for each of the notification configurations.
+* `queue_arn` - (Required) SQS queue ARN.
 
-The `queue` notification configuration supports the following:
+### `lambda_function`
 
-* `id` - (Optional) Specifies unique identifier for each of the notification configurations.
-* `queue_arn` - (Required) Specifies Amazon SQS queue ARN.
-* `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
-* `filter_prefix` - (Optional) Specifies object key name prefix.
-* `filter_suffix` - (Optional) Specifies object key name suffix.
-
-The `lambda_function` notification configuration supports the following:
-
-* `id` - (Optional) Specifies unique identifier for each of the notification configurations.
-* `lambda_function_arn` - (Required) Specifies Amazon Lambda function ARN.
-* `events` - (Required) Specifies [event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
-* `filter_prefix` - (Optional) Specifies object key name prefix.
-* `filter_suffix` - (Optional) Specifies object key name suffix.
+* `events` - (Required) [Event](http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations) for which to send notifications.
+* `filter_prefix` - (Optional) Object key name prefix.
+* `filter_suffix` - (Optional) Object key name suffix.
+* `id` - (Optional) Unique identifier for each of the notification configurations.
+* `lambda_function_arn` - (Required) Lambda function ARN.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Added a boolean eventbridge attribute to s3/bucket_notification in order to support the EventBridge notifications for S3 buckets.

This is a draft PR. IMHO the code looks good and the acceptance test looks good, but I haven't gone through all the contribution document in detail yet. I do have one question right now though. Where/how do I write the documentation for the new attribute I have added?

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #22013.

Output from acceptance testing:


```
lloyd@riftsweeper:software/terraform-provider-aws$ AWS_PROFILE=cicd make testacc TESTS=TestAccS3BucketNotification_eventbridge PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketNotification_eventbridge' -timeout 180m
=== RUN   TestAccS3BucketNotification_eventbridge
=== PAUSE TestAccS3BucketNotification_eventbridge
=== CONT  TestAccS3BucketNotification_eventbridge
--- PASS: TestAccS3BucketNotification_eventbridge (36.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 36.702s
...
```
