### PR TITLE
linter/semgrep: Enables `d.IsNewResource` check for all services starting with "A"

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -312,7 +312,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/**/*_data_source.go
-        - internal/service/apigatewayv2
         - internal/service/appautoscaling
         - internal/service/appsync
         - internal/service/athena

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -312,8 +312,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/**/*_data_source.go
-        - internal/service/autoscaling
-        - internal/service/autoscalingplans/scaling_plan.go
         - internal/service/[b-ce-g]*
         - internal/service/d[a-df-z]*
         - internal/service/devicefarm

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -312,7 +312,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/**/*_data_source.go
-        - internal/service/athena
         - internal/service/autoscaling
         - internal/service/autoscalingplans/scaling_plan.go
         - internal/service/[b-ce-g]*

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -312,7 +312,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/**/*_data_source.go
-        - internal/service/appsync
         - internal/service/athena
         - internal/service/autoscaling
         - internal/service/autoscalingplans/scaling_plan.go

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -312,7 +312,6 @@ rules:
         - internal/service
       exclude:
         - internal/service/**/*_data_source.go
-        - internal/service/appautoscaling
         - internal/service/appsync
         - internal/service/athena
         - internal/service/autoscaling

--- a/internal/service/apigatewayv2/api.go
+++ b/internal/service/apigatewayv2/api.go
@@ -281,7 +281,7 @@ func resourceAPIRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.GetApi(&apigatewayv2.GetApiInput{
 		ApiId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 API (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/api_mapping.go
+++ b/internal/service/apigatewayv2/api_mapping.go
@@ -75,7 +75,7 @@ func resourceAPIMappingRead(d *schema.ResourceData, meta interface{}) error {
 		ApiMappingId: aws.String(d.Id()),
 		DomainName:   aws.String(d.Get("domain_name").(string)),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 API mapping (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/authorizer.go
+++ b/internal/service/apigatewayv2/authorizer.go
@@ -155,7 +155,7 @@ func resourceAuthorizerRead(d *schema.ResourceData, meta interface{}) error {
 		ApiId:        aws.String(d.Get("api_id").(string)),
 		AuthorizerId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 authorizer (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/deployment.go
+++ b/internal/service/apigatewayv2/deployment.go
@@ -77,7 +77,7 @@ func resourceDeploymentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).APIGatewayV2Conn
 
 	outputRaw, _, err := StatusDeployment(conn, d.Get("api_id").(string), d.Id())()
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 deployment (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/integration.go
+++ b/internal/service/apigatewayv2/integration.go
@@ -243,7 +243,7 @@ func resourceIntegrationRead(d *schema.ResourceData, meta interface{}) error {
 		ApiId:         aws.String(d.Get("api_id").(string)),
 		IntegrationId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 integration (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/integration_response.go
+++ b/internal/service/apigatewayv2/integration_response.go
@@ -98,7 +98,7 @@ func resourceIntegrationResponseRead(d *schema.ResourceData, meta interface{}) e
 		IntegrationId:         aws.String(d.Get("integration_id").(string)),
 		IntegrationResponseId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 integration response (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/model.go
+++ b/internal/service/apigatewayv2/model.go
@@ -98,7 +98,7 @@ func resourceModelRead(d *schema.ResourceData, meta interface{}) error {
 		ApiId:   aws.String(d.Get("api_id").(string)),
 		ModelId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 model (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -152,7 +152,7 @@ func resourceRouteRead(d *schema.ResourceData, meta interface{}) error {
 		RouteId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 route (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/route_response.go
+++ b/internal/service/apigatewayv2/route_response.go
@@ -86,7 +86,7 @@ func resourceRouteResponseRead(d *schema.ResourceData, meta interface{}) error {
 		RouteId:         aws.String(d.Get("route_id").(string)),
 		RouteResponseId: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 route response (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -251,7 +251,7 @@ func resourceStageRead(d *schema.ResourceData, meta interface{}) error {
 		ApiId:     aws.String(apiId),
 		StageName: aws.String(d.Id()),
 	})
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 stage (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/apigatewayv2/vpc_link.go
+++ b/internal/service/apigatewayv2/vpc_link.go
@@ -91,7 +91,7 @@ func resourceVPCLinkRead(d *schema.ResourceData, meta interface{}) error {
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	outputRaw, _, err := StatusVPCLink(conn, d.Id())()
-	if tfawserr.ErrMessageContains(err, apigatewayv2.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, apigatewayv2.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] API Gateway v2 VPC Link (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -271,7 +271,7 @@ func resourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Failed to read scaling policy: %s", err)
 	}
 
-	if p == nil {
+	if p == nil && !d.IsNewResource() {
 		log.Printf("[WARN] Application AutoScaling Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/appautoscaling/scheduled_action.go
+++ b/internal/service/appautoscaling/scheduled_action.go
@@ -201,7 +201,7 @@ func resourceScheduledActionRead(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*conns.AWSClient).AppAutoScalingConn
 
 	scheduledAction, err := FindScheduledAction(conn, d.Get("name").(string), d.Get("service_namespace").(string), d.Get("resource_id").(string))
-	if tfresource.NotFound(err) {
+	if tfresource.NotFound(err) && !d.IsNewResource() {
 		log.Printf("[WARN] Application Auto Scaling Scheduled Action (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -131,7 +131,7 @@ func resourceTargetRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if t == nil {
+	if t == nil && !d.IsNewResource() {
 		log.Printf("[WARN] Application AutoScaling Target (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/appsync/api_key.go
+++ b/internal/service/appsync/api_key.go
@@ -90,8 +90,8 @@ func resourceAPIKeyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error getting Appsync API Key %q: %s", d.Id(), err)
 	}
-	if key == nil {
-		log.Printf("[WARN] AppSync API Key %q not found, removing from state", d.Id())
+	if key == nil && !d.IsNewResource() {
+		log.Printf("[WARN] AppSync API Key (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -146,7 +146,7 @@ func resourceAPIKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	_, err = conn.DeleteApiKey(input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+		if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 			return nil
 		}
 		return err

--- a/internal/service/appsync/api_key_test.go
+++ b/internal/service/appsync/api_key_test.go
@@ -131,7 +131,7 @@ func testAccCheckAPIKeyDestroy(s *terraform.State) error {
 
 		apiKey, err := tfappsync.GetAPIKey(apiID, keyID, conn)
 		if err == nil {
-			if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+			if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 				return nil
 			}
 			return err

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -200,7 +200,7 @@ func resourceDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.GetDataSource(input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+		if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) && !d.IsNewResource() {
 			log.Printf("[WARN] AppSync Datasource %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -298,7 +298,7 @@ func resourceDataSourceDelete(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = conn.DeleteDataSource(input)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+		if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 			return nil
 		}
 		return err

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -422,7 +422,7 @@ func testAccCheckDestroyDataSource(s *terraform.State) error {
 
 		_, err = conn.GetDataSource(input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+			if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 				return nil
 			}
 			return err

--- a/internal/service/appsync/function.go
+++ b/internal/service/appsync/function.go
@@ -123,8 +123,8 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	resp, err := conn.GetFunction(input)
-	if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] No such entity found for Appsync Function (%s)", d.Id())
+	if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) && !d.IsNewResource() {
+		log.Printf("[WARN] AppSync Function (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -171,11 +171,6 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	_, err = conn.UpdateFunction(input)
-	if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] No such entity found for Appsync Function (%s)", d.Id())
-		d.SetId("")
-		return nil
-	}
 	if err != nil {
 		return fmt.Errorf("Error updating AppSync Function %s: %s", d.Id(), err)
 	}
@@ -197,7 +192,7 @@ func resourceFunctionDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	_, err = conn.DeleteFunction(input)
-	if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 		return nil
 	}
 	if err != nil {

--- a/internal/service/appsync/function_test.go
+++ b/internal/service/appsync/function_test.go
@@ -161,7 +161,7 @@ func testAccCheckFunctionDestroy(s *terraform.State) error {
 
 		_, err = conn.GetFunction(input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+			if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 				return nil
 			}
 			return err

--- a/internal/service/appsync/graphql_api.go
+++ b/internal/service/appsync/graphql_api.go
@@ -270,8 +270,8 @@ func resourceGraphQLAPIRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.GetGraphqlApi(input)
 
-	if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
-		log.Printf("[WARN] No such entity found for Appsync Graphql API (%s)", d.Id())
+	if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) && !d.IsNewResource() {
+		log.Printf("[WARN] AppSync GraphQL API (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -381,7 +381,7 @@ func resourceGraphQLAPIDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	_, err := conn.DeleteGraphqlApi(input)
 
-	if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 		return nil
 	}
 

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -932,7 +932,7 @@ func testAccCheckGraphQLAPIDestroy(s *terraform.State) error {
 
 		_, err := conn.GetGraphqlApi(input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+			if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 				return nil
 			}
 			return err

--- a/internal/service/appsync/resolver.go
+++ b/internal/service/appsync/resolver.go
@@ -177,7 +177,7 @@ func resourceResolverRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.GetResolver(input)
 
-	if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+	if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) && !d.IsNewResource() {
 		log.Printf("[WARN] AppSync Resolver (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/appsync/resolver_test.go
+++ b/internal/service/appsync/resolver_test.go
@@ -307,7 +307,7 @@ func testAccCheckResolverDestroy(s *terraform.State) error {
 
 		_, err = conn.GetResolver(input)
 
-		if tfawserr.ErrMessageContains(err, appsync.ErrCodeNotFoundException, "") {
+		if tfawserr.ErrCodeEquals(err, appsync.ErrCodeNotFoundException) {
 			continue
 		}
 

--- a/internal/service/athena/named_query.go
+++ b/internal/service/athena/named_query.go
@@ -1,6 +1,7 @@
 package athena
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -82,13 +83,13 @@ func resourceNamedQueryRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	resp, err := conn.GetNamedQuery(input)
+	if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, d.Id()) && !d.IsNewResource() {
+		log.Printf("[WARN] Athena Named Query (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, d.Id()) {
-			log.Printf("[WARN] Athena Named Query (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error getting Athena Named Query (%s): %w", d.Id(), err)
 	}
 
 	d.Set("name", resp.NamedQuery.Name)

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -172,7 +172,7 @@ func resourceWorkGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	_, err := conn.CreateWorkGroup(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating Athena WorkGroup: %s", err)
+		return fmt.Errorf("error creating Athena WorkGroup: %w", err)
 	}
 
 	d.SetId(name)
@@ -184,7 +184,7 @@ func resourceWorkGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := conn.UpdateWorkGroup(input); err != nil {
-			return fmt.Errorf("error disabling Athena WorkGroup (%s): %s", d.Id(), err)
+			return fmt.Errorf("error disabling Athena WorkGroup (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -202,14 +202,14 @@ func resourceWorkGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.GetWorkGroup(input)
 
-	if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "is not found") {
+	if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "is not found") && !d.IsNewResource() {
 		log.Printf("[WARN] Athena WorkGroup (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading Athena WorkGroup (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading Athena WorkGroup (%s): %w", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -224,7 +224,7 @@ func resourceWorkGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", resp.WorkGroup.Description)
 
 	if err := d.Set("configuration", flattenAthenaWorkGroupConfiguration(resp.WorkGroup.Configuration)); err != nil {
-		return fmt.Errorf("error setting configuration: %s", err)
+		return fmt.Errorf("error setting configuration: %w", err)
 	}
 
 	d.Set("name", resp.WorkGroup.Name)
@@ -239,7 +239,7 @@ func resourceWorkGroupRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn.String())
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for resource (%s): %s", arn, err)
+		return fmt.Errorf("error listing tags for resource (%s): %w", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -269,7 +269,7 @@ func resourceWorkGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	_, err := conn.DeleteWorkGroup(input)
 
 	if err != nil {
-		return fmt.Errorf("error deleting Athena WorkGroup (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting Athena WorkGroup (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -303,14 +303,14 @@ func resourceWorkGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		_, err := conn.UpdateWorkGroup(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating Athena WorkGroup (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating Athena WorkGroup (%s): %w", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 

--- a/internal/service/autoscaling/attachment.go
+++ b/internal/service/autoscaling/attachment.go
@@ -85,7 +85,7 @@ func resourceAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if asg == nil {
+	if asg == nil && !d.IsNewResource() {
 		log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -837,7 +837,7 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if g == nil {
+	if g == nil && !d.IsNewResource() {
 		log.Printf("[WARN] Auto Scaling Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -1661,8 +1661,6 @@ func resourceGroupDrain(d *schema.ResourceData, meta interface{}) error {
 			return resource.NonRetryableError(err)
 		}
 		if g == nil {
-			log.Printf("[WARN] Auto Scaling Group (%s) not found, removing from state", d.Id())
-			d.SetId("")
 			return nil
 		}
 

--- a/internal/service/autoscaling/group_waiting.go
+++ b/internal/service/autoscaling/group_waiting.go
@@ -42,7 +42,7 @@ func waitForASGCapacity(
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-		if g == nil {
+		if g == nil && !d.IsNewResource() {
 			log.Printf("[WARN] Auto Scaling Group (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -62,7 +62,7 @@ func waitForASGCapacity(
 			return fmt.Errorf("Error getting Auto Scaling Group info: %s", err)
 		}
 
-		if g == nil {
+		if g == nil && !d.IsNewResource() {
 			log.Printf("[WARN] Auto Scaling Group (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -558,7 +558,7 @@ func resourceLaunchConfigurationCreate(d *schema.ResourceData, meta interface{})
 		_, err = autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 	}
 	if err != nil {
-		return fmt.Errorf("Error creating launch configuration: %s", err)
+		return fmt.Errorf("Error creating launch configuration: %w", err)
 	}
 
 	d.SetId(lcName)
@@ -577,9 +577,9 @@ func resourceLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] launch configuration describe configuration: %s", describeOpts)
 	describConfs, err := autoscalingconn.DescribeLaunchConfigurations(&describeOpts)
 	if err != nil {
-		return fmt.Errorf("Error retrieving launch configuration: %s", err)
+		return fmt.Errorf("Error retrieving launch configuration: %w", err)
 	}
-	if len(describConfs.LaunchConfigurations) == 0 {
+	if len(describConfs.LaunchConfigurations) == 0 && !d.IsNewResource() {
 		log.Printf("[WARN] Launch Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -608,7 +608,7 @@ func resourceLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("enable_monitoring", lc.InstanceMonitoring.Enabled)
 	d.Set("associate_public_ip_address", lc.AssociatePublicIpAddress)
 	if err := d.Set("security_groups", flex.FlattenStringList(lc.SecurityGroups)); err != nil {
-		return fmt.Errorf("error setting security_groups: %s", err)
+		return fmt.Errorf("error setting security_groups: %w", err)
 	}
 	if v := aws.StringValue(lc.UserData); v != "" {
 		_, b64 := d.GetOk("user_data_base64")
@@ -621,11 +621,11 @@ func resourceLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("vpc_classic_link_id", lc.ClassicLinkVPCId)
 	if err := d.Set("vpc_classic_link_security_groups", flex.FlattenStringList(lc.ClassicLinkVPCSecurityGroups)); err != nil {
-		return fmt.Errorf("error setting vpc_classic_link_security_groups: %s", err)
+		return fmt.Errorf("error setting vpc_classic_link_security_groups: %w", err)
 	}
 
 	if err := d.Set("metadata_options", flattenLaunchConfigInstanceMetadataOptions(lc.MetadataOptions)); err != nil {
-		return fmt.Errorf("error setting metadata_options: %s", err)
+		return fmt.Errorf("error setting metadata_options: %w", err)
 	}
 
 	if err := readLCBlockDevices(d, lc, ec2conn); err != nil {
@@ -666,7 +666,7 @@ func resourceLaunchConfigurationDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Autoscaling Launch Configuration (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting Autoscaling Launch Configuration (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/autoscaling/lifecycle_hook.go
+++ b/internal/service/autoscaling/lifecycle_hook.go
@@ -73,10 +73,10 @@ func resourceLifecycleHookPutOp(conn *autoscaling.AutoScaling, params *autoscali
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if strings.Contains(awsErr.Message(), "Unable to publish test message to notification target") {
-					return resource.RetryableError(fmt.Errorf("Retrying AWS AutoScaling Lifecycle Hook: %s", awsErr))
+					return resource.RetryableError(fmt.Errorf("Retrying AWS AutoScaling Lifecycle Hook: %w", awsErr))
 				}
 			}
-			return resource.NonRetryableError(fmt.Errorf("Error putting lifecycle hook: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("Error putting lifecycle hook: %w", err))
 		}
 		return nil
 	})
@@ -84,7 +84,7 @@ func resourceLifecycleHookPutOp(conn *autoscaling.AutoScaling, params *autoscali
 		_, err = conn.PutLifecycleHook(params)
 	}
 	if err != nil {
-		return fmt.Errorf("Error putting autoscaling lifecycle hook: %s", err)
+		return fmt.Errorf("Error putting autoscaling lifecycle hook: %w", err)
 	}
 	return nil
 }
@@ -107,7 +107,7 @@ func resourceLifecycleHookRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if p == nil {
+	if p == nil && !d.IsNewResource() {
 		log.Printf("[WARN] Autoscaling Lifecycle Hook (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -141,7 +141,7 @@ func resourceLifecycleHookDelete(d *schema.ResourceData, meta interface{}) error
 		LifecycleHookName:    aws.String(d.Get("name").(string)),
 	}
 	if _, err := conn.DeleteLifecycleHook(&params); err != nil {
-		return fmt.Errorf("Autoscaling Lifecycle Hook: %s", err)
+		return fmt.Errorf("Autoscaling Lifecycle Hook: %w", err)
 	}
 
 	return nil
@@ -191,7 +191,7 @@ func getLifecycleHook(d *schema.ResourceData, meta interface{}) (*autoscaling.Li
 	log.Printf("[DEBUG] AutoScaling Lifecycle Hook Describe Params: %#v", params)
 	resp, err := conn.DescribeLifecycleHooks(&params)
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving lifecycle hooks: %s", err)
+		return nil, fmt.Errorf("Error retrieving lifecycle hooks: %w", err)
 	}
 
 	// find lifecycle hooks

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -329,7 +329,7 @@ func resourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if p == nil {
+	if p == nil && !d.IsNewResource() {
 		log.Printf("[WARN] Autoscaling Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/autoscaling/schedule.go
+++ b/internal/service/autoscaling/schedule.go
@@ -112,7 +112,7 @@ func resourceScheduleCreate(d *schema.ResourceData, meta interface{}) error {
 	if attr, ok := d.GetOk("start_time"); ok {
 		t, err := time.Parse(ScheduleTimeLayout, attr.(string))
 		if err != nil {
-			return fmt.Errorf("Error Parsing AWS Autoscaling Group Schedule Start Time: %s", err.Error())
+			return fmt.Errorf("Error Parsing AWS Autoscaling Group Schedule Start Time: %w", err)
 		}
 		params.StartTime = aws.Time(t)
 	}
@@ -120,7 +120,7 @@ func resourceScheduleCreate(d *schema.ResourceData, meta interface{}) error {
 	if attr, ok := d.GetOk("end_time"); ok {
 		t, err := time.Parse(ScheduleTimeLayout, attr.(string))
 		if err != nil {
-			return fmt.Errorf("Error Parsing AWS Autoscaling Group Schedule End Time: %s", err.Error())
+			return fmt.Errorf("Error Parsing AWS Autoscaling Group Schedule End Time: %w", err)
 		}
 		params.EndTime = aws.Time(t)
 	}
@@ -155,7 +155,7 @@ func resourceScheduleCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating Autoscaling Scheduled Action: %s", d.Get("scheduled_action_name").(string))
 	_, err := conn.PutScheduledUpdateGroupAction(params)
 	if err != nil {
-		return fmt.Errorf("Error Creating Autoscaling Scheduled Action: %s", err.Error())
+		return fmt.Errorf("Error Creating Autoscaling Scheduled Action: %w", err)
 	}
 
 	d.SetId(d.Get("scheduled_action_name").(string))
@@ -169,7 +169,7 @@ func resourceScheduleRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if !exists {
+	if !exists && !d.IsNewResource() {
 		log.Printf("[WARN] Autoscaling Scheduled Action (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -222,7 +222,7 @@ func resourceScheduleDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Autoscaling Scheduled Action: %s", d.Id())
 	_, err := conn.DeleteScheduledAction(params)
 	if err != nil {
-		return fmt.Errorf("Error deleting Autoscaling Scheduled Action: %s", err.Error())
+		return fmt.Errorf("Error deleting Autoscaling Scheduled Action: %w", err)
 	}
 
 	return nil
@@ -246,7 +246,7 @@ func resourceASGScheduledActionRetrieve(d *schema.ResourceData, meta interface{}
 
 			return nil, false, nil
 		}
-		return nil, false, fmt.Errorf("Error retrieving Autoscaling Scheduled Actions: %s", err)
+		return nil, false, fmt.Errorf("Error retrieving Autoscaling Scheduled Actions: %w", err)
 	}
 
 	if len(actions.ScheduledUpdateGroupActions) != 1 ||


### PR DESCRIPTION
Enables `d.IsNewResource` check for all services starting with "A"

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAPIGatewayV2Model|TestAccAppAutoScalingPolicy|TestAccAPIGatewayV2VPCLink|TestAccAPIGatewayV2Integration|TestPutWarmPoolInput|TestAccAPIGatewayV2RouteResponse|TestAccAppSyncDataSource|TestAccAPIGatewayV2Stage|TestAccAPIGatewayV2API|TestAccAPIGatewayV2APIMapping|TestAccAppAutoScalingTarget|TestAccAutoScalingAttachment|TestAccAppAutoScalingScheduledAction|TestAccAPIGatewayV2Authorizer|TestAccAPIGatewayV2Route|TestAccAPIGatewayV2Deployment|TestAccAPIGatewayV2IntegrationResponse|TestAccAthenaNamedQuery|TestAccAthenaWorkGroup|TestAccAutoScalingGroup

--- PASS: TestValidateAppAutoScalingPolicyImportInput (0.00s)
--- PASS: TestAccAppAutoScalingTarget_multipleTargets (110.25s)
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_timezone (110.60s)
--- PASS: TestAccAppAutoScalingPolicy_multiplePoliciesSameName (114.58s)
--- PASS: TestAccAppAutoScalingTarget_optionalRoleARN (119.36s)
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleAtExpression_timezone (120.33s)
--- PASS: TestAccAppAutoScalingScheduledAction_Name_duplicate (121.51s)
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_basic (122.93s)
--- PASS: TestAccAppAutoScalingPolicy_DynamoDB_table (127.20s)
--- PASS: TestAccAppAutoScalingPolicy_DynamoDB_index (141.25s)
--- PASS: TestAccAppAutoScalingPolicy_multiplePoliciesSameResource (155.77s)
--- PASS: TestAccAppAutoScalingTarget_disappears (159.55s)
--- PASS: TestAccAppAutoScalingScheduledAction_ecs (170.73s)
--- PASS: TestAccAppAutoScalingTarget_spotFleetRequest (177.38s)
--- PASS: TestAccAppAutoScalingScheduledAction_spotFleet (178.78s)
--- PASS: TestAccAppAutoScalingPolicy_basic (184.93s)
--- PASS: TestAccAppAutoScalingScheduledAction_dynamoDB (191.32s)
--- PASS: TestAccAPIGatewayV2APIMapping_basic (197.98s)
    --- PASS: TestAccAPIGatewayV2APIMapping_basic/createCertificate (5.70s)
    --- PASS: TestAccAPIGatewayV2APIMapping_basic/ApiMappingKey (76.15s)
    --- PASS: TestAccAPIGatewayV2APIMapping_basic/basic (54.95s)
    --- PASS: TestAccAPIGatewayV2APIMapping_basic/disappears (61.18s)
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_timezone (107.23s)
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleRateExpression_basic (109.30s)
--- PASS: TestAccAthenaWorkGroup_disappears (128.22s)
--- PASS: TestAccAppAutoScalingTarget_basic (258.02s)
--- PASS: TestAccAppAutoScalingPolicy_ResourceID_forceNew (258.13s)
--- PASS: TestAccAppAutoScalingPolicy_spotFleetRequest (145.80s)
--- PASS: TestAccAppAutoScalingScheduledAction_ScheduleCronExpression_startEndTimeTimezone (150.02s)
--- PASS: TestAccAPIGatewayV2APIsDataSource_name (79.92s)
--- PASS: TestAccAppAutoScalingPolicy_disappears (152.37s)
--- PASS: TestAccAthenaWorkGroup_basic (159.67s)
--- PASS: TestAccAthenaWorkGroup_ResultEncryption_sseS3 (161.12s)
--- PASS: TestAccAppAutoScalingPolicy_scaleOutAndIn (171.70s)
--- PASS: TestAccAppAutoScalingScheduledAction_minCapacity (179.98s)
--- PASS: TestAccAthenaWorkGroup_forceDestroy (169.38s)
--- PASS: TestAccAthenaNamedQuery_basic (169.63s)
--- PASS: TestAccAthenaNamedQuery_withWorkGroup (170.20s)
--- PASS: TestAccAppAutoScalingScheduledAction_maxCapacity (184.32s)
--- PASS: TestAccAthenaWorkGroup_requesterPaysEnabled (196.86s)
--- PASS: TestAccAthenaWorkGroup_description (198.77s)
--- PASS: TestAccAthenaWorkGroup_bytesScannedCutoffPerQuery (198.84s)
--- PASS: TestAccAthenaWorkGroup_enforceWorkGroup (199.96s)
--- PASS: TestAccAthenaWorkGroup_publishCloudWatchMetricsEnabled (200.12s)
--- PASS: TestAccAthenaWorkGroup_ResultEncryption_kms (200.39s)
--- PASS: TestAccAPIGatewayV2APIsDataSource_protocolType (50.01s)
--- PASS: TestAccAthenaWorkGroup_Result_outputLocation (202.91s)
--- PASS: TestAccAthenaWorkGroup_ResultOutputLocation_forceDestroy (203.44s)
--- PASS: TestAccAthenaWorkGroup_configurationEngineVersion (213.77s)
--- PASS: TestAccAthenaWorkGroup_tags (214.50s)
--- PASS: TestAccAthenaWorkGroup_state (214.70s)
--- PASS: TestAccAPIGatewayV2APIsDataSource_tags (17.70s)
--- PASS: TestCreateAutoScalingGroupInstanceRefreshInput (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/empty_list (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/nil (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/defaults (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_only (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_zero (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/instance_warmup_empty_string (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/min_healthy_percentage_only (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/preferences (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/checkpoint_delay (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/checkpoint_delay_zero (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/checkpoint_delay_empty_string (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/checkpoint_percentages_empty (0.00s)
    --- PASS: TestCreateAutoScalingGroupInstanceRefreshInput/checkpoint_percentages (0.00s)
--- PASS: TestPutWarmPoolInput (0.00s)
    --- PASS: TestPutWarmPoolInput/empty_interface (0.00s)
    --- PASS: TestPutWarmPoolInput/nil (0.00s)
    --- PASS: TestPutWarmPoolInput/only_pool_state (0.00s)
    --- PASS: TestPutWarmPoolInput/0_min_size (0.00s)
    --- PASS: TestPutWarmPoolInput/-1_max_prepared_size (0.00s)
    --- PASS: TestPutWarmPoolInput/all_values (0.00s)
--- PASS: TestFlattenWarmPoolConfiguration (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/empty_interface (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/only_pool_state (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/only_max_group_prepared_capacity (0.00s)
    --- PASS: TestFlattenWarmPoolConfiguration/all_values (0.00s)
--- PASS: TestCapacitySatisfiedCreate (0.00s)
--- PASS: TestCapacitySatisfiedUpdate (0.00s)
--- PASS: TestAccAPIGatewayV2APIDataSource_http (123.89s)
--- PASS: TestAccAPIGatewayV2Stage_disappears (133.20s)
--- PASS: TestAccAPIGatewayV2Stage_defaultHTTPStage (139.17s)
--- PASS: TestAccAPIGatewayV2Stage_deployment (153.52s)
--- PASS: TestAccAPIGatewayV2Route_target (179.45s)
--- PASS: TestAccAutoScalingGroupsDataSource_basic (202.87s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (203.14s)
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (206.72s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (214.00s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (214.30s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (220.58s)
--- PASS: TestAccAPIGatewayV2Stage_clientCertificateIdAndDescription (246.80s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (222.57s)
--- PASS: TestAccAPIGatewayV2Stage_stageVariables (250.03s)
--- PASS: TestAccAPIGatewayV2Stage_tags (252.38s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_iamInstanceProfile (226.71s)
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (230.92s)
--- PASS: TestAccAPIGatewayV2Stage_accessLogSettings (267.54s)
--- PASS: TestAccAPIGatewayV2Stage_RouteSettingsHTTP_withRoute (280.33s)
--- PASS: TestAccAPIGatewayV2Stage_basicWebSocket (176.78s)
--- PASS: TestAccAPIGatewayV2Stage_basicHTTP (183.11s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (312.12s)
--- PASS: TestAccAPIGatewayV2VPCLink_disappears (342.12s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (328.48s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (333.18s)
--- FAIL: TestAccAPIGatewayV2Integration_lambdaWebSocket (110.61s)
--- FAIL: TestAccAPIGatewayV2Integration_lambdaHTTP (114.96s)
--- PASS: TestAccAPIGatewayV2Route_simpleAttributes (363.86s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (341.48s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (342.94s)
--- PASS: TestAccAPIGatewayV2Stage_defaultRouteSettingsHTTP (376.62s)
--- PASS: TestAccAPIGatewayV2Stage_routeSettingsHTTP (383.96s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (367.14s)
--- PASS: TestAccAPIGatewayV2Stage_defaultRouteSettingsWebSocket (394.23s)
--- PASS: TestAccAPIGatewayV2Route_requestParameters (401.74s)
--- PASS: TestAccAPIGatewayV2Stage_routeSettingsWebSocket (409.75s)
--- PASS: TestAccAutoScalingGroup_classicVPCZoneIdentifier (195.43s)
--- PASS: TestAccAutoScalingGroup_launchTemplate (199.55s)
--- PASS: TestAccAppAutoScalingScheduledAction_emr (785.66s)
--- PASS: TestAccAPIGatewayV2Integration_disappears (168.01s)
--- PASS: TestAccAPIGatewayV2Stage_autoDeployHTTP (324.80s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (431.93s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (464.17s)
--- PASS: TestAccAPIGatewayV2Authorizer_jwt (344.65s)
--- PASS: TestAccAPIGatewayV2Integration_basicHTTP (191.50s)
--- PASS: TestAccAPIGatewayV2VPCLink_tags (507.67s)
--- PASS: TestAccAPIGatewayV2Integration_basicWebSocket (200.82s)
--- PASS: TestAccAPIGatewayV2IntegrationResponse_disappears (174.35s)
--- PASS: TestAccAppAutoScalingTarget_emrCluster (883.22s)
--- PASS: TestAccAPIGatewayV2VPCLink_basic (545.61s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (532.86s)
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (191.42s)
--- PASS: TestAccAPIGatewayV2Deployment_disappears (186.02s)
--- PASS: TestAccAPIGatewayV2IntegrationResponse_basic (205.30s)
--- PASS: TestAccAPIGatewayV2Integration_integrationTypeHTTP (321.43s)
--- PASS: TestAccAPIGatewayV2Integration_dataMappingHTTP (316.25s)
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (394.08s)
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (299.41s)
--- PASS: TestAccAutoScalingGroup_withMetrics (300.12s)
--- PASS: TestAccAPIGatewayV2IntegrationResponse_allAttributes (331.77s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (434.47s)
--- PASS: TestAccAutoScalingAttachment_elb (650.28s)
--- PASS: TestAccAPIGatewayV2Integration_vpcLinkHTTP (682.15s)
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (432.03s)
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (441.36s)
--- PASS: TestAccAPIGatewayV2Authorizer_disappears (195.80s)
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (270.85s)
--- PASS: TestAccAPIGatewayV2API_quickCreate (188.09s)
--- PASS: TestAccAPIGatewayV2Deployment_basic (343.13s)
--- PASS: TestAccAPIGatewayV2Route_updateRouteKey (322.33s)
--- PASS: TestAccAPIGatewayV2Authorizer_basic (231.91s)
--- PASS: TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialZeroCacheTTL (358.21s)
--- PASS: TestAccAPIGatewayV2RouteResponse_model (204.59s)
--- PASS: TestAccAPIGatewayV2Route_model (202.28s)
--- PASS: TestAccAPIGatewayV2API_OpenAPI_withMoreFields (340.45s)
--- PASS: TestAccAutoScalingGroup_loadBalancers (767.94s)
--- PASS: TestAccAutoScalingGroup_enablingMetrics (375.00s)
--- PASS: TestAccAutoScalingGroup_ALB_targetGroups (459.38s)
--- PASS: TestAccAppSyncDataSource_Elasticsearch_region (1082.60s)
--- PASS: TestAccAutoScalingGroup_targetGroupARNs (492.97s)
--- PASS: TestAccAutoScalingGroup_warmPool (611.27s)
--- PASS: TestAccAutoScalingGroup_namePrefix (197.93s)
--- PASS: TestAccAPIGatewayV2Route_disappears (178.71s)
--- PASS: TestAccAutoScalingGroupTag_basic (188.33s)
--- PASS: TestAccAutoScalingGroupDataSource_basic (175.31s)
--- PASS: TestAccAutoScalingGroup_vpcUpdates (304.90s)
--- PASS: TestAccAutoScalingGroup_Name_generated (195.31s)
--- PASS: TestAccAutoScalingGroupDataSource_launchTemplate (169.45s)
--- PASS: TestAccAutoScalingGroupTag_disappears (184.28s)
--- PASS: TestAccAPIGatewayV2API_tags (329.01s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (657.76s)
--- PASS: TestAccAPIGatewayV2Route_basic (202.27s)
--- PASS: TestAccAPIGatewayV2Authorizer_HTTPAPILambdaRequestAuthorizer_initialMissingCacheTTL (497.04s)
--- PASS: TestAccAutoScalingGroupTag_value (236.72s)
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (523.12s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (688.56s)
--- PASS: TestAccAPIGatewayV2Route_jwtAuthorization (354.24s)
--- PASS: TestAccAPIGatewayV2RouteResponse_disappears (167.63s)
--- PASS: TestAccAPIGatewayV2API_OpenAPI_failOnWarnings (376.83s)
--- PASS: TestAccAPIGatewayV2Authorizer_credentials (496.79s)
--- PASS: TestAccAPIGatewayV2API_OpenAPI_withCors (446.65s)
--- PASS: TestAccAPIGatewayV2RouteResponse_basic (178.58s)
--- PASS: TestAccAPIGatewayV2Deployment_triggers (592.63s)
--- PASS: TestAccAPIGatewayV2API_basicHTTP (169.91s)
--- PASS: TestAccAPIGatewayV2API_cors (424.30s)
--- PASS: TestAccAppSyncDataSource_Type_elasticSearch (1211.55s)
--- PASS: TestAccAPIGatewayV2API_disappears (112.42s)
--- PASS: TestAccAPIGatewayV2API_openAPI (258.53s)
--- PASS: TestAccAutoScalingGroup_terminationPolicies (340.05s)
--- PASS: TestAccAPIGatewayV2API_OpenAPI_withTags (264.38s)
--- PASS: TestAccAPIGatewayV2Route_authorizer (317.82s)
--- PASS: TestAccAutoScalingGroup_tags (434.52s)
--- PASS: TestAccAPIGatewayV2Model_disappears (99.62s)
--- PASS: TestAccAPIGatewayV2Model_basic (121.26s)
--- PASS: TestAccAPIGatewayV2APIDataSource_webSocket (70.05s)
--- PASS: TestAccAPIGatewayV2API_basicWebSocket (73.45s)
--- PASS: TestAccAPIGatewayV2Integration_vpcLinkWebSocket (833.65s)
--- PASS: TestAccAPIGatewayV2Model_allAttributes (272.15s)
--- PASS: TestAccAutoScalingGroup_basic (538.11s)
--- PASS: TestAccAPIGatewayV2Integration_awsServiceIntegration (134.60s)
--- PASS: TestAccAPIGatewayV2API_allAttributesWebSocket (325.60s)
--- PASS: TestAccAPIGatewayV2API_allAttributesHTTP (304.93s)
--- PASS: TestAccAutoScalingAttachment_albTargetGroup (252.33s)
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (652.49s)
```

Failed tests `TestAccAPIGatewayV2Integration_lambdaWebSocket` and `TestAccAPIGatewayV2Integration_lambdaHTTP` are pre-existing failures