### PR TITLE
Upgrade to v0.10.0 of `tflint-ruleset-aws`

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,10 +1,5 @@
 plugin "aws" {
   enabled = true
-  version = "0.7.1"
+  version = "0.10.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-
-# https://github.com/terraform-linters/tflint-ruleset-aws/issues/206
-rule "aws_transfer_server_invalid_identity_provider_type" {
-  enabled = false
 }

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,3 +3,7 @@ plugin "aws" {
   version = "0.10.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
+
+rule "aws_acm_certificate_lifecycle" {
+  enabled = false
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22039.

[`tflint-ruleset-aws@0.10.0`](https://github.com/terraform-linters/tflint-ruleset-aws/releases/tag/v0.10.0) is now available.
Upgrade the relevant linters.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
