### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; https://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
https://editorconfig.org/#overview

* Utilised across most of hashicorp real estate https://github.com/search?p=1&q=org%3Ahashicorp+.editorconfig&type=Code
* Instructs most IDEs on standard formatting beyond gofmt (markdown etc)
* Existing codebase is a mix of spaces/tabs across go code and trailing whitespaces yet enforcement in actions seems to deem the standard to be 2 spaces no trailing spaces
* Makes changing these code bases more tolerable



<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
