### PR TITLE
IAM: Only set policy if actually changed

### DIFF
--- a/.changelog/22067.txt
+++ b/.changelog/22067.txt
@@ -5,3 +5,7 @@ resource/aws_iam_group_policy: Fix order-related diffs in `policy`
 ```release-note:bug
 resource/aws_iam_policy: Fix order-related diffs in `policy`
 ```
+
+```release-note:bug
+resource/aws_iam_role_policy: Fix order-related diffs in `policy`
+```

--- a/.changelog/22067.txt
+++ b/.changelog/22067.txt
@@ -9,3 +9,7 @@ resource/aws_iam_policy: Fix order-related diffs in `policy`
 ```release-note:bug
 resource/aws_iam_role_policy: Fix order-related diffs in `policy`
 ```
+
+```release-note:bug
+resource/aws_iam_user_policy: Fix order-related diffs in `policy`
+```

--- a/.changelog/22067.txt
+++ b/.changelog/22067.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_iam_group_policy: Fix order-related diffs in `policy`
 ```
+
+```release-note:bug
+resource/aws_iam_policy: Fix order-related diffs in `policy`
+```

--- a/.changelog/22067.txt
+++ b/.changelog/22067.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_group_policy: Fix order-related diffs in `policy`
+```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.14.0
 	github.com/hashicorp/aws-sdk-go-base v1.0.0
-	github.com/hashicorp/awspolicyequivalence v1.3.0
+	github.com/hashicorp/awspolicyequivalence v1.4.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.14.0 h1:2Usl5C
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.14.0/go.mod h1:C6GVuO9RWOrt6QCGTmLCOYuSHpkfQSBDuRqTteOlo0g=
 github.com/hashicorp/aws-sdk-go-base v1.0.0 h1:J7MMLOfSoDWkusy+cSzKYG1/aFyCzYJmdE0mod3/WLw=
 github.com/hashicorp/aws-sdk-go-base v1.0.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
-github.com/hashicorp/awspolicyequivalence v1.3.0 h1:T6GloJqof+yP6Gf4NAfIRPrTIIsJohVAk5z6MHuJK2U=
-github.com/hashicorp/awspolicyequivalence v1.3.0/go.mod h1:9IOaIHx+a7C0NfUNk1A93M7kHd5rJ19aoUx37LZGC14=
+github.com/hashicorp/awspolicyequivalence v1.4.0 h1:mpQ7/MnyOsaMcXQcJiYbE3LAONzMH1MnwEK/HMvE6Ss=
+github.com/hashicorp/awspolicyequivalence v1.4.0/go.mod h1:9IOaIHx+a7C0NfUNk1A93M7kHd5rJ19aoUx37LZGC14=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/internal/service/iam/group_policy.go
+++ b/internal/service/iam/group_policy.go
@@ -138,9 +138,13 @@ func resourceGroupPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if err := d.Set("policy", policy); err != nil {
-		return fmt.Errorf("error setting policy: %s", err)
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
 	}
+
+	d.Set("policy", policyToSet)
 
 	if err := d.Set("name", name); err != nil {
 		return fmt.Errorf("error setting name: %s", err)

--- a/internal/service/iam/group_policy_test.go
+++ b/internal/service/iam/group_policy_test.go
@@ -18,7 +18,8 @@ import (
 
 func TestAccIAMGroupPolicy_basic(t *testing.T) {
 	var groupPolicy1, groupPolicy2 iam.GetGroupPolicyOutput
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
@@ -26,7 +27,7 @@ func TestAccIAMGroupPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMGroupPolicyConfig(rInt),
+				Config: testAccIAMGroupPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.group",
@@ -41,7 +42,7 @@ func TestAccIAMGroupPolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMGroupPolicyConfigUpdate(rInt),
+				Config: testAccIAMGroupPolicyConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.group",
@@ -62,7 +63,7 @@ func TestAccIAMGroupPolicy_basic(t *testing.T) {
 
 func TestAccIAMGroupPolicy_disappears(t *testing.T) {
 	var out iam.GetGroupPolicyOutput
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -71,7 +72,7 @@ func TestAccIAMGroupPolicy_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMGroupPolicyConfig(rInt),
+				Config: testAccIAMGroupPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.group",
@@ -88,7 +89,8 @@ func TestAccIAMGroupPolicy_disappears(t *testing.T) {
 
 func TestAccIAMGroupPolicy_namePrefix(t *testing.T) {
 	var groupPolicy1, groupPolicy2 iam.GetGroupPolicyOutput
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
@@ -96,7 +98,7 @@ func TestAccIAMGroupPolicy_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMGroupPolicyConfig_namePrefix(rInt, "*"),
+				Config: testAccIAMGroupPolicyConfig_namePrefix(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.test",
@@ -106,7 +108,7 @@ func TestAccIAMGroupPolicy_namePrefix(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIAMGroupPolicyConfig_namePrefix(rInt, "ec2:*"),
+				Config: testAccIAMGroupPolicyConfig_namePrefix(rName, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.test",
@@ -128,7 +130,8 @@ func TestAccIAMGroupPolicy_namePrefix(t *testing.T) {
 
 func TestAccIAMGroupPolicy_generatedName(t *testing.T) {
 	var groupPolicy1, groupPolicy2 iam.GetGroupPolicyOutput
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
@@ -136,7 +139,7 @@ func TestAccIAMGroupPolicy_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMGroupPolicyConfig_generatedName(rInt, "*"),
+				Config: testAccIAMGroupPolicyConfig_generatedName(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.test",
@@ -146,7 +149,7 @@ func TestAccIAMGroupPolicy_generatedName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIAMGroupPolicyConfig_generatedName(rInt, "ec2:*"),
+				Config: testAccIAMGroupPolicyConfig_generatedName(rName, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
 						"aws_iam_group.test",
@@ -274,15 +277,15 @@ func testAccCheckGroupPolicyNameMatches(i, j *iam.GetGroupPolicyOutput) resource
 	}
 }
 
-func testAccIAMGroupPolicyConfig(rInt int) string {
+func testAccIAMGroupPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
-  name = "test_group_%d"
+  name = %[1]q
   path = "/"
 }
 
 resource "aws_iam_group_policy" "foo" {
-  name  = "foo_policy_%d"
+  name  = %[1]q
   group = aws_iam_group.group.name
 
   policy = <<EOF
@@ -296,18 +299,18 @@ resource "aws_iam_group_policy" "foo" {
 }
 EOF
 }
-`, rInt, rInt)
+`, rName)
 }
 
-func testAccIAMGroupPolicyConfig_namePrefix(rInt int, policyAction string) string {
+func testAccIAMGroupPolicyConfig_namePrefix(rName, policyAction string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "test" {
-  name = "test_group_%d"
+  name = %[1]q
   path = "/"
 }
 
 resource "aws_iam_group_policy" "test" {
-  name_prefix = "test-%d"
+  name_prefix = %[1]q
   group       = aws_iam_group.test.name
 
   policy = <<EOF
@@ -315,19 +318,19 @@ resource "aws_iam_group_policy" "test" {
   "Version": "2012-10-17",
   "Statement": {
     "Effect": "Allow",
-    "Action": "%s",
+    "Action": %[2]q,
     "Resource": "*"
   }
 }
 EOF
 }
-`, rInt, rInt, policyAction)
+`, rName, policyAction)
 }
 
-func testAccIAMGroupPolicyConfig_generatedName(rInt int, policyAction string) string {
+func testAccIAMGroupPolicyConfig_generatedName(rName, policyAction string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "test" {
-  name = "test_group_%d"
+  name = %[1]q
   path = "/"
 }
 
@@ -339,24 +342,24 @@ resource "aws_iam_group_policy" "test" {
   "Version": "2012-10-17",
   "Statement": {
     "Effect": "Allow",
-    "Action": "%s",
+    "Action": %[2]q,
     "Resource": "*"
   }
 }
 EOF
 }
-`, rInt, policyAction)
+`, rName, policyAction)
 }
 
-func testAccIAMGroupPolicyConfigUpdate(rInt int) string {
+func testAccIAMGroupPolicyConfigUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
-  name = "test_group_%d"
+  name = %[1]q
   path = "/"
 }
 
 resource "aws_iam_group_policy" "foo" {
-  name  = "foo_policy_%d"
+  name  = %[1]q
   group = aws_iam_group.group.name
 
   policy = <<EOF
@@ -372,7 +375,7 @@ EOF
 }
 
 resource "aws_iam_group_policy" "bar" {
-  name  = "bar_policy_%d"
+  name  = "%[1]s-2"
   group = aws_iam_group.group.name
 
   policy = <<EOF
@@ -386,5 +389,5 @@ resource "aws_iam_group_policy" "bar" {
 }
 EOF
 }
-`, rInt, rInt, rInt)
+`, rName)
 }

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -147,7 +147,6 @@ func TestAccIAMPolicy_disappears(t *testing.T) {
 
 func TestAccIAMPolicy_namePrefix(t *testing.T) {
 	var out iam.GetPolicyOutput
-	namePrefix := "tf-acc-test-"
 	resourceName := "aws_iam_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -157,10 +156,10 @@ func TestAccIAMPolicy_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicyNamePrefixConfig(namePrefix),
+				Config: testAccPolicyNamePrefixConfig(acctest.ResourcePrefix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicyExists(resourceName, &out),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(fmt.Sprintf("^%s", namePrefix))),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(fmt.Sprintf("^%s", acctest.ResourcePrefix))),
 				),
 			},
 			{

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -20,19 +20,8 @@ func TestAccIAMPolicy_basic(t *testing.T) {
 	var out iam.GetPolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_policy.test"
-	expectedPolicyText := `{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-`
+	expectedPolicyText := `{"Statement":[{"Action":["ec2:Describe*"],"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}`
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
@@ -215,8 +204,8 @@ func TestAccIAMPolicy_policy(t *testing.T) {
 	var out iam.GetPolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_policy.test"
-	policy1 := "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"ec2:Describe*\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}"
-	policy2 := "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"ec2:*\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}"
+	policy1 := `{"Statement":[{"Action":["ec2:Describe*"],"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}`
+	policy2 := `{"Statement":[{"Action":["ec2:*"],"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -212,15 +212,15 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	roleName := aws.StringValue(outputRaw.(*iam.CreateRoleOutput).Role.RoleName)
 
 	if v, ok := d.GetOk("inline_policy"); ok && v.(*schema.Set).Len() > 0 {
-		policies := expandIamInlinePolicies(roleName, v.(*schema.Set).List())
-		if err := addIamInlinePolicies(policies, meta); err != nil {
+		policies := expandRoleInlinePolicies(roleName, v.(*schema.Set).List())
+		if err := addRoleInlinePolicies(policies, meta); err != nil {
 			return err
 		}
 	}
 
 	if v, ok := d.GetOk("managed_policy_arns"); ok && v.(*schema.Set).Len() > 0 {
 		managedPolicies := flex.ExpandStringSet(v.(*schema.Set))
-		if err := addIamManagedPolicies(roleName, managedPolicies, meta); err != nil {
+		if err := addRoleManagedPolicies(roleName, managedPolicies, meta); err != nil {
 			return err
 		}
 	}
@@ -288,15 +288,15 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	inlinePolicies, err := readIamInlinePolicies(aws.StringValue(role.RoleName), meta)
+	inlinePolicies, err := readRoleInlinePolicies(aws.StringValue(role.RoleName), meta)
 	if err != nil {
 		return fmt.Errorf("reading inline policies for IAM role %s, error: %s", d.Id(), err)
 	}
-	if err := d.Set("inline_policy", flattenIamInlinePolicies(inlinePolicies)); err != nil {
+	if err := d.Set("inline_policy", flattenRoleInlinePolicies(inlinePolicies)); err != nil {
 		return fmt.Errorf("error setting inline_policy: %w", err)
 	}
 
-	managedPolicies, err := readIamRolePolicyAttachments(conn, aws.StringValue(role.RoleName))
+	managedPolicies, err := readRolePolicyAttachments(conn, aws.StringValue(role.RoleName))
 	if err != nil {
 		return fmt.Errorf("reading managed policies for IAM role %s, error: %s", d.Id(), err)
 	}
@@ -420,12 +420,12 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 				policyNames = append(policyNames, aws.String(tfMap["name"].(string)))
 			}
 		}
-		if err := deleteIamRolePolicies(conn, roleName, policyNames); err != nil {
+		if err := deleteRolePolicies(conn, roleName, policyNames); err != nil {
 			return fmt.Errorf("unable to delete inline policies: %w", err)
 		}
 
-		policies := expandIamInlinePolicies(roleName, add)
-		if err := addIamInlinePolicies(policies, meta); err != nil {
+		policies := expandRoleInlinePolicies(roleName, add)
+		if err := addRoleInlinePolicies(policies, meta); err != nil {
 			return err
 		}
 	}
@@ -446,11 +446,11 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		remove := flex.ExpandStringSet(os.Difference(ns))
 		add := flex.ExpandStringSet(ns.Difference(os))
 
-		if err := deleteIamRolePolicyAttachments(conn, roleName, remove); err != nil {
+		if err := deleteRolePolicyAttachments(conn, roleName, remove); err != nil {
 			return fmt.Errorf("unable to detach policies: %w", err)
 		}
 
-		if err := addIamManagedPolicies(roleName, add, meta); err != nil {
+		if err := addRoleManagedPolicies(roleName, add, meta); err != nil {
 			return err
 		}
 	}
@@ -485,28 +485,28 @@ func resourceRoleDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteRole(conn *iam.IAM, roleName string, forceDetach, hasInline, hasManaged bool) error {
-	if err := deleteIamRoleInstanceProfiles(conn, roleName); err != nil {
+	if err := deleteRoleInstanceProfiles(conn, roleName); err != nil {
 		return fmt.Errorf("unable to detach instance profiles: %w", err)
 	}
 
 	if forceDetach || hasManaged {
-		managedPolicies, err := readIamRolePolicyAttachments(conn, roleName)
+		managedPolicies, err := readRolePolicyAttachments(conn, roleName)
 		if err != nil {
 			return err
 		}
 
-		if err := deleteIamRolePolicyAttachments(conn, roleName, managedPolicies); err != nil {
+		if err := deleteRolePolicyAttachments(conn, roleName, managedPolicies); err != nil {
 			return fmt.Errorf("unable to detach policies: %w", err)
 		}
 	}
 
 	if forceDetach || hasInline {
-		inlinePolicies, err := readIamRolePolicyNames(conn, roleName)
+		inlinePolicies, err := readRolePolicyNames(conn, roleName)
 		if err != nil {
 			return err
 		}
 
-		if err := deleteIamRolePolicies(conn, roleName, inlinePolicies); err != nil {
+		if err := deleteRolePolicies(conn, roleName, inlinePolicies); err != nil {
 			return fmt.Errorf("unable to delete inline policies: %w", err)
 		}
 	}
@@ -532,7 +532,7 @@ func DeleteRole(conn *iam.IAM, roleName string, forceDetach, hasInline, hasManag
 	return err
 }
 
-func deleteIamRoleInstanceProfiles(conn *iam.IAM, roleName string) error {
+func deleteRoleInstanceProfiles(conn *iam.IAM, roleName string) error {
 	resp, err := conn.ListInstanceProfilesForRole(&iam.ListInstanceProfilesForRoleInput{
 		RoleName: aws.String(roleName),
 	})
@@ -562,7 +562,7 @@ func deleteIamRoleInstanceProfiles(conn *iam.IAM, roleName string) error {
 	return nil
 }
 
-func readIamRolePolicyAttachments(conn *iam.IAM, roleName string) ([]*string, error) {
+func readRolePolicyAttachments(conn *iam.IAM, roleName string) ([]*string, error) {
 	managedPolicies := make([]*string, 0)
 	input := &iam.ListAttachedRolePoliciesInput{
 		RoleName: aws.String(roleName),
@@ -581,7 +581,7 @@ func readIamRolePolicyAttachments(conn *iam.IAM, roleName string) ([]*string, er
 	return managedPolicies, nil
 }
 
-func deleteIamRolePolicyAttachments(conn *iam.IAM, roleName string, managedPolicies []*string) error {
+func deleteRolePolicyAttachments(conn *iam.IAM, roleName string, managedPolicies []*string) error {
 	for _, parn := range managedPolicies {
 		input := &iam.DetachRolePolicyInput{
 			PolicyArn: parn,
@@ -600,7 +600,7 @@ func deleteIamRolePolicyAttachments(conn *iam.IAM, roleName string, managedPolic
 	return nil
 }
 
-func readIamRolePolicyNames(conn *iam.IAM, roleName string) ([]*string, error) {
+func readRolePolicyNames(conn *iam.IAM, roleName string) ([]*string, error) {
 	inlinePolicies := make([]*string, 0)
 	input := &iam.ListRolePoliciesInput{
 		RoleName: aws.String(roleName),
@@ -618,7 +618,7 @@ func readIamRolePolicyNames(conn *iam.IAM, roleName string) ([]*string, error) {
 	return inlinePolicies, nil
 }
 
-func deleteIamRolePolicies(conn *iam.IAM, roleName string, policyNames []*string) error {
+func deleteRolePolicies(conn *iam.IAM, roleName string, policyNames []*string) error {
 	for _, name := range policyNames {
 		if len(aws.StringValue(name)) == 0 {
 			continue
@@ -641,7 +641,7 @@ func deleteIamRolePolicies(conn *iam.IAM, roleName string, policyNames []*string
 	return nil
 }
 
-func flattenIamInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]interface{} {
+func flattenRoleInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -654,7 +654,7 @@ func flattenIamInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]interf
 	return tfMap
 }
 
-func flattenIamInlinePolicies(apiObjects []*iam.PutRolePolicyInput) []interface{} {
+func flattenRoleInlinePolicies(apiObjects []*iam.PutRolePolicyInput) []interface{} {
 	if len(apiObjects) == 0 {
 		return nil
 	}
@@ -666,13 +666,13 @@ func flattenIamInlinePolicies(apiObjects []*iam.PutRolePolicyInput) []interface{
 			continue
 		}
 
-		tfList = append(tfList, flattenIamInlinePolicy(apiObject))
+		tfList = append(tfList, flattenRoleInlinePolicy(apiObject))
 	}
 
 	return tfList
 }
 
-func expandIamInlinePolicy(roleName string, tfMap map[string]interface{}) *iam.PutRolePolicyInput {
+func expandRoleInlinePolicy(roleName string, tfMap map[string]interface{}) *iam.PutRolePolicyInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -692,7 +692,7 @@ func expandIamInlinePolicy(roleName string, tfMap map[string]interface{}) *iam.P
 	return apiObject
 }
 
-func expandIamInlinePolicies(roleName string, tfList []interface{}) []*iam.PutRolePolicyInput {
+func expandRoleInlinePolicies(roleName string, tfList []interface{}) []*iam.PutRolePolicyInput {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -706,7 +706,7 @@ func expandIamInlinePolicies(roleName string, tfList []interface{}) []*iam.PutRo
 			continue
 		}
 
-		apiObject := expandIamInlinePolicy(roleName, tfMap)
+		apiObject := expandRoleInlinePolicy(roleName, tfMap)
 
 		if apiObject == nil {
 			continue
@@ -718,7 +718,7 @@ func expandIamInlinePolicies(roleName string, tfList []interface{}) []*iam.PutRo
 	return apiObjects
 }
 
-func addIamInlinePolicies(policies []*iam.PutRolePolicyInput, meta interface{}) error {
+func addRoleInlinePolicies(policies []*iam.PutRolePolicyInput, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 
 	var errs *multierror.Error
@@ -737,7 +737,7 @@ func addIamInlinePolicies(policies []*iam.PutRolePolicyInput, meta interface{}) 
 	return errs.ErrorOrNil()
 }
 
-func addIamManagedPolicies(roleName string, policies []*string, meta interface{}) error {
+func addRoleManagedPolicies(roleName string, policies []*string, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn
 
 	var errs *multierror.Error
@@ -752,10 +752,10 @@ func addIamManagedPolicies(roleName string, policies []*string, meta interface{}
 	return errs.ErrorOrNil()
 }
 
-func readIamInlinePolicies(roleName string, meta interface{}) ([]*iam.PutRolePolicyInput, error) {
+func readRoleInlinePolicies(roleName string, meta interface{}) ([]*iam.PutRolePolicyInput, error) {
 	conn := meta.(*conns.AWSClient).IAMConn
 
-	policyNames, err := readIamRolePolicyNames(conn, roleName)
+	policyNames, err := readRolePolicyNames(conn, roleName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -138,9 +138,15 @@ func resourceRolePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("policy", policy); err != nil {
-		return err
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
 	}
+
+	d.Set("policy", policyToSet)
+
 	if err := d.Set("name", name); err != nil {
 		return err
 	}

--- a/internal/service/iam/role_policy_test.go
+++ b/internal/service/iam/role_policy_test.go
@@ -68,6 +68,34 @@ func TestAccIAMRolePolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccIAMRolePolicy_disappears(t *testing.T) {
+	var out iam.GetRolePolicyOutput
+	suffix := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
+	roleResourceName := fmt.Sprintf("aws_iam_role.role_%s", suffix)
+	rolePolicyResourceName := fmt.Sprintf("aws_iam_role_policy.test_%s", suffix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolePolicyConfig(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMRolePolicyExists(
+						roleResourceName,
+						rolePolicyResourceName,
+						&out,
+					),
+					testAccCheckIAMRolePolicyDisappears(&out),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccIAMRolePolicy_policyOrder(t *testing.T) {
 	var rolePolicy1 iam.GetRolePolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -93,34 +121,6 @@ func TestAccIAMRolePolicy_policyOrder(t *testing.T) {
 			{
 				Config:   testAccIAMRolePolicyNewOrderConfig(rName),
 				PlanOnly: true,
-			},
-		},
-	})
-}
-
-func TestAccIAMRolePolicy_disappears(t *testing.T) {
-	var out iam.GetRolePolicyOutput
-	suffix := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
-	roleResourceName := fmt.Sprintf("aws_iam_role.role_%s", suffix)
-	rolePolicyResourceName := fmt.Sprintf("aws_iam_role_policy.test_%s", suffix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, iam.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRolePolicyConfig(suffix),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMRolePolicyExists(
-						roleResourceName,
-						rolePolicyResourceName,
-						&out,
-					),
-					testAccCheckIAMRolePolicyDisappears(&out),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/iam/role_policy_test.go
+++ b/internal/service/iam/role_policy_test.go
@@ -19,9 +19,7 @@ import (
 
 func TestAccIAMRolePolicy_basic(t *testing.T) {
 	var rolePolicy1, rolePolicy2, rolePolicy3 iam.GetRolePolicyOutput
-	role := sdkacctest.RandString(10)
-	policy1 := sdkacctest.RandString(10)
-	policy2 := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 	resourceName2 := "aws_iam_role_policy.test2"
 	roleName := "aws_iam_role.test"
@@ -33,7 +31,7 @@ func TestAccIAMRolePolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMRolePolicyConfig(role, policy1),
+				Config: testAccIAMRolePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleName,
@@ -48,7 +46,7 @@ func TestAccIAMRolePolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMRolePolicyConfigUpdate(role, policy1, policy2),
+				Config: testAccIAMRolePolicyConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleName,
@@ -70,9 +68,9 @@ func TestAccIAMRolePolicy_basic(t *testing.T) {
 
 func TestAccIAMRolePolicy_disappears(t *testing.T) {
 	var out iam.GetRolePolicyOutput
-	suffix := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
-	roleResourceName := fmt.Sprintf("aws_iam_role.role_%s", suffix)
-	rolePolicyResourceName := fmt.Sprintf("aws_iam_role_policy.test_%s", suffix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleResourceName := "aws_iam_role.test"
+	rolePolicyResourceName := "aws_iam_role_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -81,7 +79,7 @@ func TestAccIAMRolePolicy_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRolePolicyConfig(suffix),
+				Config: testAccRolePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleResourceName,
@@ -128,7 +126,7 @@ func TestAccIAMRolePolicy_policyOrder(t *testing.T) {
 
 func TestAccIAMRolePolicy_namePrefix(t *testing.T) {
 	var rolePolicy1, rolePolicy2 iam.GetRolePolicyOutput
-	role := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 	roleName := "aws_iam_role.test"
 
@@ -139,7 +137,7 @@ func TestAccIAMRolePolicy_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMRolePolicyConfig_namePrefix(role, "*"),
+				Config: testAccIAMRolePolicyConfig_namePrefix(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleName,
@@ -156,7 +154,7 @@ func TestAccIAMRolePolicy_namePrefix(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 			{
-				Config: testAccIAMRolePolicyConfig_namePrefix(role, "ec2:*"),
+				Config: testAccIAMRolePolicyConfig_namePrefix(rName, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleName,
@@ -173,7 +171,7 @@ func TestAccIAMRolePolicy_namePrefix(t *testing.T) {
 
 func TestAccIAMRolePolicy_generatedName(t *testing.T) {
 	var rolePolicy1, rolePolicy2 iam.GetRolePolicyOutput
-	role := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role_policy.test"
 	roleName := "aws_iam_role.test"
 
@@ -184,7 +182,7 @@ func TestAccIAMRolePolicy_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMRolePolicyConfig_generatedName(role, "*"),
+				Config: testAccIAMRolePolicyConfig_generatedName(rName, "*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleName,
@@ -200,7 +198,7 @@ func TestAccIAMRolePolicy_generatedName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMRolePolicyConfig_generatedName(role, "ec2:*"),
+				Config: testAccIAMRolePolicyConfig_generatedName(rName, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
 						roleName,
@@ -216,7 +214,7 @@ func TestAccIAMRolePolicy_generatedName(t *testing.T) {
 }
 
 func TestAccIAMRolePolicy_invalidJSON(t *testing.T) {
-	role := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -225,7 +223,7 @@ func TestAccIAMRolePolicy_invalidJSON(t *testing.T) {
 		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccIAMRolePolicyConfig_invalidJSON(role),
+				Config:      testAccIAMRolePolicyConfig_invalidJSON(rName),
 				ExpectError: regexp.MustCompile("invalid JSON"),
 			},
 		},
@@ -357,10 +355,10 @@ func testAccCheckRolePolicyNameMatches(i, j *iam.GetRolePolicyOutput) resource.T
 	}
 }
 
-func testAccRolePolicyConfig(suffix string) string {
+func testAccRolePolicyConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role_%[1]s" {
-  name = "tf_test_role_test_%[1]s"
+resource "aws_iam_role" "test" {
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -380,9 +378,9 @@ resource "aws_iam_role" "role_%[1]s" {
 EOF
 }
 
-resource "aws_iam_role_policy" "test_%[1]s" {
-  name = "tf_test_policy_test_%[1]s"
-  role = "${aws_iam_role.role_%[1]s.name}"
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
 
   policy = <<EOF
 {
@@ -395,13 +393,13 @@ resource "aws_iam_role_policy" "test_%[1]s" {
 }
 EOF
 }
-`, suffix)
+`, rName)
 }
 
-func testAccIAMRolePolicyConfig(role, policy1 string) string {
+func testAccIAMRolePolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "tf_test_role_%s"
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -422,7 +420,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf_test_policy_%s"
+  name = %[1]q
   role = aws_iam_role.test.name
 
   policy = <<EOF
@@ -436,13 +434,13 @@ resource "aws_iam_role_policy" "test" {
 }
 EOF
 }
-`, role, policy1)
+`, rName)
 }
 
-func testAccIAMRolePolicyConfig_namePrefix(role, policyAction string) string {
+func testAccIAMRolePolicyConfig_namePrefix(rName, action string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "tf_test_role_%s"
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -471,19 +469,19 @@ resource "aws_iam_role_policy" "test" {
   "Version": "2012-10-17",
   "Statement": {
     "Effect": "Allow",
-    "Action": "%s",
+    "Action": %[2]q,
     "Resource": "*"
   }
 }
 EOF
 }
-`, role, policyAction)
+`, rName, action)
 }
 
-func testAccIAMRolePolicyConfig_generatedName(role, policyAction string) string {
+func testAccIAMRolePolicyConfig_generatedName(rName, policyAction string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "tf_test_role_%s"
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -511,19 +509,19 @@ resource "aws_iam_role_policy" "test" {
   "Version": "2012-10-17",
   "Statement": {
     "Effect": "Allow",
-    "Action": "%s",
+    "Action": %[2]q,
     "Resource": "*"
   }
 }
 EOF
 }
-`, role, policyAction)
+`, rName, policyAction)
 }
 
-func testAccIAMRolePolicyConfigUpdate(role, policy1, policy2 string) string {
+func testAccIAMRolePolicyConfigUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "tf_test_role_%s"
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -544,7 +542,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf_test_policy_%s"
+  name = %[1]q
   role = aws_iam_role.test.name
 
   policy = <<EOF
@@ -560,7 +558,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test2" {
-  name = "tf_test_policy_2_%s"
+  name = "%[1]s-2"
   role = aws_iam_role.test.name
 
   policy = <<EOF
@@ -574,13 +572,13 @@ resource "aws_iam_role_policy" "test2" {
 }
 EOF
 }
-`, role, policy1, policy2)
+`, rName)
 }
 
-func testAccIAMRolePolicyConfig_invalidJSON(role string) string {
+func testAccIAMRolePolicyConfig_invalidJSON(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "tf_test_role_%s"
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -601,7 +599,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf_test_policy_%s"
+  name = %[1]q
   role = aws_iam_role.test.name
 
   policy = <<EOF
@@ -614,7 +612,7 @@ resource "aws_iam_role_policy" "test" {
   }
   EOF
 }
-`, role, role)
+`, rName)
 }
 
 func testAccIAMRolePolicyConfig_Policy_InvalidResource(rName string) string {

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestAccIAMRole_basic(t *testing.T) {
 	var conf iam.Role
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccIAMRole_basic(t *testing.T) {
 
 func TestAccIAMRole_basicWithDescription(t *testing.T) {
 	var conf iam.Role
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -119,7 +119,6 @@ func TestAccIAMRole_nameGenerated(t *testing.T) {
 
 func TestAccIAMRole_namePrefix(t *testing.T) {
 	var conf iam.Role
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -129,11 +128,11 @@ func TestAccIAMRole_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoleNamePrefixConfig(rName),
+				Config: testAccRoleNamePrefixConfig(acctest.ResourcePrefix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists(resourceName, &conf),
-					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
+					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", acctest.ResourcePrefix),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", acctest.ResourcePrefix),
 				),
 			},
 			{
@@ -147,7 +146,7 @@ func TestAccIAMRole_namePrefix(t *testing.T) {
 
 func TestAccIAMRole_testNameChange(t *testing.T) {
 	var conf iam.Role
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -178,7 +177,7 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 }
 
 func TestAccIAMRole_badJSON(t *testing.T) {
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -218,9 +217,9 @@ func TestAccIAMRole_disappears(t *testing.T) {
 	})
 }
 
-func TestAccIAMRole_ForceDetach_policies(t *testing.T) {
+func TestAccIAMRole_policiesForceDetach(t *testing.T) {
 	var conf iam.Role
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -248,7 +247,7 @@ func TestAccIAMRole_ForceDetach_policies(t *testing.T) {
 
 func TestAccIAMRole_maxSessionDuration(t *testing.T) {
 	var conf iam.Role
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -296,7 +295,7 @@ func TestAccIAMRole_maxSessionDuration(t *testing.T) {
 func TestAccIAMRole_permissionsBoundary(t *testing.T) {
 	var role iam.Role
 
-	rName := sdkacctest.RandString(10)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
 
 	permissionsBoundary1 := fmt.Sprintf("arn:%s:iam::aws:policy/AdministratorAccess", acctest.Partition())
@@ -403,7 +402,7 @@ func TestAccIAMRole_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMRole_policyBasicInline(t *testing.T) {
+func TestAccIAMRole_InlinePolicy_basic(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -481,7 +480,7 @@ func TestAccIAMRole_InlinePolicy_ignoreOrder(t *testing.T) {
 	})
 }
 
-func TestAccIAMRole_policyBasicInlineEmpty(t *testing.T) {
+func TestAccIAMRole_InlinePolicy_empty(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_iam_role.test"
@@ -502,7 +501,7 @@ func TestAccIAMRole_policyBasicInlineEmpty(t *testing.T) {
 	})
 }
 
-func TestAccIAMRole_policyBasicManaged(t *testing.T) {
+func TestAccIAMRole_ManagedPolicy_basic(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -549,7 +548,7 @@ func TestAccIAMRole_policyBasicManaged(t *testing.T) {
 
 // TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_managedNonEmpty: if a policy is detached
 // out of band, it should be reattached.
-func TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_managedNonEmpty(t *testing.T) {
+func TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -582,7 +581,7 @@ func TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_managedNonEmpty(t *testing.T
 
 // TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_inlineNonEmpty: if a policy is removed
 // out of band, it should be recreated.
-func TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_inlineNonEmpty(t *testing.T) {
+func TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -613,9 +612,9 @@ func TestAccIAMRole_PolicyOutOfBandRemovalAddedBack_inlineNonEmpty(t *testing.T)
 	})
 }
 
-// TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedNonEmpty: if managed_policies arg
+// TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved: if managed_policy_arns arg
 // exists and is non-empty, policy attached out of band should be removed
-func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedNonEmpty(t *testing.T) {
+func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -649,7 +648,7 @@ func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedNonEmpty(t *testing.T)
 
 // TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineNonEmpty: if inline_policy arg
 // exists and is non-empty, policy added out of band should be removed
-func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineNonEmpty(t *testing.T) {
+func TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -684,7 +683,7 @@ func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineNonEmpty(t *testing.T) 
 
 // TestAccIAMRole_PolicyOutOfBandAdditionIgnored_inlineNonExistent: if there is no
 // inline_policy attribute, out of band changes should be ignored.
-func TestAccIAMRole_PolicyOutOfBandAdditionIgnored_inlineNonExistent(t *testing.T) {
+func TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -724,8 +723,8 @@ func TestAccIAMRole_PolicyOutOfBandAdditionIgnored_inlineNonExistent(t *testing.
 }
 
 // TestAccIAMRole_PolicyOutOfBandAdditionIgnored_managedNonExistent: if there is no
-// managed_policies attribute, out of band changes should be ignored.
-func TestAccIAMRole_PolicyOutOfBandAdditionIgnored_managedNonExistent(t *testing.T) {
+// managed_policy_arns attribute, out of band changes should be ignored.
+func TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -757,7 +756,7 @@ func TestAccIAMRole_PolicyOutOfBandAdditionIgnored_managedNonExistent(t *testing
 
 // TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineEmpty: if inline is added
 // out of band with empty inline arg, should be removed
-func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineEmpty(t *testing.T) {
+func TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -789,7 +788,7 @@ func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_inlineEmpty(t *testing.T) {
 
 // TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedEmpty: if managed is attached
 // out of band with empty managed arg, should be detached
-func TestAccIAMRole_PolicyOutOfBandAdditionRemoved_managedEmpty(t *testing.T) {
+func TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1674,7 +1674,7 @@ resource "aws_iam_role" "test" {
         Service = "ec2.${data.aws_partition.current.dns_suffix}",
       }
       Effect = "Allow"
-      Sid = ""
+      Sid    = ""
     }]
   })
 
@@ -1690,7 +1690,7 @@ resource "aws_iam_role" "test" {
           "ec2:DescribeFastSnapshotRestores",
           "ec2:DescribeElasticGpus",
         ]
-        Effect = "Allow"
+        Effect   = "Allow"
         Resource = "*"
       }]
     })
@@ -1714,7 +1714,7 @@ resource "aws_iam_role" "test" {
         Service = "ec2.${data.aws_partition.current.dns_suffix}",
       }
       Effect = "Allow"
-      Sid = ""
+      Sid    = ""
     }]
   })
 
@@ -1730,7 +1730,7 @@ resource "aws_iam_role" "test" {
           "ec2:DescribeFastSnapshotRestores",
           "ec2:DescribeScheduledInstanceAvailability",
         ]
-        Effect = "Allow"
+        Effect   = "Allow"
         Resource = "*"
       }]
     })

--- a/internal/service/iam/user_policy.go
+++ b/internal/service/iam/user_policy.go
@@ -142,9 +142,15 @@ func resourceUserPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("policy", policy); err != nil {
-		return err
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
 	}
+
+	d.Set("policy", policyToSet)
+
 	if err := d.Set("name", name); err != nil {
 		return err
 	}

--- a/internal/service/iam/user_policy_test.go
+++ b/internal/service/iam/user_policy_test.go
@@ -18,13 +18,11 @@ import (
 )
 
 func TestAccIAMUserPolicy_basic(t *testing.T) {
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
 	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
-	policyName := fmt.Sprintf("foo_policy_%d", rInt)
-	policyResourceName := "aws_iam_user_policy.foo"
-	userResourceName := "aws_iam_user.user"
-	userName := fmt.Sprintf("test_user_%d", rInt)
+	policyResourceName := "aws_iam_user_policy.test"
+	userResourceName := "aws_iam_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -33,18 +31,18 @@ func TestAccIAMUserPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccIAMUserPolicyConfig_name(rInt, strconv.Quote("NonJSONString")),
+				Config:      testAccIAMUserPolicyConfig_name(rName, strconv.Quote("NonJSONString")),
 				ExpectError: regexp.MustCompile("invalid JSON"),
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_name(rInt, strconv.Quote(policy1)),
+				Config: testAccIAMUserPolicyConfig_name(rName, strconv.Quote(policy1)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
-					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%s:%s$", userName, policyName))),
-					resource.TestCheckResourceAttr(policyResourceName, "name", policyName),
+					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%[1]s:%[1]s$", rName))),
+					resource.TestCheckResourceAttr(policyResourceName, "name", rName),
 					resource.TestCheckResourceAttr(policyResourceName, "policy", policy1),
-					resource.TestCheckResourceAttr(policyResourceName, "user", userName),
+					resource.TestCheckResourceAttr(policyResourceName, "user", rName),
 				),
 			},
 			{
@@ -53,7 +51,7 @@ func TestAccIAMUserPolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_name(rInt, strconv.Quote(policy2)),
+				Config: testAccIAMUserPolicyConfig_name(rName, strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
@@ -66,8 +64,8 @@ func TestAccIAMUserPolicy_basic(t *testing.T) {
 
 func TestAccIAMUserPolicy_disappears(t *testing.T) {
 	var out iam.GetUserPolicyOutput
-	suffix := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlpha)
-	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -76,7 +74,7 @@ func TestAccIAMUserPolicy_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserPolicyConfig(suffix),
+				Config: testAccUserPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicyExists(resourceName, &out),
 					testAccCheckIAMUserPolicyDisappears(&out),
@@ -88,13 +86,11 @@ func TestAccIAMUserPolicy_disappears(t *testing.T) {
 }
 
 func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
 	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
-	policyNamePrefix := "foo_policy_"
-	policyResourceName := "aws_iam_user_policy.foo"
-	userResourceName := "aws_iam_user.user"
-	userName := fmt.Sprintf("test_user_%d", rInt)
+	policyResourceName := "aws_iam_user_policy.test"
+	userResourceName := "aws_iam_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -103,12 +99,12 @@ func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMUserPolicyConfig_namePrefix(rInt, strconv.Quote(policy1)),
+				Config: testAccIAMUserPolicyConfig_namePrefix(rName, acctest.ResourcePrefix, strconv.Quote(policy1)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
-					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%s:%s.+$", userName, policyNamePrefix))),
-					resource.TestCheckResourceAttr(policyResourceName, "name_prefix", policyNamePrefix),
+					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%s:%s.+$", rName, acctest.ResourcePrefix))),
+					resource.TestCheckResourceAttr(policyResourceName, "name_prefix", acctest.ResourcePrefix),
 					resource.TestCheckResourceAttr(policyResourceName, "policy", policy1),
 				),
 			},
@@ -119,7 +115,7 @@ func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_namePrefix(rInt, strconv.Quote(policy2)),
+				Config: testAccIAMUserPolicyConfig_namePrefix(rName, acctest.ResourcePrefix, strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
@@ -131,12 +127,11 @@ func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 }
 
 func TestAccIAMUserPolicy_generatedName(t *testing.T) {
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
 	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
-	policyResourceName := "aws_iam_user_policy.foo"
-	userResourceName := "aws_iam_user.user"
-	userName := fmt.Sprintf("test_user_%d", rInt)
+	policyResourceName := "aws_iam_user_policy.test"
+	userResourceName := "aws_iam_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -145,11 +140,11 @@ func TestAccIAMUserPolicy_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMUserPolicyConfig_generatedName(rInt, strconv.Quote(policy1)),
+				Config: testAccIAMUserPolicyConfig_generatedName(rName, strconv.Quote(policy1)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
-					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%s:.+$", userName))),
+					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%s:.+$", rName))),
 					resource.TestCheckResourceAttr(policyResourceName, "policy", policy1),
 				),
 			},
@@ -159,7 +154,7 @@ func TestAccIAMUserPolicy_generatedName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_generatedName(rInt, strconv.Quote(policy2)),
+				Config: testAccIAMUserPolicyConfig_generatedName(rName, strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
@@ -171,14 +166,12 @@ func TestAccIAMUserPolicy_generatedName(t *testing.T) {
 }
 
 func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
-	rInt := sdkacctest.RandInt()
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
 	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
-	policyName1 := fmt.Sprintf("foo_policy_%d", rInt)
-	policyName2 := fmt.Sprintf("bar_policy_%d", rInt)
-	policyResourceName1 := "aws_iam_user_policy.foo"
-	policyResourceName2 := "aws_iam_user_policy.bar"
-	userResourceName := "aws_iam_user.user"
+	policyResourceName1 := "aws_iam_user_policy.test"
+	policyResourceName2 := "aws_iam_user_policy.test2"
+	userResourceName := "aws_iam_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -187,11 +180,11 @@ func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMUserPolicyConfig_name(rInt, strconv.Quote(policy1)),
+				Config: testAccIAMUserPolicyConfig_name(rName, strconv.Quote(policy1)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName1),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
-					resource.TestCheckResourceAttr(policyResourceName1, "name", policyName1),
+					resource.TestCheckResourceAttr(policyResourceName1, "name", rName),
 					resource.TestCheckResourceAttr(policyResourceName1, "policy", policy1),
 				),
 			},
@@ -201,18 +194,18 @@ func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_multiplePolicies(rInt, strconv.Quote(policy1), strconv.Quote(policy2)),
+				Config: testAccIAMUserPolicyConfig_multiplePolicies(rName, strconv.Quote(policy1), strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName1),
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName2),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 2),
 					resource.TestCheckResourceAttr(policyResourceName1, "policy", policy1),
-					resource.TestCheckResourceAttr(policyResourceName2, "name", policyName2),
+					resource.TestCheckResourceAttr(policyResourceName2, "name", fmt.Sprintf("%s-2", rName)),
 					resource.TestCheckResourceAttr(policyResourceName2, "policy", policy2),
 				),
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_multiplePolicies(rInt, strconv.Quote(policy2), strconv.Quote(policy2)),
+				Config: testAccIAMUserPolicyConfig_multiplePolicies(rName, strconv.Quote(policy2), strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName1),
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName2),
@@ -221,7 +214,7 @@ func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIAMUserPolicyConfig_name(rInt, strconv.Quote(policy2)),
+				Config: testAccIAMUserPolicyConfig_name(rName, strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName1),
 					testAccCheckIAMUserPolicyExpectedPolicies(userResourceName, 1),
@@ -399,16 +392,22 @@ func testAccCheckIAMUserPolicyExpectedPolicies(iamUserResource string, expected 
 	}
 }
 
-func testAccUserPolicyConfig(suffix string) string {
+func testAccUserPolicyUserBaseConfig(rName, path string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_user" "user_%[1]s" {
-  name = "tf_test_user_test_%[1]s"
-  path = "/"
+resource "aws_iam_user" "test" {
+  name = %[1]q
+  path = %[2]q
+}
+`, rName, path)
 }
 
-resource "aws_iam_user_policy" "foo_%[1]s" {
-  name = "tf_test_policy_test_%[1]s"
-  user = "${aws_iam_user.user_%[1]s.name}"
+func testAccUserPolicyConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
+resource "aws_iam_user_policy" "test" {
+  name = %[1]q
+  user = aws_iam_user.test.name
 
   policy = <<EOF
 {
@@ -421,69 +420,66 @@ resource "aws_iam_user_policy" "foo_%[1]s" {
 }
 EOF
 }
-`, suffix)
+`, rName))
 }
 
-func testAccIAMUserPolicyConfig_name(rInt int, policy string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_iam_user_policy" "foo" {
-  name   = "foo_policy_%d"
-  user   = aws_iam_user.user.name
-  policy = %s
+func testAccIAMUserPolicyConfig_name(rName, policy string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
+resource "aws_iam_user_policy" "test" {
+  name   = %[1]q
+  user   = aws_iam_user.test.name
+  policy = %[2]s
 }
-`, testAccUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), rInt, policy)
-}
-
-func testAccIAMUserPolicyConfig_namePrefix(rInt int, policy string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_iam_user_policy" "foo" {
-  name_prefix = "foo_policy_"
-  user        = aws_iam_user.user.name
-  policy      = %s
-}
-`, testAccUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), policy)
+`, rName, policy))
 }
 
-func testAccIAMUserPolicyConfig_generatedName(rInt int, policy string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_iam_user_policy" "foo" {
-  user   = aws_iam_user.user.name
-  policy = %s
+func testAccIAMUserPolicyConfig_namePrefix(rName, prefix, policy string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
+resource "aws_iam_user_policy" "test" {
+  name_prefix = %[1]q
+  user        = aws_iam_user.test.name
+  policy      = %[2]s
 }
-`, testAccUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), policy)
+`, prefix, policy))
 }
 
-func testAccIAMUserPolicyConfig_multiplePolicies(rInt int, policy1, policy2 string) string {
-	return fmt.Sprintf(`
-%[1]s
+func testAccIAMUserPolicyConfig_generatedName(rName, policy string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
+resource "aws_iam_user_policy" "test" {
+  user   = aws_iam_user.test.name
+  policy = %[1]s
+}
+`, policy))
+}
 
-resource "aws_iam_user_policy" "foo" {
-  name   = "foo_policy_%[2]d"
-  user   = aws_iam_user.user.name
+func testAccIAMUserPolicyConfig_multiplePolicies(rName, policy1, policy2 string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
+resource "aws_iam_user_policy" "test" {
+  name   = %[1]q
+  user   = aws_iam_user.test.name
+  policy = %[2]s
+}
+
+resource "aws_iam_user_policy" "test2" {
+  name   = "%[1]s-2"
+  user   = aws_iam_user.test.name
   policy = %[3]s
 }
-
-resource "aws_iam_user_policy" "bar" {
-  name   = "bar_policy_%[2]d"
-  user   = aws_iam_user.user.name
-  policy = %[4]s
-}
-`, testAccUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), rInt, policy1, policy2)
+`, rName, policy1, policy2))
 }
 
-func testAccUserPolicyOrderConfig(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_user" "test" {
-  name = %[1]q
-  path = "/"
-}
-
+func testAccUserPolicyOrderConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
 resource "aws_iam_user_policy" "test" {
   name = %[1]q
   user = aws_iam_user.test.name
@@ -504,16 +500,13 @@ resource "aws_iam_user_policy" "test" {
 }
 EOF
 }
-`, suffix)
+`, rName))
 }
 
-func testAccUserPolicyNewOrderConfig(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_user" "test" {
-  name = %[1]q
-  path = "/"
-}
-
+func testAccUserPolicyNewOrderConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPolicyUserBaseConfig(rName, "/"),
+		fmt.Sprintf(`
 resource "aws_iam_user_policy" "test" {
   name = %[1]q
   user = aws_iam_user.test.name
@@ -534,5 +527,5 @@ resource "aws_iam_user_policy" "test" {
 }
 EOF
 }
-`, suffix)
+`, rName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968
Relates #19444
Releates hashicorp/awspolicyequivalence#7

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccIAMPolicy_disappears (16.22s)
--- PASS: TestAccIAMPolicy_description (23.95s)
--- PASS: TestAccIAMPolicy_namePrefix (23.97s)
--- PASS: TestAccIAMPolicy_path (23.97s)
--- PASS: TestAccIAMPolicy_basic (23.98s)
--- PASS: TestAccIAMPolicy_policy (38.30s)
--- PASS: TestAccIAMPolicy_tags (50.37s)

--- PASS: TestAccIAMGroupPolicy_disappears (16.72s)
--- PASS: TestAccIAMGroupPolicy_generatedName (31.88s)
--- PASS: TestAccIAMGroupPolicy_namePrefix (31.95s)
--- PASS: TestAccIAMGroupPolicy_basic (34.36s)

--- PASS: TestAccIAMRolePolicy_invalidJSON (3.20s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (13.73s)
--- PASS: TestAccIAMRolePolicy_disappears (21.89s)
--- PASS: TestAccIAMRolePolicy_policyOrder (33.38s)
--- PASS: TestAccIAMRolePolicy_namePrefix (40.47s)
--- PASS: TestAccIAMRolePolicy_generatedName (40.47s)
--- PASS: TestAccIAMRolePolicy_basic (40.83s)

--- PASS: TestAccIAMUserPolicy_disappears (18.68s)
--- PASS: TestAccIAMUserPolicy_policyOrder (29.39s)
--- PASS: TestAccIAMUserPolicy_basic (37.38s)
--- PASS: TestAccIAMUserPolicy_namePrefix (37.43s)
--- PASS: TestAccIAMUserPolicy_generatedName (37.52s)
--- PASS: TestAccIAMUserPolicy_multiplePolicies (63.15s)

--- PASS: TestAccIAMRole_badJSON (5.31s)
--- PASS: TestAccIAMRole_disappears (22.07s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (25.95s)
--- PASS: TestAccIAMRole_basic (30.19s)
--- PASS: TestAccIAMRole_namePrefix (30.88s)
--- PASS: TestAccIAMRole_policiesForceDetach (32.61s)
--- FAIL: TestAccIAMRole_InlinePolicy_ignoreOrder (33.77s) (* expected)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (42.46s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (46.02s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (46.06s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (46.06s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (46.51s)
--- PASS: TestAccIAMRole_tags (50.10s)
--- PASS: TestAccIAMRole_nameGenerated (28.03s)
--- PASS: TestAccIAMRole_testNameChange (50.26s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (44.95s)
--- PASS: TestAccIAMRole_maxSessionDuration (52.80s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (53.16s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (56.23s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (64.19s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (68.21s)
--- PASS: TestAccIAMRole_basicWithDescription (52.73s)
--- PASS: TestAccIAMRole_permissionsBoundary (87.88s)
```

Output from acceptance testing (`us-west-2`):

```
--- PASS: TestAccIAMPolicy_disappears (11.89s)
--- PASS: TestAccIAMPolicy_namePrefix (15.41s)
--- PASS: TestAccIAMPolicy_path (15.41s)
--- PASS: TestAccIAMPolicy_description (15.52s)
--- PASS: TestAccIAMPolicy_basic (15.63s)
--- PASS: TestAccIAMPolicy_policy (23.51s)
--- PASS: TestAccIAMPolicy_tags (30.99s)

--- PASS: TestAccIAMGroupPolicy_disappears (11.01s)
--- PASS: TestAccIAMGroupPolicy_namePrefix (20.59s)
--- PASS: TestAccIAMGroupPolicy_generatedName (20.62s)
--- PASS: TestAccIAMGroupPolicy_basic (21.95s)

--- PASS: TestAccIAMRolePolicy_invalidJSON (7.16s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (13.66s)
--- PASS: TestAccIAMRolePolicy_disappears (18.95s)
--- PASS: TestAccIAMRolePolicy_policyOrder (26.08s)
--- PASS: TestAccIAMRolePolicy_namePrefix (31.22s)
--- PASS: TestAccIAMRolePolicy_basic (31.68s)
--- PASS: TestAccIAMRolePolicy_generatedName (32.70s)

--- PASS: TestAccIAMUserPolicy_disappears (14.38s)
--- PASS: TestAccIAMUserPolicy_policyOrder (20.11s)
--- PASS: TestAccIAMUserPolicy_basic (24.76s)
--- PASS: TestAccIAMUserPolicy_namePrefix (24.76s)
--- PASS: TestAccIAMUserPolicy_generatedName (24.84s)
--- PASS: TestAccIAMUserPolicy_multiplePolicies (40.34s)

--- PASS: TestAccIAMRole_badJSON (8.35s)
--- PASS: TestAccIAMRole_disappears (28.83s)
--- PASS: TestAccIAMRole_nameGenerated (39.13s)
--- PASS: TestAccIAMRole_namePrefix (41.08s)
--- PASS: TestAccIAMRole_basic (41.08s)
--- PASS: TestAccIAMRole_policiesForceDetach (42.74s)
--- FAIL: TestAccIAMRole_InlinePolicy_ignoreOrder (45.00s) (*expected)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (55.12s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (26.30s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (58.81s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (58.81s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (59.18s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (59.47s)
--- PASS: TestAccIAMRole_tags (60.73s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (61.71s)
--- PASS: TestAccIAMRole_maxSessionDuration (63.13s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (63.32s)
--- PASS: TestAccIAMRole_testNameChange (65.57s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (69.97s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (79.67s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (74.01s)
--- PASS: TestAccIAMRole_basicWithDescription (54.28s)
--- PASS: TestAccIAMRole_permissionsBoundary (104.26s)
```