### PR TITLE
r/alb: on create, only modify `enable_waf_fail_open` argument if change is present

### DIFF
--- a/.changelog/22072.txt
+++ b/.changelog/22072.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb: Correctly configure `enable_waf_fail_open` during resource creation
+```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -487,7 +487,12 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 			})
 		}
 
-		if d.HasChange("enable_waf_fail_open") || d.IsNewResource() {
+		// The "waf.fail_open.enabled" attribute is not available in all AWS regions
+		// e.g. us-gov-east-1; thus, we can instead only modify the attribute as a result of d.HasChange()
+		// to avoid "ValidationError: Load balancer attribute key 'waf.fail_open.enabled' is not recognized"
+		// when modifying the attribute right after resource creation.
+		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/22037
+		if d.HasChange("enable_waf_fail_open") {
 			attributes = append(attributes, &elbv2.LoadBalancerAttribute{
 				Key:   aws.String("waf.fail_open.enabled"),
 				Value: aws.String(strconv.FormatBool(d.Get("enable_waf_fail_open").(bool))),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22037

Output from acceptance testing before code change (`us-gov-east-1`): _Test tf config does not explicitly configure `enable_waf_fail_open`_
```
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
    load_balancer_test.go:69: Step 1/1 error: Error running apply: exit status 1

        Error: failure configuring LB attributes: ValidationError: Load balancer attribute key 'waf.fail_open.enabled' is not recognized
        	status code: 400, request id: 3294a3f6-a621-4d6d-b60a-bb44a7c4f80b

          with aws_lb.lb_test,
          on terraform_plugin_test.tf line 11, in resource "aws_lb" "lb_test":
          11: resource "aws_lb" "lb_test" {

--- FAIL: TestAccELBV2LoadBalancer_ALB_basic (171.81s)
```

Output from acceptance testing (`us-west-2`):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (158.63s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen (311.50s)
```

Output from acceptance testing (`us-gov-west-1`):
```
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (175.30s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen (296.87s)
```

Output from acceptance testing (`us-gov-east-1`):
```
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (206.77s)
```
