### PR TITLE
r/appstream_image_builder: create with `image_arn` if configured

### DIFF
--- a/.changelog/22077.txt
+++ b/.changelog/22077.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_image_builder: Correctly create resource with `image_arn` argument
+```

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -116,6 +116,7 @@ func ResourceImageBuilder() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{"image_arn", "image_name"},
+				ValidateFunc: verify.ValidARN,
 			},
 			"image_name": {
 				Type:         schema.TypeString,
@@ -202,6 +203,10 @@ func resourceImageBuilderCreate(ctx context.Context, d *schema.ResourceData, met
 
 	if v, ok := d.GetOk("enable_default_internet_access"); ok {
 		input.EnableDefaultInternetAccess = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("image_arn"); ok {
+		input.ImageArn = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("image_name"); ok {

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -317,8 +317,8 @@ data "aws_partition" "current" {}
 
 resource "aws_appstream_image_builder" "test" {
   image_arn     = "arn:${data.aws_partition.current.partition}:appstream:%[1]s::image/%[2]s"
-  instance_type = %[2]q
-  name          = %[3]q
+  instance_type = %[3]q
+  name          = %[4]q
 }
 `, acctest.Region(), imageName, instanceType, rName)
 }

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -166,6 +166,36 @@ func TestAccAppStreamImageBuilder_tags(t *testing.T) {
 	})
 }
 
+func TestAccAppStreamImageBuilder_imageARN(t *testing.T) {
+	resourceName := "aws_appstream_image_builder.test"
+	// imageName selected from the available AWS Managed AppStream 2.0 Base Images
+	// Reference: https://docs.aws.amazon.com/appstream2/latest/developerguide/base-image-version-history.html
+	imageName := "AppStream-WinServer2012R2-07-19-2021"
+	instanceType := "stream.standard.small"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageBuilderDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, appstream.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageBuilderByImageARNConfig(rName, imageName, instanceType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageBuilderExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "image_arn", "appstream", fmt.Sprintf("image/%s", imageName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckImageBuilderExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -279,4 +309,16 @@ resource "aws_appstream_image_builder" "test" {
   }
 }
 `, instanceType, name, key1, value1, key2, value2)
+}
+
+func testAccImageBuilderByImageARNConfig(rName, imageName, instanceType string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_appstream_image_builder" "test" {
+  image_arn     = "arn:${data.aws_partition.current.partition}:appstream:%[1]s::image/%[2]s"
+  instance_type = %[2]q
+  name          = %[3]q
+}
+`, acctest.Region(), imageName, instanceType, rName)
 }

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -184,7 +184,7 @@ func TestAccAppStreamImageBuilder_imageARN(t *testing.T) {
 				Config: testAccImageBuilderByImageARNConfig(rName, imageName, instanceType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageBuilderExists(resourceName),
-					acctest.CheckResourceAttrRegionalARN(resourceName, "image_arn", "appstream", fmt.Sprintf("image/%s", imageName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, "image_arn", "appstream", fmt.Sprintf("image/%s", imageName)),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22065 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAppStreamImageBuilder_imageARN (762.97s)
```
