### PR TITLE
b/aws_redshift_cluster: Adds retries to enabling and disabling the redshift cluster's logging

### DIFF
--- a/.changelog/22080.txt
+++ b/.changelog/22080.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ resource/aws_redshift_cluster: Adds retries to enabling and disabling the redshift cluster's logging
+ ```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -803,7 +803,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			log.Printf("[INFO] Disabling Logging for Redshift Cluster %q", d.Id())
 			_, err := tfresource.RetryWhenAWSErrCodeEquals(
-				5*time.Minute,
+				clusterInvalidClusterStateFaultTimeout,
 				func() (interface{}, error) {
 					return conn.DisableLogging(&redshift.DisableLoggingInput{
 						ClusterIdentifier: aws.String(d.Id()),
@@ -813,7 +813,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 			)
 
 			if err != nil {
-				return err
+				return fmt.Errorf("error disabling Redshift Cluster (%s) logging: %w", d.Id(), err)
 			}
 		}
 	}
@@ -838,7 +838,7 @@ func enableRedshiftClusterLogging(d *schema.ResourceData, conn *redshift.Redshif
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(
-		5*time.Minute,
+		clusterInvalidClusterStateFaultTimeout,
 		func() (interface{}, error) {
 			return conn.EnableLogging(params)
 		},
@@ -846,7 +846,7 @@ func enableRedshiftClusterLogging(d *schema.ResourceData, conn *redshift.Redshif
 	)
 
 	if err != nil {
-		return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %s", d.Id(), err)
+		return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -802,9 +802,16 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		} else {
 			log.Printf("[INFO] Disabling Logging for Redshift Cluster %q", d.Id())
-			_, err := conn.DisableLogging(&redshift.DisableLoggingInput{
-				ClusterIdentifier: aws.String(d.Id()),
-			})
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(
+				5*time.Minute,
+				func() (interface{}, error) {
+					return conn.DisableLogging(&redshift.DisableLoggingInput{
+						ClusterIdentifier: aws.String(d.Id()),
+					})
+				},
+				redshift.ErrCodeInvalidClusterStateFault,
+			)
+
 			if err != nil {
 				return err
 			}
@@ -830,9 +837,18 @@ func enableRedshiftClusterLogging(d *schema.ResourceData, conn *redshift.Redshif
 		params.S3KeyPrefix = aws.String(v.(string))
 	}
 
-	if _, err := conn.EnableLogging(params); err != nil {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(
+		5*time.Minute,
+		func() (interface{}, error) {
+			return conn.EnableLogging(params)
+		},
+		redshift.ErrCodeInvalidClusterStateFault,
+	)
+
+	if err != nil {
 		return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %s", d.Id(), err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Adds retries to actions that enable or disable the redshift cluster's logging when returned the error code "InvalidClusterState".


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21815

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./internal/service/redshift -v -count 1 -parallel 20 -run=TestAccRedshiftCluster_loggingEnabled -timeout 180m
=== RUN   TestAccRedshiftCluster_loggingEnabled
=== PAUSE TestAccRedshiftCluster_loggingEnabled
=== CONT  TestAccRedshiftCluster_loggingEnabled
--- PASS: TestAccRedshiftCluster_loggingEnabled (311.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	314.640s
...
```


Previously:
(Test would intermittently fail, in this example we fail on removing logging)
```
lars@Lars's-MacBook-Pro terraform-provider-aws % TF_ACC=1 go test ./internal/service/redshift -v -count 1 -parallel 20 -run=TestAccRedshiftCluster_loggingEnabled -timeout 180m
=== RUN   TestAccRedshiftCluster_loggingEnabled
=== PAUSE TestAccRedshiftCluster_loggingEnabled
=== CONT  TestAccRedshiftCluster_loggingEnabled
--- PASS: TestAccRedshiftCluster_loggingEnabled (260.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   262.972s
lars@Lars's-MacBook-Pro terraform-provider-aws % TF_ACC=1 go test ./internal/service/redshift -v -count 1 -parallel 20 -run=TestAccRedshiftCluster_loggingEnabled -timeout 180m
=== RUN   TestAccRedshiftCluster_loggingEnabled
=== PAUSE TestAccRedshiftCluster_loggingEnabled
=== CONT  TestAccRedshiftCluster_loggingEnabled
    cluster_test.go:191: Step 3/3 error: Error running apply: exit status 1

        Error: InvalidClusterState: There is an operation running on the Cluster. Please try to disable logging at a later time.
                status code: 400, request id: a30468db-ea8e-4b9e-b92f-f338ca5db0fd

          with aws_redshift_cluster.test,
          on terraform_plugin_test.tf line 12, in resource "aws_redshift_cluster" "test":
          12: resource "aws_redshift_cluster" "test" {

--- FAIL: TestAccRedshiftCluster_loggingEnabled (279.75s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/redshift   282.620s
FAIL
```