### PR TITLE
r/aws_kms_key: Add acceptance test for policy with boolean condition

### DIFF
--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -864,6 +864,7 @@ resource "aws_kms_key" "test" {
       Principal = {
         AWS = "*"
       }
+
       Action   = "kms:*"
       Resource = "*"
     },
@@ -873,15 +874,19 @@ resource "aws_kms_key" "test" {
         "kms:ListGrants",
         "kms:RevokeGrant"
       ]
+
       Effect = "Allow"
+
       Principal = {
         AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       }
+
       Condition = {
         Bool = {
           "kms:GrantIsForAWSResource" = true
         }
       }
+
       Resource = "*"
       Sid      = "Allow attachment of persistent resources"
     }]

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -858,38 +858,39 @@ resource "aws_kms_key" "test" {
   policy = jsonencode({
     Id = %[1]q
     Statement = [
-    {
-      Sid    = "Enable IAM User Permissions"
-      Effect = "Allow"
-      Principal = {
-        AWS = "*"
-      }
-
-      Action   = "kms:*"
-      Resource = "*"
-    },
-    {
-      Action = [
-        "kms:CreateGrant",
-        "kms:ListGrants",
-        "kms:RevokeGrant"
-      ]
-
-      Effect = "Allow"
-
-      Principal = {
-        AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-      }
-
-      Condition = {
-        Bool = {
-          "kms:GrantIsForAWSResource" = true
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
         }
-      }
 
-      Resource = "*"
-      Sid      = "Allow attachment of persistent resources"
-    }]
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+        ]
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+
+        Condition = {
+          Bool = {
+            "kms:GrantIsForAWSResource" = true
+          }
+        }
+      },
+    ]
     Version = "2012-10-17"
   })
 }

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -851,6 +851,8 @@ func testAccKeyPolicyBooleanConditionConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
@@ -878,7 +880,7 @@ resource "aws_kms_key" "test" {
         ]
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
         }
 
         Resource = "*"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21225.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Before merge of #22067 and  hashicorp/awspolicyequivalence@1.4.0:

```console
% make testacc TESTARGS='-run=TestAccKMSKey_Policy_booleanCondition' PKG_NAME=internal/service/kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20 -run=TestAccKMSKey_Policy_booleanCondition -timeout 180m
=== RUN   TestAccKMSKey_Policy_booleanCondition
=== PAUSE TestAccKMSKey_Policy_booleanCondition
=== CONT  TestAccKMSKey_Policy_booleanCondition
    key_test.go:323: Step 1/2 error: Error running apply: exit status 1
        
        Error: error waiting for KMS Key (5ff04996-79ef-47e5-8f68-fe5bc7a16804) policy propagation: timeout while waiting for state to become 'TRUE' (last state: 'FALSE', timeout: 5m0s)
        
          with aws_kms_key.test,
          on terraform_plugin_test.tf line 4, in resource "aws_kms_key" "test":
           4: resource "aws_kms_key" "test" {
        
--- FAIL: TestAccKMSKey_Policy_booleanCondition (308.33s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/kms	311.870s
FAIL
```

Now:

```console
% make testacc TESTARGS='-run=TestAccKMSKey_Policy_booleanCondition' PKG_NAME=internal/service/kms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 20 -run=TestAccKMSKey_Policy_booleanCondition -timeout 180m
=== RUN   TestAccKMSKey_Policy_booleanCondition
=== PAUSE TestAccKMSKey_Policy_booleanCondition
=== CONT  TestAccKMSKey_Policy_booleanCondition
--- PASS: TestAccKMSKey_Policy_booleanCondition (20.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	24.358s
```