### PR TITLE
iam/role: Fix spurious diffs with inline_policy ordering

### DIFF
--- a/.changelog/22099.txt
+++ b/.changelog/22099.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_role: Fix order-related diffs in `policy`
+```

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -830,11 +830,7 @@ func inlinePoliciesActualDiff(d *schema.ResourceData) bool {
 	osPolicies := expandRoleInlinePolicies(roleName, os.List())
 	nsPolicies := expandRoleInlinePolicies(roleName, ns.List())
 
-	if !inlinePoliciesEquivalent(osPolicies, nsPolicies) {
-		return true
-	}
-
-	return false
+	return !inlinePoliciesEquivalent(osPolicies, nsPolicies)
 }
 
 func inlinePoliciesEquivalent(one, two []*iam.PutRolePolicyInput) bool {
@@ -860,9 +856,5 @@ func inlinePoliciesEquivalent(one, two []*iam.PutRolePolicyInput) bool {
 		}
 	}
 
-	if matches != len(one) {
-		return false
-	}
-
-	return true
+	return matches == len(one)
 }

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -126,7 +127,7 @@ func ResourceRole() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Optional: true, // semantically required but syntactically optional to allow empty inline_policy
 							ValidateFunc: validation.All(
 								validation.StringIsNotEmpty,
 								validRolePolicyName,
@@ -134,11 +135,18 @@ func ResourceRole() *schema.Resource {
 						},
 						"policy": {
 							Type:             schema.TypeString,
-							Optional:         true,
+							Optional:         true, // semantically required but syntactically optional to allow empty inline_policy
 							ValidateFunc:     verify.ValidIAMPolicyJSON,
 							DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
 						},
 					},
+				},
+				DiffSuppressFunc: func(k, _, _ string, d *schema.ResourceData) bool {
+					if d.Id() == "" {
+						return false
+					}
+
+					return !inlinePoliciesActualDiff(d)
 				},
 			},
 
@@ -292,8 +300,16 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("reading inline policies for IAM role %s, error: %s", d.Id(), err)
 	}
-	if err := d.Set("inline_policy", flattenRoleInlinePolicies(inlinePolicies)); err != nil {
-		return fmt.Errorf("error setting inline_policy: %w", err)
+
+	var configPoliciesList []*iam.PutRolePolicyInput
+	if v := d.Get("inline_policy").(*schema.Set); v.Len() > 0 {
+		configPoliciesList = expandRoleInlinePolicies(aws.StringValue(role.RoleName), v.List())
+	}
+
+	if !inlinePoliciesEquivalent(inlinePolicies, configPoliciesList) {
+		if err := d.Set("inline_policy", flattenRoleInlinePolicies(inlinePolicies)); err != nil {
+			return fmt.Errorf("error setting inline_policy: %w", err)
+		}
 	}
 
 	managedPolicies, err := readRolePolicyAttachments(conn, aws.StringValue(role.RoleName))
@@ -393,18 +409,22 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("inline_policy") {
+	if d.HasChange("inline_policy") && inlinePoliciesActualDiff(d) {
 		roleName := d.Get("name").(string)
+
 		o, n := d.GetChange("inline_policy")
+
 		if o == nil {
 			o = new(schema.Set)
 		}
+
 		if n == nil {
 			n = new(schema.Set)
 		}
 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
+
 		remove := os.Difference(ns).List()
 		add := ns.Difference(os).List()
 
@@ -792,4 +812,57 @@ func readRoleInlinePolicies(roleName string, meta interface{}) ([]*iam.PutRolePo
 	}
 
 	return apiObjects, nil
+}
+
+func inlinePoliciesActualDiff(d *schema.ResourceData) bool {
+	roleName := d.Get("name").(string)
+	o, n := d.GetChange("inline_policy")
+	if o == nil {
+		o = new(schema.Set)
+	}
+	if n == nil {
+		n = new(schema.Set)
+	}
+
+	os := o.(*schema.Set)
+	ns := n.(*schema.Set)
+
+	osPolicies := expandRoleInlinePolicies(roleName, os.List())
+	nsPolicies := expandRoleInlinePolicies(roleName, ns.List())
+
+	if !inlinePoliciesEquivalent(osPolicies, nsPolicies) {
+		return true
+	}
+
+	return false
+}
+
+func inlinePoliciesEquivalent(one, two []*iam.PutRolePolicyInput) bool {
+	if one == nil && two == nil {
+		return true
+	}
+
+	if len(one) != len(two) {
+		return false
+	}
+
+	matches := 0
+
+	for _, policyOne := range one {
+		for _, policyTwo := range two {
+			if aws.StringValue(policyOne.PolicyName) == aws.StringValue(policyTwo.PolicyName) {
+				matches++
+				if equivalent, err := awspolicy.PoliciesAreEquivalent(aws.StringValue(policyOne.PolicyDocument), aws.StringValue(policyTwo.PolicyDocument)); err != nil || !equivalent {
+					return false
+				}
+				break
+			}
+		}
+	}
+
+	if matches != len(one) {
+		return false
+	}
+
+	return true
 }

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -183,7 +183,7 @@ The following arguments are optional:
 
 * `description` - (Optional) Description of the role.
 * `force_detach_policies` - (Optional) Whether to force detaching any policies the role has before destroying it. Defaults to `false`.
-* `inline_policy` - (Optional) Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. Defined below. If no blocks are configured, Terraform will ignore any managing any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause Terraform to remove _all_ inline policies.
+* `inline_policy` - (Optional) Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, Terraform will not manage any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause Terraform to remove _all_ inline policies added out of band on `apply`.
 * `managed_policy_arns` - (Optional) Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, Terraform will ignore policy attachments to this resource. When configured, Terraform will align the role's managed policy attachments with this set by attaching or detaching managed policies. Configuring an empty set (i.e., `managed_policy_arns = []`) will cause Terraform to remove _all_ managed policy attachments.
 * `max_session_duration` - (Optional) Maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
 * `name` - (Optional, Forces new resource) Friendly name of the role. If omitted, Terraform will assign a random, unique name. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
@@ -195,6 +195,8 @@ The following arguments are optional:
 ### inline_policy
 
 This configuration block supports the following:
+
+~> **NOTE:** Since one empty block (i.e., `inline_policy {}`) is valid syntactically to remove out of band policies on `apply`, `name` and `policy` are technically _optional_. However, they are both _required_ in order to manage actual inline policies. Not including one or the other may not result in Terraform errors but will result in unpredictable and incorrect behavior.
 
 * `name` - (Required) Name of the role policy.
 * `policy` - (Required) Policy document as a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/tutorials/terraform/aws-iam-policy).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968
Fixes #19444

Output from acceptance testing (`us-west-2`):
```console
% make testacc TESTS=TestAccIAMRole PKG=iam
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole' -timeout 180m
--- PASS: TestAccIAMRolePolicy_invalidJSON (4.27s)
--- PASS: TestAccIAMRolesDataSource_nonExistentPathPrefix (23.85s)
--- PASS: TestAccIAMRolesDataSource_basic (25.41s)
--- PASS: TestAccIAMRoleDataSource_basic (31.72s)
--- PASS: TestAccIAMRolesDataSource_pathPrefix (32.82s)
--- PASS: TestAccIAMRolesDataSource_nameRegexAndPathPrefix (32.83s)
--- PASS: TestAccIAMRolesDataSource_nameRegex (32.85s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (33.05s)
--- PASS: TestAccIAMRole_badJSON (5.21s)
--- PASS: TestAccIAMRole_policiesForceDetach (39.23s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (53.38s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (56.74s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (56.80s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (57.57s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (57.62s)
--- PASS: TestAccIAMRole_disappears (25.52s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (62.95s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (62.99s)
--- PASS: TestAccIAMRole_maxSessionDuration (65.89s)
--- PASS: TestAccIAMRole_namePrefix (34.99s)
--- PASS: TestAccIAMRole_nameGenerated (31.70s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (73.21s)
--- PASS: TestAccIAMRole_tags (53.78s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (79.13s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (15.11s)
--- PASS: TestAccIAMRolePolicy_disappears (24.46s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (78.43s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (21.44s)
--- PASS: TestAccIAMRole_basic (27.42s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (85.61s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (23.69s)
--- PASS: TestAccIAMRole_testNameChange (54.29s)
--- PASS: TestAccIAMRolePolicy_basic (48.21s)
--- PASS: TestAccIAMRoleDataSource_tags (22.99s)
--- PASS: TestAccIAMRolePolicy_policyOrder (34.37s)
--- PASS: TestAccIAMRolePolicy_generatedName (40.02s)
--- PASS: TestAccIAMRole_basicWithDescription (62.64s)
--- PASS: TestAccIAMRolePolicy_namePrefix (39.04s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (37.61s)
--- PASS: TestAccIAMRole_permissionsBoundary (84.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	111.476s
```

Output from acceptance testing (`GovCloud`):

```
--- PASS: TestAccIAMRole_badJSON (6.19s)
--- PASS: TestAccIAMRole_basic (45.18s)
--- PASS: TestAccIAMRole_basicWithDescription (76.34s)
--- PASS: TestAccIAMRole_disappears (30.23s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (88.88s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (30.90s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (80.71s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (76.55s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (60.75s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (60.38s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (60.85s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (94.05s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (30.18s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (69.40s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (60.48s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (69.40s)
--- PASS: TestAccIAMRole_maxSessionDuration (63.65s)
--- PASS: TestAccIAMRole_nameGenerated (36.35s)
--- PASS: TestAccIAMRole_namePrefix (45.20s)
--- PASS: TestAccIAMRole_permissionsBoundary (122.71s)
--- PASS: TestAccIAMRole_policiesForceDetach (50.79s)
--- PASS: TestAccIAMRole_tags (62.42s)
--- PASS: TestAccIAMRole_testNameChange (69.78s)
```
