### PR TITLE
efs/file_system_policy: Fix diffs with equivalent policies

### DIFF
--- a/.changelog/22100.txt
+++ b/.changelog/22100.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_efs_file_system_policy: Fix diffs in `policy` when policies are equivalent
+resource/aws_efs_file_system_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
 ```

--- a/.changelog/22100.txt
+++ b/.changelog/22100.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_efs_file_system_policy: Fix diffs in `policy` when policies are equivalent
+```

--- a/internal/service/efs/file_system_policy.go
+++ b/internal/service/efs/file_system_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -39,7 +40,7 @@ func ResourceFileSystemPolicy() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
 			},
 		},
 	}
@@ -48,15 +49,22 @@ func ResourceFileSystemPolicy() *schema.Resource {
 func resourceFileSystemPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EFSConn
 
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
+
 	fsID := d.Get("file_system_id").(string)
 	input := &efs.PutFileSystemPolicyInput{
 		BypassPolicyLockoutSafetyCheck: aws.Bool(d.Get("bypass_policy_lockout_safety_check").(bool)),
 		FileSystemId:                   aws.String(fsID),
-		Policy:                         aws.String(d.Get("policy").(string)),
+		Policy:                         aws.String(policy),
 	}
 
 	log.Printf("[DEBUG] Putting EFS File System Policy: %s", input)
-	_, err := conn.PutFileSystemPolicy(input)
+
+	_, err = conn.PutFileSystemPolicy(input)
 
 	if err != nil {
 		return fmt.Errorf("error putting EFS File System Policy (%s): %w", fsID, err)
@@ -83,7 +91,20 @@ func resourceFileSystemPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("file_system_id", output.FileSystemId)
-	d.Set("policy", output.Policy)
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.StringValue(output.Policy))
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
+	}
+
+	policyToSet, err = structure.NormalizeJsonString(policyToSet)
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policyToSet, err)
+	}
+
+	d.Set("policy", policyToSet)
 
 	return nil
 }

--- a/internal/service/efs/file_system_policy_test.go
+++ b/internal/service/efs/file_system_policy_test.go
@@ -225,7 +225,7 @@ resource "aws_efs_file_system_policy" "test" {
     "Id": "ExamplePolicy01",
     "Statement": [
         {
-            "Sid": "ExampleSatement01",
+            "Sid": "ExampleStatement01",
             "Effect": "Allow",
             "Principal": {
                 "AWS": "*"
@@ -263,7 +263,7 @@ resource "aws_efs_file_system_policy" "test" {
     "Id": "ExamplePolicy01",
     "Statement": [
         {
-            "Sid": "ExampleSatement01",
+            "Sid": "ExampleStatement01",
             "Effect": "Allow",
             "Principal": {
                 "AWS": "*"
@@ -300,7 +300,7 @@ resource "aws_efs_file_system_policy" "test" {
     "Id": "ExamplePolicy01",
     "Statement": [
         {
-            "Sid": "ExampleSatement01",
+            "Sid": "ExampleStatement01",
             "Effect": "Allow",
             "Principal": {
                 "AWS": "*"
@@ -336,7 +336,7 @@ resource "aws_efs_file_system_policy" "test" {
     Version = "2012-10-17"
     Id      = "ExamplePolicy01"
     Statement = [{
-      Sid    = "ExampleSatement01"
+      Sid    = "ExampleStatement01"
       Effect = "Allow"
       Principal = {
         AWS = "*"
@@ -370,7 +370,7 @@ resource "aws_efs_file_system_policy" "test" {
     Version = "2012-10-17"
     Id      = "ExamplePolicy01"
     Statement = [{
-      Sid    = "ExampleSatement01"
+      Sid    = "ExampleStatement01"
       Effect = "Allow"
       Principal = {
         AWS = "*"

--- a/internal/service/efs/file_system_policy_test.go
+++ b/internal/service/efs/file_system_policy_test.go
@@ -334,9 +334,9 @@ resource "aws_efs_file_system_policy" "test" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "ExamplePolicy01"
+    Id      = "ExamplePolicy01"
     Statement = [{
-      Sid = "ExampleSatement01"
+      Sid    = "ExampleSatement01"
       Effect = "Allow"
       Principal = {
         AWS = "*"
@@ -368,9 +368,9 @@ resource "aws_efs_file_system_policy" "test" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "ExamplePolicy01"
+    Id      = "ExamplePolicy01"
     Statement = [{
-      Sid = "ExampleSatement01"
+      Sid    = "ExampleSatement01"
       Effect = "Allow"
       Principal = {
         AWS = "*"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968
Fixes #19245

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccEFSFileSystemPolicy PKG=efs                            
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 20 -run='TestAccEFSFileSystemPolicy' -timeout 180m
--- PASS: TestAccEFSFileSystemPolicy_disappears (26.35s)
--- PASS: TestAccEFSFileSystemPolicy_equivalentPolicies (35.35s)
--- PASS: TestAccEFSFileSystemPolicy_equivalentPoliciesIAMPolicyDoc (35.53s)
--- PASS: TestAccEFSFileSystemPolicy_basic (41.84s)
--- PASS: TestAccEFSFileSystemPolicy_policyBypass (41.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	43.510s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccEFSFileSystemPolicy PKG=efs                            
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 20 -run='TestAccEFSFileSystemPolicy' -timeout 180m
--- PASS: TestAccEFSFileSystemPolicy_disappears (29.98s)
--- PASS: TestAccEFSFileSystemPolicy_equivalentPolicies (42.54s)
--- PASS: TestAccEFSFileSystemPolicy_equivalentPoliciesIAMPolicyDoc (42.64s)
--- PASS: TestAccEFSFileSystemPolicy_policyBypass (51.10s)
--- PASS: TestAccEFSFileSystemPolicy_basic (51.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	52.786s
```
