### PR TITLE
apigateway/rest_api: Fix diffs from equivalent policies

### DIFF
--- a/.changelog/22115.txt
+++ b/.changelog/22115.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_api_gateway_rest_api_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```
+
+```release-note:bug
+resource/aws_api_gateway_rest_api: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -54,6 +55,10 @@ func ResourceRestAPI() *schema.Resource {
 				Computed:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"binary_media_types": {
@@ -176,7 +181,13 @@ func resourceRestAPICreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("policy"); ok {
-		params.Policy = aws.String(v.(string))
+		policy, err := structure.NormalizeJsonString(v.(string))
+
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+		}
+
+		params.Policy = aws.String(policy)
 	}
 
 	if len(tags) > 0 {
@@ -308,12 +319,16 @@ func resourceRestAPICreate(d *schema.ResourceData, meta interface{}) error {
 			})
 		}
 
-		if v, ok := d.GetOk("policy"); ok && v.(string) != aws.StringValue(output.Policy) {
-			updateInput.PatchOperations = append(updateInput.PatchOperations, &apigateway.PatchOperation{
-				Op:    aws.String(apigateway.OpReplace),
-				Path:  aws.String("/policy"),
-				Value: aws.String(v.(string)),
-			})
+		if v, ok := d.GetOk("policy"); ok {
+			if equivalent, err := awspolicy.PoliciesAreEquivalent(v.(string), aws.StringValue(output.Policy)); err != nil || !equivalent {
+				policy, _ := structure.NormalizeJsonString(v.(string)) // validation covers error
+
+				updateInput.PatchOperations = append(updateInput.PatchOperations, &apigateway.PatchOperation{
+					Op:    aws.String(apigateway.OpReplace),
+					Path:  aws.String("/policy"),
+					Value: aws.String(policy),
+				})
+			}
 		}
 
 		if len(updateInput.PatchOperations) > 0 {
@@ -378,11 +393,19 @@ func resourceRestAPIRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error normalizing policy JSON: %w", err)
 	}
+
 	policy, err := strconv.Unquote(normalized_policy)
 	if err != nil {
 		return fmt.Errorf("error unescaping policy: %s", err)
 	}
-	d.Set("policy", policy)
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
+	}
+
+	d.Set("policy", policyToSet)
 
 	d.Set("binary_media_types", api.BinaryMediaTypes)
 
@@ -467,10 +490,12 @@ func resourceRestAPIUpdateOperations(d *schema.ResourceData) []*apigateway.Patch
 	}
 
 	if d.HasChange("policy") {
+		policy, _ := structure.NormalizeJsonString(d.Get("policy").(string)) // validation covers error
+
 		operations = append(operations, &apigateway.PatchOperation{
 			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/policy"),
-			Value: aws.String(d.Get("policy").(string)),
+			Value: aws.String(policy),
 		})
 	}
 
@@ -675,12 +700,16 @@ func resourceRestAPIUpdate(d *schema.ResourceData, meta interface{}) error {
 				})
 			}
 
-			if v, ok := d.GetOk("policy"); ok && v.(string) != aws.StringValue(output.Policy) {
-				updateInput.PatchOperations = append(updateInput.PatchOperations, &apigateway.PatchOperation{
-					Op:    aws.String(apigateway.OpReplace),
-					Path:  aws.String("/policy"),
-					Value: aws.String(v.(string)),
-				})
+			if v, ok := d.GetOk("policy"); ok {
+				if equivalent, err := awspolicy.PoliciesAreEquivalent(v.(string), aws.StringValue(output.Policy)); err != nil || !equivalent {
+					policy, _ := structure.NormalizeJsonString(v.(string)) // validation covers error
+
+					updateInput.PatchOperations = append(updateInput.PatchOperations, &apigateway.PatchOperation{
+						Op:    aws.String(apigateway.OpReplace),
+						Path:  aws.String("/policy"),
+						Value: aws.String(policy),
+					})
+				}
 			}
 
 			if len(updateInput.PatchOperations) > 0 {

--- a/internal/service/apigateway/rest_api_policy_test.go
+++ b/internal/service/apigateway/rest_api_policy_test.go
@@ -36,9 +36,10 @@ func TestAccAPIGatewayRestAPIPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"policy"},
 			},
 			{
 				Config: testAccRestAPIPolicyUpdatedConfig(rName),
@@ -171,21 +172,17 @@ resource "aws_api_gateway_rest_api" "test" {
 resource "aws_api_gateway_rest_api_policy" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-   "Statement": [
-       {
-           "Effect": "Deny",
-           "Principal": {
-               "AWS": "*"
-           },
-           "Action": "execute-api:Invoke",
-           "Resource": "${aws_api_gateway_rest_api.test.arn}"
-       }
-   ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Deny"
+      Principal = {
+        AWS = "*"
+      }
+      Action = "execute-api:Invoke"
+      Resource = aws_api_gateway_rest_api.test.arn
+    }]
+  })
 }
 `, rName)
 }
@@ -199,26 +196,22 @@ resource "aws_api_gateway_rest_api" "test" {
 resource "aws_api_gateway_rest_api_policy" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "execute-api:Invoke",
-      "Resource": "${aws_api_gateway_rest_api.test.arn}",
-      "Condition": {
-        "IpAddress": {
-          "aws:SourceIp": "123.123.123.123/32"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        AWS = "*"
+      }
+      Action = "execute-api:Invoke"
+      Resource = aws_api_gateway_rest_api.test.arn
+      Condition = {
+        IpAddress = {
+          "aws:SourceIp" = "123.123.123.123/32"
         }
       }
-    }
-  ]
-}
-EOF
+    }]
+  })
 }
 `, rName)
 }

--- a/internal/service/apigateway/rest_api_policy_test.go
+++ b/internal/service/apigateway/rest_api_policy_test.go
@@ -179,7 +179,7 @@ resource "aws_api_gateway_rest_api_policy" "test" {
       Principal = {
         AWS = "*"
       }
-      Action = "execute-api:Invoke"
+      Action   = "execute-api:Invoke"
       Resource = aws_api_gateway_rest_api.test.arn
     }]
   })
@@ -203,7 +203,7 @@ resource "aws_api_gateway_rest_api_policy" "test" {
       Principal = {
         AWS = "*"
       }
-      Action = "execute-api:Invoke"
+      Action   = "execute-api:Invoke"
       Resource = aws_api_gateway_rest_api.test.arn
       Condition = {
         IpAddress = {

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1078,10 +1078,10 @@ func TestAccAPIGatewayRestAPI_parameters(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayRestAPI_policy(t *testing.T) {
+func TestAccAPIGatewayRestAPI_Policy_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_rest_api.test"
-	expectedPolicyText := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"execute-api:Invoke","Resource":"*","Condition":{"IpAddress":{"aws:SourceIp":"123.123.123.123/32"}}}]}`
-	expectedUpdatePolicyText := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":{"AWS":"*"},"Action":"execute-api:Invoke","Resource":"*"}]}`
+	expectedPolicyText := `{"Statement":[{"Action":"execute-api:Invoke","Condition":{"IpAddress":{"aws:SourceIp":"123.123.123.123/32"}},"Effect":"Allow","Principal":{"AWS":"*"},"Resource":"*"}],"Version":"2012-10-17"}`
+	expectedUpdatePolicyText := `{"Statement":[{"Action":"execute-api:Invoke","Effect":"Deny","Principal":{"AWS":"*"},"Resource":"*"}],"Version":"2012-10-17"}`
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1097,15 +1097,41 @@ func TestAccAPIGatewayRestAPI_policy(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"policy"},
 			},
 			{
 				Config: testAccRestAPIUpdatePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "policy", expectedUpdatePolicyText),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayRestAPI_Policy_order(t *testing.T) {
+	resourceName := "aws_api_gateway_rest_api.test"
+	expectedPolicyText := `{"Statement":[{"Action":"execute-api:Invoke","Condition":{"IpAddress":{"aws:SourceIp":["123.123.123.123/32","122.122.122.122/32","169.254.169.253/32"]}},"Effect":"Allow","Principal":{"AWS":"*"},"Resource":"*"}],"Version":"2012-10-17"}`
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apigateway.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckRestAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRestAPIWithPolicyOrderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "policy", expectedPolicyText),
+				),
+			},
+			{
+				Config:   testAccRestAPIWithPolicyNewOrderConfig(rName),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -1134,7 +1160,7 @@ func TestAccAPIGatewayRestAPI_Policy_overrideBody(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"body"},
+				ImportStateVerifyIgnore: []string{"body", "policy"},
 			},
 			// Verify updated body still has override policy
 			{
@@ -1689,26 +1715,22 @@ func testAccRestAPIWithPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name   = %[1]q
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "execute-api:Invoke",
-      "Resource": "*",
-      "Condition": {
-        "IpAddress": {
-          "aws:SourceIp": "123.123.123.123/32"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "execute-api:Invoke"
+      Condition = {
+        IpAddress = {
+          "aws:SourceIp" = "123.123.123.123/32"
         }
       }
-    }
-  ]
-}
-EOF
+      Effect = "Allow"
+      Principal = {
+        AWS = "*"
+      }
+      Resource = "*"
+    }]
+  })
 }
 `, rName)
 }
@@ -1717,21 +1739,73 @@ func testAccRestAPIUpdatePolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name   = %[1]q
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Deny",
-            "Principal": {
-                "AWS": "*"
-            },
-            "Action": "execute-api:Invoke",
-            "Resource": "*"
-        }
-    ]
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "execute-api:Invoke"
+      Effect = "Deny"
+      Principal = {
+        AWS = "*"
+      }
+      Resource = "*"
+    }]
+  })
 }
-EOF
+`, rName)
+}
+
+func testAccRestAPIWithPolicyOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name   = %[1]q
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "execute-api:Invoke"
+      Condition = {
+        IpAddress = {
+          "aws:SourceIp" = [
+            "123.123.123.123/32",
+            "122.122.122.122/32",
+            "169.254.169.253/32",
+          ]
+        }
+      }
+      Effect = "Allow"
+      Principal = {
+        AWS = "*"
+      }
+      Resource = "*"
+    }]
+  })
+}
+`, rName)
+}
+
+func testAccRestAPIWithPolicyNewOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name   = %[1]q
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "execute-api:Invoke"
+      Condition = {
+        IpAddress = {
+          "aws:SourceIp" = [
+            "122.122.122.122/32",
+            "169.254.169.253/32",
+            "123.123.123.123/32",
+          ]
+        }
+      }
+      Effect = "Allow"
+      Principal = {
+        AWS = "*"
+      }
+      Resource = "*"
+    }]
+  })
 }
 `, rName)
 }

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1714,7 +1714,7 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccRestAPIWithPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name   = %[1]q
+  name = %[1]q
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -1738,7 +1738,7 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccRestAPIUpdatePolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name   = %[1]q
+  name = %[1]q
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -1757,7 +1757,7 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccRestAPIWithPolicyOrderConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name   = %[1]q
+  name = %[1]q
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -1785,7 +1785,7 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccRestAPIWithPolicyNewOrderConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name   = %[1]q
+  name = %[1]q
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968

Output from acceptance testing:

```console
% make testacc TESTS=TestAccAPIGatewayRestAPI PKG=apigateway
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI' -timeout 180m
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_private (21.93s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByBody (25.58s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_order (28.93s)
--- PASS: TestAccAPIGatewayRestAPI_description (66.02s)
--- PASS: TestAccAPIGatewayRestAPI_parameters (66.06s)
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody (131.60s)
--- PASS: TestAccAPIGatewayRestAPI_binaryMediaTypes (77.84s)
--- PASS: TestAccAPIGatewayRestAPI_tags (46.19s)
--- PASS: TestAccAPIGatewayRestAPI_body (208.29s)
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody (247.34s)
--- PASS: TestAccAPIGatewayRestAPI_minimumCompressionSize (34.38s)
--- PASS: TestAccAPIGatewayRestAPIPolicy_basic (40.33s)
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody (314.79s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody (169.37s)
--- PASS: TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI (38.16s)
--- PASS: TestAccAPIGatewayRestAPI_Description_setByBody (391.68s)
--- PASS: TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint (439.05s)
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs (447.69s)
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_overrideBody (449.90s)
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody (483.83s)
--- PASS: TestAccAPIGatewayRestAPIPolicy_disappears (189.19s)
--- PASS: TestAccAPIGatewayRestAPIDataSource_Endpoint_vpcEndpointIDs (230.71s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody (294.39s)
--- PASS: TestAccAPIGatewayRestAPI_endpoint (489.47s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_basic (641.53s)
--- PASS: TestAccAPIGatewayRestAPI_Description_overrideBody (706.69s)
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody (742.88s)
--- PASS: TestAccAPIGatewayRestAPI_Name_overrideBody (746.04s)
--- PASS: TestAccAPIGatewayRestAPI_apiKeySource (838.47s)
--- PASS: TestAccAPIGatewayRestAPI_basic (824.98s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_overrideBody (911.47s)
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_setByBody (879.86s)
--- PASS: TestAccAPIGatewayRestAPI_disappears (755.87s)
--- PASS: TestAccAPIGatewayRestAPIDataSource_basic (1073.47s)
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody (1112.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	1114.104s
```
