### PR TITLE
r/aws_apigatewayv2_integration: Use `nodejs14.x` Lambda runtime

### DIFF
--- a/internal/service/apigatewayv2/integration_test.go
+++ b/internal/service/apigatewayv2/integration_test.go
@@ -731,7 +731,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "index.handler"
-  runtime       = "nodejs10.x"
+  runtime       = "nodejs14.x"
 
   depends_on = [aws_iam_role_policy.test]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21752.

CI failures:

```
=== RUN   TestAccAPIGatewayV2Integration_lambdaWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_lambdaWebSocket
=== CONT  TestAccAPIGatewayV2Integration_lambdaWebSocket
integration_test.go:307: Step 1/2 error: Error running apply: exit status 1
Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.
{
RespMetadata: {
StatusCode: 400,
RequestID: "cd63f6bc-2e4d-4d30-ae3e-d86afdc406c2"
},
Message_: "The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.",
Type: "User"
}
with aws_lambda_function.test,
on terraform_plugin_test.tf line 42, in resource "aws_lambda_function" "test":
42: resource "aws_lambda_function" "test" {
--- FAIL: TestAccAPIGatewayV2Integration_lambdaWebSocket (50.10s)
=== RUN   TestAccAPIGatewayV2Integration_lambdaHTTP
=== PAUSE TestAccAPIGatewayV2Integration_lambdaHTTP
=== CONT  TestAccAPIGatewayV2Integration_lambdaHTTP
integration_test.go:353: Step 1/2 error: Error running apply: exit status 1
Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.
{
RespMetadata: {
StatusCode: 400,
RequestID: "2e1525dd-bdc2-433c-b031-fc733cfa29cd"
},
Message_: "The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.",
Type: "User"
}
with aws_lambda_function.test,
on terraform_plugin_test.tf line 41, in resource "aws_lambda_function" "test":
41: resource "aws_lambda_function" "test" {
--- FAIL: TestAccAPIGatewayV2Integration_lambdaHTTP (48.29s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccAPIGatewayV2Integration_ PKG=apigatewayv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2Integration_' -timeout 180m
=== RUN   TestAccAPIGatewayV2Integration_basicWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_basicWebSocket
=== RUN   TestAccAPIGatewayV2Integration_basicHTTP
=== PAUSE TestAccAPIGatewayV2Integration_basicHTTP
=== RUN   TestAccAPIGatewayV2Integration_disappears
=== PAUSE TestAccAPIGatewayV2Integration_disappears
=== RUN   TestAccAPIGatewayV2Integration_dataMappingHTTP
=== PAUSE TestAccAPIGatewayV2Integration_dataMappingHTTP
=== RUN   TestAccAPIGatewayV2Integration_integrationTypeHTTP
=== PAUSE TestAccAPIGatewayV2Integration_integrationTypeHTTP
=== RUN   TestAccAPIGatewayV2Integration_lambdaWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_lambdaWebSocket
=== RUN   TestAccAPIGatewayV2Integration_lambdaHTTP
=== PAUSE TestAccAPIGatewayV2Integration_lambdaHTTP
=== RUN   TestAccAPIGatewayV2Integration_vpcLinkWebSocket
=== PAUSE TestAccAPIGatewayV2Integration_vpcLinkWebSocket
=== RUN   TestAccAPIGatewayV2Integration_vpcLinkHTTP
=== PAUSE TestAccAPIGatewayV2Integration_vpcLinkHTTP
=== RUN   TestAccAPIGatewayV2Integration_awsServiceIntegration
=== PAUSE TestAccAPIGatewayV2Integration_awsServiceIntegration
=== CONT  TestAccAPIGatewayV2Integration_basicWebSocket
=== CONT  TestAccAPIGatewayV2Integration_vpcLinkWebSocket
=== CONT  TestAccAPIGatewayV2Integration_integrationTypeHTTP
=== CONT  TestAccAPIGatewayV2Integration_basicHTTP
=== CONT  TestAccAPIGatewayV2Integration_lambdaHTTP
=== CONT  TestAccAPIGatewayV2Integration_awsServiceIntegration
=== CONT  TestAccAPIGatewayV2Integration_vpcLinkHTTP
=== CONT  TestAccAPIGatewayV2Integration_disappears
=== CONT  TestAccAPIGatewayV2Integration_dataMappingHTTP
=== CONT  TestAccAPIGatewayV2Integration_lambdaWebSocket
--- PASS: TestAccAPIGatewayV2Integration_disappears (27.72s)
--- PASS: TestAccAPIGatewayV2Integration_basicWebSocket (31.67s)
--- PASS: TestAccAPIGatewayV2Integration_basicHTTP (31.73s)
--- PASS: TestAccAPIGatewayV2Integration_dataMappingHTTP (43.72s)
--- PASS: TestAccAPIGatewayV2Integration_integrationTypeHTTP (44.23s)
--- PASS: TestAccAPIGatewayV2Integration_awsServiceIntegration (52.53s)
--- PASS: TestAccAPIGatewayV2Integration_lambdaWebSocket (60.09s)
--- PASS: TestAccAPIGatewayV2Integration_lambdaHTTP (77.39s)
--- PASS: TestAccAPIGatewayV2Integration_vpcLinkHTTP (316.25s)
--- PASS: TestAccAPIGatewayV2Integration_vpcLinkWebSocket (722.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	727.085s
```
