### PR TITLE
tests/d/aws_ecs_cluster: Fix 'Attribute "setting.#" not set, but "setting.#" is set in aws_ecs_cluster.test as "1"'

### DIFF
--- a/.changelog/22119.txt
+++ b/.changelog/22119.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ecs_cluster: Ensure that `setting` attribute is set consistently
+```

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -242,7 +242,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	var out *ecs.DescribeClustersOutput
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
-		out, err = FindClusterByARN(conn, d.Id())
+		out, err = FindClusterByNameOrARN(conn, d.Id())
 
 		if err != nil {
 			return resource.NonRetryableError(err)
@@ -258,7 +258,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 	if tfresource.TimedOut(err) {
-		out, err = FindClusterByARN(conn, d.Id())
+		out, err = FindClusterByNameOrARN(conn, d.Id())
 	}
 
 	if tfresource.NotFound(err) {

--- a/internal/service/ecs/cluster_test.go
+++ b/internal/service/ecs/cluster_test.go
@@ -345,7 +345,7 @@ func testAccCheckClusterDestroy(s *terraform.State) error {
 			continue
 		}
 
-		out, err := tfecs.FindClusterByARN(conn, rs.Primary.ID)
+		out, err := tfecs.FindClusterByNameOrARN(conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -369,7 +369,7 @@ func testAccCheckClusterExists(resourceName string, cluster *ecs.Cluster) resour
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECSConn
-		output, err := tfecs.FindClusterByARN(conn, rs.Primary.ID)
+		output, err := tfecs.FindClusterByNameOrARN(conn, rs.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("error reading ECS Cluster (%s): %w", rs.Primary.ID, err)

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider, error) {
@@ -37,14 +38,10 @@ func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider
 	return capacityProvider, nil
 }
 
-func FindClusterByARN(conn *ecs.ECS, arn string) (*ecs.DescribeClustersOutput, error) {
+func FindClusterByNameOrARN(conn *ecs.ECS, nameOrARN string) (*ecs.DescribeClustersOutput, error) {
 	input := &ecs.DescribeClustersInput{
-		Clusters: []*string{aws.String(arn)},
-		Include: []*string{
-			aws.String(ecs.ClusterFieldTags),
-			aws.String(ecs.ClusterFieldConfigurations),
-			aws.String(ecs.ClusterFieldSettings),
-		},
+		Clusters: aws.StringSlice([]string{nameOrARN}),
+		Include:  aws.StringSlice([]string{ecs.ClusterFieldTags, ecs.ClusterFieldConfigurations, ecs.ClusterFieldSettings}),
 	}
 
 	output, err := conn.DescribeClusters(input)
@@ -57,10 +54,7 @@ func FindClusterByARN(conn *ecs.ECS, arn string) (*ecs.DescribeClustersOutput, e
 	}
 
 	if output == nil {
-		return nil, &resource.NotFoundError{
-			Message:     "Empty result",
-			LastRequest: input,
-		}
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/internal/service/ecs/status.go
+++ b/internal/service/ecs/status.go
@@ -87,7 +87,7 @@ func statusService(conn *ecs.ECS, id, cluster string) resource.StateRefreshFunc 
 
 func statusCluster(conn *ecs.ECS, arn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindClusterByARN(conn, arn)
+		output, err := FindClusterByNameOrARN(conn, arn)
 
 		if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException) {
 			return nil, clusterStatusNone, nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20720.

Continual CI failure:

```
=== RUN   TestAccECSClusterDataSource_ecsClusterContainerInsights
=== PAUSE TestAccECSClusterDataSource_ecsClusterContainerInsights
=== CONT  TestAccECSClusterDataSource_ecsClusterContainerInsights
cluster_data_source_test.go:42: Step 1/1 error: Check failed: Check 6/6 error: data.aws_ecs_cluster.test: Attribute "setting.#" not set, but "setting.#" is set in aws_ecs_cluster.test as "1"
--- FAIL: TestAccECSClusterDataSource_ecsClusterContainerInsights (48.24s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTARGS='-run=TestAccECSCluster_\|TestAccECSClusterDataSource_' PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run=TestAccECSCluster_\|TestAccECSClusterDataSource_ -timeout 180m
=== RUN   TestAccECSClusterDataSource_ecsCluster
=== PAUSE TestAccECSClusterDataSource_ecsCluster
=== RUN   TestAccECSClusterDataSource_ecsClusterContainerInsights
=== PAUSE TestAccECSClusterDataSource_ecsClusterContainerInsights
=== RUN   TestAccECSCluster_basic
=== PAUSE TestAccECSCluster_basic
=== RUN   TestAccECSCluster_disappears
=== PAUSE TestAccECSCluster_disappears
=== RUN   TestAccECSCluster_tags
=== PAUSE TestAccECSCluster_tags
=== RUN   TestAccECSCluster_singleCapacityProvider
=== PAUSE TestAccECSCluster_singleCapacityProvider
=== RUN   TestAccECSCluster_capacityProviders
=== PAUSE TestAccECSCluster_capacityProviders
=== RUN   TestAccECSCluster_capacityProvidersUpdate
=== PAUSE TestAccECSCluster_capacityProvidersUpdate
=== RUN   TestAccECSCluster_capacityProvidersNoStrategy
=== PAUSE TestAccECSCluster_capacityProvidersNoStrategy
=== RUN   TestAccECSCluster_containerInsights
=== PAUSE TestAccECSCluster_containerInsights
=== RUN   TestAccECSCluster_configuration
=== PAUSE TestAccECSCluster_configuration
=== CONT  TestAccECSClusterDataSource_ecsCluster
=== CONT  TestAccECSCluster_capacityProviders
=== CONT  TestAccECSCluster_basic
=== CONT  TestAccECSClusterDataSource_ecsClusterContainerInsights
=== CONT  TestAccECSCluster_disappears
=== CONT  TestAccECSCluster_singleCapacityProvider
=== CONT  TestAccECSCluster_tags
=== CONT  TestAccECSCluster_containerInsights
=== CONT  TestAccECSCluster_configuration
=== CONT  TestAccECSCluster_capacityProvidersNoStrategy
=== CONT  TestAccECSCluster_capacityProvidersUpdate
--- PASS: TestAccECSCluster_disappears (47.24s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (53.84s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (53.88s)
--- PASS: TestAccECSCluster_basic (58.87s)
--- PASS: TestAccECSCluster_capacityProviders (84.36s)
--- PASS: TestAccECSCluster_configuration (92.13s)
--- PASS: TestAccECSCluster_tags (92.62s)
--- PASS: TestAccECSCluster_singleCapacityProvider (99.12s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (102.96s)
--- PASS: TestAccECSCluster_containerInsights (110.08s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (114.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	121.405s
```
