### PR TITLE
test/lambda: Fix TestAccLambdaFunction_runtimes

### DIFF
--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -1963,6 +1963,8 @@ func TestAccLambdaFunction_runtimes(t *testing.T) {
 			fallthrough
 		case lambda.RuntimeDotnetcore10:
 			fallthrough
+		case lambda.RuntimeNodejs10X:
+			fallthrough
 		case lambda.RuntimeNodejs810:
 			fallthrough
 		case lambda.RuntimeNodejs610:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #21752.
Relates #22118.

Continual CI failure:

```
=== RUN   TestAccLambdaFunction_runtimes
=== PAUSE TestAccLambdaFunction_runtimes
=== CONT  TestAccLambdaFunction_runtimes
function_test.go:1991: Step 2/20 error: Error running apply: exit status 1
Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.
{
RespMetadata: {
StatusCode: 400,
RequestID: "8d67262f-27b9-496a-a274-8bbf2b928b76"
},
Message_: "The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions.",
Type: "User"
}
with aws_lambda_function.test,
on terraform_plugin_test.tf line 134, in resource "aws_lambda_function" "test":
134: resource "aws_lambda_function" "test" {
--- FAIL: TestAccLambdaFunction_runtimes (37.32s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccLambdaFunction_runtimes PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_runtimes' -timeout 180m
=== RUN   TestAccLambdaFunction_runtimes
=== PAUSE TestAccLambdaFunction_runtimes
=== CONT  TestAccLambdaFunction_runtimes
--- PASS: TestAccLambdaFunction_runtimes (490.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	493.932s
```
