### PR TITLE
logs/resource_policy: Fix equivalent policy diffs

### DIFF
--- a/.changelog/22135.txt
+++ b/.changelog/22135.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_resource_policy: Fix erroneous diffs in `policy_document` when no changes made or policies are equivalent
+```

--- a/internal/service/cloudwatchlogs/resource_policy_test.go
+++ b/internal/service/cloudwatchlogs/resource_policy_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccCloudWatchLogsResourcePolicy_basic(t *testing.T) {
-	name := sdkacctest.RandString(5)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_resource_policy.test"
 	var resourcePolicy cloudwatchlogs.ResourcePolicy
 
@@ -22,14 +22,14 @@ func TestAccCloudWatchLogsResourcePolicy_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, cloudwatchlogs.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckCloudWatchLogResourcePolicyDestroy,
+		CheckDestroy: testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourcePolicyResourceBasic1Config(name),
+				Config: testAccCheckResourcePolicyResourceBasic1Config(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
-					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
-					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\"}]}", acctest.PartitionDNSSuffix(), acctest.Partition())),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
 			},
 			{
@@ -38,11 +38,42 @@ func TestAccCloudWatchLogsResourcePolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckResourcePolicyResourceBasic2Config(name),
+				Config: testAccCheckResourcePolicyResourceBasic2Config(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
-					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
-					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"}]}", acctest.PartitionDNSSuffix(), acctest.Partition())),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\",\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudWatchLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_log_resource_policy.test"
+	var resourcePolicy cloudwatchlogs.ResourcePolicy
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloudwatchlogs.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckResourcePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourcePolicyResourceOrderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"rds.%s\"]},\"Resource\":[\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"]}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
+				),
+			},
+			{
+				Config: testAccCheckResourcePolicyResourceNewOrderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"rds.%s\"]},\"Resource\":[\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"]}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
 			},
 		},
@@ -75,7 +106,7 @@ func testAccCheckCloudWatchLogResourcePolicy(pr string, resourcePolicy *cloudwat
 	}
 }
 
-func testAccCheckCloudWatchLogResourcePolicyDestroy(s *terraform.State) error {
+func testAccCheckResourcePolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchLogsConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -97,7 +128,7 @@ func testAccCheckCloudWatchLogResourcePolicyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourcePolicyResourceBasic1Config(name string) string {
+func testAccCheckResourcePolicyResourceBasic1Config(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -118,13 +149,13 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "test" {
-  policy_name     = "%s"
+  policy_name     = %[1]q
   policy_document = data.aws_iam_policy_document.test.json
 }
-`, name)
+`, rName)
 }
 
-func testAccCheckResourcePolicyResourceBasic2Config(name string) string {
+func testAccCheckResourcePolicyResourceBasic2Config(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -145,8 +176,64 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "test" {
-  policy_name     = "%s"
+  policy_name     = %[1]q
   policy_document = data.aws_iam_policy_document.test.json
 }
-`, name)
+`, rName)
+}
+
+func testAccCheckResourcePolicyResourceOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_cloudwatch_log_resource_policy" "test" {
+  policy_name     = %[1]q
+  policy_document = jsonencode({
+    Statement = [{
+      Action = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ]
+      Effect = "Allow"
+      Resource = [
+        "arn:${data.aws_partition.current.partition}:logs:*:*:log-group:/aws/rds/example.com",
+      ]
+      Principal = {
+        Service = [
+          "rds.${data.aws_partition.current.dns_suffix}",
+        ]
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+`, rName)
+}
+
+func testAccCheckResourcePolicyResourceNewOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_cloudwatch_log_resource_policy" "test" {
+  policy_name     = %[1]q
+  policy_document = jsonencode({
+    Statement = [{
+      Action = [
+        "logs:PutLogEvents",
+        "logs:CreateLogStream",
+      ]
+      Effect = "Allow"
+      Resource = [
+        "arn:${data.aws_partition.current.partition}:logs:*:*:log-group:/aws/rds/example.com",
+      ]
+      Principal = {
+        Service = [
+          "rds.${data.aws_partition.current.dns_suffix}",
+        ]
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+`, rName)
 }

--- a/internal/service/cloudwatchlogs/resource_policy_test.go
+++ b/internal/service/cloudwatchlogs/resource_policy_test.go
@@ -187,7 +187,7 @@ func testAccCheckResourcePolicyResourceOrderConfig(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_cloudwatch_log_resource_policy" "test" {
-  policy_name     = %[1]q
+  policy_name = %[1]q
   policy_document = jsonencode({
     Statement = [{
       Action = [
@@ -215,7 +215,7 @@ func testAccCheckResourcePolicyResourceNewOrderConfig(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_cloudwatch_log_resource_policy" "test" {
-  policy_name     = %[1]q
+  policy_name = %[1]q
   policy_document = jsonencode({
     Statement = [{
       Action = [


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968 

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccCloudWatchLogsResourcePolicy_ PKG=cloudwatchlogs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatchlogs/... -v -count 1 -parallel 20 -run='TestAccCloudWatchLogsResourcePolicy_' -timeout 180m
--- PASS: TestAccCloudWatchLogsResourcePolicy_ignoreEquivalent (22.26s)
--- PASS: TestAccCloudWatchLogsResourcePolicy_basic (25.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs	27.496s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccCloudWatchLogsResourcePolicy_ PKG=cloudwatchlogs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatchlogs/... -v -count 1 -parallel 20 -run='TestAccCloudWatchLogsResourcePolicy_' -timeout 180m
--- PASS: TestAccCloudWatchLogsResourcePolicy_ignoreEquivalent (28.89s)
--- PASS: TestAccCloudWatchLogsResourcePolicy_basic (33.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs	35.107s
```