### PR TITLE
ec2/vpc_endpoint: Fix erroneous diffs with equivalent policies

### DIFF
--- a/.changelog/22137.txt
+++ b/.changelog/22137.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -182,6 +182,31 @@ func TestAccEC2VPCEndpoint_gatewayPolicy(t *testing.T) {
 	})
 }
 
+func TestAccEC2VPCEndpoint_ignoreEquivalent(t *testing.T) {
+	var endpoint ec2.VpcEndpoint
+	resourceName := "aws_vpc_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVpcEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEndpointOrderPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointExists(resourceName, &endpoint),
+				),
+			},
+			{
+				Config:   testAccVpcEndpointNewOrderPolicyConfig(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccEC2VPCEndpoint_interfaceBasic(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
@@ -1006,4 +1031,82 @@ resource "aws_vpc_endpoint" "test" {
   }
 }
 `, rName))
+}
+
+func testAccVpcEndpointOrderPolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_vpc_endpoint_service" "test" {
+  service = "dynamodb"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "ReadOnly"
+      Principal = "*"
+      Action = [
+        "dynamodb:DescribeTable",
+        "dynamodb:ListTables",
+        "dynamodb:ListTagsOfResource",
+      ]
+      Effect   = "Allow"
+      Resource = "*"
+    }]
+  })
+  service_name = data.aws_vpc_endpoint_service.test.service_name
+  vpc_id       = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccVpcEndpointNewOrderPolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_vpc_endpoint_service" "test" {
+  service = "dynamodb"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "ReadOnly"
+      Principal = "*"
+      Action = [
+        "dynamodb:ListTables",
+        "dynamodb:ListTagsOfResource",
+        "dynamodb:DescribeTable",
+      ]
+      Effect   = "Allow"
+      Resource = "*"
+    }]
+  })
+  service_name = data.aws_vpc_endpoint_service.test.service_name
+  vpc_id       = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccEC2VPCEndpoint_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2VPCEndpoint_' -timeout 180m
--- PASS: TestAccEC2VPCEndpoint_disappears (36.26s)
--- PASS: TestAccEC2VPCEndpoint_gatewayBasic (40.61s)
--- PASS: TestAccEC2VPCEndpoint_ignoreEquivalent (54.81s)
--- PASS: TestAccEC2VPCEndpoint_gatewayPolicy (68.12s)
--- PASS: TestAccEC2VPCEndpoint_tags (80.34s)
--- PASS: TestAccEC2VPCEndpoint_gatewayWithRouteTableAndPolicy (80.82s)
--- PASS: TestAccEC2VPCEndpoint_interfaceBasic (88.38s)
--- PASS: TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnCreate (277.97s)
--- PASS: TestAccEC2VPCEndpoint_VPCEndpointType_gatewayLoadBalancer (306.22s)
--- PASS: TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate (313.55s)
--- PASS: TestAccEC2VPCEndpoint_interfaceWithSubnetAndSecurityGroup (413.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	415.290s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccEC2VPCEndpoint_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2VPCEndpoint_' -timeout 180m
--- PASS: TestAccEC2VPCEndpoint_disappears (36.49s)
--- PASS: TestAccEC2VPCEndpoint_gatewayBasic (40.11s)
--- PASS: TestAccEC2VPCEndpoint_ignoreEquivalent (57.82s)
--- PASS: TestAccEC2VPCEndpoint_gatewayPolicy (70.88s)
--- PASS: TestAccEC2VPCEndpoint_interfaceBasic (73.45s)
--- PASS: TestAccEC2VPCEndpoint_gatewayWithRouteTableAndPolicy (78.59s)
--- PASS: TestAccEC2VPCEndpoint_tags (79.94s)
--- PASS: TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate (292.86s)
--- PASS: TestAccEC2VPCEndpoint_interfaceNonAWSServiceAcceptOnCreate (297.68s)
--- PASS: TestAccEC2VPCEndpoint_VPCEndpointType_gatewayLoadBalancer (320.04s)
--- PASS: TestAccEC2VPCEndpoint_interfaceWithSubnetAndSecurityGroup (349.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	351.217s
```