### PR TITLE
ecr/lifecycle_policy: Fix diffs when policy equivalent

### DIFF
--- a/.changelog/22142.txt
+++ b/.changelog/22142.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecr_lifecycle_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/ecr/lifecycle_policy.go
+++ b/internal/service/ecr/lifecycle_policy.go
@@ -1,18 +1,23 @@
 package ecr
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceLifecyclePolicy() *schema.Resource {
@@ -32,11 +37,19 @@ func ResourceLifecyclePolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsJSON,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					equal, _ := equivalentLifecyclePolicyJSON(old, new)
+
+					return equal
+				},
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"registry_id": {
 				Type:     schema.TypeString,
@@ -49,9 +62,15 @@ func ResourceLifecyclePolicy() *schema.Resource {
 func resourceLifecyclePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ECRConn
 
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
+
 	input := &ecr.PutLifecyclePolicyInput{
 		RepositoryName:      aws.String(d.Get("repository").(string)),
-		LifecyclePolicyText: aws.String(d.Get("policy").(string)),
+		LifecyclePolicyText: aws.String(policy),
 	}
 
 	resp, err := conn.PutLifecyclePolicy(input)
@@ -118,7 +137,22 @@ func resourceLifecyclePolicyRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("repository", resp.RepositoryName)
 	d.Set("registry_id", resp.RegistryId)
-	d.Set("policy", resp.LifecyclePolicyText)
+
+	equivalent, err := equivalentLifecyclePolicyJSON(d.Get("policy").(string), aws.StringValue(resp.LifecyclePolicyText))
+
+	if err != nil {
+		return fmt.Errorf("while comparing policy (state: %s) (from AWS: %s), encountered: %w", d.Get("policy").(string), aws.StringValue(resp.LifecyclePolicyText), err)
+	}
+
+	if !equivalent {
+		policyToSet, err := structure.NormalizeJsonString(aws.StringValue(resp.LifecyclePolicyText))
+
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", policyToSet, err)
+		}
+
+		d.Set("policy", policyToSet)
+	}
 
 	return nil
 }
@@ -142,4 +176,95 @@ func resourceLifecyclePolicyDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return nil
+}
+
+type lifecyclePolicyRuleSelection struct {
+	TagStatus     *string   `locationName:"tagStatus" type:"string" enum:"tagStatus" required:"true"`
+	TagPrefixList []*string `locationName:"tagPrefixList" type:"list"`
+	CountType     *string   `locationName:"countType" type:"string" enum:"countType" required:"true"`
+	CountUnit     *string   `locationName:"countUnit" type:"string" enum:"countType"`
+	CountNumber   *int64    `locationName:"countNumber" min:"1" type:"integer"`
+}
+
+type lifecyclePolicyRuleAction struct {
+	ActionType *string `locationName:"type" type:"string" required:"true"`
+}
+
+type lifecyclePolicyRule struct {
+	RulePriority *int64                        `locationName:"countNumber" type:"integer" required:"true"`
+	Description  *string                       `locationName:"description" type:"string"`
+	Selection    *lifecyclePolicyRuleSelection `location:"selection" type:"structure" required:"true"`
+	Action       *lifecyclePolicyRuleAction    `location:"action" type:"structure" required:"true"`
+}
+
+type lifecyclePolicy struct {
+	Rules []*lifecyclePolicyRule `locationName:"rules" min:"1" type:"list" required:"true"`
+}
+
+func (lp *lifecyclePolicy) reduce() error {
+	sort.Slice(lp.Rules, func(i, j int) bool {
+		return aws.Int64Value(lp.Rules[i].RulePriority) < aws.Int64Value(lp.Rules[j].RulePriority)
+	})
+
+	for _, rule := range lp.Rules {
+		_ = rule.Selection.reduce()
+	}
+
+	return nil
+}
+
+func (lprs *lifecyclePolicyRuleSelection) reduce() error {
+	sort.Slice(lprs.TagPrefixList, func(i, j int) bool {
+		return aws.StringValue(lprs.TagPrefixList[i]) < aws.StringValue(lprs.TagPrefixList[j])
+	})
+
+	if len(lprs.TagPrefixList) == 0 {
+		lprs.TagPrefixList = nil
+	}
+
+	return nil
+}
+
+func equivalentLifecyclePolicyJSON(str1, str2 string) (bool, error) {
+	if strings.TrimSpace(str1) == "" {
+		str1 = "{}"
+	}
+
+	if strings.TrimSpace(str2) == "" {
+		str2 = "{}"
+	}
+
+	var lp1, lp2 lifecyclePolicy
+
+	if err := json.Unmarshal([]byte(str1), &lp1); err != nil {
+		return false, err
+	}
+
+	_ = lp1.reduce()
+
+	canonicalJSON1, err := jsonutil.BuildJSON(lp1)
+
+	if err != nil {
+		return false, err
+	}
+
+	if err := json.Unmarshal([]byte(str2), &lp2); err != nil {
+		return false, err
+	}
+
+	_ = lp2.reduce()
+
+	canonicalJSON2, err := jsonutil.BuildJSON(lp2)
+
+	if err != nil {
+		return false, err
+	}
+
+	equal := bytes.Equal(canonicalJSON1, canonicalJSON2)
+
+	if !equal {
+		log.Printf("[DEBUG] Canonical Lifecycle Policy JSONs are not equal.\nFirst: %s\nSecond: %s\n", canonicalJSON1, canonicalJSON2)
+	}
+
+	return equal, nil
 }

--- a/internal/service/ecr/lifecycle_policy.go
+++ b/internal/service/ecr/lifecycle_policy.go
@@ -201,19 +201,17 @@ type lifecyclePolicy struct {
 	Rules []*lifecyclePolicyRule `locationName:"rules" min:"1" type:"list" required:"true"`
 }
 
-func (lp *lifecyclePolicy) reduce() error {
+func (lp *lifecyclePolicy) reduce() {
 	sort.Slice(lp.Rules, func(i, j int) bool {
 		return aws.Int64Value(lp.Rules[i].RulePriority) < aws.Int64Value(lp.Rules[j].RulePriority)
 	})
 
 	for _, rule := range lp.Rules {
-		_ = rule.Selection.reduce()
+		rule.Selection.reduce()
 	}
-
-	return nil
 }
 
-func (lprs *lifecyclePolicyRuleSelection) reduce() error {
+func (lprs *lifecyclePolicyRuleSelection) reduce() {
 	sort.Slice(lprs.TagPrefixList, func(i, j int) bool {
 		return aws.StringValue(lprs.TagPrefixList[i]) < aws.StringValue(lprs.TagPrefixList[j])
 	})
@@ -221,8 +219,6 @@ func (lprs *lifecyclePolicyRuleSelection) reduce() error {
 	if len(lprs.TagPrefixList) == 0 {
 		lprs.TagPrefixList = nil
 	}
-
-	return nil
 }
 
 func equivalentLifecyclePolicyJSON(str1, str2 string) (bool, error) {
@@ -240,7 +236,7 @@ func equivalentLifecyclePolicyJSON(str1, str2 string) (bool, error) {
 		return false, err
 	}
 
-	_ = lp1.reduce()
+	lp1.reduce()
 
 	canonicalJSON1, err := jsonutil.BuildJSON(lp1)
 
@@ -252,7 +248,7 @@ func equivalentLifecyclePolicyJSON(str1, str2 string) (bool, error) {
 		return false, err
 	}
 
-	_ = lp2.reduce()
+	lp2.reduce()
 
 	canonicalJSON2, err := jsonutil.BuildJSON(lp2)
 

--- a/internal/service/ecr/lifecycle_policy_test.go
+++ b/internal/service/ecr/lifecycle_policy_test.go
@@ -40,6 +40,30 @@ func TestAccECRLifecyclePolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccECRLifecyclePolicy_ignoreEquivalent(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecr_lifecycle_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLifecyclePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcrLifecyclePolicyOrderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLifecyclePolicyExists(resourceName),
+				),
+			},
+			{
+				Config:   testAccEcrLifecyclePolicyNewOrderConfig(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckLifecyclePolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn
 
@@ -113,6 +137,102 @@ resource "aws_ecr_lifecycle_policy" "test" {
   ]
 }
 EOF
+}
+`, rName)
+}
+
+func testAccEcrLifecyclePolicyOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = "%s"
+}
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  repository = aws_ecr_repository.test.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire images older than 14 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description = "Expire tagged images older than 14 days"
+        selection = {
+          tagStatus = "tagged"
+          tagPrefixList = [
+            "first",
+            "second",
+            "third",
+          ]
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      },
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccEcrLifecyclePolicyNewOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = "%s"
+}
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  repository = aws_ecr_repository.test.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 2
+        description = "Expire tagged images older than 14 days"
+        selection = {
+          tagStatus = "tagged"
+          tagPrefixList = [
+            "third",
+            "first",
+            "second",
+          ]
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 1
+        description  = "Expire images older than 14 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      },
+    ]
+  })
 }
 `, rName)
 }

--- a/internal/service/ecr/lifecycle_policy_test.go
+++ b/internal/service/ecr/lifecycle_policy_test.go
@@ -144,7 +144,7 @@ EOF
 func testAccEcrLifecyclePolicyOrderConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_repository" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_ecr_lifecycle_policy" "test" {
@@ -167,7 +167,7 @@ resource "aws_ecr_lifecycle_policy" "test" {
       },
       {
         rulePriority = 2
-        description = "Expire tagged images older than 14 days"
+        description  = "Expire tagged images older than 14 days"
         selection = {
           tagStatus = "tagged"
           tagPrefixList = [
@@ -202,7 +202,7 @@ resource "aws_ecr_lifecycle_policy" "test" {
     rules = [
       {
         rulePriority = 2
-        description = "Expire tagged images older than 14 days"
+        description  = "Expire tagged images older than 14 days"
         selection = {
           tagStatus = "tagged"
           tagPrefixList = [


### PR DESCRIPTION
 <!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968
Relates #22004

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccECRLifecyclePolicy_ PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRLifecyclePolicy_' -timeout 180m
--- PASS: TestAccECRLifecyclePolicy_basic (16.38s)
--- PASS: TestAccECRLifecyclePolicy_ignoreEquivalent (21.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	22.770s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccECRLifecyclePolicy_ PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRLifecyclePolicy_' -timeout 180m
--- PASS: TestAccECRLifecyclePolicy_basic (21.90s)
--- PASS: TestAccECRLifecyclePolicy_ignoreEquivalent (28.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	30.143s
```
