### PR TITLE
Adds Queued as a StackSet Operating Waiter Pending state

### DIFF
--- a/.changelog/22160.txt
+++ b/.changelog/22160.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack_set: Consider `QUEUED` a valid pending state for resource creation
+```

--- a/internal/service/cloudformation/wait.go
+++ b/internal/service/cloudformation/wait.go
@@ -58,7 +58,7 @@ const (
 
 func WaitStackSetOperationSucceeded(conn *cloudformation.CloudFormation, stackSetName, operationID string, timeout time.Duration) (*cloudformation.StackSetOperation, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{cloudformation.StackSetOperationStatusRunning},
+		Pending: []string{cloudformation.StackSetOperationStatusRunning, cloudformation.StackSetOperationStatusQueued},
 		Target:  []string{cloudformation.StackSetOperationStatusSucceeded},
 		Refresh: StatusStackSetOperation(conn, stackSetName, operationID),
 		Timeout: timeout,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

A StackSet using [Managed Execution](https://aws.amazon.com/about-aws/whats-new/2021/11/aws-cloudformation-stacksets-operations-execution/) can internally queue Operations before they're executed. 

When doing so the status of the Operation is set to Queued.

Initially, concurrent Operations may also be set to Queued, until they're deemed safe to start.

The waiter doesn't handle the case where the Operation status is Queued. After which terraform loses track of the Operation. 

This treats the Queued status as a 'Pending' status in the waiter. Allowing terraform to successfully track Queued Operations, until they reach the Target state. 