### PR TITLE
New resource for Detective Member and Invitation Accepter

### DIFF
--- a/.changelog/22163.txt
+++ b/.changelog/22163.txt
@@ -1,0 +1,6 @@
+```release-note:new-resource
+aws_detective_member
+```
+```release-note:new-resource
+aws_detective_invitation_accepter
+```

--- a/internal/conns/envvar.go
+++ b/internal/conns/envvar.go
@@ -44,7 +44,7 @@ const (
 
 	// For tests using an alternate AWS account, the equivalent of AWS_SECRET_ACCESS_KEY for that account
 	EnvVarAlternateSecretAccessKey = "AWS_ALTERNATE_SECRET_ACCESS_KEY"
-
+	EnvVarAlternateToken           = "AWS_ALTERNATE_TOKEN"
 	// For tests using a third AWS region, the equivalent of AWS_DEFAULT_REGION for that region
 	EnvVarThirdRegion = "AWS_THIRD_REGION"
 

--- a/internal/conns/envvar.go
+++ b/internal/conns/envvar.go
@@ -44,7 +44,7 @@ const (
 
 	// For tests using an alternate AWS account, the equivalent of AWS_SECRET_ACCESS_KEY for that account
 	EnvVarAlternateSecretAccessKey = "AWS_ALTERNATE_SECRET_ACCESS_KEY"
-	EnvVarAlternateToken           = "AWS_ALTERNATE_TOKEN"
+
 	// For tests using a third AWS region, the equivalent of AWS_DEFAULT_REGION for that region
 	EnvVarThirdRegion = "AWS_THIRD_REGION"
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -975,7 +975,9 @@ func Provider() *schema.Provider {
 
 			"aws_devicefarm_project": devicefarm.ResourceProject(),
 
-			"aws_detective_graph": detective.ResourceGraph(),
+			"aws_detective_graph":               detective.ResourceGraph(),
+			"aws_detective_invitation_accepter": detective.ResourceInvitationAccepter(),
+			"aws_detective_member":              detective.ResourceMember(),
 
 			"aws_dx_bgp_peer":                                  directconnect.ResourceBGPPeer(),
 			"aws_dx_connection":                                directconnect.ResourceConnection(),

--- a/internal/service/detective/detective_test.go
+++ b/internal/service/detective/detective_test.go
@@ -1,0 +1,57 @@
+package detective_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAccDetective_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Graph": {
+			"basic":      testAccDetectiveGraph_basic,
+			"disappears": testAccDetectiveGraph_disappears,
+			"tags":       testAccDetectiveGraph_tags,
+		},
+		"InvitationAccepter": {
+			"basic": testAccDetectiveInvitationAccepter_basic,
+		},
+		"Member": {
+			"basic":             testAccDetectiveMember_basic,
+			"disappear":         testAccDetectiveMember_disappears,
+			"invitationMessage": testAccDetectiveMember_invitationMessage,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}
+
+func testAccMemberFromEnv(t *testing.T, isAlternate bool) string {
+	var email string
+	if isAlternate {
+		email = os.Getenv("AWS_DETECTIVE_ALTERNATE_ACCOUNT_EMAIL")
+		if email == "" {
+			t.Skip(
+				"Environment variable AWS_DETECTIVE_ALTERNATE_ACCOUNT_EMAIL is not set. " +
+					"To properly test inviting Detective member account must be provided.")
+		}
+		return email
+	}
+
+	email = os.Getenv("AWS_DETECTIVE_ACCOUNT_EMAIL")
+	if email == "" {
+		t.Skip(
+			"Environment variable AWS_DETECTIVE_ACCOUNT_EMAIL is not set. " +
+				"To properly test inviting Detective member account must be provided")
+	}
+	return email
+}

--- a/internal/service/detective/detective_test.go
+++ b/internal/service/detective/detective_test.go
@@ -16,9 +16,9 @@ func TestAccDetective_serial(t *testing.T) {
 			"basic": testAccDetectiveInvitationAccepter_basic,
 		},
 		"Member": {
-			"basic":             testAccDetectiveMember_basic,
-			"disappear":         testAccDetectiveMember_disappears,
-			"invitationMessage": testAccDetectiveMember_invitationMessage,
+			"basic":     testAccDetectiveMember_basic,
+			"disappear": testAccDetectiveMember_disappears,
+			"message":   testAccDetectiveMember_message,
 		},
 	}
 

--- a/internal/service/detective/detective_test.go
+++ b/internal/service/detective/detective_test.go
@@ -35,23 +35,14 @@ func TestAccDetective_serial(t *testing.T) {
 	}
 }
 
-func testAccMemberFromEnv(t *testing.T, isAlternate bool) string {
-	var email string
-	if isAlternate {
-		email = os.Getenv("AWS_DETECTIVE_ALTERNATE_ACCOUNT_EMAIL")
-		if email == "" {
-			t.Skip(
-				"Environment variable AWS_DETECTIVE_ALTERNATE_ACCOUNT_EMAIL is not set. " +
-					"To properly test inviting Detective member account must be provided.")
-		}
-		return email
-	}
-
-	email = os.Getenv("AWS_DETECTIVE_ACCOUNT_EMAIL")
+func testAccMemberFromEnv(t *testing.T) string {
+	email := os.Getenv("AWS_DETECTIVE_MEMBER_EMAIL")
 	if email == "" {
 		t.Skip(
-			"Environment variable AWS_DETECTIVE_ACCOUNT_EMAIL is not set. " +
-				"To properly test inviting Detective member account must be provided")
+			"Environment variable AWS_DETECTIVE_MEMBER_EMAIL is not set. " +
+				"To properly test inviting Detective member accounts, " +
+				"a valid email associated with the alternate AWS acceptance " +
+				"test account must be provided.")
 	}
 	return email
 }

--- a/internal/service/detective/find.go
+++ b/internal/service/detective/find.go
@@ -50,3 +50,82 @@ func FindDetectiveGraphByArn(conn *detective.Detective, ctx context.Context, arn
 
 	return result, nil
 }
+
+func FindInvitationByGraphArn(ctx context.Context, conn *detective.Detective, graphARN string) (*string, error) {
+	input := &detective.ListInvitationsInput{}
+
+	var result *string
+
+	err := conn.ListInvitationsPages(&detective.ListInvitationsInput{}, func(page *detective.ListInvitationsOutput, lastPage bool) bool {
+		for _, invitation := range page.Invitations {
+			if aws.StringValue(invitation.GraphArn) == graphARN {
+				result = invitation.GraphArn
+				return false
+			}
+		}
+		return !lastPage
+	})
+	if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, &resource.NotFoundError{
+			Message:     fmt.Sprintf("No member found with arn %q ", graphARN),
+			LastRequest: input,
+		}
+	}
+
+	return result, nil
+}
+
+func FindMemberByGraphArnAndAccountID(ctx context.Context, conn *detective.Detective, graphARN string, accountID string) (*detective.MemberDetail, error) {
+	input := &detective.ListMembersInput{
+		GraphArn: aws.String(graphARN),
+	}
+
+	var result *detective.MemberDetail
+
+	err := conn.ListMembersPagesWithContext(ctx, input, func(page *detective.ListMembersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, member := range page.MemberDetails {
+			if member == nil {
+				continue
+			}
+
+			if aws.StringValue(member.AccountId) == accountID {
+				result = member
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+	if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, &resource.NotFoundError{
+			Message:     fmt.Sprintf("No member found with arn %q and accountID %q", graphARN, accountID),
+			LastRequest: input,
+		}
+	}
+
+	return result, nil
+}

--- a/internal/service/detective/find.go
+++ b/internal/service/detective/find.go
@@ -56,7 +56,7 @@ func FindInvitationByGraphArn(ctx context.Context, conn *detective.Detective, gr
 
 	var result *string
 
-	err := conn.ListInvitationsPages(&detective.ListInvitationsInput{}, func(page *detective.ListInvitationsOutput, lastPage bool) bool {
+	err := conn.ListInvitationsPagesWithContext(ctx, input, func(page *detective.ListInvitationsOutput, lastPage bool) bool {
 		for _, invitation := range page.Invitations {
 			if aws.StringValue(invitation.GraphArn) == graphARN {
 				result = invitation.GraphArn

--- a/internal/service/detective/graph.go
+++ b/internal/service/detective/graph.go
@@ -55,7 +55,7 @@ func resourceGraphCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	var output *detective.CreateGraphOutput
 	var err error
-	err = resource.RetryContext(ctx, DetectiveOperationTimeout, func() *resource.RetryError {
+	err = resource.RetryContext(ctx, GraphOperationTimeout, func() *resource.RetryError {
 		output, err = conn.CreateGraphWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, detective.ErrCodeInternalServerException) {

--- a/internal/service/detective/graph_test.go
+++ b/internal/service/detective/graph_test.go
@@ -15,7 +15,7 @@ import (
 	tfdetective "github.com/hashicorp/terraform-provider-aws/internal/service/detective"
 )
 
-func TestAccDetectiveGraph_basic(t *testing.T) {
+func testAccDetectiveGraph_basic(t *testing.T) {
 	var graphOutput detective.Graph
 	resourceName := "aws_detective_graph.test"
 
@@ -41,7 +41,7 @@ func TestAccDetectiveGraph_basic(t *testing.T) {
 	})
 }
 
-func TestAccDetectiveGraph_tags(t *testing.T) {
+func testAccDetectiveGraph_tags(t *testing.T) {
 	var graph1, graph2 detective.Graph
 	resourceName := "aws_detective_graph.test"
 
@@ -97,7 +97,7 @@ func TestAccDetectiveGraph_tags(t *testing.T) {
 	})
 }
 
-func TestAccDetectiveGraph_disappears(t *testing.T) {
+func testAccDetectiveGraph_disappears(t *testing.T) {
 	var graphOutput detective.Graph
 	resourceName := "aws_detective_graph.test"
 

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -15,9 +15,9 @@ import (
 
 func ResourceInvitationAccepter() *schema.Resource {
 	return &schema.Resource{
-		CreateWithoutTimeout: resourceInvitationAccepterCreate,
-		ReadWithoutTimeout:   resourceInvitationAccepterRead,
-		DeleteWithoutTimeout: resourceInvitationAccepterDelete,
+		CreateContext: resourceInvitationAccepterCreate,
+		ReadContext:   resourceInvitationAccepterRead,
+		DeleteContext: resourceInvitationAccepterDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -71,7 +71,7 @@ func resourceInvitationAccepterRead(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error reading Detective InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
-	d.Set("graph_arn", aws.StringValue(graphArn))
+	d.Set("graph_arn", graphArn)
 	return nil
 }
 

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -1,0 +1,93 @@
+package detective
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceInvitationAccepter() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceInvitationAccepterCreate,
+		ReadWithoutTimeout:   resourceInvitationAccepterRead,
+		DeleteWithoutTimeout: resourceInvitationAccepterDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"graph_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+		},
+	}
+}
+
+func resourceInvitationAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DetectiveConn
+
+	graphArn := d.Get("graph_arn").(string)
+
+	acceptInvitationInput := &detective.AcceptInvitationInput{
+		GraphArn: aws.String(graphArn),
+	}
+
+	_, err := conn.AcceptInvitationWithContext(ctx, acceptInvitationInput)
+
+	if err != nil {
+		return diag.Errorf("error accepting Detective InvitationAccepter (%s): %s", d.Id(), err)
+	}
+
+	d.SetId(graphArn)
+
+	return resourceInvitationAccepterRead(ctx, d, meta)
+}
+
+func resourceInvitationAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DetectiveConn
+
+	graphArn, err := FindInvitationByGraphArn(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] Detective InvitationAccepter (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error listing Detective InvitationAccepter (%s): %s", d.Id(), err)
+	}
+
+	if err != nil {
+		return diag.Errorf("error reading Detective InvitationAccepter (%s): %s", d.Id(), err)
+	}
+
+	d.Set("graph_arn", aws.StringValue(graphArn))
+	return nil
+}
+
+func resourceInvitationAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DetectiveConn
+
+	input := &detective.DisassociateMembershipInput{
+		GraphArn: aws.String(d.Id()),
+	}
+
+	_, err := conn.DisassociateMembershipWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return diag.Errorf("error disassociating Detective InvitationAccepter (%s): %s", d.Id(), err)
+	}
+	return nil
+}

--- a/internal/service/detective/invitation_accepter_test.go
+++ b/internal/service/detective/invitation_accepter_test.go
@@ -18,8 +18,8 @@ import (
 
 func testAccDetectiveInvitationAccepter_basic(t *testing.T) {
 	var providers []*schema.Provider
-	resourceName := "aws_detective_invitation_accepter.member"
-	email := testAccMemberFromEnv(t, false)
+	resourceName := "aws_detective_invitation_accepter.test"
+	email := testAccMemberFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -103,18 +103,20 @@ data "aws_caller_identity" "member" {
   provider = "awsalternate"
 }
 
-resource "aws_detective_graph" "admin" {}
+resource "aws_detective_graph" "test" {}
 
-resource "aws_detective_member" "member" {
+resource "aws_detective_member" "test" {
   account_id    = data.aws_caller_identity.member.account_id
-  graph_arn     = aws_detective_graph.admin.id
+  graph_arn     = aws_detective_graph.test.id
   email_address = %[1]q
   message       = "This is a message of the invite"
 }
 
-resource "aws_detective_invitation_accepter" "member" {
+resource "aws_detective_invitation_accepter" "test" {
   provider  = "awsalternate"
-  graph_arn = aws_detective_member.member.graph_arn
+  graph_arn = aws_detective_member.test.graph_arn
+
+  depends_on = [aws_detective_member.test]
 }
 `, email)
 }

--- a/internal/service/detective/invitation_accepter_test.go
+++ b/internal/service/detective/invitation_accepter_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccDetectiveInvitationAccepter_basic(t *testing.T) {
+func testAccDetectiveInvitationAccepter_basic(t *testing.T) {
 	var providers []*schema.Provider
 	resourceName := "aws_detective_invitation_accepter.member"
-	email := conns.SkipIfEnvVarEmpty(t, EnvVarDetectivePrincipalEmail, EnvVarDetectivePrincipalEmailMessageError)
+	email := testAccMemberFromEnv(t, false)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -99,18 +99,13 @@ func testAccCheckDetectiveInvitationAccepterDestroy(s *terraform.State) error {
 
 func testAccDetectiveInvitationAccepterConfigBasic(email string) string {
 	return acctest.ConfigAlternateAccountProvider() + fmt.Sprintf(`
-data "aws_caller_identity" "admin" {
+data "aws_caller_identity" "member" {
   provider = "awsalternate"
 }
 
-data "aws_caller_identity" "member" {}
-
-resource "aws_detective_graph" "admin" {
-  provider = "awsalternate"
-}
+resource "aws_detective_graph" "admin" {}
 
 resource "aws_detective_member" "member" {
-  provider      = "awsalternate"
   account_id    = data.aws_caller_identity.member.account_id
   graph_arn     = aws_detective_graph.admin.id
   email_address = %[1]q
@@ -118,8 +113,8 @@ resource "aws_detective_member" "member" {
 }
 
 resource "aws_detective_invitation_accepter" "member" {
+  provider = "awsalternate"
   graph_arn  = aws_detective_member.member.graph_arn
-  depends_on = [data.aws_caller_identity.member]
 }
 `, email)
 }

--- a/internal/service/detective/invitation_accepter_test.go
+++ b/internal/service/detective/invitation_accepter_test.go
@@ -113,8 +113,8 @@ resource "aws_detective_member" "member" {
 }
 
 resource "aws_detective_invitation_accepter" "member" {
-  provider = "awsalternate"
-  graph_arn  = aws_detective_member.member.graph_arn
+  provider  = "awsalternate"
+  graph_arn = aws_detective_member.member.graph_arn
 }
 `, email)
 }

--- a/internal/service/detective/invitation_accepter_test.go
+++ b/internal/service/detective/invitation_accepter_test.go
@@ -1,0 +1,125 @@
+package detective_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdetective "github.com/hashicorp/terraform-provider-aws/internal/service/detective"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccDetectiveInvitationAccepter_basic(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_detective_invitation_accepter.member"
+	email := conns.SkipIfEnvVarEmpty(t, EnvVarDetectivePrincipalEmail, EnvVarDetectivePrincipalEmailMessageError)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      testAccCheckDetectiveInvitationAccepterDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, detective.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDetectiveInvitationAccepterConfigBasic(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectiveInvitationAccepterExists(resourceName),
+				),
+			},
+			{
+				Config:            testAccDetectiveInvitationAccepterConfigBasic(email),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDetectiveInvitationAccepterExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource (%s) has empty ID", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DetectiveConn
+
+		result, err := tfdetective.FindInvitationByGraphArn(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if result == nil {
+			return fmt.Errorf("no detective invitation found for (%s): %s", resourceName, rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDetectiveInvitationAccepterDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DetectiveConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_detective_invitation_accepter" {
+			continue
+		}
+
+		result, err := tfdetective.FindInvitationByGraphArn(context.Background(), conn, rs.Primary.ID)
+
+		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) ||
+			tfresource.NotFound(err) {
+			continue
+		}
+
+		if result != nil {
+			return fmt.Errorf("detective InvitationAccepter %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccDetectiveInvitationAccepterConfigBasic(email string) string {
+	return acctest.ConfigAlternateAccountProvider() + fmt.Sprintf(`
+data "aws_caller_identity" "admin" {
+  provider = "awsalternate"
+}
+
+data "aws_caller_identity" "member" {}
+
+resource "aws_detective_graph" "admin" {
+  provider = "awsalternate"
+}
+
+resource "aws_detective_member" "member" {
+  provider      = "awsalternate"
+  account_id    = data.aws_caller_identity.member.account_id
+  graph_arn     = aws_detective_graph.admin.id
+  email_address = %[1]q
+  message       = "This is a message of the invite"
+}
+
+resource "aws_detective_invitation_accepter" "member" {
+  graph_arn  = aws_detective_member.member.graph_arn
+  depends_on = [data.aws_caller_identity.member]
+}
+`, email)
+}

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -126,7 +126,7 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error creating Detective Member: %s", err)
 	}
 
-	if _, err = MemberUpdated(ctx, conn, graphArn, accountId, detective.MemberStatusInvited); err != nil {
+	if _, err = MemberStatusUpdated(ctx, conn, graphArn, accountId, detective.MemberStatusInvited); err != nil {
 		return diag.Errorf("error waiting for Detective Member (%s) to be invited: %s", d.Id(), err)
 	}
 

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -1,0 +1,216 @@
+package detective
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceMember() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceMemberCreate,
+		ReadWithoutTimeout:   resourceMemberRead,
+		DeleteWithoutTimeout: resourceMemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"administrator_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disable_email_notification": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"email_address": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"graph_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"invited_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"percent_of_graph_utilization": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"percent_of_graph_utilization_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_usage_in_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"volume_usage_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DetectiveConn
+
+	accountId := d.Get("account_id").(string)
+	graphArn := d.Get("graph_arn").(string)
+
+	accountInput := &detective.Account{
+		AccountId:    aws.String(accountId),
+		EmailAddress: aws.String(d.Get("email_address").(string)),
+	}
+
+	input := &detective.CreateMembersInput{
+		Accounts: []*detective.Account{accountInput},
+		GraphArn: aws.String(graphArn),
+	}
+
+	var err error
+	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		_, err := conn.CreateMembersWithContext(ctx, input)
+
+		if tfawserr.ErrCodeEquals(err, detective.ErrCodeInternalServerException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.CreateMembersWithContext(ctx, input)
+	}
+
+	if err != nil {
+		return diag.Errorf("error creating Detective Member: %s", err)
+	}
+
+	if _, err = MemberInvited(ctx, conn, graphArn, accountId); err != nil {
+		return diag.Errorf("error waiting for Detective Member (%s) to be invited: %s", d.Id(), err)
+	}
+
+	d.SetId(EncodeMemberAccountID(graphArn, accountId))
+
+	return resourceMemberRead(ctx, d, meta)
+}
+
+func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DetectiveConn
+
+	graphArn, accountId, err := DecodeMemberAccountID(d.Id())
+	if err != nil {
+		return diag.Errorf("error decoding ID Detective Member (%s): %s", d.Id(), err)
+	}
+
+	resp, err := FindMemberByGraphArnAndAccountID(ctx, conn, graphArn, accountId)
+
+	if err != nil {
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) ||
+			tfresource.NotFound(err) {
+			log.Printf("[WARN] Detective Member (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("error reading Detective Member (%s): %s", d.Id(), err)
+	}
+
+	if resp == nil {
+		log.Printf("[WARN] Detective Member (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("account_id", resp.AccountId)
+	d.Set("administrator_id", resp.AdministratorId)
+	d.Set("email_address", resp.EmailAddress)
+	d.Set("graph_arn", resp.GraphArn)
+	d.Set("invited_time", aws.TimeValue(resp.InvitedTime).Format(time.RFC3339))
+	d.Set("master_id", resp.MasterId)
+	d.Set("status", resp.Status)
+	d.Set("percent_of_graph_utilization", resp.PercentOfGraphUtilization)
+	d.Set("percent_of_graph_utilization_updated_time", aws.TimeValue(resp.PercentOfGraphUtilizationUpdatedTime).Format(time.RFC3339))
+	d.Set("updated_time", aws.TimeValue(resp.UpdatedTime).Format(time.RFC3339))
+	d.Set("volume_usage_in_bytes", resp.VolumeUsageInBytes)
+	d.Set("volume_usage_updated_time", aws.TimeValue(resp.VolumeUsageUpdatedTime).Format(time.RFC3339))
+
+	return nil
+}
+func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DetectiveConn
+
+	graphArn, accountId, err := DecodeMemberAccountID(d.Id())
+	if err != nil {
+		return diag.Errorf("error decoding ID Detective Member (%s): %s", d.Id(), err)
+	}
+
+	input := &detective.DeleteMembersInput{
+		AccountIds: []*string{aws.String(accountId)},
+		GraphArn:   aws.String(graphArn),
+	}
+
+	_, err = conn.DeleteMembersWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+		return diag.Errorf("error deleting Detective Member (%s): %s", d.Id(), err)
+	}
+	return nil
+}
+
+func EncodeMemberAccountID(graphArn, accountId string) string {
+	return fmt.Sprintf("%s/%s", graphArn, accountId)
+}
+
+func DecodeMemberAccountID(id string) (string, string, error) {
+	idParts := strings.Split(id, "/")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return "", "", fmt.Errorf("expected ID in the form of graph_arn/account_id, given: %q", id)
+	}
+	return idParts[0], idParts[1], nil
+}

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -41,7 +41,6 @@ func ResourceMember() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Default:  false,
 			},
 			"disabled_reason": {
 				Type:     schema.TypeString,

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -74,6 +74,10 @@ func ResourceMember() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"volume_usage_in_bytes": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -168,6 +172,7 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("invited_time", aws.TimeValue(resp.InvitedTime).Format(time.RFC3339))
 	d.Set("status", resp.Status)
 	d.Set("updated_time", aws.TimeValue(resp.UpdatedTime).Format(time.RFC3339))
+	d.Set("volume_usage_in_bytes", resp.VolumeUsageInBytes)
 
 	return nil
 }

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -159,7 +159,7 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error reading Detective Member (%s): %s", d.Id(), err)
 	}
 
-	if resp == nil {
+	if !d.IsNewResource() && resp == nil {
 		log.Printf("[WARN] Detective Member (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/internal/service/detective/member_test.go
+++ b/internal/service/detective/member_test.go
@@ -1,0 +1,234 @@
+package detective_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdetective "github.com/hashicorp/terraform-provider-aws/internal/service/detective"
+)
+
+const (
+	EnvVarDetectivePrincipalEmail             = "AWS_DETECTIVE_ACCOUNT_EMAIL"
+	EnvVarDetectiveAlternateEmail             = "AWS_DETECTIVE_ALTERNATE_ACCOUNT_EMAIL"
+	EnvVarDetectivePrincipalEmailMessageError = "Environment variable AWS_DETECTIVE_ACCOUNT_EMAIL is not set. " +
+		"To properly test inviting Detective member account must be provided."
+	EnvVarDetectiveAlternateEmailMessageError = "Environment variable AWS_DETECTIVE_ALTERNATE_ACCOUNT_EMAIL is not set. " +
+		"To properly test inviting Detective member account must be provided."
+)
+
+func TestAccDetectiveMember_basic(t *testing.T) {
+	var providers []*schema.Provider
+	var detectiveOutput detective.MemberDetail
+	resourceName := "aws_detective_member.member"
+	dataSourceAlternate := "data.aws_caller_identity.member"
+	email := conns.SkipIfEnvVarEmpty(t, EnvVarDetectiveAlternateEmail, EnvVarDetectiveAlternateEmailMessageError)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      testAccCheckDetectiveMemberDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, detective.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDetectiveMemberConfigBasic(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectiveMemberExists(resourceName, &detectiveOutput),
+					acctest.CheckResourceAttrAccountID(resourceName, "administrator_id"),
+					acctest.CheckResourceAttrAccountID(resourceName, "master_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "account_id", dataSourceAlternate, "account_id"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "invited_time"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "updated_time"),
+					resource.TestCheckResourceAttr(resourceName, "status", detective.MemberStatusInvited),
+				),
+			},
+			{
+				Config:            testAccDetectiveMemberConfigBasic(email),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDetectiveMember_disappears(t *testing.T) {
+	var providers []*schema.Provider
+	var detectiveOutput detective.MemberDetail
+	resourceName := "aws_detective_member.member"
+	email := conns.SkipIfEnvVarEmpty(t, EnvVarDetectiveAlternateEmail, EnvVarDetectiveAlternateEmailMessageError)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      testAccCheckDetectiveMemberDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, detective.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDetectiveMemberConfigBasic(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectiveMemberExists(resourceName, &detectiveOutput),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdetective.ResourceMember(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDetectiveMember_invite(t *testing.T) {
+	var detectiveOutput detective.MemberDetail
+	var providers []*schema.Provider
+	resourceName := "aws_detective_member.member"
+	dataSourceAlternate := "data.aws_caller_identity.member"
+	email := conns.SkipIfEnvVarEmpty(t, EnvVarDetectiveAlternateEmail, EnvVarDetectiveAlternateEmailMessageError)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy:      testAccCheckDetectiveInvitationAccepterDestroy,
+		ErrorCheck:        acctest.ErrorCheck(t, detective.EndpointsID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDetectiveMemberConfigInvite(email, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectiveMemberExists(resourceName, &detectiveOutput),
+					acctest.CheckResourceAttrAccountID(resourceName, "administrator_id"),
+					acctest.CheckResourceAttrAccountID(resourceName, "master_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "account_id", dataSourceAlternate, "account_id"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "invited_time"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "updated_time"),
+					resource.TestCheckResourceAttr(resourceName, "status", detective.MemberStatusInvited),
+				),
+			},
+			{
+				Config: testAccDetectiveMemberConfigInvite(email, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDetectiveMemberExists(resourceName, &detectiveOutput),
+					acctest.CheckResourceAttrAccountID(resourceName, "administrator_id"),
+					acctest.CheckResourceAttrAccountID(resourceName, "master_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "account_id", dataSourceAlternate, "account_id"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "invited_time"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "updated_time"),
+					resource.TestCheckResourceAttr(resourceName, "status", detective.MemberStatusInvited),
+				),
+			},
+			{
+				Config:                  testAccDetectiveMemberConfigInvite(email, true),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"message"},
+			},
+		},
+	})
+}
+
+func testAccCheckDetectiveMemberExists(resourceName string, detectiveSession *detective.MemberDetail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DetectiveConn
+
+		graphArn, accountId, err := tfdetective.DecodeMemberAccountID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := tfdetective.FindMemberByGraphArnAndAccountID(context.Background(), conn, graphArn, accountId)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("detective Member %q does not exist", rs.Primary.ID)
+		}
+
+		*detectiveSession = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckDetectiveMemberDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DetectiveConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_detective_member" {
+			continue
+		}
+
+		graphArn, accountId, err := tfdetective.DecodeMemberAccountID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := tfdetective.FindMemberByGraphArnAndAccountID(context.Background(), conn, graphArn, accountId)
+		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if resp != nil {
+			return fmt.Errorf("detective Member %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccDetectiveMemberConfigBasic(email string) string {
+	return acctest.ConfigAlternateAccountProvider() + fmt.Sprintf(`
+data "aws_caller_identity" "member" {
+  provider = "awsalternate"
+}
+
+resource "aws_detective_graph" "member" {}
+
+resource "aws_detective_member" "member" {
+  account_id    = data.aws_caller_identity.member.account_id
+  graph_arn     = aws_detective_graph.member.id
+  email_address = %[1]q
+}
+`, email)
+}
+
+func testAccDetectiveMemberConfigInvite(email string, invite bool) string {
+	return acctest.ConfigAlternateAccountProvider() + fmt.Sprintf(`
+data "aws_caller_identity" "member" {
+  provider = "awsalternate"
+}
+
+resource "aws_detective_graph" "member" {}
+
+resource "aws_detective_member" "member" {
+  account_id    = data.aws_caller_identity.member.account_id
+  graph_arn     = aws_detective_graph.member.id
+  email_address = %[1]q
+  message       = "This is a message of the invitation"
+}
+`, email, invite)
+}

--- a/internal/service/detective/member_test.go
+++ b/internal/service/detective/member_test.go
@@ -80,7 +80,7 @@ func testAccDetectiveMember_disappears(t *testing.T) {
 	})
 }
 
-func testAccDetectiveMember_invitationMessage(t *testing.T) {
+func testAccDetectiveMember_message(t *testing.T) {
 	var detectiveOutput detective.MemberDetail
 	var providers []*schema.Provider
 	resourceName := "aws_detective_member.member"

--- a/internal/service/detective/member_test.go
+++ b/internal/service/detective/member_test.go
@@ -18,9 +18,9 @@ import (
 func testAccDetectiveMember_basic(t *testing.T) {
 	var providers []*schema.Provider
 	var detectiveOutput detective.MemberDetail
-	resourceName := "aws_detective_member.member"
+	resourceName := "aws_detective_member.test"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := testAccMemberFromEnv(t, false)
+	email := testAccMemberFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -56,8 +56,8 @@ func testAccDetectiveMember_basic(t *testing.T) {
 func testAccDetectiveMember_disappears(t *testing.T) {
 	var providers []*schema.Provider
 	var detectiveOutput detective.MemberDetail
-	resourceName := "aws_detective_member.member"
-	email := testAccMemberFromEnv(t, false)
+	resourceName := "aws_detective_member.test"
+	email := testAccMemberFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -83,9 +83,9 @@ func testAccDetectiveMember_disappears(t *testing.T) {
 func testAccDetectiveMember_message(t *testing.T) {
 	var detectiveOutput detective.MemberDetail
 	var providers []*schema.Provider
-	resourceName := "aws_detective_member.member"
+	resourceName := "aws_detective_member.test"
 	dataSourceAlternate := "data.aws_caller_identity.member"
-	email := testAccMemberFromEnv(t, true)
+	email := testAccMemberFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -195,11 +195,11 @@ data "aws_caller_identity" "member" {
   provider = "awsalternate"
 }
 
-resource "aws_detective_graph" "member" {}
+resource "aws_detective_graph" "test" {}
 
-resource "aws_detective_member" "member" {
+resource "aws_detective_member" "test" {
   account_id    = data.aws_caller_identity.member.account_id
-  graph_arn     = aws_detective_graph.member.id
+  graph_arn     = aws_detective_graph.test.id
   email_address = %[1]q
 }
 `, email)
@@ -211,11 +211,11 @@ data "aws_caller_identity" "member" {
   provider = "awsalternate"
 }
 
-resource "aws_detective_graph" "member" {}
+resource "aws_detective_graph" "test" {}
 
-resource "aws_detective_member" "member" {
+resource "aws_detective_member" "test" {
   account_id    = data.aws_caller_identity.member.account_id
-  graph_arn     = aws_detective_graph.member.id
+  graph_arn     = aws_detective_graph.test.id
   email_address = %[1]q
   message       = "This is a message of the invitation"
 }

--- a/internal/service/detective/status.go
+++ b/internal/service/detective/status.go
@@ -1,0 +1,26 @@
+package detective
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// StatusMember fetches the Member and its status
+func StatusMember(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindMemberByGraphArnAndAccountID(ctx, conn, graphARN, adminAccountID)
+
+		if err != nil {
+			return nil, "Unknown", err
+		}
+
+		if output == nil {
+			return output, "NotFound", nil
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/internal/service/detective/status.go
+++ b/internal/service/detective/status.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// StatusMember fetches the Member and its status
-func StatusMember(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID string) resource.StateRefreshFunc {
+// MemberStatus fetches the Member and its status
+func MemberStatus(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindMemberByGraphArnAndAccountID(ctx, conn, graphARN, adminAccountID)
 

--- a/internal/service/detective/wait.go
+++ b/internal/service/detective/wait.go
@@ -11,15 +11,15 @@ import (
 const (
 	// GraphOperationTimeout Maximum amount of time to wait for a detective graph to be created, deleted
 	GraphOperationTimeout = 4 * time.Minute
-	// MemberStatusPropagationTimeout Maximum amount of time to wait for a detective member
+	// MemberStatusPropagationTimeout Maximum amount of time to wait for a detective member status to return Invited
 	MemberStatusPropagationTimeout = 4 * time.Minute
 )
 
-// MemberUpdated waits for an AdminAccount and graph arn to return Invited
-func MemberUpdated(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID, expectedValue string) (*detective.MemberDetail, error) {
+// MemberStatusUpdated waits for an AdminAccount and graph arn to return Invited
+func MemberStatusUpdated(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID, expectedValue string) (*detective.MemberDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{detective.MemberStatusVerificationInProgress},
-		Target:  []string{expectedValue},
+		Target:  []string{detective.MemberStatusInvited},
 		Refresh: MemberStatus(ctx, conn, graphARN, adminAccountID),
 		Timeout: MemberStatusPropagationTimeout,
 	}

--- a/internal/service/detective/wait.go
+++ b/internal/service/detective/wait.go
@@ -9,17 +9,19 @@ import (
 )
 
 const (
-	// DetectiveOperationTimeout Maximum amount of time to wait for a detective graph to be created, deleted
-	DetectiveOperationTimeout = 4 * time.Minute
+	// GraphOperationTimeout Maximum amount of time to wait for a detective graph to be created, deleted
+	GraphOperationTimeout = 4 * time.Minute
+	// MemberStatusPropagationTimeout Maximum amount of time to wait for a detective member
+	MemberStatusPropagationTimeout = 4 * time.Minute
 )
 
-// MemberInvited waits for an AdminAccount and graph arn to return Invited
-func MemberInvited(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID string) (*detective.MemberDetail, error) {
+// MemberUpdated waits for an AdminAccount and graph arn to return Invited
+func MemberUpdated(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID, expectedValue string) (*detective.MemberDetail, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{detective.MemberStatusVerificationInProgress},
-		Target:  []string{detective.MemberStatusInvited},
-		Refresh: StatusMember(ctx, conn, graphARN, adminAccountID),
-		Timeout: DetectiveOperationTimeout,
+		Target:  []string{expectedValue},
+		Refresh: MemberStatus(ctx, conn, graphARN, adminAccountID),
+		Timeout: MemberStatusPropagationTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/detective/wait.go
+++ b/internal/service/detective/wait.go
@@ -1,8 +1,32 @@
 package detective
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/detective"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
 const (
 	// DetectiveOperationTimeout Maximum amount of time to wait for a detective graph to be created, deleted
 	DetectiveOperationTimeout = 4 * time.Minute
 )
+
+// MemberInvited waits for an AdminAccount and graph arn to return Invited
+func MemberInvited(ctx context.Context, conn *detective.Detective, graphARN, adminAccountID string) (*detective.MemberDetail, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{detective.MemberStatusVerificationInProgress},
+		Target:  []string{detective.MemberStatusInvited},
+		Refresh: StatusMember(ctx, conn, graphARN, adminAccountID),
+		Timeout: DetectiveOperationTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*detective.MemberDetail); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/website/docs/r/detective_graph.html.markdown
+++ b/website/docs/r/detective_graph.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Detective"
 layout: "aws"
 page_title: "AWS: aws_detective_graph"
 description: |-
-  Provides a resource to manage Amazon Detective on a Graph.
+  Provides a resource to manage an Amazon Detective graph.
 ---
 
 # Resource: aws_detective_graph
@@ -36,7 +36,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_detective_graph` can be imported using the arn, e.g.
+`aws_detective_graph` can be imported using the ARN, e.g.
 
 ```
 $ terraform import aws_detective_graph.example arn:aws:detective:us-east-1:123456789101:graph:231684d34gh74g4bae1dbc7bd807d02d

--- a/website/docs/r/detective_invitation_accepter.html.markdown
+++ b/website/docs/r/detective_invitation_accepter.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Detective"
 layout: "aws"
 page_title: "AWS: aws_detective_invitation_accepter"
 description: |-
-  Provides a resource to manage an Amazon Detective Invitation Accepter.
+  Provides a resource to manage an Amazon Detective member invitation accepter.
 ---
 
 # Resource: aws_detective_invitation_accepter
 
-rovides a resource to manage an [Amazon Detective Invitation Accepter](https://docs.aws.amazon.com/detective/latest/APIReference/API_AcceptInvitation.html). Ensure that the accepter is configured to use the AWS account you wish to _accept_ the invitation from the primary graph owner account.
+Provides a resource to manage an [Amazon Detective Invitation Accepter](https://docs.aws.amazon.com/detective/latest/APIReference/API_AcceptInvitation.html). Ensure that the accepter is configured to use the AWS account you wish to _accept_ the invitation from the primary graph owner account.
 
 ## Example Usage
 
@@ -25,6 +25,8 @@ resource "aws_detective_member" "primary" {
 resource "aws_detective_invitation_accepter" "member" {
   provider  = "awsalternate"
   graph_arn = aws_detective_member.primary.graph_arn
+
+  depends_on = [aws_detective_member.test]
 }
 ```
 
@@ -45,5 +47,5 @@ In addition to all arguments above, the following attributes are exported:
 `aws_detective_invitation_accepter` can be imported using the graph ARN, e.g.
 
 ```
-$ terraform import aws_detective_invitation_accepter.example arn:aws:detective:us-east1:graph:testing
+$ terraform import aws_detective_invitation_accepter.example arn:aws:detective:us-east-1:123456789101:graph:231684d34gh74g4bae1dbc7bd807d02d
 ```

--- a/website/docs/r/detective_invitation_accepter.html.markdown
+++ b/website/docs/r/detective_invitation_accepter.html.markdown
@@ -19,7 +19,6 @@ resource "aws_detective_graph" "primary" {
 
 resource "aws_detective2_member" "primary" {
   provider   = "awsalternate"
-  
   account_id = "ACCOUNT ID"
   email      = "EMAIL"
   graph_arn  = aws_detective_graph.admin.id

--- a/website/docs/r/detective_invitation_accepter.html.markdown
+++ b/website/docs/r/detective_invitation_accepter.html.markdown
@@ -8,25 +8,23 @@ description: |-
 
 # Resource: aws_detective_invitation_accepter
 
-Provides a resource to manage an [Amazon Detective Invitation Accepter](https://docs.aws.amazon.com/detective/latest/APIReference/API_AcceptInvitation.html).
+rovides a resource to manage an [Amazon Detective Invitation Accepter](https://docs.aws.amazon.com/detective/latest/APIReference/API_AcceptInvitation.html). Ensure that the accepter is configured to use the AWS account you wish to _accept_ the invitation from the primary graph owner account.
 
 ## Example Usage
 
 ```terraform
-resource "aws_detective_graph" "primary" {
-  provider = "awsalternate"
-}
+resource "aws_detective_graph" "primary" {}
 
-resource "aws_detective2_member" "primary" {
-  provider   = "awsalternate"
+resource "aws_detective_member" "primary" {
   account_id = "ACCOUNT ID"
   email      = "EMAIL"
-  graph_arn  = aws_detective_graph.admin.id
+  graph_arn  = aws_detective_graph.primary.id
   message    = "Message of the invite"
 }
 
 resource "aws_detective_invitation_accepter" "member" {
-  graph_arn = aws_detective_graph.primary.id
+  provider   = "awsalternate"
+  graph_arn = aws_detective_member.primary.graph_arn
 }
 ```
 
@@ -40,11 +38,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Unique identifier (ID) of the detective invitation accepter.
+* `id` - Unique identifier (ID) of the Detective invitation accepter.
 
 ## Import
 
-`aws_detective_invitation_accepter` can be imported using the admin account ID, e.g.
+`aws_detective_invitation_accepter` can be imported using the graph ARN, e.g.
 
 ```
 $ terraform import aws_detective_invitation_accepter.example arn:aws:detective:us-east1:graph:testing

--- a/website/docs/r/detective_invitation_accepter.html.markdown
+++ b/website/docs/r/detective_invitation_accepter.html.markdown
@@ -23,7 +23,7 @@ resource "aws_detective_member" "primary" {
 }
 
 resource "aws_detective_invitation_accepter" "member" {
-  provider   = "awsalternate"
+  provider  = "awsalternate"
   graph_arn = aws_detective_member.primary.graph_arn
 }
 ```

--- a/website/docs/r/detective_invitation_accepter.html.markdown
+++ b/website/docs/r/detective_invitation_accepter.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "Detective"
+layout: "aws"
+page_title: "AWS: aws_detective_invitation_accepter"
+description: |-
+  Provides a resource to manage an Amazon Detective Invitation Accepter.
+---
+
+# Resource: aws_detective_invitation_accepter
+
+Provides a resource to manage an [Amazon Detective Invitation Accepter](https://docs.aws.amazon.com/detective/latest/APIReference/API_AcceptInvitation.html).
+
+## Example Usage
+
+```terraform
+resource "aws_detective_graph" "primary" {
+  provider = "awsalternate"
+}
+
+resource "aws_detective2_member" "primary" {
+  provider   = "awsalternate"
+  
+  account_id = "ACCOUNT ID"
+  email      = "EMAIL"
+  graph_arn  = aws_detective_graph.admin.id
+  message    = "Message of the invite"
+}
+
+resource "aws_detective_invitation_accepter" "member" {
+  graph_arn = aws_detective_graph.primary.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `graph_arn` - (Required) ARN of the behavior graph that the member account is accepting the invitation for.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Unique identifier (ID) of the detective invitation accepter.
+
+## Import
+
+`aws_detective_invitation_accepter` can be imported using the admin account ID, e.g.
+
+```
+$ terraform import aws_detective_invitation_accepter.example arn:aws:detective:us-east1:graph:testing
+```

--- a/website/docs/r/detective_member.html.markdown
+++ b/website/docs/r/detective_member.html.markdown
@@ -49,6 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_detective_member` can be imported using the ARN of the graph followed by the account ID of the member account, e.g.
 
+
 ```
-$ terraform import aws_detective_member.example arn:aws:detective:us-east1:graph:testing/123456789012
+$ terraform import aws_detective_member.example arn:aws:detective:us-east-1:123456789101:graph:231684d34gh74g4bae1dbc7bd807d02d/123456789012
 ```

--- a/website/docs/r/detective_member.html.markdown
+++ b/website/docs/r/detective_member.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_detective_member
 
-Provides a resource to manage an [Amazon Detective](https://docs.aws.amazon.com/detective/latest/APIReference/API_CreateMembers.html).
+Provides a resource to manage an [Amazon Detective Member](https://docs.aws.amazon.com/detective/latest/APIReference/API_CreateMembers.html).
 
 ## Example Usage
 
@@ -16,11 +16,11 @@ Provides a resource to manage an [Amazon Detective](https://docs.aws.amazon.com/
 resource "aws_detective_graph" "example" {}
 
 resource "aws_detective_member" "example" {
-  account_id                            = "AWS ACCOUNT ID"
-  email                                 = "EMAIL"
-  graph_arn                             = aws_detective_graph.example.id
-  invitation_message                    = "Message of the invitation"
-  invitation_disable_email_notification = true
+  account_id                 = "AWS ACCOUNT ID"
+  email                      = "EMAIL"
+  graph_arn                  = aws_detective_graph.example.id
+  message                    = "Message of the invitation"
+  disable_email_notification = true
 }
 ```
 
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `email_address` - (Required) Email address for the account.
 * `graph_arn` - (Required) ARN of the behavior graph to invite the member accounts to contribute their data to.
 * `message` - (Optional) A custom message to include in the invitation. Amazon Detective adds this message to the standard content that it sends for an invitation.
-* `disable_email_notification` - (Optional) Specifies whether to send an email notification to the root user of each account that the invitation will be sent to. This notification is in addition to an alert that the root user receives in AWS Personal Health Dashboard. To send an email notification to the root user of each account, set this value to `true`.
+* `disable_email_notification` - (Optional) If set to true, then the root user of the invited account will _not_ receive an email notification. This notification is in addition to an alert that the root user receives in AWS Personal Health Dashboard. By default, this is set to `false`.
 
 ## Attributes Reference
 
@@ -51,5 +51,5 @@ In addition to all arguments above, the following attributes are exported:
 `aws_detective_member` can be imported using the account ID of the member account and the arn of a graph, e.g.
 
 ```
-$ terraform import aws_detective_member.example 123456789012/arn:aws:detective:us-east1:graph:testing
+$ terraform import aws_detective_member.example arn:aws:detective:us-east1:graph:testing/123456789012
 ```

--- a/website/docs/r/detective_member.html.markdown
+++ b/website/docs/r/detective_member.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Detective"
 layout: "aws"
 page_title: "AWS: aws_detective_member"
 description: |-
-  Provides a resource to manage an Amazon  Detective.
+  Provides a resource to manage an Amazon Detective member.
 ---
 
 # Resource: aws_detective_member
@@ -42,13 +42,12 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - Current membership status of the member account.
 * `administrator_id` - AWS account ID for the administrator account.
 * `volume_usage_in_bytes` - Data volume in bytes per day for the member account.
-* `volume_usage_updated_time` - Date and time, in UTC and extended RFC 3339 format, of the member account data volume was last updated.
 * `invited_time` - Date and time, in UTC and extended RFC 3339 format, when an Amazon Detective membership invitation was last sent to the account.
-* `updated_time` - Date and time, in UTC and extended RFC 3339 format, of the most recent change.
+* `updated_time` - Date and time, in UTC and extended RFC 3339 format, of the most recent change to the member account's status.
 
 ## Import
 
-`aws_detective_member` can be imported using the account ID of the member account and the arn of a graph, e.g.
+`aws_detective_member` can be imported using the ARN of the graph followed by the account ID of the member account, e.g.
 
 ```
 $ terraform import aws_detective_member.example arn:aws:detective:us-east1:graph:testing/123456789012

--- a/website/docs/r/detective_member.html.markdown
+++ b/website/docs/r/detective_member.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Detective"
+layout: "aws"
+page_title: "AWS: aws_detective_member"
+description: |-
+  Provides a resource to manage an Amazon  Detective.
+---
+
+# Resource: aws_detective_member
+
+Provides a resource to manage an [Amazon Detective](https://docs.aws.amazon.com/detective/latest/APIReference/API_CreateMembers.html).
+
+## Example Usage
+
+```terraform
+resource "aws_detective_graph" "example" {}
+
+resource "aws_detective_member" "example" {
+  account_id                            = "AWS ACCOUNT ID"
+  email                                 = "EMAIL"
+  graph_arn                             = aws_detective_graph.example.id
+  invitation_message                    = "Message of the invitation"
+  invitation_disable_email_notification = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) AWS account ID for the account.
+* `email_address` - (Required) Email address for the account.
+* `graph_arn` - (Required) ARN of the behavior graph to invite the member accounts to contribute their data to.
+* `message` - (Optional) A custom message to include in the invitation. Amazon Detective adds this message to the standard content that it sends for an invitation.
+* `disable_email_notification` - (Optional) Specifies whether to send an email notification to the root user of each account that the invitation will be sent to. This notification is in addition to an alert that the root user receives in AWS Personal Health Dashboard. To send an email notification to the root user of each account, set this value to `true`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Unique identifier (ID) of the Detective.
+* `status` - Current membership status of the member account.
+* `administrator_id` - AWS account ID for the administrator account.
+* `volume_usage_in_bytes` - Data volume in bytes per day for the member account.
+* `volume_usage_updated_time` - Date and time, in UTC and extended RFC 3339 format, of the member account data volume was last updated.
+* `invited_time` - Date and time, in UTC and extended RFC 3339 format, when an Amazon Detective membership invitation was last sent to the account.
+* `updated_time` - Date and time, in UTC and extended RFC 3339 format, of the most recent change.
+
+## Import
+
+`aws_detective_member` can be imported using the account ID of the member account and the arn of a graph, e.g.
+
+```
+$ terraform import aws_detective_member.example 123456789012/arn:aws:detective:us-east1:graph:testing
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->
 Added a new resource, doc and tests for [Detective Member](https://docs.aws.amazon.com/detective/latest/APIReference/API_CreateMembers.html) called `aws_detective_member` and [Detective Invitation Accepter](https://docs.aws.amazon.com/detective/latest/APIReference/API_AcceptInvitation.html) called `aws_detective_invitation_accepter`
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11672

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Detective Member
```
$  make testacc TESTARGS='-run=TestAccDetective_serial' PKG_NAME=internal/service/detective
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/detective/... -v -count 1 -parallel 20 -run=TestAccDetective_serial -timeout 180m
=== RUN   TestAccDetective_serial
=== RUN   TestAccDetective_serial/InvitationAccepter
=== RUN   TestAccDetective_serial/InvitationAccepter/basic
=== RUN   TestAccDetective_serial/Member
=== RUN   TestAccDetective_serial/Member/invitationMessage
=== RUN   TestAccDetective_serial/Member/basic
=== RUN   TestAccDetective_serial/Member/disappear
=== RUN   TestAccDetective_serial/Graph
=== RUN   TestAccDetective_serial/Graph/tags
=== RUN   TestAccDetective_serial/Graph/basic
=== RUN   TestAccDetective_serial/Graph/disappears
--- PASS: TestAccDetective_serial (219.08s)
    --- PASS: TestAccDetective_serial/InvitationAccepter (33.86s)
        --- PASS: TestAccDetective_serial/InvitationAccepter/basic (33.86s)
    --- PASS: TestAccDetective_serial/Member (98.99s)
        --- PASS: TestAccDetective_serial/Member/invitationMessage (45.33s)
        --- PASS: TestAccDetective_serial/Member/basic (28.79s)
        --- PASS: TestAccDetective_serial/Member/disappear (24.87s)
    --- PASS: TestAccDetective_serial/Graph (86.23s)
        --- PASS: TestAccDetective_serial/Graph/tags (50.77s)
        --- PASS: TestAccDetective_serial/Graph/basic (20.61s)
        --- PASS: TestAccDetective_serial/Graph/disappears (14.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/detective  221.339s

```