### PR TITLE
events/bus_policy: Fix diffs with policy

### DIFF
--- a/.changelog/22165.txt
+++ b/.changelog/22165.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_bus_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/events/bus_policy.go
+++ b/internal/service/events/bus_policy.go
@@ -129,7 +129,13 @@ func resourceBusPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("event_bus_name", busName)
 
-	d.Set("policy", policy)
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(policy))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("policy", policyToSet)
 
 	return nil
 }

--- a/internal/service/events/bus_policy.go
+++ b/internal/service/events/bus_policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
@@ -42,6 +43,10 @@ func ResourceBusPolicy() *schema.Resource {
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 		},
 	}
@@ -51,7 +56,12 @@ func resourceBusPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EventsConn
 
 	eventBusName := d.Get("event_bus_name").(string)
-	policy := d.Get("policy").(string)
+
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
 
 	input := eventbridge.PutPermissionInput{
 		EventBusName: aws.String(eventBusName),
@@ -59,7 +69,7 @@ func resourceBusPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Creating EventBridge policy: %s", input)
-	_, err := conn.PutPermission(&input)
+	_, err = conn.PutPermission(&input)
 	if err != nil {
 		return fmt.Errorf("Creating EventBridge policy failed: %w", err)
 	}
@@ -140,13 +150,19 @@ func resourceBusPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	eventBusName := d.Id()
 
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
+
 	input := eventbridge.PutPermissionInput{
 		EventBusName: aws.String(eventBusName),
-		Policy:       aws.String(d.Get("policy").(string)),
+		Policy:       aws.String(policy),
 	}
 
 	log.Printf("[DEBUG] Update EventBridge Bus policy: %s", input)
-	_, err := conn.PutPermission(&input)
+	_, err = conn.PutPermission(&input)
 	if tfawserr.ErrMessageContains(err, eventbridge.ErrCodeResourceNotFoundException, "") {
 		log.Printf("[WARN] EventBridge Bus %q not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/events/bus_policy_test.go
+++ b/internal/service/events/bus_policy_test.go
@@ -260,7 +260,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
 
   policy = jsonencode({
     Statement = [{
-      Sid    = %[1]q
+      Sid = %[1]q
       Action = [
         "events:PutEvents",
         "events:PutRule",
@@ -277,7 +277,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
         aws_cloudwatch_event_bus.test.arn,
       ]
     }]
-    Version = "2012-10-17"    
+    Version = "2012-10-17"
   })
 }
 `, rName)
@@ -294,7 +294,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
 
   policy = jsonencode({
     Statement = [{
-      Sid    = %[1]q
+      Sid = %[1]q
       Action = [
         "events:PutRule",
         "events:DescribeRule",
@@ -311,7 +311,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
         aws_cloudwatch_event_bus.test.arn,
       ]
     }]
-    Version = "2012-10-17"    
+    Version = "2012-10-17"
   })
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccEventsBusPolicy_ PKG=events 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBusPolicy_' -timeout 180m
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (22.35s)
--- PASS: TestAccEventsBusPolicy_basic (27.73s)
--- PASS: TestAccEventsBusPolicy_disappears (133.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	135.115s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccEventsBusPolicy_ PKG=events 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBusPolicy_' -timeout 180m
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (27.80s)
--- PASS: TestAccEventsBusPolicy_basic (34.88s)
--- PASS: TestAccEventsBusPolicy_disappears (138.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	139.324s
```