### PR TITLE
glacier/vault: Fix spurious policy diffs

### DIFF
--- a/.changelog/22166.txt
+++ b/.changelog/22166.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_glacier_vault: Fix erroneous diffs in `access_policy` when no changes made or policies are equivalent
+```
+
+```release-note:bug
+resource/aws_glacier_vault_lock: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/glacier/vault_lock.go
+++ b/internal/service/glacier/vault_lock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -43,6 +44,10 @@ func ResourceVaultLock() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
 				ValidateFunc:     verify.ValidIAMPolicyJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"vault_name": {
 				Type:         schema.TypeString,
@@ -58,10 +63,16 @@ func resourceVaultLockCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GlacierConn
 	vaultName := d.Get("vault_name").(string)
 
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
+
 	input := &glacier.InitiateVaultLockInput{
 		AccountId: aws.String("-"),
 		Policy: &glacier.VaultLockPolicy{
-			Policy: aws.String(d.Get("policy").(string)),
+			Policy: aws.String(policy),
 		},
 		VaultName: aws.String(vaultName),
 	}
@@ -88,7 +99,7 @@ func resourceVaultLockCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error completing Glacier Vault (%s) Lock: %s", vaultName, err)
 	}
 
-	if err := waitForGlacierVaultLockCompletion(conn, vaultName); err != nil {
+	if err := waitVaultLockCompletion(conn, vaultName); err != nil {
 		return fmt.Errorf("error waiting for Glacier Vault Lock (%s) completion: %s", d.Id(), err)
 	}
 
@@ -123,8 +134,15 @@ func resourceVaultLockRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("complete_lock", aws.StringValue(output.State) == "Locked")
-	d.Set("policy", output.Policy)
 	d.Set("vault_name", d.Id())
+
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(output.Policy))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("policy", policyToSet)
 
 	return nil
 }
@@ -150,7 +168,7 @@ func resourceVaultLockDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func glacierVaultLockRefreshFunc(conn *glacier.Glacier, vaultName string) resource.StateRefreshFunc {
+func vaultLockRefreshFunc(conn *glacier.Glacier, vaultName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		input := &glacier.GetVaultLockInput{
 			AccountId: aws.String("-"),
@@ -176,11 +194,11 @@ func glacierVaultLockRefreshFunc(conn *glacier.Glacier, vaultName string) resour
 	}
 }
 
-func waitForGlacierVaultLockCompletion(conn *glacier.Glacier, vaultName string) error {
+func waitVaultLockCompletion(conn *glacier.Glacier, vaultName string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"InProgress"},
 		Target:  []string{"Locked"},
-		Refresh: glacierVaultLockRefreshFunc(conn, vaultName),
+		Refresh: vaultLockRefreshFunc(conn, vaultName),
 		Timeout: 5 * time.Minute,
 	}
 

--- a/internal/service/glacier/vault_lock_test.go
+++ b/internal/service/glacier/vault_lock_test.go
@@ -17,23 +17,23 @@ import (
 func TestAccGlacierVaultLock_basic(t *testing.T) {
 	var vaultLock1 glacier.GetVaultLockOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	glacierVaultResourceName := "aws_glacier_vault.test"
+	vaultResourceName := "aws_glacier_vault.test"
 	resourceName := "aws_glacier_vault_lock.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultLockDestroy,
+		CheckDestroy: testAccCheckVaultLockDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultLockConfigCompleteLock(rName, false),
+				Config: testAccVaultLockConfigCompleteLock(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultLockExists(resourceName, &vaultLock1),
+					testAccCheckVaultLockExists(resourceName, &vaultLock1),
 					resource.TestCheckResourceAttr(resourceName, "complete_lock", "false"),
 					resource.TestCheckResourceAttr(resourceName, "ignore_deletion_error", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
-					resource.TestCheckResourceAttrPair(resourceName, "vault_name", glacierVaultResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "vault_name", vaultResourceName, "name"),
 				),
 			},
 			{
@@ -49,23 +49,23 @@ func TestAccGlacierVaultLock_basic(t *testing.T) {
 func TestAccGlacierVaultLock_completeLock(t *testing.T) {
 	var vaultLock1 glacier.GetVaultLockOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	glacierVaultResourceName := "aws_glacier_vault.test"
+	vaultResourceName := "aws_glacier_vault.test"
 	resourceName := "aws_glacier_vault_lock.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultLockDestroy,
+		CheckDestroy: testAccCheckVaultLockDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultLockConfigCompleteLock(rName, true),
+				Config: testAccVaultLockConfigCompleteLock(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultLockExists(resourceName, &vaultLock1),
+					testAccCheckVaultLockExists(resourceName, &vaultLock1),
 					resource.TestCheckResourceAttr(resourceName, "complete_lock", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ignore_deletion_error", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy"),
-					resource.TestCheckResourceAttrPair(resourceName, "vault_name", glacierVaultResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "vault_name", vaultResourceName, "name"),
 				),
 			},
 			{
@@ -78,7 +78,37 @@ func TestAccGlacierVaultLock_completeLock(t *testing.T) {
 	})
 }
 
-func testAccCheckGlacierVaultLockExists(resourceName string, getVaultLockOutput *glacier.GetVaultLockOutput) resource.TestCheckFunc {
+func TestAccGlacierVaultLock_ignoreEquivalentPolicy(t *testing.T) {
+	var vaultLock1 glacier.GetVaultLockOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	vaultResourceName := "aws_glacier_vault.test"
+	resourceName := "aws_glacier_vault_lock.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVaultLockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVaultLockPolicyOrderConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVaultLockExists(resourceName, &vaultLock1),
+					resource.TestCheckResourceAttr(resourceName, "complete_lock", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_deletion_error", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(resourceName, "vault_name", vaultResourceName, "name"),
+				),
+			},
+			{
+				Config:   testAccVaultLockPolicyNewOrderConfig(rName, false),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVaultLockExists(resourceName string, getVaultLockOutput *glacier.GetVaultLockOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -110,7 +140,7 @@ func testAccCheckGlacierVaultLockExists(resourceName string, getVaultLockOutput 
 	}
 }
 
-func testAccCheckGlacierVaultLockDestroy(s *terraform.State) error {
+func testAccCheckVaultLockDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).GlacierConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -139,7 +169,7 @@ func testAccCheckGlacierVaultLockDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGlacierVaultLockConfigCompleteLock(rName string, completeLock bool) string {
+func testAccVaultLockConfigCompleteLock(rName string, completeLock bool) string {
 	return fmt.Sprintf(`
 resource "aws_glacier_vault" "test" {
   name = %q
@@ -175,4 +205,72 @@ resource "aws_glacier_vault_lock" "test" {
   vault_name            = aws_glacier_vault.test.name
 }
 `, rName, completeLock, completeLock)
+}
+
+func testAccVaultLockPolicyOrderConfig(rName string, completeLock bool) string {
+	return fmt.Sprintf(`
+resource "aws_glacier_vault" "test" {
+  name = %[1]q
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_glacier_vault_lock" "test" {
+  complete_lock         = %[2]t
+  ignore_deletion_error = %[2]t
+  vault_name            = aws_glacier_vault.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Principal = {
+        AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+      }
+      Effect = "Allow"
+      Action = [
+        "glacier:InitiateMultipartUpload",
+        "glacier:AbortMultipartUpload",
+        "glacier:CompleteMultipartUpload",
+        "glacier:DeleteArchive",
+      ]
+      Resource = aws_glacier_vault.test.arn
+    }]
+  })
+}
+`, rName, completeLock)
+}
+
+func testAccVaultLockPolicyNewOrderConfig(rName string, completeLock bool) string {
+	return fmt.Sprintf(`
+resource "aws_glacier_vault" "test" {
+  name = %[1]q
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_glacier_vault_lock" "test" {
+  complete_lock         = %[2]t
+  ignore_deletion_error = %[2]t
+  vault_name            = aws_glacier_vault.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Principal = {
+        AWS = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
+      }
+      Effect = "Allow"
+      Action = [
+        "glacier:InitiateMultipartUpload",
+        "glacier:DeleteArchive",
+        "glacier:CompleteMultipartUpload",
+        "glacier:AbortMultipartUpload",
+      ]
+      Resource = [aws_glacier_vault.test.arn]
+    }]
+  })
+}
+`, rName, completeLock)
 }

--- a/internal/service/glacier/vault_test.go
+++ b/internal/service/glacier/vault_test.go
@@ -25,12 +25,12 @@ func TestAccGlacierVault_basic(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultDestroy,
+		CheckDestroy: testAccCheckVaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultBasicConfig(rName),
+				Config: testAccVaultBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "glacier", regexp.MustCompile(`vaults/.+`)),
@@ -57,12 +57,12 @@ func TestAccGlacierVault_notification(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultDestroy,
+		CheckDestroy: testAccCheckVaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultNotificationConfig(rName),
+				Config: testAccVaultNotificationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "notification.0.events.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "notification.0.sns_topic", snsResourceName, "arn"),
@@ -74,17 +74,17 @@ func TestAccGlacierVault_notification(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGlacierVaultBasicConfig(rName),
+				Config: testAccVaultBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "0"),
 					testAccCheckVaultNotificationsMissing(resourceName),
 				),
 			},
 			{
-				Config: testAccGlacierVaultNotificationConfig(rName),
+				Config: testAccVaultNotificationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "notification.0.events.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "notification.0.sns_topic", snsResourceName, "arn"),
@@ -103,12 +103,12 @@ func TestAccGlacierVault_policy(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultDestroy,
+		CheckDestroy: testAccCheckVaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultPolicyConfig(rName),
+				Config: testAccVaultPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "access_policy",
 						regexp.MustCompile(`"Sid":"cross-account-upload".+`)),
@@ -120,18 +120,18 @@ func TestAccGlacierVault_policy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGlacierVaultPolicyConfigUpdated(rName),
+				Config: testAccVaultPolicyConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "access_policy",
 						regexp.MustCompile(`"Sid":"cross-account-upload1".+`)),
 				),
 			},
 			{
-				Config: testAccGlacierVaultBasicConfig(rName),
+				Config: testAccVaultBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "access_policy", ""),
 				),
 			},
@@ -148,12 +148,12 @@ func TestAccGlacierVault_tags(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultDestroy,
+		CheckDestroy: testAccCheckVaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultConfigTags1(rName, "key1", "value1"),
+				Config: testAccVaultConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -164,18 +164,18 @@ func TestAccGlacierVault_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccGlacierVaultConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccVaultConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccGlacierVaultConfigTags1(rName, "key2", "value2"),
+				Config: testAccVaultConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -193,12 +193,12 @@ func TestAccGlacierVault_disappears(t *testing.T) {
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
 		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckGlacierVaultDestroy,
+		CheckDestroy: testAccCheckVaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVaultBasicConfig(rName),
+				Config: testAccVaultBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists(resourceName, &vault),
+					testAccCheckVaultExists(resourceName, &vault),
 					acctest.CheckResourceDisappears(acctest.Provider, tfglacier.ResourceVault(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -207,7 +207,37 @@ func TestAccGlacierVault_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckGlacierVaultExists(name string, vault *glacier.DescribeVaultOutput) resource.TestCheckFunc {
+func TestAccGlacierVault_ignoreEquivalent(t *testing.T) {
+	var vault glacier.DescribeVaultOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glacier_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, glacier.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVaultPolicyOrderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "glacier", regexp.MustCompile(`vaults/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "0"),
+					resource.TestMatchResourceAttr(resourceName, "access_policy", regexp.MustCompile(fmt.Sprintf(`"Sid":"%s"`, rName))),
+				),
+			},
+			{
+				Config:   testAccVaultPolicyNewOrderConfig(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVaultExists(name string, vault *glacier.DescribeVaultOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -271,7 +301,7 @@ func testAccCheckVaultNotificationsMissing(name string) resource.TestCheckFunc {
 
 }
 
-func testAccCheckGlacierVaultDestroy(s *terraform.State) error {
+func testAccCheckVaultDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).GlacierConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -295,7 +325,7 @@ func testAccCheckGlacierVaultDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGlacierVaultBasicConfig(rName string) string {
+func testAccVaultBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glacier_vault" "test" {
   name = %[1]q
@@ -303,7 +333,7 @@ resource "aws_glacier_vault" "test" {
 `, rName)
 }
 
-func testAccGlacierVaultNotificationConfig(rName string) string {
+func testAccVaultNotificationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -320,7 +350,7 @@ resource "aws_glacier_vault" "test" {
 `, rName)
 }
 
-func testAccGlacierVaultPolicyConfig(rName string) string {
+func testAccVaultPolicyConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -338,7 +368,7 @@ resource "aws_glacier_vault" "test" {
        {
           "Sid":"cross-account-upload",
           "Principal": {
-             "AWS": ["*"]
+             "AWS": "*"
           },
           "Effect":"Allow",
           "Action": [
@@ -346,7 +376,7 @@ resource "aws_glacier_vault" "test" {
              "glacier:AbortMultipartUpload",
              "glacier:CompleteMultipartUpload"
           ],
-          "Resource": ["arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
+          "Resource": "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"
        }
     ]
 }
@@ -355,7 +385,7 @@ EOF
 `, rName)
 }
 
-func testAccGlacierVaultPolicyConfigUpdated(rName string) string {
+func testAccVaultPolicyConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -391,7 +421,7 @@ EOF
 `, rName)
 }
 
-func testAccGlacierVaultConfigTags1(rName, tagKey1, tagValue1 string) string {
+func testAccVaultConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_glacier_vault" "test" {
   name = %[1]q
@@ -403,7 +433,7 @@ resource "aws_glacier_vault" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccGlacierVaultConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccVaultConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_glacier_vault" "test" {
   name = %[1]q
@@ -414,4 +444,68 @@ resource "aws_glacier_vault" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccVaultPolicyOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_glacier_vault" "test" {
+  name = %[1]q
+
+  access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid = %[1]q
+      Principal = {
+        AWS = ["*"]
+      }
+      Effect = "Allow"
+      Action = [
+        "glacier:InitiateMultipartUpload",
+        "glacier:AbortMultipartUpload",
+        "glacier:CompleteMultipartUpload",
+      ]
+      Resource = [
+        "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s",
+      ]
+    }]
+  })
+}
+`, rName)
+}
+
+func testAccVaultPolicyNewOrderConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_glacier_vault" "test" {
+  name = %[1]q
+
+  access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid = %[1]q
+      Principal = {
+        AWS = ["*"]
+      }
+      Effect = "Allow"
+      Action = [
+        "glacier:CompleteMultipartUpload",
+        "glacier:InitiateMultipartUpload",
+        "glacier:AbortMultipartUpload",
+      ]
+      Resource = "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"
+    }]
+  })
+}
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968 

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccGlacierVaultLock PKG=glacier
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glacier/... -v -count 1 -parallel 20 -run='TestAccGlacierVaultLock' -timeout 180m
--- PASS: TestAccGlacierVaultLock_basic (20.78s)
--- PASS: TestAccGlacierVaultLock_completeLock (21.68s)
--- PASS: TestAccGlacierVaultLock_ignoreEquivalentPolicy (28.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	29.892s
% make testacc TESTS=TestAccGlacierVault_ PKG=glacier 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glacier/... -v -count 1 -parallel 20 -run='TestAccGlacierVault_' -timeout 180m
--- PASS: TestAccGlacierVault_disappears (15.40s)
--- PASS: TestAccGlacierVault_basic (22.40s)
--- PASS: TestAccGlacierVault_ignoreEquivalent (29.49s)
--- PASS: TestAccGlacierVault_tags (51.03s)
--- PASS: TestAccGlacierVault_policy (52.05s)
--- PASS: TestAccGlacierVault_notification (55.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	57.405s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccGlacierVault_ PKG=glacier
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glacier/... -v -count 1 -parallel 20 -run='TestAccGlacierVault_' -timeout 180m
--- PASS: TestAccGlacierVault_disappears (17.97s)
--- PASS: TestAccGlacierVault_basic (24.97s)
--- PASS: TestAccGlacierVault_ignoreEquivalent (35.61s)
--- PASS: TestAccGlacierVault_tags (58.81s)
--- PASS: TestAccGlacierVault_policy (61.93s)
--- PASS: TestAccGlacierVault_notification (63.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	65.247s
% make testacc TESTS=TestAccGlacierVaultLock PKG=glacier
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glacier/... -v -count 1 -parallel 20 -run='TestAccGlacierVaultLock' -timeout 180m
--- PASS: TestAccGlacierVaultLock_basic (25.84s)
--- PASS: TestAccGlacierVaultLock_completeLock (26.52s)
--- PASS: TestAccGlacierVaultLock_ignoreEquivalentPolicy (35.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	36.922s
```