### PR TITLE
iot/policy: Fix diffs with equivalent policies

### DIFF
--- a/.changelog/22169.txt
+++ b/.changelog/22169.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/iot/policy.go
+++ b/internal/service/iot/policy.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iot"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -31,7 +33,12 @@ func ResourcePolicy() *schema.Resource {
 			"policy": {
 				Type:             schema.TypeString,
 				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -49,9 +56,15 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	conn := meta.(*conns.AWSClient).IoTConn
 
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+	}
+
 	out, err := conn.CreatePolicy(&iot.CreatePolicyInput{
 		PolicyName:     aws.String(d.Get("name").(string)),
-		PolicyDocument: aws.String(d.Get("policy").(string)),
+		PolicyDocument: aws.String(policy),
 	})
 
 	if err != nil {
@@ -83,7 +96,14 @@ func resourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", out.PolicyArn)
 	d.Set("default_version_id", out.DefaultVersionId)
 	d.Set("name", out.PolicyName)
-	d.Set("policy", out.PolicyDocument)
+
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(out.PolicyDocument))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("policy", policyToSet)
 
 	return nil
 }
@@ -92,9 +112,15 @@ func resourcePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IoTConn
 
 	if d.HasChange("policy") {
-		_, err := conn.CreatePolicyVersion(&iot.CreatePolicyVersionInput{
+		policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
+		}
+
+		_, err = conn.CreatePolicyVersion(&iot.CreatePolicyVersionInput{
 			PolicyName:     aws.String(d.Id()),
-			PolicyDocument: aws.String(d.Get("policy").(string)),
+			PolicyDocument: aws.String(policy),
 			SetAsDefault:   aws.Bool(true),
 		})
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968 

Output from acceptance testing:

```console
% make testacc TESTS=TestAccIoTPolicy_basic PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTPolicy_basic' -timeout 180m
--- PASS: TestAccIoTPolicy_basic (16.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	18.453s
```
