### PR TITLE
networkfirewall/resource_policy: Fix equivalent policy diffs

### DIFF
--- a/.changelog/22171.txt
+++ b/.changelog/22171.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_networkfirewall_resource_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/networkfirewall/resource_policy_test.go
+++ b/internal/service/networkfirewall/resource_policy_test.go
@@ -275,7 +275,7 @@ resource "aws_networkfirewall_resource_policy" "test" {
         "network-firewall:UpdateFirewall",
         "network-firewall:AssociateFirewallPolicy",
         "network-firewall:ListFirewallPolicies",
-		"network-firewall:CreateFirewall",
+        "network-firewall:CreateFirewall",
       ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_firewall_policy.test.arn

--- a/internal/service/networkfirewall/resource_policy_test.go
+++ b/internal/service/networkfirewall/resource_policy_test.go
@@ -16,7 +16,7 @@ import (
 	tfnetworkfirewall "github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall"
 )
 
-func TestAccNetworkFirewallResourcePolicy_firewallPolicy(t *testing.T) {
+func TestAccNetworkFirewallResourcePolicy_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_networkfirewall_resource_policy.test"
 
@@ -27,7 +27,7 @@ func TestAccNetworkFirewallResourcePolicy_firewallPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkFirewallResourcePolicy_firewallPolicy(rName),
+				Config: testAccResourcePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_networkfirewall_firewall_policy.test", "arn"),
@@ -35,17 +35,38 @@ func TestAccNetworkFirewallResourcePolicy_firewallPolicy(t *testing.T) {
 				),
 			},
 			{
-				// Update the policy's Actions
-				Config: testAccNetworkFirewallResourcePolicy_firewallPolicy_updatePolicy(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourcePolicyExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:UpdateFirewall","network-firewall:AssociateFirewallPolicy","network-firewall:ListFirewallPolicies","network-firewall:CreateFirewall"\]`)),
-				),
-			},
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkFirewallResourcePolicy_ignoreEquivalent(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_resource_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, networkfirewall.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckResourcePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePolicyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_networkfirewall_firewall_policy.test", "arn"),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:CreateFirewall","network-firewall:UpdateFirewall","network-firewall:AssociateFirewallPolicy","network-firewall:ListFirewallPolicies"\]`)),
+				),
+			},
+			{
+				Config: testAccResourcePolicyEquivalentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourcePolicyExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:CreateFirewall","network-firewall:UpdateFirewall","network-firewall:AssociateFirewallPolicy","network-firewall:ListFirewallPolicies"\]`)),
+				),
 			},
 		},
 	})
@@ -62,7 +83,7 @@ func TestAccNetworkFirewallResourcePolicy_ruleGroup(t *testing.T) {
 		CheckDestroy: testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkFirewallResourcePolicy_ruleGroup(rName),
+				Config: testAccResourcePolicy_ruleGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_arn", "aws_networkfirewall_rule_group.test", "arn"),
@@ -71,10 +92,10 @@ func TestAccNetworkFirewallResourcePolicy_ruleGroup(t *testing.T) {
 			},
 			{
 				// Update the policy's Actions
-				Config: testAccNetworkFirewallResourcePolicy_ruleGroup_updatePolicy(rName),
+				Config: testAccResourcePolicy_ruleGroup_updatePolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:UpdateFirewallPolicy","network-firewall:ListRuleGroups","network-firewall:CreateFirewallPolicy"\]`)),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`"Action":\["network-firewall:CreateFirewallPolicy","network-firewall:UpdateFirewallPolicy","network-firewall:ListRuleGroups"\]`)),
 				),
 			},
 			{
@@ -97,7 +118,7 @@ func TestAccNetworkFirewallResourcePolicy_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkFirewallResourcePolicy_firewallPolicy(rName),
+				Config: testAccResourcePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfnetworkfirewall.ResourceResourcePolicy(), resourceName),
@@ -119,7 +140,7 @@ func TestAccNetworkFirewallResourcePolicy_Disappears_firewallPolicy(t *testing.T
 		CheckDestroy: testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkFirewallResourcePolicy_firewallPolicy(rName),
+				Config: testAccResourcePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfnetworkfirewall.ResourceFirewallPolicy(), "aws_networkfirewall_firewall_policy.test"),
@@ -141,7 +162,7 @@ func TestAccNetworkFirewallResourcePolicy_Disappears_ruleGroup(t *testing.T) {
 		CheckDestroy: testAccCheckResourcePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkFirewallResourcePolicy_ruleGroup(rName),
+				Config: testAccResourcePolicy_ruleGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourcePolicyExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfnetworkfirewall.ResourceRuleGroup(), "aws_networkfirewall_rule_group.test"),
@@ -200,14 +221,14 @@ func testAccCheckResourcePolicyExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccNetworkFirewallResourcePolicyFirewallPolicyBaseConfig(rName string) string {
+func testAccResourcePolicyFirewallPolicyBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}
 
 resource "aws_networkfirewall_firewall_policy" "test" {
-  name = %q
+  name = %[1]q
   firewall_policy {
     stateless_fragment_default_actions = ["aws:drop"]
     stateless_default_actions          = ["aws:pass"]
@@ -216,9 +237,9 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 `, rName)
 }
 
-func testAccNetworkFirewallResourcePolicy_firewallPolicy(rName string) string {
+func testAccResourcePolicyConfig(rName string) string {
 	return acctest.ConfigCompose(
-		testAccNetworkFirewallResourcePolicyFirewallPolicyBaseConfig(rName), `
+		testAccResourcePolicyFirewallPolicyBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_firewall_policy.test.arn
   # policy's Action element must include all of the following operations
@@ -228,7 +249,7 @@ resource "aws_networkfirewall_resource_policy" "test" {
         "network-firewall:CreateFirewall",
         "network-firewall:UpdateFirewall",
         "network-firewall:AssociateFirewallPolicy",
-        "network-firewall:ListFirewallPolicies"
+        "network-firewall:ListFirewallPolicies",
       ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_firewall_policy.test.arn
@@ -242,9 +263,9 @@ resource "aws_networkfirewall_resource_policy" "test" {
 `)
 }
 
-func testAccNetworkFirewallResourcePolicy_firewallPolicy_updatePolicy(rName string) string {
+func testAccResourcePolicyEquivalentConfig(rName string) string {
 	return acctest.ConfigCompose(
-		testAccNetworkFirewallResourcePolicyFirewallPolicyBaseConfig(rName), `
+		testAccResourcePolicyFirewallPolicyBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_firewall_policy.test.arn
   # policy's Action element must include all of the following operations
@@ -254,7 +275,7 @@ resource "aws_networkfirewall_resource_policy" "test" {
         "network-firewall:UpdateFirewall",
         "network-firewall:AssociateFirewallPolicy",
         "network-firewall:ListFirewallPolicies",
-        "network-firewall:CreateFirewall"
+		"network-firewall:CreateFirewall",
       ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_firewall_policy.test.arn
@@ -268,7 +289,7 @@ resource "aws_networkfirewall_resource_policy" "test" {
 `)
 }
 
-func testAccNetworkFirewallResourcePolicyRuleGroupBaseConfig(rName string) string {
+func testAccResourcePolicyRuleGroupBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -291,9 +312,9 @@ resource "aws_networkfirewall_rule_group" "test" {
 `, rName)
 }
 
-func testAccNetworkFirewallResourcePolicy_ruleGroup(rName string) string {
+func testAccResourcePolicy_ruleGroup(rName string) string {
 	return acctest.ConfigCompose(
-		testAccNetworkFirewallResourcePolicyRuleGroupBaseConfig(rName), `
+		testAccResourcePolicyRuleGroupBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_rule_group.test.arn
   # policy's Action element must include all of the following operations
@@ -316,9 +337,9 @@ resource "aws_networkfirewall_resource_policy" "test" {
 `)
 }
 
-func testAccNetworkFirewallResourcePolicy_ruleGroup_updatePolicy(rName string) string {
+func testAccResourcePolicy_ruleGroup_updatePolicy(rName string) string {
 	return acctest.ConfigCompose(
-		testAccNetworkFirewallResourcePolicyRuleGroupBaseConfig(rName), `
+		testAccResourcePolicyRuleGroupBaseConfig(rName), `
 resource "aws_networkfirewall_resource_policy" "test" {
   resource_arn = aws_networkfirewall_rule_group.test.arn
   # policy's Action element must include all of the following operations
@@ -327,7 +348,7 @@ resource "aws_networkfirewall_resource_policy" "test" {
       Action = [
         "network-firewall:UpdateFirewallPolicy",
         "network-firewall:ListRuleGroups",
-        "network-firewall:CreateFirewallPolicy"
+        "network-firewall:CreateFirewallPolicy",
       ]
       Effect   = "Allow"
       Resource = aws_networkfirewall_rule_group.test.arn


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968

Output from acceptance testing:

(For failure, see #22174)

```console
--- FAIL: TestAccNetworkFirewallResourcePolicy_disappears (11.17s) (* failing prior to this PR)
--- PASS: TestAccNetworkFirewallResourcePolicy_ignoreEquivalent (146.07s)
--- PASS: TestAccNetworkFirewallResourcePolicy_basic (148.90s)
--- PASS: TestAccNetworkFirewallResourcePolicy_ruleGroup (150.59s)
--- PASS: TestAccNetworkFirewallResourcePolicy_Disappears_firewallPolicy (154.69s)
--- PASS: TestAccNetworkFirewallResourcePolicy_Disappears_ruleGroup (156.17s)
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccNetworkFirewallResourcePolicy PKG=networkfirewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallResourcePolicy' -timeout 180m
--- SKIP: TestAccNetworkFirewallResourcePolicy_Disappears_ruleGroup (19.72s)
--- SKIP: TestAccNetworkFirewallResourcePolicy_basic (25.46s)
--- SKIP: TestAccNetworkFirewallResourcePolicy_Disappears_firewallPolicy (25.74s)
--- SKIP: TestAccNetworkFirewallResourcePolicy_ruleGroup (26.10s)
--- SKIP: TestAccNetworkFirewallResourcePolicy_disappears (28.29s)
--- SKIP: TestAccNetworkFirewallResourcePolicy_ignoreEquivalent (29.30s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	30.575s
```
