### PR TITLE
New Resource: aws_ecr_pull_through_cache_rule

### DIFF
--- a/.changelog/22172.txt
+++ b/.changelog/22172.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ecr_pull_through_cache_rule
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1121,6 +1121,7 @@ func Provider() *schema.Provider {
 			"aws_vpn_gateway_route_propagation":                   ec2.ResourceVPNGatewayRoutePropagation(),
 
 			"aws_ecr_lifecycle_policy":          ecr.ResourceLifecyclePolicy(),
+			"aws_ecr_pull_through_cache_rule":   ecr.ResourcePullThroughCacheRule(),
 			"aws_ecr_registry_policy":           ecr.ResourceRegistryPolicy(),
 			"aws_ecr_replication_configuration": ecr.ResourceReplicationConfiguration(),
 			"aws_ecr_repository":                ecr.ResourceRepository(),

--- a/internal/service/ecr/find.go
+++ b/internal/service/ecr/find.go
@@ -1,0 +1,34 @@
+package ecr
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+)
+
+func FindPullThroughCacheRuleByRepositoryPrefix(
+	ctx context.Context,
+	conn *ecr.ECR,
+	repositoryPrefix string,
+) (*ecr.PullThroughCacheRule, error) {
+	input := ecr.DescribePullThroughCacheRulesInput{
+		EcrRepositoryPrefixes: aws.StringSlice([]string{repositoryPrefix}),
+	}
+
+	output, err := conn.DescribePullThroughCacheRulesWithContext(ctx, &input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, ecr.ErrCodePullThroughCacheRuleNotFoundException) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	if output == nil || len(output.PullThroughCacheRules) != 1 {
+		return nil, nil
+	}
+
+	return output.PullThroughCacheRules[0], nil
+}

--- a/internal/service/ecr/find.go
+++ b/internal/service/ecr/find.go
@@ -6,28 +6,34 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func FindPullThroughCacheRuleByRepositoryPrefix(
-	ctx context.Context,
-	conn *ecr.ECR,
-	repositoryPrefix string,
-) (*ecr.PullThroughCacheRule, error) {
+func FindPullThroughCacheRuleByRepositoryPrefix(ctx context.Context, conn *ecr.ECR, repositoryPrefix string) (*ecr.PullThroughCacheRule, error) {
 	input := ecr.DescribePullThroughCacheRulesInput{
 		EcrRepositoryPrefixes: aws.StringSlice([]string{repositoryPrefix}),
 	}
 
 	output, err := conn.DescribePullThroughCacheRulesWithContext(ctx, &input)
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, ecr.ErrCodePullThroughCacheRuleNotFoundException) {
-			return nil, nil
-		}
 
+	if tfawserr.ErrCodeEquals(err, ecr.ErrCodePullThroughCacheRuleNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || len(output.PullThroughCacheRules) != 1 {
-		return nil, nil
+	if output == nil || len(output.PullThroughCacheRules) == 0 || output.PullThroughCacheRules[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output.PullThroughCacheRules); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
 	}
 
 	return output.PullThroughCacheRules[0], nil

--- a/internal/service/ecr/pull_through_cache_rule.go
+++ b/internal/service/ecr/pull_through_cache_rule.go
@@ -1,0 +1,109 @@
+package ecr
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func ResourcePullThroughCacheRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePullThroughCacheRuleCreate,
+		ReadContext:   resourcePullThroughCacheRuleRead,
+		DeleteContext: resourcePullThroughCacheRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"ecr_repository_prefix": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 20),
+					validation.StringMatch(
+						regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`),
+						"must only include alphanumeric, underscore, period, or hyphen characters"),
+				),
+			},
+			"registry_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"upstream_registry_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourcePullThroughCacheRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ECRConn
+
+	input := &ecr.CreatePullThroughCacheRuleInput{
+		EcrRepositoryPrefix: aws.String(d.Get("ecr_repository_prefix").(string)),
+		UpstreamRegistryUrl: aws.String(d.Get("upstream_registry_url").(string)),
+	}
+
+	_, err := conn.CreatePullThroughCacheRuleWithContext(ctx, input)
+	if err != nil {
+		return diag.Errorf("failed to create pull through cache rule: %s", err)
+	}
+
+	d.SetId(d.Get("ecr_repository_prefix").(string))
+
+	return resourcePullThroughCacheRuleRead(ctx, d, meta)
+}
+
+func resourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ECRConn
+
+	rule, err := FindPullThroughCacheRuleByRepositoryPrefix(ctx, conn, d.Id())
+	if err != nil {
+		return diag.Errorf("failed to find ECR Pull Through Cache Rule: %s", err)
+	}
+
+	if rule == nil {
+		log.Printf("[WARN] ECR Pull Through Cache Rule %s not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("ecr_repository_prefix", rule.EcrRepositoryPrefix)
+	d.Set("registry_id", rule.RegistryId)
+	d.Set("upstream_registry_url", rule.UpstreamRegistryUrl)
+
+	return nil
+}
+
+func resourcePullThroughCacheRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ECRConn
+
+	input := &ecr.DeletePullThroughCacheRuleInput{
+		EcrRepositoryPrefix: aws.String(d.Get("ecr_repository_prefix").(string)),
+		RegistryId:          aws.String(d.Get("registry_id").(string)),
+	}
+
+	_, err := conn.DeletePullThroughCacheRuleWithContext(ctx, input)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, ecr.ErrCodePullThroughCacheRuleNotFoundException) {
+			return nil
+		}
+
+		return diag.Errorf("failed to delete pull through cache rule: %s", err)
+	}
+
+	return nil
+}

--- a/internal/service/ecr/pull_through_cache_rule.go
+++ b/internal/service/ecr/pull_through_cache_rule.go
@@ -59,11 +59,11 @@ func resourcePullThroughCacheRuleCreate(ctx context.Context, d *schema.ResourceD
 		UpstreamRegistryUrl: aws.String(d.Get("upstream_registry_url").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating ECR Pull Through Cache Repository: %s", input)
+	log.Printf("[DEBUG] Creating ECR Pull Through Cache Rule: %s", input)
 	_, err := conn.CreatePullThroughCacheRuleWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating ECR Pull Through Cache Repository (%s): %s", repositoryPrefix, err)
+		return diag.Errorf("error creating ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
 	}
 
 	d.SetId(repositoryPrefix)
@@ -77,13 +77,13 @@ func resourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceDat
 	rule, err := FindPullThroughCacheRuleByRepositoryPrefix(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] ECR Pull Through Cache Repository (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] ECR Pull Through Cache Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading ECR Pull Through Cache Repository (%s): %s", d.Id(), err)
+		return diag.Errorf("error reading ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
 	}
 
 	d.Set("ecr_repository_prefix", rule.EcrRepositoryPrefix)
@@ -96,7 +96,7 @@ func resourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceDat
 func resourcePullThroughCacheRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ECRConn
 
-	log.Printf("[DEBUG] Deleting ECR Pull Through Cache Repository: (%s)", d.Id())
+	log.Printf("[DEBUG] Deleting ECR Pull Through Cache Rule: (%s)", d.Id())
 	_, err := conn.DeletePullThroughCacheRuleWithContext(ctx, &ecr.DeletePullThroughCacheRuleInput{
 		EcrRepositoryPrefix: aws.String(d.Id()),
 		RegistryId:          aws.String(d.Get("registry_id").(string)),
@@ -107,7 +107,7 @@ func resourcePullThroughCacheRuleDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting ECR Pull Through Cache Repository (%s): %s", d.Id(), err)
+		return diag.Errorf("error deleting ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -70,6 +70,10 @@ func TestAccPullThroughCacheRule_failWhenAlreadyExists(t *testing.T) {
 	repositoryPrefix := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_ecr_pull_through_cache_rule.test"
 
+	if acctest.Partition() == "aws-us-gov" {
+		t.Skip("ECR Pull Through Cache Rule is not supported in GovCloud partition")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
@@ -105,7 +109,7 @@ func testAccCheckPullThroughCacheRuleDestroy(s *terraform.State) error {
 			return err
 		}
 
-		return fmt.Errorf("ECR Pull Through Cache Repository %s still exists", rs.Primary.ID)
+		return fmt.Errorf("ECR Pull Through Cache Rule %s still exists", rs.Primary.ID)
 	}
 
 	return nil
@@ -119,7 +123,7 @@ func testAccCheckPullThroughCacheRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ECR Pull Through Cache Repository ID is set")
+			return fmt.Errorf("No ECR Pull Through Cache Rule ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -6,8 +6,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfecr "github.com/hashicorp/terraform-provider-aws/internal/service/ecr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccPullThroughCacheRule_basic(t *testing.T) {
@@ -51,7 +50,7 @@ func TestAccPullThroughCacheRule_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, cloudwatch.EndpointsID),
+		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckPullThroughCacheRuleDestroy,
 		Steps: []resource.TestStep{
@@ -96,45 +95,39 @@ func testAccCheckPullThroughCacheRuleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		rule, err := tfecr.FindPullThroughCacheRuleByRepositoryPrefix(context.Background(), conn, rs.Primary.Attributes["ecr_repository_prefix"])
+		_, err := tfecr.FindPullThroughCacheRuleByRepositoryPrefix(context.Background(), conn, rs.Primary.Attributes["ecr_repository_prefix"])
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
 			return err
 		}
 
-		if rule != nil {
-			return fmt.Errorf("ECR Pull Through Cache Rule still exists: %s", rs.Primary.Attributes["ecr_repository_prefix"])
-		}
-
-		return nil
+		return fmt.Errorf("ECR Pull Through Cache Repository %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckPullThroughCacheRuleExists(resourceName string) resource.TestCheckFunc {
+func testAccCheckPullThroughCacheRuleExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("resource %s has not set its id", resourceName)
+			return fmt.Errorf("No ECR Pull Through Cache Repository ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn
 
-		rule, err := tfecr.FindPullThroughCacheRuleByRepositoryPrefix(context.Background(), conn, rs.Primary.ID)
+		_, err := tfecr.FindPullThroughCacheRuleByRepositoryPrefix(context.Background(), conn, rs.Primary.ID)
+
 		if err != nil {
-			return fmt.Errorf("error reading ECR Pull Through Cache Rule (%s): %w", rs.Primary.ID, err)
-		}
-
-		if rule == nil {
-			return fmt.Errorf("ECR Pull Through Cache Rule (%s) not found", rs.Primary.ID)
-		}
-
-		if aws.StringValue(rule.EcrRepositoryPrefix) != rs.Primary.ID {
-			return fmt.Errorf("ECR Pull Through Cache Rule (%s) ID not consistent with repository prefix", rs.Primary.ID)
+			return err
 		}
 
 		return nil

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -1,0 +1,173 @@
+package ecr_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfecr "github.com/hashicorp/terraform-provider-aws/internal/service/ecr"
+)
+
+func TestAccPullThroughCacheRule_basic(t *testing.T) {
+	repositoryPrefix := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_ecr_pull_through_cache_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckPullThroughCacheRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleConfig(repositoryPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPullThroughCacheRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ecr_repository_prefix", repositoryPrefix),
+					testAccCheckPullThroughCacheRuleRegistryID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "upstream_registry_url", "public.ecr.aws"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPullThroughCacheRule_disappears(t *testing.T) {
+	repositoryPrefix := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_ecr_pull_through_cache_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloudwatch.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckPullThroughCacheRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleConfig(repositoryPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPullThroughCacheRuleExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfecr.ResourcePullThroughCacheRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccPullThroughCacheRule_failWhenAlreadyExists(t *testing.T) {
+	repositoryPrefix := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_ecr_pull_through_cache_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckPullThroughCacheRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleConfig_failWhenAlreadyExist(repositoryPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPullThroughCacheRuleExists(resourceName),
+				),
+				ExpectError: regexp.MustCompile(`PullThroughCacheRuleAlreadyExistsException`),
+			},
+		},
+	})
+}
+
+func testAccCheckPullThroughCacheRuleDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ecr_pull_through_cache_rule" {
+			continue
+		}
+
+		rule, err := tfecr.FindPullThroughCacheRuleByRepositoryPrefix(context.Background(), conn, rs.Primary.Attributes["ecr_repository_prefix"])
+		if err != nil {
+			return err
+		}
+
+		if rule != nil {
+			return fmt.Errorf("ECR Pull Through Cache Rule still exists: %s", rs.Primary.Attributes["ecr_repository_prefix"])
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccCheckPullThroughCacheRuleExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has not set its id", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn
+
+		rule, err := tfecr.FindPullThroughCacheRuleByRepositoryPrefix(context.Background(), conn, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error reading ECR Pull Through Cache Rule (%s): %w", rs.Primary.ID, err)
+		}
+
+		if rule == nil {
+			return fmt.Errorf("ECR Pull Through Cache Rule (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(rule.EcrRepositoryPrefix) != rs.Primary.ID {
+			return fmt.Errorf("ECR Pull Through Cache Rule (%s) ID not consistent with repository prefix", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPullThroughCacheRuleRegistryID(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := acctest.AccountID()
+		return resource.TestCheckResourceAttr(resourceName, "registry_id", attributeValue)(s)
+	}
+}
+
+func testAccPullThroughCacheRuleConfig(repositoryPrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_pull_through_cache_rule" "test" {
+  ecr_repository_prefix = %[1]q
+  upstream_registry_url = "public.ecr.aws"
+}
+`, repositoryPrefix)
+}
+
+func testAccPullThroughCacheRuleConfig_failWhenAlreadyExist(repositoryPrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_pull_through_cache_rule" "test" {
+  ecr_repository_prefix = %[1]q
+  upstream_registry_url = "public.ecr.aws"
+}
+
+resource "aws_ecr_pull_through_cache_rule" "duplicate" {
+  depends_on            = [aws_ecr_pull_through_cache_rule.test]
+  ecr_repository_prefix = %[1]q
+  upstream_registry_url = "public.ecr.aws"
+}
+`, repositoryPrefix)
+}

--- a/website/docs/r/ecr_pull_through_cache_rule.html.markdown
+++ b/website/docs/r/ecr_pull_through_cache_rule.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "ECR"
+layout: "aws"
+page_title: "AWS: aws_ecr_pull_through_cache_rule"
+description: |-
+  Provides an Elastic Container Registry Pull Through Cache Rule.
+---
+
+# Resource: aws_ecr_pull_through_cache_rule
+
+Provides an Elastic Container Registry Pull Through Cache Rule.
+
+More information about pull through cache rules, including the set of supported
+upstream repositories, see [Using pull through cache rules](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html).
+
+## Example Usage
+
+```terraform
+resource "aws_ecr_pull_through_cache_rule" "example" {
+  ecr_repository_prefix = "ecr-public"
+  upstream_registry_url = "public.ecr.aws"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ecr_repository_prefix` - (Required, Forces new resource) The repository name prefix to use when caching images from the source registry.
+* `upstream_registry_url` - (Required, Forces new resource) The registry URL of the upstream public registry to use as the source.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `registry_id` - The registry ID where the repository was created.
+
+## Import
+
+Use the `ecr_repository_prefix` to import a Pull Through Cache Rule. For example:
+
+```
+$ terraform import aws_ecr_pull_through_cache_rule.example ecr-public
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21951

Implementation of `registry_id` follows the same pattern as `aws_ecr_repository`.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=ecr TESTS=TestAccPullThroughCacheRule_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccPullThroughCacheRule_' -timeout 180m
=== RUN   TestAccPullThroughCacheRule_basic
=== PAUSE TestAccPullThroughCacheRule_basic
=== RUN   TestAccPullThroughCacheRule_disappears
=== PAUSE TestAccPullThroughCacheRule_disappears
=== RUN   TestAccPullThroughCacheRule_failWhenAlreadyExists
=== PAUSE TestAccPullThroughCacheRule_failWhenAlreadyExists
=== CONT  TestAccPullThroughCacheRule_basic
=== CONT  TestAccPullThroughCacheRule_failWhenAlreadyExists
=== CONT  TestAccPullThroughCacheRule_disappears
--- PASS: TestAccPullThroughCacheRule_failWhenAlreadyExists (15.04s)
--- PASS: TestAccPullThroughCacheRule_disappears (17.12s)
--- PASS: TestAccPullThroughCacheRule_basic (22.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        24.076s
```
