### PR TITLE
Add an Action to notify of regressions

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -1,0 +1,35 @@
+name: "Regressions Slack Notifier"
+on:
+  issues:
+    types:
+      - labeled
+  pull_request:
+    types:
+      - labeled
+jobs:
+  slack-notification:
+    if: ${{ github.event.label.name == 'regression' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Issues
+        if: ${{ github.event_name == 'issues' }}
+        uses: actions-ecosystem/action-slack-notifier@v1
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: ${{ secrets.SLACK_CHANNEL }}
+          color: red
+          verbose: false
+          message: |
+            :warning: The following issue has been labeled as a regression:
+            https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}
+      - name: Pull Requests
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions-ecosystem/action-slack-notifier@v1
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: ${{ secrets.SLACK_CHANNEL }}
+          color: red
+          verbose: false
+          message: |
+            :warning: The following pull request has been labeled as a regression:
+            https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This pull request introduces a GitHub Action designed to notify the team in Slack whenever a pull request or issue is labeled as a regression.