### PR TITLE
resource/aws_db_instance: Correctly handles update and reboot for replica instances

### DIFF
--- a/.changelog/22178.txt
+++ b/.changelog/22178.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix error with reboot of replica
+```

--- a/docs/contributing/contribution-checklists.md
+++ b/docs/contributing/contribution-checklists.md
@@ -148,7 +148,7 @@ func TestAccServiceThing_nameGenerated(t *testing.T) {
         Check: resource.ComposeTestCheckFunc(
           testAccCheckThingExists(resourceName, &thing),
           create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
-          resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+          resource.TestCheckResourceAttr(resourceName, "name_prefix", resource.UniqueIdPrefix),
         ),
       },
       // If the resource supports import:

--- a/internal/generate/namevaluesfilters/generators/servicefilters/main.go
+++ b/internal/generate/namevaluesfilters/generators/servicefilters/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-provider-aws/internal/namevaluesfilters"
+	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
 )
 
 const filename = `service_filters_gen.go`

--- a/internal/service/rds/enum.go
+++ b/internal/service/rds/enum.go
@@ -29,6 +29,7 @@ const (
 	InstanceStatusCreating                      = "creating"
 	InstanceStatusDeleting                      = "deleting"
 	InstanceStatusIncompatibleParameters        = "incompatible-parameters"
+	InstanceStatusIncompatibleRestore           = "incompatible-restore"
 	InstanceStatusModifying                     = "modifying"
 	InstanceStatusStarting                      = "starting"
 	InstanceStatusStopping                      = "stopping"

--- a/internal/service/rds/enum.go
+++ b/internal/service/rds/enum.go
@@ -6,6 +6,20 @@ const (
 	ClusterRoleStatusPending = "PENDING"
 )
 
+const (
+	StorageTypeStandard = "standard"
+	StorageTypeGp2      = "gp2"
+	StorageTypeIo1      = "io1"
+)
+
+func StorageType_Values() []string {
+	return []string{
+		StorageTypeStandard,
+		StorageTypeGp2,
+		StorageTypeIo1,
+	}
+}
+
 // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html#Overview.DBInstance.Status.
 const (
 	InstanceStatusAvailable                     = "available"

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -518,18 +518,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	// we expect everything to be in sync before returning completion.
 	var requiresRebootDbInstance bool
 
-	var identifier string
-	if v, ok := d.GetOk("identifier"); ok {
-		identifier = v.(string)
-	} else {
-		if v, ok := d.GetOk("identifier_prefix"); ok {
-			identifier = resource.PrefixedUniqueId(v.(string))
-		} else {
-			identifier = resource.UniqueId()
-		}
-
-		d.Set("identifier", identifier)
-	}
+	identifier := create.Name(d.Get("identifier").(string), d.Get("identifier_prefix").(string))
 
 	if v, ok := d.GetOk("replicate_source_db"); ok {
 		opts := rds.CreateDBInstanceReadReplicaInput{
@@ -725,7 +714,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			CopyTagsToSnapshot:      aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBName:                  aws.String(d.Get("name").(string)),
 			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
-			DBInstanceIdentifier:    aws.String(d.Get("identifier").(string)),
+			DBInstanceIdentifier:    aws.String(identifier),
 			DeletionProtection:      aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:                  aws.String(d.Get("engine").(string)),
 			EngineVersion:           aws.String(d.Get("engine_version").(string)),
@@ -859,7 +848,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error creating DB Instance: %s", err)
 		}
 
-		d.SetId(d.Get("identifier").(string))
+		d.SetId(identifier)
 
 		log.Printf("[INFO] DB Instance ID: %s", d.Id())
 
@@ -887,7 +876,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 			CopyTagsToSnapshot:      aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
-			DBInstanceIdentifier:    aws.String(d.Get("identifier").(string)),
+			DBInstanceIdentifier:    aws.String(identifier),
 			DBSnapshotIdentifier:    aws.String(d.Get("snapshot_identifier").(string)),
 			DeletionProtection:      aws.Bool(d.Get("deletion_protection").(bool)),
 			PubliclyAccessible:      aws.Bool(d.Get("publicly_accessible").(bool)),
@@ -1084,7 +1073,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			input.DeletionProtection = aws.Bool(d.Get("deletion_protection").(bool))
 			input.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
 			input.Tags = Tags(tags.IgnoreAWS())
-			input.TargetDBInstanceIdentifier = aws.String(d.Get("identifier").(string))
+			input.TargetDBInstanceIdentifier = aws.String(identifier)
 
 			if v, ok := d.GetOk("availability_zone"); ok {
 				input.AvailabilityZone = aws.String(v.(string))
@@ -1187,7 +1176,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			AllocatedStorage:        aws.Int64(int64(d.Get("allocated_storage").(int))),
 			DBName:                  aws.String(d.Get("name").(string)),
 			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
-			DBInstanceIdentifier:    aws.String(d.Get("identifier").(string)),
+			DBInstanceIdentifier:    aws.String(identifier),
 			DeletionProtection:      aws.Bool(d.Get("deletion_protection").(bool)),
 			MasterUsername:          aws.String(d.Get("username").(string)),
 			MasterUserPassword:      aws.String(d.Get("password").(string)),
@@ -1345,7 +1334,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	d.SetId(d.Get("identifier").(string))
+	d.SetId(identifier)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceInstanceCreatePendingStates,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -345,6 +345,7 @@ func ResourceInstance() *schema.Resource {
 			"replica_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice(rds.ReplicaMode_Values(), false),
 			},
 			"replicas": {
@@ -479,6 +480,9 @@ func ResourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ConflictsWith: []string{
+					"replicate_source_db",
+				},
 			},
 			"vpc_security_group_ids": {
 				Type:     schema.TypeSet,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -181,11 +181,13 @@ func ResourceInstance() *schema.Resource {
 					value := v.(string)
 					return strings.ToLower(value)
 				},
+				ConflictsWith: []string{"replicate_source_db"},
 			},
 			"engine_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"replicate_source_db"},
 			},
 			"engine_version_actual": {
 				Type:     schema.TypeString,
@@ -287,13 +289,11 @@ func ResourceInstance() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ConflictsWith: []string{
-					"replicate_source_db",
-				},
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"replicate_source_db"},
 			},
 			"nchar_character_set_name": {
 				Type:     schema.TypeString,
@@ -463,9 +463,10 @@ func ResourceInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"storage_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(StorageType_Values(), false),
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
@@ -476,13 +477,11 @@ func ResourceInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"username": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ConflictsWith: []string{
-					"replicate_source_db",
-				},
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"replicate_source_db"},
 			},
 			"vpc_security_group_ids": {
 				Type:     schema.TypeSet,
@@ -544,10 +543,10 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, ok := d.GetOk("allocated_storage"); ok {
-			log.Printf("[INFO] allocated_storage was ignored for DB Instance (%s) because a replica inherits the primary's allocated_storage and this cannot be changed at creation.", d.Id())
 			// RDS doesn't allow modifying the storage of a replica within the first 6h of creation.
 			// allocated_storage is inherited from the primary so only the same value or no value is correct; a different value would fail the creation.
 			// A different value is possible, granted: the value is higher than the current, there has been 6h between
+			log.Printf("[INFO] allocated_storage was ignored for DB Instance (%s) because a replica inherits the primary's allocated_storage and this cannot be changed at creation.", d.Id())
 		}
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
@@ -1493,8 +1492,8 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		sgn.Add(*v.DBSecurityGroupName)
 	}
 	d.Set("security_group_names", sgn)
-	// replica things
 
+	// replica things
 	var replicas []string
 	for _, v := range v.ReadReplicaDBInstanceIdentifiers {
 		replicas = append(replicas, *v)

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -291,6 +291,9 @@ func ResourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ConflictsWith: []string{
+					"replicate_source_db",
+				},
 			},
 			"nchar_character_set_name": {
 				Type:     schema.TypeString,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -1417,6 +1418,7 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", v.DBName)
 	d.Set("identifier", v.DBInstanceIdentifier)
+	d.Set("identifier_prefix", create.NamePrefixFromName(aws.StringValue(v.DBInstanceIdentifier)))
 	d.Set("resource_id", v.DbiResourceId)
 	d.Set("username", v.MasterUsername)
 	d.Set("deletion_protection", v.DeletionProtection)

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7350,11 +7350,6 @@ resource "aws_db_instance" "test" {
   identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   skip_final_snapshot = true
-
-//   allocated_storage   = 5
-//   engine              = data.aws_rds_orderable_db_instance.test.engine
-//   password            = "avoid-plaintext-passwords"
-//   username            = "tfacctest"
 }
 `, rName))
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7385,7 +7385,7 @@ func testAccInstanceConfig_SnapshotIdentifier_Io1Storage(rName string, iops int)
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
   engine         = "mariadb"
-  engine_version = "10.2.15"
+  engine_version = "10.5.12"
   license_model  = "general-public-license"
   storage_type   = "io1"
 

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -154,6 +154,7 @@ func waitDBInstanceDeleted(conn *rds.RDS, id string, timeout time.Duration) (*rd
 			InstanceStatusCreating,
 			InstanceStatusDeleting,
 			InstanceStatusIncompatibleParameters,
+			InstanceStatusIncompatibleRestore,
 			InstanceStatusModifying,
 			InstanceStatusStarting,
 			InstanceStatusStopping,

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -206,7 +206,7 @@ creation. See [MSSQL User
 Guide](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone)
 for more information.
 * `username` - (Required unless a `snapshot_identifier` or `replicate_source_db`
-is provided) Username for the master DB user.
+is provided) Username for the master DB user. Cannot be specified for a replca.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to
 associate.
 * `customer_owned_ip_enabled` - (Optional) Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance. See [CoIP for RDS on Outposts](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html#rds-on-outposts.coip) for more information.

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -153,7 +153,7 @@ information on the [AWS
 Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
-* `name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case.
+* `name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replca.
 * `nchar_character_set_name` - (Optional, Forces new resource) The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
 * `option_group_name` - (Optional) Name of the DB option group to associate.

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -110,7 +110,7 @@ for additional read replica contraints.
 * `domain_iam_role_name` - (Optional, but required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service.
 * `enabled_cloudwatch_logs_exports` - (Optional) Set of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on `engine`). MySQL and MariaDB: `audit`, `error`, `general`, `slowquery`. PostgreSQL: `postgresql`, `upgrade`. MSSQL: `agent` , `error`. Oracle: `alert`, `audit`, `listener`, `trace`.
 * `engine` - (Required unless a `snapshot_identifier` or `replicate_source_db`
-is provided) The database engine to use.  For supported values, see the Engine parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
+is provided) The database engine to use.  For supported values, see the Engine parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html). Cannot be specified for a replica.
 Note that for Amazon Aurora instances the engine must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine'.
 For information on the difference between the available Aurora MySQL engines
 see [Comparison between Aurora MySQL 1 and Aurora MySQL 2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Updates.20180206.html)
@@ -119,7 +119,7 @@ in the Amazon RDS User Guide.
 is enabled, you can provide a prefix of the version such as `5.7` (for `5.7.10`).
 The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
-Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'.
+Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'. Cannot be specified for a replica.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
 when this DB instance is deleted. Must be provided if `skip_final_snapshot` is
 set to `false`. The value must begin with a letter, only contain alphanumeric characters and hyphens, and not end with a hyphen or contain two consecutive hyphens. Must not be provided when deleting a read replica.
@@ -153,7 +153,7 @@ information on the [AWS
 Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
-* `name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replca.
+* `name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
 * `nchar_character_set_name` - (Optional, Forces new resource) The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
 * `option_group_name` - (Optional) Name of the DB option group to associate.
@@ -206,7 +206,7 @@ creation. See [MSSQL User
 Guide](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone)
 for more information.
 * `username` - (Required unless a `snapshot_identifier` or `replicate_source_db`
-is provided) Username for the master DB user. Cannot be specified for a replca.
+is provided) Username for the master DB user. Cannot be specified for a replica.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to
 associate.
 * `customer_owned_ip_enabled` - (Optional) Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance. See [CoIP for RDS on Outposts](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html#rds-on-outposts.coip) for more information.


### PR DESCRIPTION
Setting some parameters on a replica RDS Instance causes a modify followed by a reboot. This sometimes caused errors.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11905
Closes #20538

Output from acceptance testing in Commercial partition

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRDSInstance_ PKG=rds

--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_Tags_Clear (0.00s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_enabledToDisabled (1.13s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_disabledToEnabled (1.23s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_restoreToPointInTime (1.28s)
--- SKIP: TestAccRDSInstance_coIPEnabled (1.69s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_snapshotIdentifier (7.99s)
--- SKIP: TestAccRDSInstance_ec2Classic (2.59s)
--- FAIL: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (29.52s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (474.81s)
--- FAIL: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3.20s)
--- FAIL: TestAccRDSInstance_MSSQL_domain (3.43s)
--- PASS: TestAccRDSInstance_caCertificateIdentifier (483.05s)
--- FAIL: TestAccRDSInstance_MSSQL_tz (3.49s)
--- PASS: TestAccRDSInstanceDataSource_basic (493.40s)
--- PASS: TestAccRDSInstance_minorVersion (510.31s)
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (622.79s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (659.37s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (845.97s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (920.56s)
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (959.87s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (962.30s)
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (1015.65s)
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (1027.94s)
--- FAIL: TestAccRDSInstance_SnapshotIdentifier_multiAZ_sqlServer (3.51s)
--- PASS: TestAccRDSInstance_portUpdate (585.59s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (1105.68s)
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (1147.08s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (689.13s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1202.01s)
--- PASS: TestAccRDSInstance_separateIopsUpdate (768.76s)
--- PASS: TestAccRDSInstance_license (1326.83s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_DBSubnetGroupName_ramShared (0.08s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (807.85s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (761.51s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1453.00s)
--- FAIL: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (589.52s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1715.05s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (1789.85s)
--- PASS: TestAccRDSInstance_monitoringInterval (1222.76s)
--- FAIL: TestAccRDSInstance_SnapshotIdentifier_io1Storage (3.14s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1913.56s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1094.70s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1183.54s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1165.06s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs_tags (1331.56s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1144.13s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1141.26s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1193.64s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1294.60s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1053.01s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1071.38s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1228.30s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_DBSubnetGroupName_vpcSecurityGroupIDs (1204.94s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (961.50s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1112.22s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1691.29s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriod_override (1417.38s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (986.41s)
--- FAIL: TestAccRDSInstance_s3Import_nameGenerated (951.20s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (1154.97s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1101.81s)
--- FAIL: TestAccRDSInstance_s3Import_namePrefix (1012.68s)
--- FAIL: TestAccRDSInstance_s3Import_basic (1001.04s)
--- SKIP: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared (0.28s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriod_unset (1973.87s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1479.10s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1286.95s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1336.58s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1469.14s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1498.23s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupName_setOnReplica (1580.74s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (2244.89s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupName_sameSetOnBoth (1508.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupName_replicaCopiesValue (1620.06s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupName_differentSetOnBoth (1609.95s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1548.55s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2228.53s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1467.17s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1426.66s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1345.29s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1577.39s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1466.68s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (2670.47s)
--- PASS: TestAccRDSInstance_password (439.59s)
--- SKIP: TestAccRDSInstance_DBSubnetGroupName_ramShared (0.14s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1718.83s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (463.05s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2246.20s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1425.47s)
--- PASS: TestAccRDSInstance_maxAllocatedStorage (586.63s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1335.02s)
--- PASS: TestAccRDSInstance_deletionProtection (497.82s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (345.17s)
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs (2175.46s)
--- PASS: TestAccRDSInstance_iamAuth (322.92s)
--- PASS: TestAccRDSInstance_allowMajorVersionUpgrade (357.13s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (706.42s)
--- SKIP: TestAccRDSInstanceDataSource_ec2Classic (0.00s)
--- FAIL: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1397.91s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (2147.03s)
--- PASS: TestAccRDSInstance_dbSubnetGroupName (446.60s)
--- PASS: TestAccRDSInstance_kmsKey (328.21s)
--- PASS: TestAccRDSInstance_replicateSourceDB_namePrefix (1184.13s)
--- PASS: TestAccRDSInstance_optionGroup (423.90s)
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (787.40s)
--- PASS: TestAccRDSInstance_replicateSourceDB_addLater (1367.40s)
--- PASS: TestAccRDSInstance_replicateSourceDB_nameGenerated (1335.62s)
--- PASS: TestAccRDSInstance_replicateSourceDB_basic (1193.96s)
--- PASS: TestAccRDSInstance_nameGenerated (475.04s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1786.92s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1725.43s)
--- PASS: TestAccRDSInstance_namePrefix (464.40s)
--- PASS: TestAccRDSInstance_onlyMajorVersion (433.56s)
--- PASS: TestAccRDSInstance_basic (486.09s)
--- PASS: TestAccRDSInstance_subnetGroup (840.11s)
--- PASS: TestAccRDSInstanceRoleAssociation_disappears (953.51s)
--- PASS: TestAccRDSInstanceRoleAssociation_basic (1023.63s)
```

All failures are pre-existing