### PR TITLE
New resource: ECR registry scanning configuration

### DIFF
--- a/.changelog/22179.txt
+++ b/.changelog/22179.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ecr_registry_scanning_configuration
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1125,12 +1125,13 @@ func Provider() *schema.Provider {
 			"aws_vpn_gateway_attachment":                          ec2.ResourceVPNGatewayAttachment(),
 			"aws_vpn_gateway_route_propagation":                   ec2.ResourceVPNGatewayRoutePropagation(),
 
-			"aws_ecr_lifecycle_policy":          ecr.ResourceLifecyclePolicy(),
-			"aws_ecr_pull_through_cache_rule":   ecr.ResourcePullThroughCacheRule(),
-			"aws_ecr_registry_policy":           ecr.ResourceRegistryPolicy(),
-			"aws_ecr_replication_configuration": ecr.ResourceReplicationConfiguration(),
-			"aws_ecr_repository":                ecr.ResourceRepository(),
-			"aws_ecr_repository_policy":         ecr.ResourceRepositoryPolicy(),
+			"aws_ecr_lifecycle_policy":                ecr.ResourceLifecyclePolicy(),
+			"aws_ecr_pull_through_cache_rule":         ecr.ResourcePullThroughCacheRule(),
+			"aws_ecr_registry_policy":                 ecr.ResourceRegistryPolicy(),
+			"aws_ecr_registry_scanning_configuration": ecr.ResourceRegistryScanningConfiguration(),
+			"aws_ecr_replication_configuration":       ecr.ResourceReplicationConfiguration(),
+			"aws_ecr_repository":                      ecr.ResourceRepository(),
+			"aws_ecr_repository_policy":               ecr.ResourceRepositoryPolicy(),
 
 			"aws_ecrpublic_repository": ecrpublic.ResourceRepository(),
 

--- a/internal/service/ecr/registry_scanning_configuration.go
+++ b/internal/service/ecr/registry_scanning_configuration.go
@@ -1,0 +1,199 @@
+package ecr
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func ResourceRegistryScanningConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRegistryScanningConfigurationPut,
+		Read:   resourceRegistryScanningConfigurationRead,
+		Update: resourceRegistryScanningConfigurationPut,
+		Delete: resourceRegistryScanningConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"scan_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(ecr.ScanType_Values(), false),
+			},
+			"rule": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 0,
+				MaxItems: 100,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"repository_filter": {
+							Type:     schema.TypeSet,
+							MinItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"filter": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 256),
+											validation.StringMatch(regexp.MustCompile(`^[a-z0-9*](?:[._\-/a-z0-9*]?[a-z0-9*]+)*$`), "must contain only lowercase alphanumeric, dot, underscore, hyphen, wildcard, and colon characters"),
+										),
+									},
+									"filter_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(ecr.ScanningRepositoryFilterType_Values(), false),
+									},
+								},
+							},
+						},
+						"scan_frequency": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(ecr.ScanFrequency_Values(), false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceRegistryScanningConfigurationPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ECRConn
+
+	input := ecr.PutRegistryScanningConfigurationInput{
+		ScanType: aws.String(d.Get("scan_type").(string)),
+		Rules:    expandEcrScanningRegistryRules(d.Get("rule").(*schema.Set).List()),
+	}
+
+	_, err := conn.PutRegistryScanningConfiguration(&input)
+	if err != nil {
+		return fmt.Errorf("Error creating ECR Scanning Configuration: %w", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).AccountID)
+
+	return resourceRegistryScanningConfigurationRead(d, meta)
+}
+
+func resourceRegistryScanningConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ECRConn
+
+	log.Printf("[DEBUG] Reading registry scanning configuration %s", d.Id())
+	out, err := conn.GetRegistryScanningConfiguration(&ecr.GetRegistryScanningConfigurationInput{})
+
+	if err != nil {
+		return fmt.Errorf("Error reading registry scanning configuration: %s", err)
+	}
+
+	d.Set("scan_type", out.ScanningConfiguration.ScanType)
+	d.Set("rule", flattenEcrScanningConfigurationRules(out.ScanningConfiguration.Rules))
+
+	return nil
+}
+
+func resourceRegistryScanningConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ECRConn
+
+	_, err := conn.PutRegistryScanningConfiguration(&ecr.PutRegistryScanningConfigurationInput{
+		Rules:    nil,
+		ScanType: aws.String(ecr.ScanTypeBasic),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting registry scanning configuration: %s", err)
+	}
+
+	return nil
+}
+
+// Helper functions
+
+func expandEcrScanningRegistryRules(l []interface{}) []*ecr.RegistryScanningRule {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	rules := make([]*ecr.RegistryScanningRule, 0)
+
+	for _, rule := range l {
+		if rule == nil {
+			continue
+		}
+		rules = append(rules, expandEcrScanningRegistryRule(rule.(map[string]interface{})))
+	}
+
+	return rules
+}
+
+func expandEcrScanningRegistryRule(m map[string]interface{}) *ecr.RegistryScanningRule {
+	if m == nil {
+		return nil
+	}
+
+	rule := &ecr.RegistryScanningRule{
+		RepositoryFilters: expandEcrScanningRegistryRuleRepositoryFilters(m["repository_filter"].(*schema.Set).List()),
+		ScanFrequency:     aws.String(m["scan_frequency"].(string)),
+	}
+
+	return rule
+}
+
+func expandEcrScanningRegistryRuleRepositoryFilters(l []interface{}) []*ecr.ScanningRepositoryFilter {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	filters := make([]*ecr.ScanningRepositoryFilter, 0)
+
+	for _, f := range l {
+		if f == nil {
+			continue
+		}
+		m := f.(map[string]interface{})
+		filters = append(filters, &ecr.ScanningRepositoryFilter{
+			Filter:     aws.String(m["filter"].(string)),
+			FilterType: aws.String(m["filter_type"].(string)),
+		})
+	}
+
+	return filters
+}
+
+func flattenEcrScanningConfigurationRules(r []*ecr.RegistryScanningRule) interface{} {
+	out := make([]map[string]interface{}, len(r))
+	for i, rule := range r {
+		m := make(map[string]interface{})
+		m["scan_frequency"] = aws.StringValue(rule.ScanFrequency)
+		m["repository_filter"] = flattenEcrScanningConfigurationFilters(rule.RepositoryFilters)
+		out[i] = m
+	}
+	return out
+}
+
+func flattenEcrScanningConfigurationFilters(l []*ecr.ScanningRepositoryFilter) []interface{} {
+	if len(l) == 0 {
+		return nil
+	}
+
+	out := make([]interface{}, len(l))
+	for i, filter := range l {
+		out[i] = map[string]interface{}{
+			"filter":      aws.StringValue(filter.Filter),
+			"filter_type": aws.StringValue(filter.FilterType),
+		}
+	}
+
+	return out
+}

--- a/internal/service/ecr/registry_scanning_configuration.go
+++ b/internal/service/ecr/registry_scanning_configuration.go
@@ -107,7 +107,7 @@ func resourceRegistryScanningConfigurationDelete(d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).ECRConn
 
 	_, err := conn.PutRegistryScanningConfiguration(&ecr.PutRegistryScanningConfigurationInput{
-		Rules:    nil,
+		Rules:    []*ecr.RegistryScanningRule{},
 		ScanType: aws.String(ecr.ScanTypeBasic),
 	})
 

--- a/internal/service/ecr/registry_scanning_configuration_test.go
+++ b/internal/service/ecr/registry_scanning_configuration_test.go
@@ -50,7 +50,7 @@ func testAccRegistryScanningConfiguration_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRegistryPolicyUpdated(),
+				Config: testAccRegistryScanningConfigurationUpdated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccRegistryScanningConfigurationExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "scan_type", "BASIC"),
@@ -60,28 +60,6 @@ func testAccRegistryScanningConfiguration_basic(t *testing.T) {
 		},
 	})
 }
-
-// func testAccRegistryScanningConfiguration_disappears(t *testing.T) {
-// 	var v ecr.GetRegistryPolicyOutput
-// 	resourceName := "aws_ecr_registry_policy.test"
-
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:     func() { acctest.PreCheck(t) },
-// 		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
-// 		Providers:    acctest.Providers,
-// 		CheckDestroy: testAccCheckRegistryPolicyDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccRegistryPolicy(),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckRegistryPolicyExists(resourceName, &v),
-// 					acctest.CheckResourceDisappears(acctest.Provider, tfecr.ResourceRegistryPolicy(), resourceName),
-// 				),
-// 				ExpectNonEmptyPlan: true,
-// 			},
-// 		},
-// 	})
-// }
 
 func testAccRegistryScanningConfigurationDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn

--- a/internal/service/ecr/registry_scanning_configuration_test.go
+++ b/internal/service/ecr/registry_scanning_configuration_test.go
@@ -124,14 +124,14 @@ resource "aws_ecr_registry_scanning_configuration" "test" {
   rule {
     scan_frequency = "CONTINUOUS_SCAN"
     repository_filter {
-      filter      = "*"
+      filter      = "example"
       filter_type = "WILDCARD"
     }
   }
   rule {
     scan_frequency = "SCAN_ON_PUSH"
     repository_filter {
-      filter      = "example"
+      filter      = "*"
       filter_type = "WILDCARD"
     }
   }

--- a/internal/service/ecr/registry_scanning_configuration_test.go
+++ b/internal/service/ecr/registry_scanning_configuration_test.go
@@ -53,8 +53,8 @@ func testAccRegistryScanningConfiguration_basic(t *testing.T) {
 				Config: testAccRegistryScanningConfigurationUpdated(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccRegistryScanningConfigurationExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "scan_type", "BASIC"),
-					resource.TestCheckResourceAttr(resourceName, "rule.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scan_type", "ENHANCED"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
 				),
 			},
 		},
@@ -120,7 +120,21 @@ resource "aws_ecr_registry_scanning_configuration" "test" {
 func testAccRegistryScanningConfigurationUpdated() string {
 	return `
 resource "aws_ecr_registry_scanning_configuration" "test" {
-  scan_type = "BASIC"
+  scan_type = "ENHANCED"
+  rule {
+    scan_frequency = "CONTINUOUS_SCAN"
+    repository_filter {
+      filter      = "*"
+      filter_type = "WILDCARD"
+    }
+  }
+  rule {
+    scan_frequency = "SCAN_ON_PUSH"
+    repository_filter {
+      filter      = "example"
+      filter_type = "WILDCARD"
+    }
+  }
 }
 `
 }

--- a/internal/service/ecr/registry_scanning_configuration_test.go
+++ b/internal/service/ecr/registry_scanning_configuration_test.go
@@ -70,6 +70,13 @@ func testAccRegistryScanningConfiguration_update(t *testing.T) {
 					testAccRegistryScanningConfigurationExists(resourceName, &v),
 					acctest.CheckResourceAttrAccountID(resourceName, "registry_id"),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"scan_frequency": "SCAN_ON_PUSH",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.repository_filter.*", map[string]string{
+						"filter":      "example",
+						"filter_type": "WILDCARD",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "scan_type", "BASIC"),
 				),
 			},
@@ -83,6 +90,20 @@ func testAccRegistryScanningConfiguration_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccRegistryScanningConfigurationExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"scan_frequency": "CONTINUOUS_SCAN",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.repository_filter.*", map[string]string{
+						"filter":      "example",
+						"filter_type": "WILDCARD",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"scan_frequency": "SCAN_ON_PUSH",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.repository_filter.*", map[string]string{
+						"filter":      "*",
+						"filter_type": "WILDCARD",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "scan_type", "ENHANCED"),
 				),
 			},

--- a/internal/service/ecr/registry_scanning_configuration_test.go
+++ b/internal/service/ecr/registry_scanning_configuration_test.go
@@ -1,0 +1,148 @@
+package ecr_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func TestAccECRScanningConfiguration_serial(t *testing.T) {
+	testFuncs := map[string]func(t *testing.T){
+		"basic": testAccRegistryScanningConfiguration_basic,
+		// "disappears": testAccRegistryPolicy_disappears,
+	}
+
+	for name, testFunc := range testFuncs {
+		testFunc := testFunc
+
+		t.Run(name, func(t *testing.T) {
+			testFunc(t)
+		})
+	}
+}
+
+func testAccRegistryScanningConfiguration_basic(t *testing.T) {
+	var v ecr.GetRegistryScanningConfigurationOutput
+	resourceName := "aws_ecr_registry_scanning_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccRegistryScanningConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegistryScanningConfiguration(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccRegistryScanningConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "scan_type", "ENHANCED"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRegistryPolicyUpdated(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccRegistryScanningConfigurationExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "scan_type", "BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// func testAccRegistryScanningConfiguration_disappears(t *testing.T) {
+// 	var v ecr.GetRegistryPolicyOutput
+// 	resourceName := "aws_ecr_registry_policy.test"
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { acctest.PreCheck(t) },
+// 		ErrorCheck:   acctest.ErrorCheck(t, ecr.EndpointsID),
+// 		Providers:    acctest.Providers,
+// 		CheckDestroy: testAccCheckRegistryPolicyDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccRegistryPolicy(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckRegistryPolicyExists(resourceName, &v),
+// 					acctest.CheckResourceDisappears(acctest.Provider, tfecr.ResourceRegistryPolicy(), resourceName),
+// 				),
+// 				ExpectNonEmptyPlan: true,
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccRegistryScanningConfigurationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ecr_registry_policy" {
+			continue
+		}
+
+		_, err := conn.GetRegistryScanningConfiguration(&ecr.GetRegistryScanningConfigurationInput{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccRegistryScanningConfigurationExists(name string, res *ecr.GetRegistryScanningConfigurationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ECR registry policy ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRConn
+
+		output, err := conn.GetRegistryScanningConfiguration(&ecr.GetRegistryScanningConfigurationInput{})
+		if err != nil {
+			return err
+		}
+
+		*res = *output
+
+		return nil
+	}
+}
+
+func testAccRegistryScanningConfiguration() string {
+	return `
+resource "aws_ecr_registry_scanning_configuration" "test" {
+  scan_type = "ENHANCED"
+  rule {
+    scan_frequency = "CONTINUOUS_SCAN"
+    repository_filter {
+      filter      = "example"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+`
+}
+
+func testAccRegistryScanningConfigurationUpdated() string {
+	return `
+resource "aws_ecr_registry_scanning_configuration" "test" {
+  scan_type = "BASIC"
+}
+`
+}

--- a/website/docs/r/ecr_registry_scanning_configuration.html.markdown
+++ b/website/docs/r/ecr_registry_scanning_configuration.html.markdown
@@ -12,9 +12,35 @@ Provides an Elastic Container Registry Scanning Configuration. Can't be deleted.
 
 ## Example Usage
 
+### Basic example
+
 ```terraform
 resource "aws_ecr_registry_scanning_configuration" "configuration" {
   scan_type = "ENHANCED"
+
+  rule {
+    scan_frequency = "CONTINUOUS_SCAN"
+    repository_filter {
+      filter      = "example"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+```
+
+### Multiple rules
+
+```terraform
+resource "aws_ecr_registry_scanning_configuration" "test" {
+  scan_type = "ENHANCED"
+
+  rule {
+    scan_frequency = "SCAN_ON_PUSH"
+    repository_filter {
+      filter      = "*"
+      filter_type = "WILDCARD"
+    }
+  }
 
   rule {
     scan_frequency = "CONTINUOUS_SCAN"

--- a/website/docs/r/ecr_registry_scanning_configuration.html.markdown
+++ b/website/docs/r/ecr_registry_scanning_configuration.html.markdown
@@ -3,12 +3,12 @@ subcategory: "ECR"
 layout: "aws"
 page_title: "AWS: aws_ecr_registry_scanning_configuration"
 description: |-
-  Provides an Elastic Container Registry Repository.
+  Provides an Elastic Container Registry Scanning Configuration.
 ---
 
 # Resource: aws_ecr_registry_scanning_configuration
 
-Provides an Elastic Container Registry Scanning Configuration. Can't be deleted.
+Provides an Elastic Container Registry Scanning Configuration. Can't be completely deleted, instead reverts to the default `BASIC` scanning configuration without rules.
 
 ## Example Usage
 
@@ -68,8 +68,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-- `registry_id` - The registry ID where the repository was created.
-- `scanning_configuration` - The scanning configuration for the registry.
+- `id` - The registry ID the scanning configuration applies to.
 
 ## Timeouts
 

--- a/website/docs/r/ecr_registry_scanning_configuration.html.markdown
+++ b/website/docs/r/ecr_registry_scanning_configuration.html.markdown
@@ -68,14 +68,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The registry ID the scanning configuration applies to.
-
-## Timeouts
-
-`aws_ecr_registry_scanning_configuration` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
-configuration options:
-
-- `delete` - (Default `20 minutes`) How long to wait for a scanning configuration to be deleted.
+* `registry_id` - The registry ID the scanning configuration applies to.
 
 ## Import
 

--- a/website/docs/r/ecr_registry_scanning_configuration.html.markdown
+++ b/website/docs/r/ecr_registry_scanning_configuration.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "ECR"
+layout: "aws"
+page_title: "AWS: aws_ecr_registry_scanning_configuration"
+description: |-
+  Provides an Elastic Container Registry Repository.
+---
+
+# Resource: aws_ecr_registry_scanning_configuration
+
+Provides an Elastic Container Registry Scanning Configuration. Can't be deleted.
+
+## Example Usage
+
+```terraform
+resource "aws_ecr_registry_scanning_configuration" "configuration" {
+  scan_type = "ENHANCED"
+
+  rule {
+    scan_frequency = "CONTINUOUS_SCAN"
+    repository_filter {
+      filter      = "example"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `scan_type` - (Required) the scanning type to set for the registry. Can be either `ENHANCED` or `BASIC`.
+- `rule` - (Optional) One or multiple blocks specifying scanning rules to determine which repository filters are used and at what frequency scanning will occur. See [below for schema](#rule).
+
+### rule
+
+- `repository_filter` - (Required) One or more repository filter blocks, containing a `filter` (required string filtering repositories, see pattern regex [here](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ScanningRepositoryFilter.html)) and a `filter_type` (required string, currently only `WILDCARD` is supported).
+- `scan_frequency` - (Required) The frequency that scans are performed at for a private registry. Can be `SCAN_ON_PUSH`, `CONTINUOUS_SCAN`, or `MANUAL`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `registry_id` - The registry ID where the repository was created.
+- `scanning_configuration` - The scanning configuration for the registry.
+
+## Timeouts
+
+`aws_ecr_registry_scanning_configuration` provides the following [Timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts)
+configuration options:
+
+- `delete` - (Default `20 minutes`) How long to wait for a scanning configuration to be deleted.
+
+## Import
+
+ECR Scanning Configurations can be imported using the `registry_id`, e.g.,
+
+```
+$ terraform import aws_ecr_registry_scanning_configuration 012345678901
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21964 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccECRScanningConfiguration_serial PKG=ecr (main|✔)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRScanningConfiguration_serial' -timeout 180m
=== RUN   TestAccECRScanningConfiguration_serial
=== RUN   TestAccECRScanningConfiguration_serial/basic
--- PASS: TestAccECRScanningConfiguration_serial (33.70s)
    --- PASS: TestAccECRScanningConfiguration_serial/basic (33.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        33.752s
...
```
