### PR TITLE
r/codebuild_project  - add support for `bucket_access_owner` and `public_visibility`

### DIFF
--- a/.changelog/22189.txt
+++ b/.changelog/22189.txt
@@ -1,5 +1,9 @@
 ```release-note:enhancement
-resource/aws_codebuild_project: Add `artifacts.bucket_owner_access`, `secondary_artifacts.bucket_owner_access`, `logs_config.s3_logs.bucket_owner_access` arguments.
+resource/aws_codebuild_project: Add `artifacts.bucket_owner_access`, `secondary_artifacts.bucket_owner_access`, `logs_config.s3_logs.bucket_owner_access`, `project_visibility`, `resource_access_role` arguments.
+```
+
+```release-note:enhancement
+resource/aws_codebuild_project: Add `public_project_alias` attribute.
 ```
 
 ```release-note:enhancement

--- a/.changelog/22189.txt
+++ b/.changelog/22189.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_codebuild_project: Add `artifacts.bucket_owner_access`, `secondary_artifacts.bucket_owner_access`, `logs_config.s3_logs.bucket_owner_access` arguments.
+```
+
+```release-note:enhancement
+resource/aws_codebuild_project: Add plan time validation for `cache.modes` and `service_role`.
+```

--- a/internal/service/codebuild/find.go
+++ b/internal/service/codebuild/find.go
@@ -3,6 +3,7 @@ package codebuild
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // FindReportGroupByARN returns the Report Group corresponding to the specified Arn.
@@ -29,4 +30,25 @@ func FindReportGroupByARN(conn *codebuild.CodeBuild, arn string) (*codebuild.Rep
 	}
 
 	return reportGroup, nil
+}
+
+func FindProjectByARN(conn *codebuild.CodeBuild, arn string) (*codebuild.Project, error) {
+	input := &codebuild.BatchGetProjectsInput{
+		Names: []*string{aws.String(arn)},
+	}
+
+	output, err := conn.BatchGetProjects(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Projects) == 0 || output.Projects[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output.Projects); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output.Projects[0], nil
 }

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -4193,7 +4193,7 @@ resource "aws_codebuild_project" "test" {
   artifacts {
     type                = "S3"
     location            = aws_s3_bucket.test.bucket
-	bucket_owner_access = %[2]q
+    bucket_owner_access = %[2]q
   }
 
   environment {

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -2402,6 +2402,11 @@ func testAccCheckProjectDestroy(s *terraform.State) error {
 		}
 
 		_, err := tfcodebuild.FindProjectByARN(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
 			return err
 		}

--- a/internal/service/codebuild/sweep.go
+++ b/internal/service/codebuild/sweep.go
@@ -20,6 +20,11 @@ func init() {
 		Name: "aws_codebuild_report_group",
 		F:    sweepReportGroups,
 	})
+
+	resource.AddTestSweepers("aws_codebuild_project", &resource.Sweeper{
+		Name: "aws_codebuild_project",
+		F:    sweepProjects,
+	})
 }
 
 func sweepReportGroups(region string) error {
@@ -64,6 +69,52 @@ func sweepReportGroups(region string) error {
 
 	if err != nil {
 		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving CodeBuild ReportGroups: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func sweepProjects(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).CodeBuildConn
+	input := &codebuild.ListProjectsInput{}
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListProjectsPages(input, func(page *codebuild.ListProjectsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, arn := range page.Projects {
+			id := aws.StringValue(arn)
+			r := ResourceProject()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			err := r.Delete(d, client)
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting CodeBuild Project (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping CodeBuild Project sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving CodeBuild Projects: %w", err))
 	}
 
 	return sweeperErrs.ErrorOrNil()

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -238,6 +238,8 @@ The following arguments are optional:
 * `file_system_locations` - (Optional) A set of file system locations to to mount inside the build. File system locations are documented below.
 * `encryption_key` - (Optional) AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.
 * `logs_config` - (Optional) Configuration block. Detailed below.
+* `project_visibility` - (Optional) Specifies the visibility of the project's builds. Possible values are: `PUBLIC_READ` and `PRIVATE`. Default value is `PRIVATE`.
+* `resource_access_role` - The ARN of the IAM role that enables CodeBuild to access the CloudWatch Logs and Amazon S3 artifacts for the project's builds.
 * `queued_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours.
 * `secondary_artifacts` - (Optional) Configuration block. Detailed below.
 * `secondary_sources` - (Optional) Configuration block. Detailed below.
@@ -406,6 +408,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - ARN of the CodeBuild project.
 * `badge_url` - URL of the build badge when `badge_enabled` is enabled.
 * `id` - Name (if imported via `name`) or ARN (if created via Terraform or imported via ARN) of the CodeBuild project.
+* `public_project_alias` - The project identifier used with the public build APIs.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -249,6 +249,7 @@ The following arguments are optional:
 ### artifacts
 
 * `artifact_identifier` - (Optional) Artifact identifier. Must be the same specified inside the AWS CodeBuild build specification.
+* `bucket_owner_access` - (Optional) Specifies the bucket owner's access for objects that another account uploads to their Amazon S3 bucket. By default, only the account that uploads the objects to the bucket has access to these objects. This property allows you to give the bucket owner access to these objects. Valid values are `NONE`, `READ_ONLY`, and `FULL`. your CodeBuild service role must have the `s3:PutBucketAcl` permission. This permission allows CodeBuild to modify the access control list for the bucket.
 * `encryption_disabled` - (Optional) Whether to disable encrypting output artifacts. If `type` is set to `NO_ARTIFACTS`, this value is ignored. Defaults to `false`.
 * `location` - (Optional) Information about the build output artifact location. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS`, this value is ignored. If `type` is set to `S3`, this is the name of the output bucket.
 * `name` - (Optional) Name of the project. If `type` is set to `S3`, this is the name of the output artifact object
@@ -316,10 +317,12 @@ Credentials for access to a private Docker registry.
 * `encryption_disabled` - (Optional) Whether to disable encrypting S3 logs. Defaults to `false`.
 * `location` - (Optional) Name of the S3 bucket and the path prefix for S3 logs. Must be set if status is `ENABLED`, otherwise it must be empty.
 * `status` - (Optional) Current status of logs in S3 for a build project. Valid values: `ENABLED`, `DISABLED`. Defaults to `DISABLED`.
+* `bucket_owner_access` - (Optional) Specifies the bucket owner's access for objects that another account uploads to their Amazon S3 bucket. By default, only the account that uploads the objects to the bucket has access to these objects. This property allows you to give the bucket owner access to these objects. Valid values are `NONE`, `READ_ONLY`, and `FULL`. your CodeBuild service role must have the `s3:PutBucketAcl` permission. This permission allows CodeBuild to modify the access control list for the bucket.
 
 ### secondary_artifacts
 
 * `artifact_identifier` - (Required) Artifact identifier. Must be the same specified inside the AWS CodeBuild build specification.
+* `bucket_owner_access` - (Optional) Specifies the bucket owner's access for objects that another account uploads to their Amazon S3 bucket. By default, only the account that uploads the objects to the bucket has access to these objects. This property allows you to give the bucket owner access to these objects. Valid values are `NONE`, `READ_ONLY`, and `FULL`. your CodeBuild service role must have the `s3:PutBucketAcl` permission. This permission allows CodeBuild to modify the access control list for the bucket.
 * `encryption_disabled` - (Optional) Whether to disable encrypting output artifacts. If `type` is set to `NO_ARTIFACTS`, this value is ignored. Defaults to `false`.
 * `location` - (Optional) Information about the build output artifact location. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS`, this value is ignored. If `type` is set to `S3`, this is the name of the output bucket. If `path` is not also specified, then `location` can also specify the path of the output artifact in the output bucket.
 * `name` - (Optional) Name of the project. If `type` is set to `S3`, this is the name of the output artifact object

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -225,6 +225,7 @@ The following arguments are required:
 * `artifacts` - (Required) Configuration block. Detailed below.
 * `environment` - (Required) Configuration block. Detailed below.
 * `name` - (Required) Project's name.
+* `service_role` - (Required) Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
 * `source` - (Required) Configuration block. Detailed below.
 
 The following arguments are optional:
@@ -243,7 +244,6 @@ The following arguments are optional:
 * `queued_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours.
 * `secondary_artifacts` - (Optional) Configuration block. Detailed below.
 * `secondary_sources` - (Optional) Configuration block. Detailed below.
-* `service_role` - (Required) Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
 * `source_version` - (Optional) Version of the build input to be built for this project. If not specified, the latest version is used.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_config` - (Optional) Configuration block. Detailed below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20126

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCodeBuildProject_ PKG=codebuild
--- PASS: TestAccCodeBuildProject_disappears (129.86s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_type (130.68s)
--- PASS: TestAccCodeBuildProject_SourceType_gitHubEnterprise (154.35s)
--- PASS: TestAccCodeBuildProject_SecondarySources_codeCommit (173.95s)
--- PASS: TestAccCodeBuildProject_SourceType_s3 (185.09s)
--- PASS: TestAccCodeBuildProject_Source_gitCloneDepth (189.97s)
--- PASS: TestAccCodeBuildProject_secondaryArtifacts (205.45s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_overrideArtifactName (217.74s)
--- PASS: TestAccCodeBuildProject_Artifacts_bucketOwnerAccess (219.06s)
--- PASS: TestAccCodeBuildProject_concurrentBuildLimit (235.55s)
--- PASS: TestAccCodeBuildProject_Environment_registryCredential (240.28s)
--- PASS: TestAccCodeBuildProject_SourceType_codePipeline (124.48s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_path (254.70s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_packaging (266.81s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_location (294.41s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_encryptionDisabled (296.43s)
--- PASS: TestAccCodeBuildProject_SourceType_bitbucket (151.45s)
--- PASS: TestAccCodeBuildProject_Artifacts_type (316.51s)
--- PASS: TestAccCodeBuildProject_SourceBuildStatus_gitHubEnterprise (117.13s)
--- PASS: TestAccCodeBuildProject_SecondaryArtifacts_namespaceType (344.03s)
--- PASS: TestAccCodeBuildProject_Artifacts_encryptionDisabled (348.60s)
--- PASS: TestAccCodeBuildProject_SourceReportBuildStatus_gitHub (185.92s)
--- PASS: TestAccCodeBuildProject_SourceReportBuildStatus_gitHubEnterprise (207.19s)
--- PASS: TestAccCodeBuildProject_SourceReportBuildStatus_bitbucket (218.58s)
--- PASS: TestAccCodeBuildProject_Source_insecureSSL (205.04s)
--- PASS: TestAccCodeBuildProject_SourceType_noSourceInvalid (88.49s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHub (201.65s)
--- PASS: TestAccCodeBuildProject_encryptionKey (121.78s)
--- PASS: TestAccCodeBuildProject_armContainer (149.34s)
--- PASS: TestAccCodeBuildProject_SourceGitSubmodules_gitHubEnterprise (207.02s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_gitHubEnterprise (246.30s)
--- PASS: TestAccCodeBuildProject_windowsServer2019Container (176.62s)
--- PASS: TestAccCodeBuildProject_SourceGitSubmodules_codeCommit (216.84s)
--- PASS: TestAccCodeBuildProject_Artifacts_artifactIdentifier (217.11s)
--- PASS: TestAccCodeBuildProject_Environment_certificate (107.76s)
--- PASS: TestAccCodeBuildProject_SourceGitSubmodules_gitHub (279.74s)
--- PASS: TestAccCodeBuildProject_Artifacts_path (251.66s)
--- PASS: TestAccCodeBuildProject_SecondarySourcesGitSubmodules_codeCommit (330.94s)
--- PASS: TestAccCodeBuildProject_tags (251.27s)
--- PASS: TestAccCodeBuildProject_sourceVersion (117.59s)
--- PASS: TestAccCodeBuildProject_vpc (345.17s)
--- PASS: TestAccCodeBuildProject_Artifacts_namespaceType (210.15s)
--- PASS: TestAccCodeBuildProject_buildTimeout (156.24s)
--- PASS: TestAccCodeBuildProject_Artifacts_name (231.83s)
--- PASS: TestAccCodeBuildProject_Logs_cloudWatchLogs (296.39s)
--- PASS: TestAccCodeBuildProject_Logs_s3Logs (329.03s)
--- PASS: TestAccCodeBuildProject_Artifacts_location (234.07s)
--- PASS: TestAccCodeBuildProject_badgeEnabled (136.61s)
--- PASS: TestAccCodeBuildProject_EnvironmentEnvironmentVariable_type (326.76s)
--- PASS: TestAccCodeBuildProject_queuedTimeout (232.23s)
--- PASS: TestAccCodeBuildProject_Environment_environmentVariable (366.99s)
--- PASS: TestAccCodeBuildProject_EnvironmentEnvironmentVariable_value (415.04s)
--- PASS: TestAccCodeBuildProject_fileSystemLocations (459.01s)
--- PASS: TestAccCodeBuildProject_basic (123.24s)
--- PASS: TestAccCodeBuildProject_cache (574.92s)
--- PASS: TestAccCodeBuildProject_publicVisibility (377.97s)
```
