### PR TITLE
Update outdated docs on DMS instance sizes

### DIFF
--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
     - Constraints: Minimum 30-minute window.
 
 * `publicly_accessible` - (Optional, Default: false) Specifies the accessibility options for the replication instance. A value of true represents an instance with a public IP address. A value of false represents an instance with a private IP address.
-* `replication_instance_class` - (Required) The compute and memory capacity of the replication instance as specified by the replication instance class. See `aws dms describe-orderable-replication-instances` for the available instance sizes.
+* `replication_instance_class` - (Required) The compute and memory capacity of the replication instance as specified by the replication instance class. See [AWS DMS User Guide](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.Types.html) for available instance sizes and advice on which one to choose.
 * `replication_instance_id` - (Required) The replication instance identifier. This parameter is stored as a lowercase string.
 
     - Must contain from 1 to 63 alphanumeric characters or hyphens.

--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
     - Constraints: Minimum 30-minute window.
 
 * `publicly_accessible` - (Optional, Default: false) Specifies the accessibility options for the replication instance. A value of true represents an instance with a public IP address. A value of false represents an instance with a private IP address.
-* `replication_instance_class` - (Required) The compute and memory capacity of the replication instance as specified by the replication instance class. Can be one of `dms.t2.micro | dms.t2.small | dms.t2.medium | dms.t2.large | dms.c4.large | dms.c4.xlarge | dms.c4.2xlarge | dms.c4.4xlarge`
+* `replication_instance_class` - (Required) The compute and memory capacity of the replication instance as specified by the replication instance class. See `aws dms describe-orderable-replication-instances` for the available instance sizes.
 * `replication_instance_id` - (Required) The replication instance identifier. This parameter is stored as a lowercase string.
 
     - Must contain from 1 to 63 alphanumeric characters or hyphens.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The docs for `aws_dms_replication_instance` are outdated and state that there are only a few available instance sizes. There are now way more available instance sizes for this, so it's probably best to just refer the user to the AWS docs.

```
$ aws dms describe-orderable-replication-instances | jq -r '.OrderableReplicationInstances[].ReplicationInstanceClass' | sort | uniq -c | wc -l
      33
```
