### PR TITLE
ssoadmin/permission_set_inline_policy: Fix errorneous diffs

### DIFF
--- a/.changelog/22192.txt
+++ b/.changelog/22192.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssoadmin_permission_set_inline_policy: Fix erroneous diffs in `inline_policy` when no changes made or policies are equivalent
+```

--- a/internal/service/ssoadmin/permission_set_inline_policy.go
+++ b/internal/service/ssoadmin/permission_set_inline_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -27,6 +28,10 @@ func ResourcePermissionSetInlinePolicy() *schema.Resource {
 				Required:         true,
 				ValidateFunc:     verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"instance_arn": {
@@ -52,13 +57,19 @@ func resourcePermissionSetInlinePolicyPut(d *schema.ResourceData, meta interface
 	instanceArn := d.Get("instance_arn").(string)
 	permissionSetArn := d.Get("permission_set_arn").(string)
 
+	policy, err := structure.NormalizeJsonString(d.Get("inline_policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("inline_policy").(string), err)
+	}
+
 	input := &ssoadmin.PutInlinePolicyToPermissionSetInput{
-		InlinePolicy:     aws.String(d.Get("inline_policy").(string)),
+		InlinePolicy:     aws.String(policy),
 		InstanceArn:      aws.String(instanceArn),
 		PermissionSetArn: aws.String(permissionSetArn),
 	}
 
-	_, err := conn.PutInlinePolicyToPermissionSet(input)
+	_, err = conn.PutInlinePolicyToPermissionSet(input)
 	if err != nil {
 		return fmt.Errorf("error putting Inline Policy for SSO Permission Set (%s): %w", permissionSetArn, err)
 	}
@@ -102,7 +113,14 @@ func resourcePermissionSetInlinePolicyRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error reading Inline Policy for SSO Permission Set (%s): empty output", permissionSetArn)
 	}
 
-	d.Set("inline_policy", output.InlinePolicy)
+	policyToSet, err := verify.PolicyToSet(d.Get("inline_policy").(string), aws.StringValue(output.InlinePolicy))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("inline_policy", policyToSet)
+
 	d.Set("instance_arn", instanceArn)
 	d.Set("permission_set_arn", permissionSetArn)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968

Output from acceptance testing (`us-west-2`):

```
--- SKIP: TestAccSSOAdminPermissionSetInlinePolicy_basic (1.47s)
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccSSOAdminPermissionSetInlinePolicy_basic (2.03s)
```
