### PR TITLE
transfer: Fix erroneous diffs with user and access policies

### DIFF
--- a/.changelog/22193.txt
+++ b/.changelog/22193.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_transfer_access: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```
+
+```release-note:bug
+resource/aws_transfer_user: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/internal/service/transfer/access.go
+++ b/internal/service/transfer/access.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -70,6 +71,10 @@ func ResourceAccess() *schema.Resource {
 				Optional:         true,
 				ValidateFunc:     verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"posix_profile": {

--- a/internal/service/transfer/access.go
+++ b/internal/service/transfer/access.go
@@ -142,7 +142,13 @@ func resourceAccessCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("policy"); ok {
-		input.Policy = aws.String(v.(string))
+		policy, err := structure.NormalizeJsonString(v.(string))
+
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", v.(string), err)
+		}
+
+		input.Policy = aws.String(policy)
 	}
 
 	if v, ok := d.GetOk("posix_profile"); ok {
@@ -192,12 +198,21 @@ func resourceAccessRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting home_directory_mappings: %w", err)
 	}
 	d.Set("home_directory_type", access.HomeDirectoryType)
-	d.Set("policy", access.Policy)
+
 	if err := d.Set("posix_profile", flattenTransferUserPosixUser(access.PosixProfile)); err != nil {
 		return fmt.Errorf("error setting posix_profile: %w", err)
 	}
 	// Role is currently not returned via the API.
 	// d.Set("role", access.Role)
+
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(access.Policy))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("policy", policyToSet)
+
 	d.Set("server_id", serverID)
 
 	return nil
@@ -230,7 +245,13 @@ func resourceAccessUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("policy") {
-		input.Policy = aws.String(d.Get("policy").(string))
+		policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
+		}
+
+		input.Policy = aws.String(policy)
 	}
 
 	if d.HasChange("posix_profile") {

--- a/internal/service/transfer/user.go
+++ b/internal/service/transfer/user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -71,6 +72,10 @@ func ResourceUser() *schema.Resource {
 				Optional:         true,
 				ValidateFunc:     verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"posix_profile": {
@@ -151,7 +156,13 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("policy"); ok {
-		input.Policy = aws.String(v.(string))
+		policy, err := structure.NormalizeJsonString(v.(string))
+
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", v.(string), err)
+		}
+
+		input.Policy = aws.String(policy)
 	}
 
 	if v, ok := d.GetOk("posix_profile"); ok {
@@ -203,7 +214,15 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting home_directory_mappings: %w", err)
 	}
 	d.Set("home_directory_type", user.HomeDirectoryType)
-	d.Set("policy", user.Policy)
+
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(user.Policy))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("policy", policyToSet)
+
 	if err := d.Set("posix_profile", flattenTransferUserPosixUser(user.PosixProfile)); err != nil {
 		return fmt.Errorf("error setting posix_profile: %w", err)
 	}
@@ -252,7 +271,13 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.HasChange("policy") {
-			input.Policy = aws.String(d.Get("policy").(string))
+			policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+			if err != nil {
+				return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
+			}
+
+			input.Policy = aws.String(policy)
 		}
 
 		if d.HasChange("posix_profile") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS="TestAccTransfer_serial/User" PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20 -run='TestAccTransfer_serial/User' -timeout 180m
--- PASS: TestAccTransfer_serial (995.77s)
    --- PASS: TestAccTransfer_serial/User (995.77s)
        --- PASS: TestAccTransfer_serial/User/UserNameValidation (15.56s)
        --- PASS: TestAccTransfer_serial/User/basic (189.83s)
        --- PASS: TestAccTransfer_serial/User/disappears (161.57s)
        --- PASS: TestAccTransfer_serial/User/HomeDirectoryMappings (203.89s)
        --- PASS: TestAccTransfer_serial/User/ModifyWithOptions (224.92s)
        --- PASS: TestAccTransfer_serial/User/Posix (200.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	997.362s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS="TestAccTransfer_serial/Access" PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20 -run='TestAccTransfer_serial/Access' -timeout 180m
--- PASS: TestAccTransfer_serial (20.48s)
    --- PASS: TestAccTransfer_serial/Access (20.48s)
        --- SKIP: TestAccTransfer_serial/Access/S3Basic (2.72s)
        --- SKIP: TestAccTransfer_serial/Access/S3Policy (1.07s)
        --- SKIP: TestAccTransfer_serial/Access/disappears (1.06s)
        --- SKIP: TestAccTransfer_serial/Access/EFSBasic (15.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	21.662s
% make testacc TESTS="TestAccTransfer_serial/User" PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20 -run='TestAccTransfer_serial/User' -timeout 180m
--- PASS: TestAccTransfer_serial (70.53s)
    --- PASS: TestAccTransfer_serial/User (70.53s)
        --- SKIP: TestAccTransfer_serial/User/ModifyWithOptions (12.54s)
        --- SKIP: TestAccTransfer_serial/User/Posix (10.62s)
        --- PASS: TestAccTransfer_serial/User/UserNameValidation (15.65s)
        --- SKIP: TestAccTransfer_serial/User/basic (10.56s)
        --- SKIP: TestAccTransfer_serial/User/disappears (10.57s)
        --- SKIP: TestAccTransfer_serial/User/HomeDirectoryMappings (10.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	71.759s
```