### PR TITLE
sqs: Fix diffs with policies

### DIFF
--- a/.changelog/22194.txt
+++ b/.changelog/22194.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_sqs_queue: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```
+
+```release-note:bug
+resource/aws_sqs_queue_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
+```

--- a/.changelog/22194.txt
+++ b/.changelog/22194.txt
@@ -5,3 +5,11 @@ resource/aws_sqs_queue: Fix erroneous diffs in `policy` when no changes made or 
 ```release-note:bug
 resource/aws_sqs_queue_policy: Fix erroneous diffs in `policy` when no changes made or policies are equivalent
 ```
+
+```release-note:bug
+resource/aws_sqs_queue: Fix "error reading, empty result" and various eventual consistency errors
+```
+
+```release-note:bug
+resource/aws_sqs_queue_policy: Fix "error reading, empty result" and various eventual consistency errors
+```

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -284,7 +284,22 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	output, err := FindQueueAttributesByURL(conn, d.Id())
+	var output map[string]string
+	err := resource.Retry(queueReadTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = FindQueueAttributesByURL(conn, d.Id())
+
+		if tfresource.NotFound(err) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue (%s) not found, removing from state", d.Id())
@@ -329,15 +344,33 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("policy", policyToSet)
 
-	tags, err := ListTags(conn, d.Id())
+	var tags tftags.KeyValueTags
+
+	err = resource.Retry(queueTagsTimeout, func() *resource.RetryError {
+		var err error
+
+		tags, err = ListTags(conn, d.Id())
+
+		if tfawserr.ErrCodeEquals(err, sqs.ErrCodeQueueDoesNotExist) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
 
 	if err != nil {
 		// Non-standard partitions (e.g. US Gov) and some local development
 		// solutions do not yet support this API call. Depending on the
 		// implementation it may return InvalidAction or AWS.SimpleQueueService.UnsupportedOperation
-		if !tfawserr.ErrCodeEquals(err, ErrCodeInvalidAction) && !tfawserr.ErrCodeEquals(err, sqs.ErrCodeUnsupportedOperation) {
-			return fmt.Errorf("error listing tags for SQS Queue (%s): %w", d.Id(), err)
+		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidAction) || tfawserr.ErrCodeEquals(err, sqs.ErrCodeUnsupportedOperation) {
+			return nil
 		}
+
+		return fmt.Errorf("error listing tags for SQS Queue (%s): %w", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -301,6 +301,14 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 
+	if tfresource.TimedOut(err) {
+		output, err = FindQueueAttributesByURL(conn, d.Id())
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading SQS Queue (%s): %w", d.Id(), err)
+	}
+
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -370,6 +370,10 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 
+	if tfresource.TimedOut(err) {
+		tags, err = ListTags(conn, d.Id())
+	}
+
 	if err != nil {
 		// Non-standard partitions (e.g. US Gov) and some local development
 		// solutions do not yet support this API call. Depending on the

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -305,10 +305,6 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		output, err = FindQueueAttributesByURL(conn, d.Id())
 	}
 
-	if err != nil {
-		return fmt.Errorf("error reading SQS Queue (%s): %w", d.Id(), err)
-	}
-
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/sqs/queue_policy.go
+++ b/internal/service/sqs/queue_policy.go
@@ -113,6 +113,14 @@ func resourceQueuePolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 
+	if tfresource.TimedOut(err) {
+		policy, err = FindQueuePolicyByURL(conn, d.Id())
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading SQS Queue Policy (%s): %w", d.Id(), err)
+	}
+
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/sqs/queue_policy.go
+++ b/internal/service/sqs/queue_policy.go
@@ -117,10 +117,6 @@ func resourceQueuePolicyRead(d *schema.ResourceData, meta interface{}) error {
 		policy, err = FindQueuePolicyByURL(conn, d.Id())
 	}
 
-	if err != nil {
-		return fmt.Errorf("error reading SQS Queue Policy (%s): %w", d.Id(), err)
-	}
-
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/internal/service/sqs/queue_policy.go
+++ b/internal/service/sqs/queue_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -39,6 +40,10 @@ func ResourceQueuePolicy() *schema.Resource {
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 
 			"queue_url": {
@@ -53,9 +58,16 @@ func ResourceQueuePolicy() *schema.Resource {
 func resourceQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SQSConn
 
-	policyAttributes := map[string]string{
-		sqs.QueueAttributeNamePolicy: d.Get("policy").(string),
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
 	}
+
+	policyAttributes := map[string]string{
+		sqs.QueueAttributeNamePolicy: policy,
+	}
+
 	url := d.Get("queue_url").(string)
 	input := &sqs.SetQueueAttributesInput{
 		Attributes: aws.StringMap(policyAttributes),
@@ -63,7 +75,7 @@ func resourceQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Setting SQS Queue Policy: %s", input)
-	_, err := conn.SetQueueAttributes(input)
+	_, err = conn.SetQueueAttributes(input)
 
 	if err != nil {
 		return fmt.Errorf("error setting SQS Queue Policy (%s): %w", url, err)
@@ -95,7 +107,14 @@ func resourceQueuePolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading SQS Queue Policy (%s): %w", d.Id(), err)
 	}
 
-	d.Set("policy", policy)
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("policy", policyToSet)
+
 	d.Set("queue_url", d.Id())
 
 	return nil

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -308,10 +308,27 @@ func TestAccSQSQueue_update(t *testing.T) {
 	})
 }
 
-func TestAccSQSQueue_policy(t *testing.T) {
+func TestAccSQSQueue_Policy_basic(t *testing.T) {
 	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	expectedPolicy := `
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement":[{
+    "Sid": "Stmt1451501026839",
+    "Effect": "Allow",
+    "Principal":"*",
+    "Action":"sqs:SendMessage",
+    "Resource":"arn:%[1]s:sqs:%[2]s:%[3]s:%[4]s",
+    "Condition":{
+      "ArnEquals":{"aws:SourceArn":"arn:%[1]s:sns:%[2]s:%[3]s:%[4]s"}
+    }
+  }]
+}
+`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -323,7 +340,7 @@ func TestAccSQSQueue_policy(t *testing.T) {
 				Config: testAccPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueueExists(resourceName, &queueAttributes),
-					testAccCheckQueuePolicyAttribute(&queueAttributes, rName),
+					testAccCheckQueuePolicyAttribute(&queueAttributes, rName, expectedPolicy),
 					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
 					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
 					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
@@ -335,6 +352,58 @@ func TestAccSQSQueue_policy(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSQSQueue_Policy_ignoreEquivalent(t *testing.T) {
+	var queueAttributes map[string]string
+	resourceName := "aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	expectedPolicy := `
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement":[{
+    "Sid": "SID1993561419",
+    "Effect": "Allow",
+    "Principal":"*",
+    "Action":[
+      "sqs:SendMessage",
+      "sqs:DeleteMessage",
+      "sqs:ListQueues"
+    ],
+    "Resource":"arn:%[1]s:sqs:%[2]s:%[3]s:%[4]s",
+    "Condition":{
+      "ArnEquals":{"aws:SourceArn":"arn:%[1]s:sns:%[2]s:%[3]s:%[4]s"}
+    }
+  }]
+}
+`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, sqs.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueuePolicyEquivalentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &queueAttributes),
+					testAccCheckQueuePolicyAttribute(&queueAttributes, rName, expectedPolicy),
+					resource.TestCheckResourceAttr(resourceName, "delay_seconds", "90"),
+					resource.TestCheckResourceAttr(resourceName, "max_message_size", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "message_retention_seconds", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", "10"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", "60"),
+				),
+			},
+			{
+				Config:   testAccQueuePolicyNewEquivalentConfig(rName),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -625,24 +694,9 @@ func TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds(t *testing.T) {
 	})
 }
 
-func testAccCheckQueuePolicyAttribute(queueAttributes *map[string]string, rName string) resource.TestCheckFunc {
+func testAccCheckQueuePolicyAttribute(queueAttributes *map[string]string, rName, policyTemplate string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		expectedPolicyText := fmt.Sprintf(
-			`{
-"Version": "2012-10-17",
-"Id": "sqspolicy",
-"Statement":[{
-  "Sid": "Stmt1451501026839",
-  "Effect": "Allow",
-  "Principal":"*",
-  "Action":"sqs:SendMessage",
-  "Resource":"arn:%[1]s:sqs:%[2]s:%[3]s:%[4]s",
-  "Condition":{
-    "ArnEquals":{"aws:SourceArn":"arn:%[1]s:sns:%[2]s:%[3]s:%[5]s"}
-  }
-}]
-             }`,
-			acctest.Partition(), acctest.Region(), acctest.AccountID(), rName, rName)
+		expectedPolicy := fmt.Sprintf(policyTemplate, acctest.Partition(), acctest.Region(), acctest.AccountID(), rName)
 
 		var actualPolicyText string
 		for key, value := range *queueAttributes {
@@ -652,12 +706,12 @@ func testAccCheckQueuePolicyAttribute(queueAttributes *map[string]string, rName 
 			}
 		}
 
-		equivalent, err := awspolicy.PoliciesAreEquivalent(actualPolicyText, expectedPolicyText)
+		equivalent, err := awspolicy.PoliciesAreEquivalent(actualPolicyText, expectedPolicy)
 		if err != nil {
 			return fmt.Errorf("Error testing policy equivalence: %s", err)
 		}
 		if !equivalent {
-			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n", expectedPolicyText, actualPolicyText)
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n", expectedPolicy, actualPolicyText)
 		}
 
 		return nil
@@ -830,6 +884,106 @@ resource "aws_sqs_queue" "test" {
   ]
 }
 EOF
+}
+
+resource "aws_sns_topic_subscription" "test" {
+  topic_arn = aws_sns_topic.test.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.test.arn
+}
+`, rName)
+}
+
+func testAccQueuePolicyEquivalentConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_sqs_queue" "test" {
+  name                       = %[1]q
+  delay_seconds              = 90
+  max_message_size           = 2048
+  message_retention_seconds  = 86400
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 60
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id = "sqspolicy"
+    Statement = [{
+      Sid = "SID1993561419"
+      Effect = "Allow"
+      Principal = "*"
+      Action = [
+        "sqs:SendMessage",
+        "sqs:DeleteMessage",
+        "sqs:ListQueues",
+      ]
+      Resource = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:%[1]s"
+      Condition = {
+        ArnEquals = {
+          "aws:SourceArn" = aws_sns_topic.test.arn
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_sns_topic_subscription" "test" {
+  topic_arn = aws_sns_topic.test.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.test.arn
+}
+`, rName)
+}
+
+func testAccQueuePolicyNewEquivalentConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_sqs_queue" "test" {
+  name                       = %[1]q
+  delay_seconds              = 90
+  max_message_size           = 2048
+  message_retention_seconds  = 86400
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 60
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id = "sqspolicy"
+    Statement = [{
+      Sid = "SID1993561419"
+      Effect = "Allow"
+      Principal = ["*"]
+      Action = [
+        "sqs:ListQueues",
+        "sqs:SendMessage",
+        "sqs:DeleteMessage",
+      ]
+      Resource = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:%[1]s"
+      Condition = {
+        ArnEquals = {
+          "aws:SourceArn" = aws_sns_topic.test.arn
+        }
+      }
+    }]
+  })
 }
 
 resource "aws_sns_topic_subscription" "test" {

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -916,10 +916,10 @@ resource "aws_sqs_queue" "test" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "sqspolicy"
+    Id      = "sqspolicy"
     Statement = [{
-      Sid = "SID1993561419"
-      Effect = "Allow"
+      Sid       = "SID1993561419"
+      Effect    = "Allow"
       Principal = "*"
       Action = [
         "sqs:SendMessage",
@@ -966,10 +966,10 @@ resource "aws_sqs_queue" "test" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "sqspolicy"
+    Id      = "sqspolicy"
     Statement = [{
-      Sid = "SID1993561419"
-      Effect = "Allow"
+      Sid       = "SID1993561419"
+      Effect    = "Allow"
       Principal = ["*"]
       Action = [
         "sqs:ListQueues",

--- a/internal/service/sqs/status.go
+++ b/internal/service/sqs/status.go
@@ -84,7 +84,7 @@ func statusQueueAttributeState(conn *sqs.SQS, url string, expected map[string]st
 		err = attributesMatch(got)
 
 		if err != nil {
-			return got, queuePolicyStateNotEqual, nil
+			return got, queuePolicyStateNotEqual, nil //nolint:nilerr
 		}
 
 		return got, queuePolicyStateEqual, nil

--- a/internal/service/sqs/status.go
+++ b/internal/service/sqs/status.go
@@ -1,7 +1,11 @@
 package sqs
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/aws/aws-sdk-go/service/sqs"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -19,5 +23,70 @@ func statusQueueState(conn *sqs.SQS, url string) resource.StateRefreshFunc {
 		}
 
 		return output, queueStateExists, nil
+	}
+}
+
+func statusQueueAttributeState(conn *sqs.SQS, url string, expected map[string]string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		attributesMatch := func(got map[string]string) error {
+			for k, e := range expected {
+				g, ok := got[k]
+
+				if !ok {
+					// Missing attribute equivalent to empty expected value.
+					if e == "" {
+						continue
+					}
+
+					// Backwards compatibility: https://github.com/hashicorp/terraform-provider-aws/issues/19786.
+					if k == sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds && e == strconv.Itoa(DefaultQueueKMSDataKeyReusePeriodSeconds) {
+						continue
+					}
+
+					return fmt.Errorf("SQS Queue attribute (%s) not available", k)
+				}
+
+				switch k {
+				case sqs.QueueAttributeNamePolicy:
+					equivalent, err := awspolicy.PoliciesAreEquivalent(g, e)
+
+					if err != nil {
+						return err
+					}
+
+					if !equivalent {
+						return fmt.Errorf("SQS Queue policies are not equivalent")
+					}
+				case sqs.QueueAttributeNameRedrivePolicy:
+					if !StringsEquivalent(g, e) {
+						return fmt.Errorf("SQS Queue redrive policies are not equivalent")
+					}
+				default:
+					if g != e {
+						return fmt.Errorf("SQS Queue attribute (%s) got: %s, expected: %s", k, g, e)
+					}
+				}
+			}
+
+			return nil
+		}
+
+		got, err := FindQueueAttributesByURL(conn, url)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		err = attributesMatch(got)
+
+		if err != nil {
+			return got, queuePolicyStateNotEqual, nil
+		}
+
+		return got, queuePolicyStateEqual, nil
 	}
 }

--- a/internal/service/sqs/wait.go
+++ b/internal/service/sqs/wait.go
@@ -1,14 +1,10 @@
 package sqs
 
 import (
-	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/sqs"
-	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 const (
@@ -17,105 +13,48 @@ const (
 	// as this will negatively impact user experience when configurations
 	// have incorrect references or permissions.
 	// Reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
-	queueAttributePropagationTimeout = 1 * time.Minute
+	queueAttributePropagationTimeout = 2 * time.Minute
 
 	// If you delete a queue, you must wait at least 60 seconds before creating a queue with the same name.
 	// ReferenceL https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html
 	queueCreatedTimeout = 70 * time.Second
+	queueReadTimeout    = 15 * time.Second
+	queueDeletedTimeout = 3 * time.Minute
+	queueTagsTimeout    = 60 * time.Second
 
-	queueDeletedTimeout = 15 * time.Second
+	queuePolicyReadTimeout = 20 * time.Second
 
 	queueStateExists = "exists"
+
+	queuePolicyStateNotEqual = "notequal"
+	queuePolicyStateEqual    = "equal"
 )
 
 func waitQueueAttributesPropagated(conn *sqs.SQS, url string, expected map[string]string) error {
-	attributesMatch := func(got map[string]string) error {
-		for k, e := range expected {
-			g, ok := got[k]
-
-			if !ok {
-				// Missing attribute equivalent to empty expected value.
-				if e == "" {
-					continue
-				}
-
-				// Backwards compatibility: https://github.com/hashicorp/terraform-provider-aws/issues/19786.
-				if k == sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds && e == strconv.Itoa(DefaultQueueKMSDataKeyReusePeriodSeconds) {
-					continue
-				}
-
-				return fmt.Errorf("SQS Queue attribute (%s) not available", k)
-			}
-
-			switch k {
-			case sqs.QueueAttributeNamePolicy:
-				equivalent, err := awspolicy.PoliciesAreEquivalent(g, e)
-
-				if err != nil {
-					return err
-				}
-
-				if !equivalent {
-					return fmt.Errorf("SQS Queue policies are not equivalent")
-				}
-			case sqs.QueueAttributeNameRedrivePolicy:
-				if !StringsEquivalent(g, e) {
-					return fmt.Errorf("SQS Queue redrive policies are not equivalent")
-				}
-			default:
-				if g != e {
-					return fmt.Errorf("SQS Queue attribute (%s) got: %s, expected: %s", k, g, e)
-				}
-			}
-		}
-
-		return nil
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{queuePolicyStateNotEqual},
+		Target:                    []string{queuePolicyStateEqual},
+		Refresh:                   statusQueueAttributeState(conn, url, expected),
+		Timeout:                   queueAttributePropagationTimeout,
+		ContinuousTargetOccurence: 3,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                7 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		NotFoundChecks:            10,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
-	var got map[string]string
-	err := resource.Retry(queueAttributePropagationTimeout, func() *resource.RetryError {
-		var err error
+	_, err := stateConf.WaitForState()
 
-		got, err = FindQueueAttributesByURL(conn, url)
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		err = attributesMatch(got)
-
-		if err != nil {
-			return resource.RetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		got, err = FindQueueAttributesByURL(conn, url)
-
-		if err != nil {
-			return err
-		}
-
-		err = attributesMatch(got)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func waitQueueDeleted(conn *sqs.SQS, url string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{queueStateExists},
-		Target:  []string{},
-		Refresh: statusQueueState(conn, url),
-		Timeout: queueDeletedTimeout,
-
-		ContinuousTargetOccurence: 3,
+		Pending:                   []string{queueStateExists},
+		Target:                    []string{},
+		Refresh:                   statusQueueState(conn, url),
+		Timeout:                   queueDeletedTimeout,
+		ContinuousTargetOccurence: 12,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                2 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		NotFoundChecks:            3,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
 	_, err := stateConf.WaitForState()

--- a/internal/service/sqs/wait.go
+++ b/internal/service/sqs/wait.go
@@ -36,8 +36,8 @@ func waitQueueAttributesPropagated(conn *sqs.SQS, url string, expected map[strin
 		Target:                    []string{queuePolicyStateEqual},
 		Refresh:                   statusQueueAttributeState(conn, url, expected),
 		Timeout:                   queueAttributePropagationTimeout,
-		ContinuousTargetOccurence: 5,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                6 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		ContinuousTargetOccurence: 6,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                5 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 		NotFoundChecks:            10,              // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 

--- a/internal/service/sqs/wait.go
+++ b/internal/service/sqs/wait.go
@@ -36,10 +36,10 @@ func waitQueueAttributesPropagated(conn *sqs.SQS, url string, expected map[strin
 		Target:                    []string{queuePolicyStateEqual},
 		Refresh:                   statusQueueAttributeState(conn, url, expected),
 		Timeout:                   queueAttributePropagationTimeout,
-		ContinuousTargetOccurence: 5,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		Delay:                     5 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                2 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		NotFoundChecks:            10,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		ContinuousTargetOccurence: 5,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		Delay:                     5 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                2 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		NotFoundChecks:            10,              // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
 	_, err := stateConf.WaitForState()
@@ -53,10 +53,10 @@ func waitQueueDeleted(conn *sqs.SQS, url string) error {
 		Target:                    []string{},
 		Refresh:                   statusQueueState(conn, url),
 		Timeout:                   queueDeletedTimeout,
-		ContinuousTargetOccurence: 15,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		Delay:                     5 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                2 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		NotFoundChecks:            5,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		ContinuousTargetOccurence: 15,              // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		Delay:                     5 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                2 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		NotFoundChecks:            5,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
 	_, err := stateConf.WaitForState()

--- a/internal/service/sqs/wait.go
+++ b/internal/service/sqs/wait.go
@@ -37,7 +37,7 @@ func waitQueueAttributesPropagated(conn *sqs.SQS, url string, expected map[strin
 		Refresh:                   statusQueueAttributeState(conn, url, expected),
 		Timeout:                   queueAttributePropagationTimeout,
 		ContinuousTargetOccurence: 5,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                3 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                6 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 		NotFoundChecks:            10,              // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 

--- a/internal/service/sqs/wait.go
+++ b/internal/service/sqs/wait.go
@@ -18,7 +18,7 @@ const (
 	// If you delete a queue, you must wait at least 60 seconds before creating a queue with the same name.
 	// ReferenceL https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html
 	queueCreatedTimeout = 70 * time.Second
-	queueReadTimeout    = 15 * time.Second
+	queueReadTimeout    = 20 * time.Second
 	queueDeletedTimeout = 3 * time.Minute
 	queueTagsTimeout    = 60 * time.Second
 
@@ -36,8 +36,9 @@ func waitQueueAttributesPropagated(conn *sqs.SQS, url string, expected map[strin
 		Target:                    []string{queuePolicyStateEqual},
 		Refresh:                   statusQueueAttributeState(conn, url, expected),
 		Timeout:                   queueAttributePropagationTimeout,
-		ContinuousTargetOccurence: 3,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                7 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		ContinuousTargetOccurence: 5,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		Delay:                     5 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                2 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
 		NotFoundChecks:            10,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
@@ -52,9 +53,10 @@ func waitQueueDeleted(conn *sqs.SQS, url string) error {
 		Target:                    []string{},
 		Refresh:                   statusQueueState(conn, url),
 		Timeout:                   queueDeletedTimeout,
-		ContinuousTargetOccurence: 12,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		ContinuousTargetOccurence: 15,              // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		Delay:                     5 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
 		MinTimeout:                2 * time.Second, // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
-		NotFoundChecks:            3,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
+		NotFoundChecks:            5,               // set to accomodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
 	_, err := stateConf.WaitForState()

--- a/internal/service/sqs/wait.go
+++ b/internal/service/sqs/wait.go
@@ -37,8 +37,7 @@ func waitQueueAttributesPropagated(conn *sqs.SQS, url string, expected map[strin
 		Refresh:                   statusQueueAttributeState(conn, url, expected),
 		Timeout:                   queueAttributePropagationTimeout,
 		ContinuousTargetOccurence: 5,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
-		Delay:                     5 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                2 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                3 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 		NotFoundChecks:            10,              // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 
@@ -54,8 +53,7 @@ func waitQueueDeleted(conn *sqs.SQS, url string) error {
 		Refresh:                   statusQueueState(conn, url),
 		Timeout:                   queueDeletedTimeout,
 		ContinuousTargetOccurence: 15,              // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
-		Delay:                     5 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
-		MinTimeout:                2 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
+		MinTimeout:                3 * time.Second, // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 		NotFoundChecks:            5,               // set to accommodate GovCloud, commercial, China, etc. - avoid lowering
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21968
Fixes #19836
Fixes #20333

**NOTE:** These changes will make SQS configurations take a little longer to apply. However, because SQS has such trouble with eventual consistency, the extra time is needed to improve consistency.

I ran each test 10X in 3 different regions. Unfortunately, these changes _do not_ perfectly fix all eventual consistency problems (see #19836 and #20333). However, the overall improvement is significant:

| Test | GovCloud | `us-west-2` | `us-east-1` |
| --- | --- | --- | --- |
| **Total** Out of 260 (before --> after) | 182 --> 258 | 255 --> 259 | 258 --> 258 |
| TestAccSQSQueue_basic | 9 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds | 6 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_disappears | 8 --> 10| 10 --> 9 | 10 --> 10 |
| TestAccSQSQueue_encryption | 2 --> 10| 9 --> 10 | 10 --> 10 |
| TestAccSQSQueue_fifoQueue | 7 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_FIFOQueue_contentBasedDeduplication | 8 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_FIFOQueue_expectNameError | 10 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_FIFOQueue_highThroughputMode | 6 --> 10| 9 --> 10 | 10 --> 10 |
| TestAccSQSQueue_Name_generated | 9 --> 10| 10 --> 10 | 10 --> 9 |
| TestAccSQSQueue_NameGenerated_fifoQueue | 7 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_namePrefix | 9 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_NamePrefix_fifoQueue | 10 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_Policy_basic | 10 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_Policy_ignoreEquivalent | 10 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_recentlyDeleted | 7 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_redrivePolicy | 7 --> 10| 9 --> 10 | 10 --> 10 |
| TestAccSQSQueue_StandardQueue_expectContentBased... | 10 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_tags | 6 --> 10| 9 --> 10 | 10 --> 10 |
| TestAccSQSQueue_update | 3 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueue_zeroVisibilityTimeoutSeconds | 7 --> 10| 10 --> 10 | 10 --> 9 |
| TestAccSQSQueueDataSource_basic | 6 --> 9 | 10 --> 10 | 10 --> 10 |
| TestAccSQSQueueDataSource_tags | 7 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueuePolicy_basic | 2 --> 10| 9 --> 10 | 9 --> 10 |
| TestAccSQSQueuePolicy_disappears | 3 --> 10| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueuePolicy_Disappears_queue | 8 --> 9| 10 --> 10 | 10 --> 10 |
| TestAccSQSQueuePolicy_update | 5 --> 10| 10 --> 10 | 9 --> 10 |

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccSQSQueue PKG=sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue' -timeout 180m
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (5.24s)
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (5.43s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (49.23s)
--- PASS: TestAccSQSQueueDataSource_basic (49.52s)
--- PASS: TestAccSQSQueue_fifoQueue (52.91s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (53.05s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (53.19s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (53.24s)
--- PASS: TestAccSQSQueue_basic (53.24s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (53.31s)
--- PASS: TestAccSQSQueue_namePrefix (53.33s)
--- PASS: TestAccSQSQueue_Name_generated (53.33s)
--- PASS: TestAccSQSQueue_disappears (58.84s)
--- PASS: TestAccSQSQueue_redrivePolicy (67.99s)
--- PASS: TestAccSQSQueue_tags (75.07s)
--- PASS: TestAccSQSQueue_update (79.35s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (79.66s)
--- PASS: TestAccSQSQueueDataSource_tags (37.40s)
--- PASS: TestAccSQSQueuePolicy_Disappears_queue (90.95s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (93.70s)
--- PASS: TestAccSQSQueuePolicy_update (102.57s)
--- PASS: TestAccSQSQueue_encryption (104.95s)
--- PASS: TestAccSQSQueuePolicy_basic (73.36s)
--- PASS: TestAccSQSQueue_recentlyDeleted (123.80s)
--- PASS: TestAccSQSQueuePolicy_disappears (83.69s)
--- PASS: TestAccSQSQueue_Policy_basic (87.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	138.023s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccSQSQueue PKG=sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue' -timeout 180m
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (6.27s)
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (6.43s)
--- PASS: TestAccSQSQueue_fifoQueue (51.83s)
--- PASS: TestAccSQSQueue_Name_generated (75.05s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (100.83s)
--- PASS: TestAccSQSQueue_Policy_basic (95.58s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (103.79s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (105.19s)
--- PASS: TestAccSQSQueue_basic (112.31s)
--- PASS: TestAccSQSQueue_disappears (116.04s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (117.01s)
--- PASS: TestAccSQSQueue_redrivePolicy (127.00s)
--- PASS: TestAccSQSQueuePolicy_update (134.62s)
--- PASS: TestAccSQSQueuePolicy_basic (139.97s)
--- PASS: TestAccSQSQueuePolicy_disappears (143.00s)
--- PASS: TestAccSQSQueuePolicy_Disappears_queue (146.17s)
--- PASS: TestAccSQSQueueDataSource_tags (153.68s)
--- PASS: TestAccSQSQueueDataSource_basic (158.34s)
--- PASS: TestAccSQSQueue_update (154.88s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (162.26s)
--- PASS: TestAccSQSQueue_encryption (164.73s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (102.71s)
--- PASS: TestAccSQSQueue_namePrefix (97.73s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (103.07s)
--- PASS: TestAccSQSQueue_recentlyDeleted (210.20s)
--- PASS: TestAccSQSQueue_tags (182.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	235.349s
```