### PR TITLE
fix: increase golanci timeout to 25m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,4 +72,4 @@ linters-settings:
       - gomnd
 
 run:
-  timeout: 20m
+  timeout: 25m


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Notes

* `Terraform Provider` Github actions workflows often error out during the `golangci-lint` job after exceeding the 20min run timeout e.g. https://github.com/hashicorp/terraform-provider-aws/runs/4513217734?check_suite_focus=true


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A
```
