### PR TITLE
d/aws_connect_hours_of_operation

### DIFF
--- a/.changelog/22207.txt
+++ b/.changelog/22207.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_connect_hours_of_operation
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -402,6 +402,7 @@ func Provider() *schema.Provider {
 
 			"aws_connect_bot_association":             connect.DataSourceBotAssociation(),
 			"aws_connect_contact_flow":                connect.DataSourceContactFlow(),
+			"aws_connect_hours_of_operation":          connect.DataSourceHoursOfOperation(),
 			"aws_connect_instance":                    connect.DataSourceInstance(),
 			"aws_connect_lambda_function_association": connect.DataSourceLambdaFunctionAssociation(),
 

--- a/internal/service/connect/enum.go
+++ b/internal/service/connect/enum.go
@@ -11,6 +11,9 @@ const (
 	ListContactFlowsMaxResults = 60
 	// MaxResults Valid Range: Minimum value of 1. Maximum value of 25
 	ListBotsMaxResults = 25
+	// MaxResults Valid Range: Minimum value of 1. Maximum value of 1000
+	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListHoursOfOperations.html
+	ListHoursOfOperationsMaxResults = 60
 	// ListLambdaFunctionsMaxResults Valid Range: Minimum value of 1. Maximum value of 25.
 	//https://docs.aws.amazon.com/connect/latest/APIReference/API_ListLambdaFunctions.html
 	ListLambdaFunctionsMaxResults = 25

--- a/internal/service/connect/hours_of_operation_data_source.go
+++ b/internal/service/connect/hours_of_operation_data_source.go
@@ -1,0 +1,105 @@
+package connect
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/connect"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceHoursOfOperation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHoursOfOperationRead,
+		Schema: map[string]*schema.Schema{
+			"config": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"day": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_time": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hours": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"minutes": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"start_time": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hours": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"minutes": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(m["day"].(string))
+					buf.WriteString(fmt.Sprintf("%+v", m["end_time"].([]interface{})))
+					buf.WriteString(fmt.Sprintf("%+v", m["start_time"].([]interface{})))
+					return create.StringHashcode(buf.String())
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hours_of_operation_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hours_of_operation_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"hours_of_operation_id", "name"},
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"name", "hours_of_operation_id"},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"time_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+

--- a/internal/service/connect/hours_of_operation_data_source_test.go
+++ b/internal/service/connect/hours_of_operation_data_source_test.go
@@ -75,43 +75,43 @@ resource "aws_connect_instance" "test" {
 }
 
 resource "aws_connect_hours_of_operation" "test" {
-	instance_id = aws_connect_instance.test.id
-	name        = %[2]q
-	description = "Test Hours of Operation Description"
-	time_zone   = "EST"
+  instance_id = aws_connect_instance.test.id
+  name        = %[2]q
+  description = "Test Hours of Operation Description"
+  time_zone   = "EST"
 
-	config {
-	  day = "MONDAY"
+  config {
+    day = "MONDAY"
 
-	  end_time {
-		hours   = 23
-		minutes = 8
-	  }
+    end_time {
+      hours   = 23
+      minutes = 8
+    }
 
-	  start_time {
-		hours   = 8
-		minutes = 0
-	  }
-	}
-
-	config {
-	  day = "TUESDAY"
-
-	  end_time {
-		hours   = 21
-		minutes = 0
-	  }
-
-	  start_time {
-		hours   = 9
-		minutes = 0
-	  }
-	}
-
-	tags = {
-	  "Name" = "Test Hours of Operation"
-	}
+    start_time {
+      hours   = 8
+      minutes = 0
+    }
   }
+
+  config {
+    day = "TUESDAY"
+
+    end_time {
+      hours   = 21
+      minutes = 0
+    }
+
+    start_time {
+      hours   = 9
+      minutes = 0
+    }
+  }
+
+  tags = {
+    "Name" = "Test Hours of Operation"
+  }
+}
 	`, rName, rName2)
 }
 

--- a/internal/service/connect/hours_of_operation_data_source_test.go
+++ b/internal/service/connect/hours_of_operation_data_source_test.go
@@ -1,0 +1,134 @@
+package connect_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/connect"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccConnectHoursOfOperationDataSource_hoursOfOperationID(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_hours_of_operation.test"
+	datasourceName := "data.aws_connect_hours_of_operation.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHoursOfOperationDataSourceConfig_HoursOfOperationID(rName, resourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_arn", resourceName, "hours_of_operation_arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_id", resourceName, "hours_of_operation_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "time_zone", resourceName, "time_zone"),
+					resource.TestCheckResourceAttrPair(datasourceName, "config.#", resourceName, "config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConnectHoursOfOperationDataSource_name(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_hours_of_operation.test"
+	datasourceName := "data.aws_connect_hours_of_operation.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHoursOfOperationDataSourceConfig_Name(rName, rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_arn", resourceName, "hours_of_operation_arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_id", resourceName, "hours_of_operation_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "time_zone", resourceName, "time_zone"),
+					resource.TestCheckResourceAttrPair(datasourceName, "config.#", resourceName, "config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHoursOfOperationBaseDataSourceConfig(rName, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+}
+
+resource "aws_connect_hours_of_operation" "test" {
+	instance_id = aws_connect_instance.test.id
+	name        = %[2]q
+	description = "Test Hours of Operation Description"
+	time_zone   = "EST"
+
+	config {
+	  day = "MONDAY"
+
+	  end_time {
+		hours   = 23
+		minutes = 8
+	  }
+
+	  start_time {
+		hours   = 8
+		minutes = 0
+	  }
+	}
+
+	config {
+	  day = "TUESDAY"
+
+	  end_time {
+		hours   = 21
+		minutes = 0
+	  }
+
+	  start_time {
+		hours   = 9
+		minutes = 0
+	  }
+	}
+
+	tags = {
+	  "Name" = "Test Hours of Operation"
+	}
+  }
+	`, rName, rName2)
+}
+
+func testAccHoursOfOperationDataSourceConfig_HoursOfOperationID(rName, rName2 string) string {
+	return fmt.Sprintf(testAccHoursOfOperationBaseDataSourceConfig(rName, rName2) + `
+data "aws_connect_hours_of_operation" "test" {
+  instance_id           = aws_connect_instance.test.id
+  hours_of_operation_id = aws_connect_hours_of_operation.test.hours_of_operation_id
+}
+`)
+}
+
+func testAccHoursOfOperationDataSourceConfig_Name(rName, rName2 string) string {
+	return fmt.Sprintf(testAccHoursOfOperationBaseDataSourceConfig(rName, rName2) + `
+data "aws_connect_hours_of_operation" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = aws_connect_hours_of_operation.test.name
+}
+`)
+}

--- a/website/docs/d/connect_hours_of_operation.html.markdown
+++ b/website/docs/d/connect_hours_of_operation.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Connect"
+layout: "aws"
+page_title: "AWS: aws_connect_hours_of_operation"
+description: |-
+  Provides details about a specific Amazon Connect Hours of Operation.
+---
+
+# Data Source: aws_connect_hours_of_operation
+
+Provides details about a specific Amazon Connect Hours of Operation.
+
+## Example Usage
+By `name`
+
+```hcl
+data "aws_connect_hours_of_operation" "test" {
+  instance_id = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name        = "Test"
+}
+```
+
+By `hours_of_operation_id`
+
+```hcl
+data "aws_connect_hours_of_operation" "test" {
+  instance_id           = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  hours_of_operation_id = "cccccccc-bbbb-cccc-dddd-111111111111"
+}
+```
+
+## Argument Reference
+
+~> **NOTE:** `instance_id` and one of either `name` or `hours_of_operation_id` is required.
+
+The following arguments are supported:
+
+* `hours_of_operation_id` - (Optional) Returns information on a specific Hours of Operation by hours of operation id
+* `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
+* `name` - (Optional) Returns information on a specific Hours of Operation by name
+
+## Attributes Reference
+
+In addition to all of the arguments above, the following attributes are exported:
+
+* `config` - Specifies configuration information for the hours of operation: day, start time, and end time . Config blocks are documented below. Config blocks are documented below.
+* `description` - Specifies the description of the Hours of Operation.
+* `hours_of_operation_arn` - The Amazon Resource Name (ARN) of the Hours of Operation.
+* `hours_of_operation_id` - The identifier for the hours of operation.
+* `instance_id` - Specifies the identifier of the hosting Amazon Connect Instance.
+* `name` - Specifies the name of the Hours of Operation.
+* `tags` - A the map of tags to assign to the Hours of Operation.
+* `time_zone` - Specifies the time zone of the Hours of Operation.
+
+A `config` blog supports the following arguments:
+
+* `day` - Specifies the day that the hours of operation applies to.
+* `end_time` - A end time block specifies the time that your contact center closes. The `end_time` is documented below.
+* `start_time` - A start time block specifies the time that your contact center opens. The `start_time` is documented below.
+
+A `end_time` blocks supports the following arguments:
+
+* `hours` - Specifies the hour of closing.
+* `minutes` - Specifies the minute of closing.
+
+A `start_time` blocks supports the following arguments:
+
+* `hours` - Specifies the hour of opening.
+* `minutes` - Specifies the minute of opening.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21043

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccConnectHoursOfOperationDataSource PKG=connect

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnectHoursOfOperationDataSource' -timeout 180m
=== RUN   TestAccConnectHoursOfOperationDataSource_hoursOfOperationID
--- PASS: TestAccConnectHoursOfOperationDataSource_hoursOfOperationID (153.93s)
=== RUN   TestAccConnectHoursOfOperationDataSource_name
--- PASS: TestAccConnectHoursOfOperationDataSource_name (110.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    271.342s

...
```