### PR TITLE
Correct valid argument options for rules for aws_wafregional_web_acl

### DIFF
--- a/website/docs/r/wafregional_web_acl.html.markdown
+++ b/website/docs/r/wafregional_web_acl.html.markdown
@@ -147,7 +147,7 @@ The following arguments are supported:
 
 #### `action` / `override_action` Configuration Block
 
-* `type` - (Required) Specifies how you want AWS WAF Regional to respond to requests that match the settings in a ruleE.g., `ALLOW`, `BLOCK` or `COUNT`
+* `type` - (Required) Specifies how you want AWS WAF Regional to respond to requests that match the settings in a rule. Valid values for `action` are `ALLOW`, `BLOCK` or `COUNT`. Valid values for `override_action` are `COUNT` and `NONE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22182

Output from acceptance testing: N/a, docs

### Information

This PR updates the documentation to correctly display the accepted values for `aws_wafregional_web_acl.rule.[action|override_action]`.

### References

https://github.com/hashicorp/terraform-provider-aws/blob/6b9ff3272b74cb5e57e18cfb083138b165065fc4/internal/service/wafregional/web_acl.go#L116-L150