### PR TITLE
r/s3_bucket: handle `versioning` configuration when explicitly disabled

### DIFF
--- a/.changelog/22221.txt
+++ b/.changelog/22221.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket: Ensure `versioning` is set correctly when nested values are explicitly set to `false`.
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -2899,6 +2899,11 @@ func expandVersioningWhenIsNewResource(l []interface{}) *s3.VersioningConfigurat
 
 	output := &s3.VersioningConfiguration{}
 
+	// Only set and return a non-nil VersioningConfiguration with at least one of
+	// MFADelete or Status enabled as the PutBucketVersioning API request
+	// does not need to be made for new buckets that don't require versioning.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4494
+
 	if v, ok := tfMap["enabled"].(bool); ok && v {
 		output.Status = aws.String(s3.BucketVersioningStatusEnabled)
 	}
@@ -2907,10 +2912,6 @@ func expandVersioningWhenIsNewResource(l []interface{}) *s3.VersioningConfigurat
 		output.MFADelete = aws.String(s3.MFADeleteEnabled)
 	}
 
-	// Only return a non-nil VersioningConfiguration with at least one of
-	// MFADelete or Status enabled as the PutBucketVersioning API request
-	// does not need to be made for new buckets that don't require versioning.
-	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4494
 	if output.MFADelete == nil && output.Status == nil {
 		return nil
 	}

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -777,10 +777,22 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("versioning") {
-		if err := resourceBucketVersioningUpdate(conn, d); err != nil {
-			return err
+		v := d.Get("versioning").([]interface{})
+
+		if d.IsNewResource() {
+			if versioning := expandVersioningWhenIsNewResource(v); versioning != nil {
+				err := resourceBucketVersioningUpdate(conn, d.Id(), versioning)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := resourceBucketVersioningUpdate(conn, d.Id(), expandVersioning(v)); err != nil {
+				return err
+			}
 		}
 	}
+
 	if d.HasChange("acl") && !d.IsNewResource() {
 		if err := resourceBucketACLUpdate(conn, d); err != nil {
 			return err
@@ -1054,28 +1066,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
 	}
 
-	vcl := make([]map[string]interface{}, 0, 1)
 	if versioning, ok := versioningResponse.(*s3.GetBucketVersioningOutput); ok {
-		vc := make(map[string]interface{})
-		if versioning.Status != nil && aws.StringValue(versioning.Status) == s3.BucketVersioningStatusEnabled {
-			vc["enabled"] = true
-		} else {
-			vc["enabled"] = false
+		if err := d.Set("versioning", flattenVersioning(versioning)); err != nil {
+			return fmt.Errorf("error setting versioning: %w", err)
 		}
-
-		if versioning.MFADelete != nil && aws.StringValue(versioning.MFADelete) == s3.MFADeleteEnabled {
-			vc["mfa_delete"] = true
-		} else {
-			vc["mfa_delete"] = false
-		}
-		vcl = append(vcl, vc)
-	}
-	if err := d.Set("versioning", vcl); err != nil {
-		return fmt.Errorf("error setting versioning: %s", err)
 	}
 
 	// Read the acceleration status
@@ -1843,41 +1842,18 @@ func resourceBucketACLUpdate(conn *s3.S3, d *schema.ResourceData) error {
 	return nil
 }
 
-func resourceBucketVersioningUpdate(conn *s3.S3, d *schema.ResourceData) error {
-	v := d.Get("versioning").([]interface{})
-	bucket := d.Get("bucket").(string)
-	vc := &s3.VersioningConfiguration{}
-
-	if len(v) > 0 {
-		c := v[0].(map[string]interface{})
-
-		if c["enabled"].(bool) {
-			vc.Status = aws.String(s3.BucketVersioningStatusEnabled)
-		} else {
-			vc.Status = aws.String(s3.BucketVersioningStatusSuspended)
-		}
-
-		if c["mfa_delete"].(bool) {
-			vc.MFADelete = aws.String(s3.MFADeleteEnabled)
-		} else {
-			vc.MFADelete = aws.String(s3.MFADeleteDisabled)
-		}
-
-	} else {
-		vc.Status = aws.String(s3.BucketVersioningStatusSuspended)
-	}
-
-	i := &s3.PutBucketVersioningInput{
+func resourceBucketVersioningUpdate(conn *s3.S3, bucket string, versioningConfig *s3.VersioningConfiguration) error {
+	input := &s3.PutBucketVersioningInput{
 		Bucket:                  aws.String(bucket),
-		VersioningConfiguration: vc,
+		VersioningConfiguration: versioningConfig,
 	}
-	log.Printf("[DEBUG] S3 put bucket versioning: %#v", i)
 
 	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.PutBucketVersioning(i)
+		return conn.PutBucketVersioning(input)
 	})
+
 	if err != nil {
-		return fmt.Errorf("Error putting S3 versioning: %s", err)
+		return fmt.Errorf("error putting S3 versioning for bucket (%s): %w", bucket, err)
 	}
 
 	return nil
@@ -2874,6 +2850,94 @@ func expandS3ObjectLockConfiguration(vConf []interface{}) *s3.ObjectLockConfigur
 	}
 
 	return conf
+}
+
+// Versioning functions
+
+func expandVersioning(l []interface{}) *s3.VersioningConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	output := &s3.VersioningConfiguration{}
+
+	if v, ok := tfMap["enabled"].(bool); ok {
+		if v {
+			output.Status = aws.String(s3.BucketVersioningStatusEnabled)
+		} else {
+			output.Status = aws.String(s3.BucketVersioningStatusSuspended)
+		}
+	}
+
+	if v, ok := tfMap["mfa_delete"].(bool); ok {
+		if v {
+			output.MFADelete = aws.String(s3.MFADeleteEnabled)
+		} else {
+			output.MFADelete = aws.String(s3.MFADeleteDisabled)
+		}
+	}
+
+	return output
+}
+
+func expandVersioningWhenIsNewResource(l []interface{}) *s3.VersioningConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	output := &s3.VersioningConfiguration{}
+
+	if v, ok := tfMap["enabled"].(bool); ok && v {
+		output.Status = aws.String(s3.BucketVersioningStatusEnabled)
+	}
+
+	if v, ok := tfMap["mfa_delete"].(bool); ok && v {
+		output.MFADelete = aws.String(s3.MFADeleteEnabled)
+	}
+
+	// Only return a non-nil VersioningConfiguration with at least one of
+	// MFADelete or Status enabled as the PutBucketVersioning API request
+	// does not need to be made for new buckets that don't require versioning.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4494
+	if output.MFADelete == nil && output.Status == nil {
+		return nil
+	}
+
+	return output
+}
+
+func flattenVersioning(versioning *s3.GetBucketVersioningOutput) []interface{} {
+	if versioning == nil {
+		return []interface{}{}
+	}
+
+	vc := make(map[string]interface{})
+
+	if aws.StringValue(versioning.Status) == s3.BucketVersioningStatusEnabled {
+		vc["enabled"] = true
+	} else {
+		vc["enabled"] = false
+	}
+
+	if aws.StringValue(versioning.MFADelete) == s3.MFADeleteEnabled {
+		vc["mfa_delete"] = true
+	} else {
+		vc["mfa_delete"] = false
+	}
+
+	return []interface{}{vc}
 }
 
 func flattenS3ObjectLockConfiguration(conf *s3.ObjectLockConfiguration) []interface{} {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -54,6 +54,9 @@ func TestAccS3Bucket_Basic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
 					testAccCheckS3BucketDomainName(resourceName, "bucket_domain_name", bucketName),
 					resource.TestCheckResourceAttr(resourceName, "bucket_regional_domain_name", testAccBucketRegionalDomainName(bucketName, region)),
+					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
 				),
 			},
 			{
@@ -939,10 +942,12 @@ func TestAccS3Bucket_Manage_versioning(t *testing.T) {
 		CheckDestroy: testAccCheckBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketConfig_Basic(bucketName),
+				Config: testAccBucketWithVersioningConfig(bucketName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
-					testAccCheckBucketVersioning(resourceName, ""),
+					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
 				),
 			},
 			{
@@ -952,18 +957,48 @@ func TestAccS3Bucket_Manage_versioning(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
 			},
 			{
-				Config: testAccBucketWithVersioningConfig(bucketName),
+				Config: testAccBucketWithVersioningConfig(bucketName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
-					testAccCheckBucketVersioning(resourceName, s3.BucketVersioningStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
 				),
 			},
 			{
-				Config: testAccBucketWithDisableVersioningConfig(bucketName),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+			},
+		},
+	})
+}
+
+func TestAccS3Bucket_Manage_versioningDisabled(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithVersioningConfig(bucketName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
-					testAccCheckBucketVersioning(resourceName, s3.BucketVersioningStatusSuspended),
+					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
 			},
 		},
 	})
@@ -3140,33 +3175,6 @@ func testAccCheckBucketWebsiteRoutingRules(n string, routingRules []*s3.RoutingR
 	}
 }
 
-func testAccCheckBucketVersioning(n string, versioningStatus string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs := s.RootModule().Resources[n]
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
-
-		out, err := conn.GetBucketVersioning(&s3.GetBucketVersioningInput{
-			Bucket: aws.String(rs.Primary.ID),
-		})
-
-		if err != nil {
-			return fmt.Errorf("GetBucketVersioning error: %v", err)
-		}
-
-		if v := out.Status; v == nil {
-			if versioningStatus != "" {
-				return fmt.Errorf("bad error versioning status, found nil, expected: %s", versioningStatus)
-			}
-		} else {
-			if *v != versioningStatus {
-				return fmt.Errorf("bad error versioning status, expected: %s, got %s", versioningStatus, *v)
-			}
-		}
-
-		return nil
-	}
-}
-
 func testAccCheckBucketCors(n string, corsRules []*s3.CORSRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[n]
@@ -3740,28 +3748,16 @@ resource "aws_s3_bucket" "bucket" {
 `, bucketName)
 }
 
-func testAccBucketWithVersioningConfig(bucketName string) string {
+func testAccBucketWithVersioningConfig(bucketName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 
   versioning {
-    enabled = true
+    enabled = %[2]t
   }
 }
-`, bucketName)
-}
-
-func testAccBucketWithDisableVersioningConfig(bucketName string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
-
-  versioning {
-    enabled = false
-  }
-}
-`, bucketName)
+`, bucketName, enabled)
 }
 
 func testAccBucketWithCORSConfig(bucketName string) string {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -1004,6 +1004,64 @@ func TestAccS3Bucket_Manage_versioningDisabled(t *testing.T) {
 	})
 }
 
+func TestAccS3Bucket_Manage_MfaDeleteDisabled(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithVersioningMfaDeleteConfig(bucketName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+			},
+		},
+	})
+}
+
+func TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketWithVersioningVersioningAndMfaDeleteConfig(bucketName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "versioning.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "versioning.0.mfa_delete", "false"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+			},
+		},
+	})
+}
+
 func TestAccS3Bucket_Security_corsUpdate(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
@@ -3758,6 +3816,31 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 `, bucketName, enabled)
+}
+
+func testAccBucketWithVersioningMfaDeleteConfig(bucketName string, mfaDelete bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+
+  versioning {
+    mfa_delete = %[2]t
+  }
+}
+`, bucketName, mfaDelete)
+}
+
+func testAccBucketWithVersioningVersioningAndMfaDeleteConfig(bucketName string, enabled, mfaDelete bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = %[1]q
+
+  versioning {
+    enabled    = %[2]t
+    mfa_delete = %[3]t
+  }
+}
+`, bucketName, enabled, mfaDelete)
 }
 
 func testAccBucketWithCORSConfig(bucketName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/4494

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3Bucket_Basic_basic (92.94s)
--- PASS: TestAccS3Bucket_Manage_versioning (177.77s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (90.48s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (93.08s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (94.33s)

--- PASS: TestAccS3Bucket_Basic_acceleration (162.07s)
--- PASS: TestAccS3Bucket_Basic_emptyString (93.52s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (82.73s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (78.55s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (69.24s)
--- PASS: TestAccS3Bucket_Basic_generatedName (89.22s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (95.98s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (89.23s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (156.57s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (70.36s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (208.52s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (169.03s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (96.58s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (82.26s)
--- PASS: TestAccS3Bucket_Manage_objectLock (115.14s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (198.83s)
--- PASS: TestAccS3Bucket_Replication_basic (257.21s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (70.96s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (157.10s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (155.38s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (174.02s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (171.97s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (235.06s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (99.31s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (165.73s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (131.80s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (136.67s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (150.57s)
--- PASS: TestAccS3Bucket_Security_corsDelete (83.41s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (97.97s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (165.67s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (166.49s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (92.44s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (92.69s)
--- PASS: TestAccS3Bucket_Security_grantToACL (148.74s)
--- PASS: TestAccS3Bucket_Security_logging (100.96s)
--- PASS: TestAccS3Bucket_Security_policy (222.65s)
--- PASS: TestAccS3Bucket_Security_updateACL (159.79s)
--- PASS: TestAccS3Bucket_Security_updateGrant (226.20s)
--- PASS: TestAccS3Bucket_Tags_basic (92.14s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (146.17s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (291.89s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (346.97s)
--- PASS: TestAccS3Bucket_Web_redirect (223.59s)
--- PASS: TestAccS3Bucket_Web_routingRules (159.33s)
--- PASS: TestAccS3Bucket_Web_simple (227.56s)
```
