### PR TITLE
f/aws_ssm_parameters_by_path: Add support for recursive parameter retrieval

### DIFF
--- a/.changelog/22222.txt
+++ b/.changelog/22222.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_ssm_parameters_by_path: Enable recursive retrieval of SSM parameters.
+data-source/aws_ssm_parameters_by_path: Add `recursive` argument
 ```

--- a/.changelog/22222.txt
+++ b/.changelog/22222.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ssm_parameters_by_path: Enable recursive retrieval of SSM parameters.
+```

--- a/internal/service/ssm/parameters_by_path_data_source.go
+++ b/internal/service/ssm/parameters_by_path_data_source.go
@@ -44,6 +44,11 @@ func DataSourceParametersByPath() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"recursive": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -52,9 +57,12 @@ func dataSourceParametersReadByPath(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*conns.AWSClient).SSMConn
 
 	path := d.Get("path").(string)
+	recursive := d.Get("recursive").(bool)
+
 	input := &ssm.GetParametersByPathInput{
 		Path:           aws.String(path),
 		WithDecryption: aws.Bool(d.Get("with_decryption").(bool)),
+		Recursive:      &recursive,
 	}
 
 	arns := make([]string, 0)

--- a/internal/service/ssm/parameters_by_path_data_source.go
+++ b/internal/service/ssm/parameters_by_path_data_source.go
@@ -28,6 +28,11 @@ func DataSourceParametersByPath() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"recursive": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"types": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -44,11 +49,6 @@ func DataSourceParametersByPath() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"recursive": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 		},
 	}
 }
@@ -57,12 +57,10 @@ func dataSourceParametersReadByPath(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*conns.AWSClient).SSMConn
 
 	path := d.Get("path").(string)
-	recursive := d.Get("recursive").(bool)
-
 	input := &ssm.GetParametersByPathInput{
 		Path:           aws.String(path),
+		Recursive:      aws.Bool(d.Get("recursive").(bool)),
 		WithDecryption: aws.Bool(d.Get("with_decryption").(bool)),
-		Recursive:      &recursive,
 	}
 
 	arns := make([]string, 0)

--- a/internal/service/ssm/parameters_by_path_data_source_test.go
+++ b/internal/service/ssm/parameters_by_path_data_source_test.go
@@ -69,7 +69,7 @@ data "aws_ssm_parameters_by_path" "test" {
 }
 
 func TestAccSSMParametersByPathDataSource_withRecursion(t *testing.T) {
-	resourceName := "data.aws_ssm_parameters_by_path.recursive_test"
+	resourceName := "data.aws_ssm_parameters_by_path.recursive"
 	pathPrefix := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -105,7 +105,7 @@ resource "aws_ssm_parameter" "nested" {
   value = "TestValueB"
 }
 
-data "aws_ssm_parameters_by_path" "recursive_test" {
+data "aws_ssm_parameters_by_path" "recursive" {
   path      = "/%[1]s/"
   recursive = true
 

--- a/internal/service/ssm/parameters_by_path_data_source_test.go
+++ b/internal/service/ssm/parameters_by_path_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccSSMParametersByPathDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "types.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "values.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "with_decryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "recursive", "false"),
 				),
 			},
 		},
@@ -65,4 +66,53 @@ data "aws_ssm_parameters_by_path" "test" {
   ]
 }
 `, rName1, rName2, withDecryption)
+}
+
+func TestAccSSMParametersByPathDataSource_withRecursion(t *testing.T) {
+	resourceName := "data.aws_ssm_parameters_by_path.recursive_test"
+	pathPrefix := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, ssm.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckParametersByPathDataSourceConfigWithRecursion(pathPrefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "arns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "types.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "recursive", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckParametersByPathDataSourceConfigWithRecursion(pathPrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "top_level" {
+  name  = "/%[1]s/top_param"
+  type  = "String"
+  value = "TestValueA"
+}
+
+resource "aws_ssm_parameter" "nested" {
+  name  = "/%[1]s/nested/param"
+  type  = "String"
+  value = "TestValueB"
+}
+
+data "aws_ssm_parameters_by_path" "recursive_test" {
+  path            = "/%[1]s/"
+  recursive = true
+
+  depends_on = [
+    aws_ssm_parameter.top_level,
+    aws_ssm_parameter.nested,
+  ]
+}
+`, pathPrefix)
 }

--- a/internal/service/ssm/parameters_by_path_data_source_test.go
+++ b/internal/service/ssm/parameters_by_path_data_source_test.go
@@ -106,7 +106,7 @@ resource "aws_ssm_parameter" "nested" {
 }
 
 data "aws_ssm_parameters_by_path" "recursive_test" {
-  path            = "/%[1]s/"
+  path      = "/%[1]s/"
   recursive = true
 
   depends_on = [

--- a/website/docs/d/ssm_parameters_by_path.html.markdown
+++ b/website/docs/d/ssm_parameters_by_path.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `path` - (Required) The prefix path of the parameter.
 * `with_decryption` - (Optional) Whether to return decrypted `SecureString` value. Defaults to `true`.
-
+* `recursive` - (Optional) Whether to recursively return parameters under `path`. Defaults to `false`.
 
 In addition to all arguments above, the following attributes are exported:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->
This pull request adds the ability to recursively retrieve ssm parameters under the provided  `path`. The `recursive` argument has been added to the `aws_ssm_parameters_by_path` data source. The argument remains optional and defaults to false if not provided.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [#21896](https://github.com/hashicorp/terraform-provider-aws/issues/21274)

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccSSMParametersByPathDataSource_' PKG_NAME=internal/service/ssm
```
```
make testacc TESTARGS='-run=TestAccSSMParametersByPathDataSource_' PKG_NAME=internal/service/ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run=TestAccSSMParametersByPathDataSource_ -timeout 180m
=== RUN   TestAccSSMParametersByPathDataSource_basic
=== PAUSE TestAccSSMParametersByPathDataSource_basic
=== RUN   TestAccSSMParametersByPathDataSource_withRecursion
=== PAUSE TestAccSSMParametersByPathDataSource_withRecursion
=== CONT  TestAccSSMParametersByPathDataSource_basic
=== CONT  TestAccSSMParametersByPathDataSource_withRecursion
--- PASS: TestAccSSMParametersByPathDataSource_withRecursion (31.70s)
--- PASS: TestAccSSMParametersByPathDataSource_basic (31.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        45.079s
```

Example Usage
```
data "aws_ssm_parameters_by_path" "params" {
  path = "/my/fake/path/"
  recursive = true
}
```