### PR TITLE
Fix FSX typo

### DIFF
--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -82,7 +82,7 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
-									"organizational_unit_distinguidshed_name": {
+									"organizational_unit_distinguished_name": {
 										Type:         schema.TypeString,
 										Optional:     true,
 										ForceNew:     true,
@@ -421,7 +421,7 @@ func expandFsxOntapSvmSelfManagedActiveDirectoryConfiguration(cfg []interface{})
 		out.FileSystemAdministratorsGroup = aws.String(v)
 	}
 
-	if v, ok := conf["organizational_unit_distinguidshed_name"].(string); ok && len(v) > 0 {
+	if v, ok := conf["organizational_unit_distinguished_name"].(string); ok && len(v) > 0 {
 		out.OrganizationalUnitDistinguishedName = aws.String(v)
 	}
 
@@ -512,7 +512,7 @@ func flattenFsxOntapSelfManagedActiveDirectoryConfiguration(d *schema.ResourceDa
 	}
 
 	if rs.OrganizationalUnitDistinguishedName != nil {
-		m["organizational_unit_distinguidshed_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
+		m["organizational_unit_distinguished_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
 	}
 
 	if rs.UserName != nil {

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -473,7 +473,7 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
       domain_name                             = %[3]q
       password                                = %[4]q
       username                                = "Admin"
-      organizational_unit_distinguidshed_name = "OU=computers,OU=%[5]s"
+      organizational_unit_distinguished_name = "OU=computers,OU=%[5]s"
     }
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #22238 + #21987

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTS=TestAccFSxOntapStorageVirtualMachine_activeDirectory PKG=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxOntapStorageVirtualMachine_activeDirectory' -timeout 180m
=== RUN   TestAccFSxOntapStorageVirtualMachine_activeDirectory
=== PAUSE TestAccFSxOntapStorageVirtualMachine_activeDirectory
=== CONT  TestAccFSxOntapStorageVirtualMachine_activeDirectory
--- PASS: TestAccFSxOntapStorageVirtualMachine_activeDirectory (2838.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        2841.980s
```
