### PR TITLE
(v2.x) r/aws_lambda_function: Wait for successful completion of code update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.70.1 (Unreleased)
+
+BUG FIXES:
+
+* resource/aws_lambda_function: Wait for successful completion of function code update ([#22242](https://github.com/hashicorp/terraform-provider-aws/issues/22242))
+
 ## 2.70.0 (July 10, 2020)
 
 FEATURES:

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -871,12 +871,12 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 				_, err = conn.UpdateFunctionConfiguration(configReq)
 			}
 			if err != nil {
-				return fmt.Errorf("Error modifying Lambda Function Configuration %s: %s", d.Id(), err)
+				return fmt.Errorf("error modifying Lambda Function (%s) Configuration: %w", d.Id(), err)
 			}
 		}
 
 		if err := waitForLambdaFunctionUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("error waiting for Lambda Function (%s) update: %s", d.Id(), err)
+			return fmt.Errorf("error waiting for Lambda Function (%s) configuration update: %w", d.Id(), err)
 		}
 	}
 
@@ -913,7 +913,11 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 
 		_, err := conn.UpdateFunctionCode(codeReq)
 		if err != nil {
-			return fmt.Errorf("Error modifying Lambda Function Code %s: %s", d.Id(), err)
+			return fmt.Errorf("error modifying Lambda Function (%s) Code: %w", d.Id(), err)
+		}
+
+		if err := waitForLambdaFunctionUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error waiting for Lambda Function (%s) code update: %w", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -666,8 +666,11 @@ func TestAccAWSLambdaFunction_FileSystemConfig(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
-	var conf lambda.GetFunctionOutput
+	if testAccGetPartition() == "aws-us-gov" {
+		t.Skip("Lambda tracing config is not supported in GovCloud partition")
+	}
 
+	var conf lambda.GetFunctionOutput
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_tracing_cfg_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tracing_cfg_%s", rString)
@@ -1347,38 +1350,6 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 	})
 }
 
-func TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x(t *testing.T) {
-	var conf lambda.GetFunctionOutput
-
-	rString := acctest.RandString(8)
-	resourceName := "aws_lambda_function.test"
-	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs10x_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs10x_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs10x_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_nodejs10x_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigNodeJs10xRuntime(funcName, policyName, roleName, sgName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs10X),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
-			},
-		},
-	})
-}
-
 func TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
@@ -1399,38 +1370,6 @@ func TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs12X),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
-			},
-		},
-	})
-}
-
-func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
-	var conf lambda.GetFunctionOutput
-
-	rString := acctest.RandString(8)
-	resourceName := "aws_lambda_function.test"
-	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_p27_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_p27_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_p27_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_p27_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigPython27Runtime(funcName, policyName, roleName, sgName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimePython27),
 				),
 			},
 			{
@@ -1679,38 +1618,6 @@ func TestAccAWSLambdaFunction_runtimeValidation_python38(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimePython38),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
-			},
-		},
-	})
-}
-
-func TestAccAWSLambdaFunction_runtimeValidation_ruby25(t *testing.T) {
-	var conf lambda.GetFunctionOutput
-
-	rString := acctest.RandString(8)
-	resourceName := "aws_lambda_function.test"
-	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_r25_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_r25_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_r25_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_r25_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigRuby25Runtime(funcName, policyName, roleName, sgName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeRuby25),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Port of #19386 to **v2** of the Terraform AWS Provider.

Relates:

* https://docs.aws.amazon.com/lambda/latest/dg/functions-states.html
* https://aws.amazon.com/blogs/compute/tracking-the-state-of-lambda-functions/
* https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### AWS Commercial

```
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (1.51s)
--- PASS: TestAccAWSLambdaFunction_basic (48.11s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_dotnetcore31 (53.67s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (65.70s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (78.76s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (89.79s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (90.14s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby27 (96.43s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (80.50s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (133.04s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (138.39s)
--- PASS: TestAccAWSLambdaFunction_s3 (47.91s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (150.90s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (151.49s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (85.54s)
--- PASS: TestAccAWSLambdaFunction_envVariables (207.64s)
--- PASS: TestAccAWSLambdaFunction_VPC (897.79s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (911.95s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (28.17s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (935.67s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (1050.77s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (1035.29s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (1104.03s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (1113.81s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (1009.08s)
--- PASS: TestAccAWSLambdaFunction_Layers (1001.64s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (1002.20s)
--- PASS: TestAccAWSLambdaFunction_tags (1081.74s)
--- PASS: TestAccAWSLambdaFunction_versioned (998.89s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (1002.69s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (1026.93s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (994.44s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (420.87s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (1280.09s)
--- PASS: TestAccAWSLambdaFunction_disappears (287.54s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (1285.16s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (474.59s)
--- PASS: TestAccAWSLambdaFunction_concurrency (462.18s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (1419.81s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (2868.04s)
```

#### AWS US GovCloud

```
--- SKIP: TestAccAWSLambdaFunction_tracingConfig (0.00s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (39.43s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (42.94s)
--- PASS: TestAccAWSLambdaFunction_disappears (54.39s)
--- PASS: TestAccAWSLambdaFunction_basic (75.86s)
--- PASS: TestAccAWSLambdaFunction_versioned (85.79s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (115.21s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (118.88s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (123.34s)
--- PASS: TestAccAWSLambdaFunction_concurrency (125.53s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (140.35s)
--- PASS: TestAccAWSLambdaFunction_Layers (143.99s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (156.00s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (170.71s)
--- PASS: TestAccAWSLambdaFunction_envVariables (203.68s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (87.81s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (89.19s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (295.08s)
--- PASS: TestAccAWSLambdaFunction_s3 (51.60s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (618.88s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (1.94s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_dotnetcore31 (615.28s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby27 (609.95s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (647.25s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (606.20s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (706.29s)
--- PASS: TestAccAWSLambdaFunction_VPC (713.30s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (708.73s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (713.13s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (714.88s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (710.57s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (709.31s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (874.22s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (582.81s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (891.67s)
--- PASS: TestAccAWSLambdaFunction_tags (767.70s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (856.48s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (714.85s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (717.31s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (1490.00s)
```