### PR TITLE
r/aws_fsx_ontap_storage_virtual_machine: Deprecate `organizational_unit_distinguidshed_name` in favor of `organizational_unit_distinguished_name`

### DIFF
--- a/.changelog/22246.txt
+++ b/.changelog/22246.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_fsx_ontap_storage_virtual_machine: The `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguidshed_name` attribute has been deprecated. All configurations using `broken` should be updated to use the new `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguished_name` attribute instead
+resource/aws_fsx_ontap_storage_virtual_machine: The `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguidshed_name` attribute has been deprecated. All configurations using `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguidshed_name` should be updated to use the new `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguished_name` attribute instead
 ```

--- a/.changelog/22246.txt
+++ b/.changelog/22246.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_fsx_ontap_storage_virtual_machine: The `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguidshed_name` attribute has been deprecated. All configurations using `broken` should be updated to use the new `active_directory_configuration.self_managed_active_directory_configuration.organizational_unit_distinguished_name` attribute instead
+```

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -83,10 +83,19 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 									"organizational_unit_distinguidshed_name": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(1, 2000),
+										Type:          schema.TypeString,
+										Optional:      true,
+										ForceNew:      true,
+										ValidateFunc:  validation.StringLenBetween(1, 2000),
+										Deprecated:    "use 'organizational_unit_distinguished_name' instead",
+										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"},
+									},
+									"organizational_unit_distinguished_name": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										ForceNew:      true,
+										ValidateFunc:  validation.StringLenBetween(1, 2000),
+										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"},
 									},
 									"password": {
 										Type:         schema.TypeString,
@@ -423,6 +432,8 @@ func expandFsxOntapSvmSelfManagedActiveDirectoryConfiguration(cfg []interface{})
 
 	if v, ok := conf["organizational_unit_distinguidshed_name"].(string); ok && len(v) > 0 {
 		out.OrganizationalUnitDistinguishedName = aws.String(v)
+	} else if v, ok := conf["organizational_unit_distinguished_name"].(string); ok && len(v) > 0 {
+		out.OrganizationalUnitDistinguishedName = aws.String(v)
 	}
 
 	if v, ok := conf["password"].(string); ok && len(v) > 0 {
@@ -512,7 +523,11 @@ func flattenFsxOntapSelfManagedActiveDirectoryConfiguration(d *schema.ResourceDa
 	}
 
 	if rs.OrganizationalUnitDistinguishedName != nil {
-		m["organizational_unit_distinguidshed_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
+		if _, ok := d.GetOk("active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"); ok {
+			m["organizational_unit_distinguidshed_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
+		} else {
+			m["organizational_unit_distinguished_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
+		}
 	}
 
 	if rs.UserName != nil {

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -510,11 +510,11 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
   active_directory_configuration {
     netbios_name = %[2]q
     self_managed_active_directory_configuration {
-      dns_ips                                 = aws_directory_service_directory.test.dns_ip_addresses
-      domain_name                             = %[3]q
-      password                                = %[4]q
-      username                                = "Admin"
-      organizational_unit_distinguished_name  = "OU=computers,OU=%[5]s"
+      dns_ips                                = aws_directory_service_directory.test.dns_ip_addresses
+      domain_name                            = %[3]q
+      password                               = %[4]q
+      username                               = "Admin"
+      organizational_unit_distinguished_name = "OU=computers,OU=%[5]s"
     }
   }
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -261,6 +261,47 @@ func TestAccFSxOntapStorageVirtualMachine_activeDirectory(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.domain_name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "endpoints.0.smb.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoints.0.smb.0.dns_name"),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name", fmt.Sprintf("OU=computers,OU=%s", domainNetbiosName)),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.password", domainPassword1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"active_directory_configuration",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationalUnitDistinguishedName(t *testing.T) {
+	var storageVirtualMachine1 fsx.StorageVirtualMachine
+	resourceName := "aws_fsx_ontap_storage_virtual_machine.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	netBiosName := "tftest-" + sdkacctest.RandString(7)
+	domainNetbiosName := "tftestcorp"
+	domainName := "tftestcorp.local"
+	domainPassword1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, fsx.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFsxOntapStorageVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedOrganizationalUnitDistinguishedName(rName, netBiosName, domainNetbiosName, domainName, domainPassword1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxOntapStorageVirtualMachineExists(resourceName, &storageVirtualMachine1),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.netbios_name", strings.ToUpper(netBiosName)),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.domain_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "endpoints.0.smb.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoints.0.smb.0.dns_name"),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name", fmt.Sprintf("OU=computers,OU=%s", domainNetbiosName)),
 					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.password", domainPassword1),
 				),
 			},
@@ -460,6 +501,27 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
 }
 
 func testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfig(rName string, netBiosName string, domainNetbiosName string, domainName string, domainPassword string) string {
+	return acctest.ConfigCompose(testAccOntapStorageVirtualMachineADConfig(rName, domainName, domainPassword), fmt.Sprintf(`
+resource "aws_fsx_ontap_storage_virtual_machine" "test" {
+  file_system_id = aws_fsx_ontap_file_system.test.id
+  name           = %[1]q
+  depends_on     = [aws_directory_service_directory.test]
+
+  active_directory_configuration {
+    netbios_name = %[2]q
+    self_managed_active_directory_configuration {
+      dns_ips                                 = aws_directory_service_directory.test.dns_ip_addresses
+      domain_name                             = %[3]q
+      password                                = %[4]q
+      username                                = "Admin"
+      organizational_unit_distinguished_name  = "OU=computers,OU=%[5]s"
+    }
+  }
+}
+`, rName, netBiosName, domainName, domainPassword, domainNetbiosName))
+}
+
+func testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedOrganizationalUnitDistinguishedName(rName string, netBiosName string, domainNetbiosName string, domainName string, domainPassword string) string {
 	return acctest.ConfigCompose(testAccOntapStorageVirtualMachineADConfig(rName, domainName, domainPassword), fmt.Sprintf(`
 resource "aws_fsx_ontap_storage_virtual_machine" "test" {
   file_system_id = aws_fsx_ontap_file_system.test.id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21987.

Deprecates `organizational_unit_distinguidshed_name` in the `active_directory_configuration.self_managed_active_directory_configuration` configuration block in favor of `organizational_unit_distinguished_name`.
Follows the [documented best practices](https://www.terraform.io/plugin/sdkv2/best-practices/deprecations#renaming-an-optional-attribute) adapted for a nested attribute.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccFSxOntapStorageVirtualMachine_activeDirectory' PKG=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run=TestAccFSxOntapStorageVirtualMachine_activeDirectory -timeout 180m
=== RUN   TestAccFSxOntapStorageVirtualMachine_activeDirectory
=== PAUSE TestAccFSxOntapStorageVirtualMachine_activeDirectory
=== RUN   TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationalUnitDistinguishedName
=== PAUSE TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationalUnitDistinguishedName
=== CONT  TestAccFSxOntapStorageVirtualMachine_activeDirectory
=== CONT  TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationalUnitDistinguishedName
--- PASS: TestAccFSxOntapStorageVirtualMachine_activeDirectory (2645.81s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationalUnitDistinguishedName (2709.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	2712.791s
```
