### PR TITLE
sagemaker/model_package_group_policy: Fix equivalent policy diffs

### DIFF
--- a/.changelog/22259.txt
+++ b/.changelog/22259.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_model_package_group_policy: Fix erroneous diffs in `resource_policy` when no changes made or policies are equivalent
+```

--- a/internal/service/sagemaker/model_package_group_policy.go
+++ b/internal/service/sagemaker/model_package_group_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -35,6 +36,10 @@ func ResourceModelPackageGroupPolicy() *schema.Resource {
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 		},
 	}
@@ -43,13 +48,19 @@ func ResourceModelPackageGroupPolicy() *schema.Resource {
 func resourceModelPackageGroupPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SageMakerConn
 
+	policy, err := structure.NormalizeJsonString(d.Get("resource_policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("resource_policy").(string), err)
+	}
+
 	name := d.Get("model_package_group_name").(string)
 	input := &sagemaker.PutModelPackageGroupPolicyInput{
 		ModelPackageGroupName: aws.String(name),
-		ResourcePolicy:        aws.String(d.Get("resource_policy").(string)),
+		ResourcePolicy:        aws.String(policy),
 	}
 
-	_, err := conn.PutModelPackageGroupPolicy(input)
+	_, err = conn.PutModelPackageGroupPolicy(input)
 	if err != nil {
 		return fmt.Errorf("error creating SageMaker Model Package Group Policy %s: %w", name, err)
 	}
@@ -74,7 +85,14 @@ func resourceModelPackageGroupPolicyRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("model_package_group_name", d.Id())
-	d.Set("resource_policy", mpg.ResourcePolicy)
+
+	policyToSet, err := verify.PolicyToSet(d.Get("resource_policy").(string), aws.StringValue(mpg.ResourcePolicy))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("resource_policy", policyToSet)
 
 	return nil
 }

--- a/internal/service/sagemaker/model_package_group_policy_test.go
+++ b/internal/service/sagemaker/model_package_group_policy_test.go
@@ -136,6 +136,7 @@ func testAccCheckModelPackageGroupPolicyExists(n string, mpg *sagemaker.GetModel
 func testAccModelPackageGroupPolicyBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "test" {
   statement {
@@ -143,7 +144,7 @@ data "aws_iam_policy_document" "test" {
     actions   = ["sagemaker:DescribeModelPackage", "sagemaker:ListModelPackages"]
     resources = [aws_sagemaker_model_package_group.test.arn]
     principals {
-      identifiers = [data.aws_caller_identity.current.account_id]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
       type        = "AWS"
     }
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21968
Closes #11801

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccSageMakerModelPackageGroupPolicy_ PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerModelPackageGroupPolicy_' -timeout 180m
--- PASS: TestAccSageMakerModelPackageGroupPolicy_basic (25.46s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_disappears (25.57s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup (26.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	28.833s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccSageMakerModelPackageGroupPolicy_ PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerModelPackageGroupPolicy_' -timeout 180m
--- SKIP: TestAccSageMakerModelPackageGroupPolicy_disappears (10.89s)
--- SKIP: TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup (10.89s)
--- SKIP: TestAccSageMakerModelPackageGroupPolicy_basic (10.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	12.514s
```