### PR TITLE
New Resource: aws_memorydb_user

### DIFF
--- a/.changelog/22261.txt
+++ b/.changelog/22261.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_memorydb_user
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1379,6 +1379,7 @@ func Provider() *schema.Provider {
 			"aws_media_store_container_policy": mediastore.ResourceContainerPolicy(),
 
 			"aws_memorydb_subnet_group": memorydb.ResourceSubnetGroup(),
+			"aws_memorydb_user":         memorydb.ResourceUser(),
 
 			"aws_mq_broker":        mq.ResourceBroker(),
 			"aws_mq_configuration": mq.ResourceConfiguration(),

--- a/internal/service/memorydb/find.go
+++ b/internal/service/memorydb/find.go
@@ -38,3 +38,32 @@ func FindSubnetGroupByName(ctx context.Context, conn *memorydb.MemoryDB, name st
 
 	return output.SubnetGroups[0], nil
 }
+
+func FindUserByName(ctx context.Context, conn *memorydb.MemoryDB, name string) (*memorydb.User, error) {
+	input := memorydb.DescribeUsersInput{
+		UserName: aws.String(name),
+	}
+
+	output, err := conn.DescribeUsersWithContext(ctx, &input)
+
+	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeUserNotFoundFault) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Users) == 0 || output.Users[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output.Users); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output.Users[0], nil
+}

--- a/internal/service/memorydb/status.go
+++ b/internal/service/memorydb/status.go
@@ -1,0 +1,33 @@
+package memorydb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+const (
+	UserStatusActive    = "active"
+	UserStatusDeleting  = "deleting"
+	UserStatusModifying = "modifying"
+)
+
+// StatusUser fetches the MemoryDB user and its status.
+func StatusUser(ctx context.Context, conn *memorydb.MemoryDB, userName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		user, err := FindUserByName(ctx, conn, userName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return user, aws.StringValue(user.Status), nil
+	}
+}

--- a/internal/service/memorydb/status.go
+++ b/internal/service/memorydb/status.go
@@ -15,8 +15,8 @@ const (
 	UserStatusModifying = "modifying"
 )
 
-// StatusUser fetches the MemoryDB user and its status.
-func StatusUser(ctx context.Context, conn *memorydb.MemoryDB, userName string) resource.StateRefreshFunc {
+// statusUser fetches the MemoryDB user and its status.
+func statusUser(ctx context.Context, conn *memorydb.MemoryDB, userName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		user, err := FindUserByName(ctx, conn, userName)
 

--- a/internal/service/memorydb/subnet_group_test.go
+++ b/internal/service/memorydb/subnet_group_test.go
@@ -26,7 +26,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func TestAccSubnetGroup_basic(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_basic(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_subnet_group.test"
 
@@ -60,7 +60,7 @@ func TestAccSubnetGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccSubnetGroup_disappears(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_disappears(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_subnet_group.test"
 
@@ -82,7 +82,7 @@ func TestAccSubnetGroup_disappears(t *testing.T) {
 	})
 }
 
-func TestAccSubnetGroup_nameGenerated(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_nameGenerated(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -103,7 +103,7 @@ func TestAccSubnetGroup_nameGenerated(t *testing.T) {
 	})
 }
 
-func TestAccSubnetGroup_namePrefix(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_namePrefix(t *testing.T) {
 	resourceName := "aws_memorydb_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -124,7 +124,7 @@ func TestAccSubnetGroup_namePrefix(t *testing.T) {
 	})
 }
 
-func TestAccSubnetGroup_update_description(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_update_description(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_subnet_group.test"
 
@@ -162,7 +162,7 @@ func TestAccSubnetGroup_update_description(t *testing.T) {
 	})
 }
 
-func TestAccSubnetGroup_update_subnetIds(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_update_subnetIds(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_subnet_group.test"
 
@@ -218,7 +218,7 @@ func TestAccSubnetGroup_update_subnetIds(t *testing.T) {
 	})
 }
 
-func TestAccSubnetGroup_update_tags(t *testing.T) {
+func TestAccMemoryDBSubnetGroup_update_tags(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_subnet_group.test"
 

--- a/internal/service/memorydb/user.go
+++ b/internal/service/memorydb/user.go
@@ -148,7 +148,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			return diag.Errorf("error updating MemoryDB User (%s): %s", d.Id(), err)
 		}
 
-		if err := WaitUserActive(ctx, conn, d.Id()); err != nil {
+		if err := waitUserActive(ctx, conn, d.Id()); err != nil {
 			return diag.Errorf("error waiting for MemoryDB User (%s) to be modified: %s", d.Id(), err)
 		}
 	}
@@ -236,11 +236,7 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error deleting MemoryDB User (%s): %s", d.Id(), err)
 	}
 
-	if err := WaitUserDeleted(ctx, conn, d.Id()); err != nil {
-		if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeUserNotFoundFault) {
-			return nil
-		}
-
+	if err := waitUserDeleted(ctx, conn, d.Id()); err != nil {
 		return diag.Errorf("error waiting for MemoryDB User (%s) to be deleted: %s", d.Id(), err)
 	}
 

--- a/internal/service/memorydb/user.go
+++ b/internal/service/memorydb/user.go
@@ -1,0 +1,248 @@
+package memorydb
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUserCreate,
+		ReadContext:   resourceUserRead,
+		UpdateContext: resourceUserUpdate,
+		DeleteContext: resourceUserDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+
+		Schema: map[string]*schema.Schema{
+			"access_string": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authentication_mode": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"passwords": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 2,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(16, 128),
+							},
+							Set:       schema.HashString,
+							Sensitive: true,
+						},
+						"password_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(memorydb.InputAuthenticationType_Values(), false),
+						},
+					},
+				},
+			},
+			"minimum_engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 40),
+					validation.StringMatch(
+						// MemoryDB normalises names to lowercase, so disallow uppercase characters.
+						regexp.MustCompile(`[a-z][a-z0-9-]*`),
+						"The user name must consist of letters, numbers, and hyphens.",
+					),
+				),
+			},
+		},
+	}
+}
+
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	userName := d.Get("user_name").(string)
+
+	input := &memorydb.CreateUserInput{
+		AccessString: aws.String(d.Get("access_string").(string)),
+		AuthenticationMode: &memorydb.AuthenticationMode{
+			Passwords: flex.ExpandStringSet(d.Get("authentication_mode.0.passwords").(*schema.Set)),
+			Type:      aws.String(d.Get("authentication_mode.0.type").(string)),
+		},
+		Tags:     Tags(tags.IgnoreAWS()),
+		UserName: aws.String(userName),
+	}
+
+	log.Printf("[DEBUG] Creating MemoryDB User: %s", input)
+	_, err := conn.CreateUserWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("error creating MemoryDB User (%s): %s", userName, err)
+	}
+
+	d.SetId(userName)
+
+	return resourceUserRead(ctx, d, meta)
+}
+
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &memorydb.UpdateUserInput{
+			UserName: aws.String(d.Id()),
+		}
+
+		if d.HasChange("access_string") {
+			input.AccessString = aws.String(d.Get("access_string").(string))
+		}
+
+		if d.HasChange("authentication_mode") {
+			input.AuthenticationMode = &memorydb.AuthenticationMode{
+				Passwords: flex.ExpandStringSet(d.Get("authentication_mode.0.passwords").(*schema.Set)),
+				Type:      aws.String(d.Get("authentication_mode.0.type").(string)),
+			}
+		}
+
+		log.Printf("[DEBUG] Updating MemoryDB User (%s)", d.Id())
+
+		_, err := conn.UpdateUserWithContext(ctx, input)
+		if err != nil {
+			return diag.Errorf("error updating MemoryDB User (%s): %s", d.Id(), err)
+		}
+
+		if err := WaitUserActive(ctx, conn, d.Id()); err != nil {
+			return diag.Errorf("error waiting for MemoryDB User (%s) to be modified: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		log.Printf("[DEBUG] Updating MemoryDB User (%s) tags", d.Id())
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return diag.Errorf("error updating MemoryDB User (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceUserRead(ctx, d, meta)
+}
+
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	user, err := FindUserByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] MemoryDB User (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error reading MemoryDB User (%s): %s", d.Id(), err)
+	}
+
+	d.Set("access_string", user.AccessString)
+	d.Set("arn", user.ARN)
+
+	if v := user.Authentication; v != nil {
+		authenticationMode := map[string]interface{}{
+			"passwords":      d.Get("authentication_mode.0.passwords"),
+			"password_count": aws.Int64Value(v.PasswordCount),
+			"type":           aws.StringValue(v.Type),
+		}
+
+		if err := d.Set("authentication_mode", []interface{}{authenticationMode}); err != nil {
+			return diag.Errorf("failed to set authentication_mode of MemoryDB User (%s): %s", d.Id(), err)
+		}
+	}
+
+	d.Set("minimum_engine_version", user.MinimumEngineVersion)
+	d.Set("user_name", user.Name)
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB User (%s): %s", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags for MemoryDB User (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.Errorf("error setting tags_all for MemoryDB User (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+
+	log.Printf("[DEBUG] Deleting MemoryDB User: (%s)", d.Id())
+	_, err := conn.DeleteUserWithContext(ctx, &memorydb.DeleteUserInput{
+		UserName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeUserNotFoundFault) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error deleting MemoryDB User (%s): %s", d.Id(), err)
+	}
+
+	if err := WaitUserDeleted(ctx, conn, d.Id()); err != nil {
+		if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeUserNotFoundFault) {
+			return nil
+		}
+
+		return diag.Errorf("error waiting for MemoryDB User (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/memorydb/user_test.go
+++ b/internal/service/memorydb/user_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccUser_basic(t *testing.T) {
+func TestAccMemoryDBUser_basic(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_user.test"
 
@@ -51,7 +51,7 @@ func TestAccUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccUser_disappears(t *testing.T) {
+func TestAccMemoryDBUser_disappears(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_user.test"
 
@@ -73,7 +73,7 @@ func TestAccUser_disappears(t *testing.T) {
 	})
 }
 
-func TestAccUser_update_accessString(t *testing.T) {
+func TestAccMemoryDBUser_update_accessString(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_user.test"
 
@@ -107,7 +107,7 @@ func TestAccUser_update_accessString(t *testing.T) {
 	})
 }
 
-func TestAccUser_update_passwords(t *testing.T) {
+func TestAccMemoryDBUser_update_passwords(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_user.test"
 
@@ -160,7 +160,7 @@ func TestAccUser_update_passwords(t *testing.T) {
 	})
 }
 
-func TestAccUser_update_tags(t *testing.T) {
+func TestAccMemoryDBUser_update_tags(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_memorydb_user.test"
 

--- a/internal/service/memorydb/user_test.go
+++ b/internal/service/memorydb/user_test.go
@@ -1,0 +1,395 @@
+package memorydb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfmemorydb "github.com/hashicorp/terraform-provider-aws/internal/service/memorydb"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccUser_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_string", "on ~* &* +@all"),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "memorydb", "user/"+rName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.passwords.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "authentication_mode.0.passwords.*", "aaaaaaaaaaaaaaaa"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "password"),
+					resource.TestCheckResourceAttrSet(resourceName, "minimum_engine_version"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Test", "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+		},
+	})
+}
+
+func TestAccUser_disappears(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfmemorydb.ResourceUser(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccUser_update_accessString(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_withAccessString(rName, "on ~* &* +@all"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_string", "on ~* &* +@all"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+			{
+				Config: testAccUserConfig_withAccessString(rName, "off ~* &* +@all"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_string", "off ~* &* +@all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccUser_update_passwords(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_withPasswords2(rName, "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+			{
+				Config: testAccUserConfig_withPasswords1(rName, "aaaaaaaaaaaaaaaa"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+			{
+				Config: testAccUserConfig_withPasswords2(rName, "cccccccccccccccc", "dddddddddddddddd"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+		},
+	})
+}
+
+func TestAccUser_update_tags(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_withTags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+			{
+				Config: testAccUserConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key2", "value2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+			{
+				Config: testAccUserConfig_withTags1(rName, "Key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+			{
+				Config: testAccUserConfig_withTags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication_mode.0.passwords"},
+			},
+		},
+	})
+}
+
+func testAccCheckUserDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).MemoryDBConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_memorydb_user" {
+			continue
+		}
+
+		_, err := tfmemorydb.FindUserByName(context.Background(), conn, rs.Primary.Attributes["user_name"])
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("MemoryDB User %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckUserExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No MemoryDB User ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MemoryDBConn
+
+		_, err := tfmemorydb.FindUserByName(context.Background(), conn, rs.Primary.Attributes["user_name"])
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccUserConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = ["aaaaaaaaaaaaaaaa"]
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+`, rName)
+}
+
+func testAccUserConfig_withAccessString(rName, accessString string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = %[2]q
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = ["aaaaaaaaaaaaaaaa"]
+  }
+}
+`, rName, accessString)
+}
+
+func testAccUserConfig_withPasswords1(rName, password1 string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = [%[2]q]
+  }
+}
+`, rName, password1)
+}
+
+func testAccUserConfig_withPasswords2(rName, password1, password2 string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = [%[2]q, %[3]q]
+  }
+}
+`, rName, password1, password2)
+}
+
+func testAccUserConfig_withTags0(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = ["aaaaaaaaaaaaaaaa"]
+  }
+}
+`, rName)
+}
+
+func testAccUserConfig_withTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = ["aaaaaaaaaaaaaaaa"]
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccUserConfig_withTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_memorydb_user" "test" {
+  access_string = "on ~* &* +@all"
+  user_name     = %[1]q
+
+  authentication_mode {
+    type      = "password"
+    passwords = ["aaaaaaaaaaaaaaaa"]
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/memorydb/user_test.go
+++ b/internal/service/memorydb/user_test.go
@@ -20,7 +20,7 @@ func TestAccUser_basic(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckUserDestroy,
@@ -56,7 +56,7 @@ func TestAccUser_disappears(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckUserDestroy,
@@ -78,7 +78,7 @@ func TestAccUser_update_accessString(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckUserDestroy,
@@ -112,7 +112,7 @@ func TestAccUser_update_passwords(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckUserDestroy,
@@ -165,7 +165,7 @@ func TestAccUser_update_tags(t *testing.T) {
 	resourceName := "aws_memorydb_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckUserDestroy,

--- a/internal/service/memorydb/wait.go
+++ b/internal/service/memorydb/wait.go
@@ -9,17 +9,17 @@ import (
 )
 
 const (
-	UserActiveTimeout  = 5 * time.Minute
-	UserDeletedTimeout = 5 * time.Minute
+	userActiveTimeout  = 5 * time.Minute
+	userDeletedTimeout = 5 * time.Minute
 )
 
-// WaitUserActive waits for MemoryDB user to reach an active state after modifications.
-func WaitUserActive(ctx context.Context, conn *memorydb.MemoryDB, userId string) error {
+// waitUserActive waits for MemoryDB user to reach an active state after modifications.
+func waitUserActive(ctx context.Context, conn *memorydb.MemoryDB, userId string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{UserStatusModifying},
 		Target:  []string{UserStatusActive},
-		Refresh: StatusUser(ctx, conn, userId),
-		Timeout: UserActiveTimeout,
+		Refresh: statusUser(ctx, conn, userId),
+		Timeout: userActiveTimeout,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -27,13 +27,13 @@ func WaitUserActive(ctx context.Context, conn *memorydb.MemoryDB, userId string)
 	return err
 }
 
-// WaitUserDeleted waits for MemoryDB user to reach an active state after modifications.
-func WaitUserDeleted(ctx context.Context, conn *memorydb.MemoryDB, userId string) error {
+// waitUserDeleted waits for MemoryDB user to reach an active state after modifications.
+func waitUserDeleted(ctx context.Context, conn *memorydb.MemoryDB, userId string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{UserStatusDeleting},
 		Target:  []string{},
-		Refresh: StatusUser(ctx, conn, userId),
-		Timeout: UserDeletedTimeout,
+		Refresh: statusUser(ctx, conn, userId),
+		Timeout: userDeletedTimeout,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/memorydb/wait.go
+++ b/internal/service/memorydb/wait.go
@@ -1,0 +1,42 @@
+package memorydb
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	UserActiveTimeout  = 5 * time.Minute
+	UserDeletedTimeout = 5 * time.Minute
+)
+
+// WaitUserActive waits for MemoryDB user to reach an active state after modifications.
+func WaitUserActive(ctx context.Context, conn *memorydb.MemoryDB, userId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{UserStatusModifying},
+		Target:  []string{UserStatusActive},
+		Refresh: StatusUser(ctx, conn, userId),
+		Timeout: UserActiveTimeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}
+
+// WaitUserDeleted waits for MemoryDB user to reach an active state after modifications.
+func WaitUserDeleted(ctx context.Context, conn *memorydb.MemoryDB, userId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{UserStatusDeleting},
+		Target:  []string{},
+		Refresh: StatusUser(ctx, conn, userId),
+		Timeout: UserDeletedTimeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}

--- a/website/docs/r/memorydb_user.html.markdown
+++ b/website/docs/r/memorydb_user.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_user"
+description: |-
+  Provides a MemoryDB User.
+---
+
+# Resource: aws_memorydb_user
+
+Provides a MemoryDB User.
+
+More information about users and ACL-s can be found in the [MemoryDB User Guide](https://docs.aws.amazon.com/memorydb/latest/devguide/clusters.acls.html).
+
+~> **Note:** All arguments including the username and passwords will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```terraform
+resource "random_password" "example" {
+  length = 16
+}
+
+resource "aws_memorydb_user" "example" {
+  user_name     = "my-user"
+  access_string = "on ~* &* +@all"
+
+  authentication_mode {
+    type      = "password"
+    passwords = [random_password.example.result]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `access_string` - (Required) The access permissions string used for this user.
+* `authentication_mode` - (Required) Denotes the user's authentication properties. Detailed below.
+* `user_name` - (Required, Forces new resource) Name of the MemoryDB user. Up to 40 characters.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### authentication_mode Configuration Block
+
+* `passwords` - (Required) The set of passwords used for authentication. You can create up to two passwords for each user.
+* `type` - (Required) Indicates whether the user requires a password to authenticate. Must be set to `password`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Same as `user_name`.
+* `arn` - The ARN of the user.
+* `minimum_engine_version` - The minimum engine version supported for the user.
+* `authentication_mode` configuration block
+    * `password_count` - The number of passwords belonging to the user.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Use the `user_name` to import a user. For example:
+
+```
+$ terraform import aws_memorydb_user.example my-user
+```
+
+The `passwords` are not available for imported resources, as this information cannot be read back from the MemoryDB API.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20631

Depends on PR https://github.com/hashicorp/terraform-provider-aws/pull/22256

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccUser_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccUser_' -timeout 180m
=== RUN   TestAccUser_basic
=== PAUSE TestAccUser_basic
=== RUN   TestAccUser_disappears
=== PAUSE TestAccUser_disappears
=== RUN   TestAccUser_update_accessString
=== PAUSE TestAccUser_update_accessString
=== RUN   TestAccUser_update_passwords
=== PAUSE TestAccUser_update_passwords
=== RUN   TestAccUser_update_tags
=== PAUSE TestAccUser_update_tags
=== CONT  TestAccUser_basic
=== CONT  TestAccUser_update_passwords
=== CONT  TestAccUser_update_accessString
=== CONT  TestAccUser_disappears
=== CONT  TestAccUser_update_tags
--- PASS: TestAccUser_basic (70.81s)
--- PASS: TestAccUser_update_tags (74.31s)
--- PASS: TestAccUser_disappears (76.66s)
--- PASS: TestAccUser_update_accessString (135.37s)
--- PASS: TestAccUser_update_passwords (192.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   194.847s
```
