### PR TITLE
r/aws_batch_scheduling_policy

### DIFF
--- a/.changelog/22262.txt
+++ b/.changelog/22262.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_batch_scheduling_policy
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -845,6 +845,7 @@ func Provider() *schema.Provider {
 			"aws_batch_compute_environment": batch.ResourceComputeEnvironment(),
 			"aws_batch_job_definition":      batch.ResourceJobDefinition(),
 			"aws_batch_job_queue":           batch.ResourceJobQueue(),
+			"aws_batch_scheduling_policy":   batch.ResourceSchedulingPolicy(),
 
 			"aws_budgets_budget":        budgets.ResourceBudget(),
 			"aws_budgets_budget_action": budgets.ResourceBudgetAction(),

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -54,10 +54,9 @@ func ResourceSchedulingPolicy() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"share_identifier": {
-										Type:     schema.TypeString,
-										Required: true,
-										// limited to 255 alphanumeric characters, optionally followed by an asterisk (*).
-										ValidateFunc: validation.StringLenBetween(1, 256),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validShareIdentifier,
 									},
 									"weight_factor": {
 										Type:         schema.TypeFloat,
@@ -83,7 +82,7 @@ func ResourceSchedulingPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 127),
+				ValidateFunc: validName,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -90,3 +90,63 @@ func ResourceSchedulingPolicy() *schema.Resource {
 		},
 	}
 }
+
+
+func expandFairsharePolicy(fairsharePolicy []interface{}) *batch.FairsharePolicy {
+	if len(fairsharePolicy) == 0 || fairsharePolicy[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := fairsharePolicy[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &batch.FairsharePolicy{
+		ComputeReservation: aws.Int64(int64(tfMap["compute_reservation"].(int))),
+		ShareDecaySeconds:  aws.Int64(int64(tfMap["share_decay_seconds"].(int))),
+	}
+
+	shareDistributions := tfMap["share_distribution"].(*schema.Set).List()
+
+	fairsharePolicyShareDistributions := []*batch.ShareAttributes{}
+
+	for _, shareDistribution := range shareDistributions {
+		data := shareDistribution.(map[string]interface{})
+
+		schedulingPolicyConfig := &batch.ShareAttributes{
+			ShareIdentifier: aws.String(data["share_identifier"].(string)),
+			WeightFactor:    aws.Float64(float64(data["weight_factor"].(float64))),
+		}
+		fairsharePolicyShareDistributions = append(fairsharePolicyShareDistributions, schedulingPolicyConfig)
+	}
+
+	result.ShareDistribution = fairsharePolicyShareDistributions
+
+	return result
+}
+
+func flattenFairsharePolicy(fairsharePolicy *batch.FairsharePolicy) []interface{} {
+	if fairsharePolicy == nil {
+		return []interface{}{}
+	}
+
+	values := map[string]interface{}{
+		"compute_reservation": aws.Int64Value(fairsharePolicy.ComputeReservation),
+		"share_decay_seconds": aws.Int64Value(fairsharePolicy.ShareDecaySeconds),
+	}
+
+	shareDistributions := fairsharePolicy.ShareDistribution
+
+	fairsharePolicyShareDistributions := []interface{}{}
+	for _, shareDistribution := range shareDistributions {
+		sdValues := map[string]interface{}{
+			"share_identifier": aws.StringValue(shareDistribution.ShareIdentifier),
+			"weight_factor":    aws.Float64Value(shareDistribution.WeightFactor),
+		}
+		fairsharePolicyShareDistributions = append(fairsharePolicyShareDistributions, sdValues)
+	}
+	values["share_distribution"] = fairsharePolicyShareDistributions
+
+	return []interface{}{values}
+}

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -1,0 +1,92 @@
+package batch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func ResourceSchedulingPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSchedulingPolicyCreate,
+		ReadContext:   resourceSchedulingPolicyRead,
+		UpdateContext: resourceSchedulingPolicyUpdate,
+		DeleteContext: resourceSchedulingPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fair_share_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"compute_reservation": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 99),
+						},
+						"share_decay_seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 604800),
+						},
+						"share_distribution": {
+							Type: schema.TypeSet,
+							// There can be no more than 500 fair share identifiers active in a job queue.
+							MaxItems: 500,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"share_identifier": {
+										Type:     schema.TypeString,
+										Required: true,
+										// limited to 255 alphanumeric characters, optionally followed by an asterisk (*).
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+									"weight_factor": {
+										Type:         schema.TypeFloat,
+										Optional:     true,
+										ValidateFunc: validation.FloatBetween(0.0001, 999.9999),
+									},
+								},
+							},
+							Set: func(v interface{}) int {
+								var buf bytes.Buffer
+								m := v.(map[string]interface{})
+								buf.WriteString(m["share_identifier"].(string))
+								if v, ok := m["weight_factor"]; ok {
+									buf.WriteString(fmt.Sprintf("%s-", v))
+								}
+								return create.StringHashcode(buf.String())
+							},
+						},
+					},
+				},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 127),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+	}
+}

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -190,6 +190,21 @@ func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 
 	return resourceSchedulingPolicyRead(ctx, d, meta)
 }
+
+func resourceSchedulingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).BatchConn
+
+	_, err := conn.DeleteSchedulingPolicyWithContext(ctx, &batch.DeleteSchedulingPolicyInput{
+		Arn: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting SchedulingPolicy (%s): %w", d.Id(), err))
+	}
+
+	return nil
+}
+
 func GetSchedulingPolicy(ctx context.Context, conn *batch.Batch, arn string) (*batch.SchedulingPolicyDetail, error) {
 	resp, err := conn.DescribeSchedulingPoliciesWithContext(ctx, &batch.DescribeSchedulingPoliciesInput{
 		Arns: []*string{aws.String(arn)},

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -250,7 +250,7 @@ func expandFairsharePolicy(fairsharePolicy []interface{}) *batch.FairsharePolicy
 
 		schedulingPolicyConfig := &batch.ShareAttributes{
 			ShareIdentifier: aws.String(data["share_identifier"].(string)),
-			WeightFactor:    aws.Float64(float64(data["weight_factor"].(float64))),
+			WeightFactor:    aws.Float64(data["weight_factor"].(float64)),
 		}
 		fairsharePolicyShareDistributions = append(fairsharePolicyShareDistributions, schedulingPolicyConfig)
 	}

--- a/internal/service/batch/scheduling_policy_test.go
+++ b/internal/service/batch/scheduling_policy_test.go
@@ -61,6 +61,30 @@ func TestAccBatchSchedulingPolicy_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBatchSchedulingPolicy_disappears(t *testing.T) {
+	var schedulingPolicy1 batch.SchedulingPolicyDetail
+	resourceName := "aws_batch_scheduling_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, batch.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBatchSchedulingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchSchedulingPolicyConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchSchedulingPolicyExists(resourceName, &schedulingPolicy1),
+					acctest.CheckResourceDisappears(acctest.Provider, tfbatch.ResourceSchedulingPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBatchSchedulingPolicyExists(n string, sp *batch.SchedulingPolicyDetail) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/internal/service/batch/scheduling_policy_test.go
+++ b/internal/service/batch/scheduling_policy_test.go
@@ -1,0 +1,68 @@
+package batch_test
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfbatch "github.com/hashicorp/terraform-provider-aws/internal/service/batch"
+)
+
+
+func testAccBatchSchedulingPolicyConfigBasic(rName string) string {
+	return acctest.ConfigCompose(
+		fmt.Sprintf(`
+resource "aws_batch_scheduling_policy" "test" {
+  name = %[1]q
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A1*"
+      weight_factor    = 0.1
+    }
+  }
+
+  tags = {
+    "Name" = "Test Batch Scheduling Policy"
+  }
+}
+`, rName))
+}
+
+func testAccBatchSchedulingPolicyConfigBasic2(rName string) string {
+	return acctest.ConfigCompose(
+		fmt.Sprintf(`
+resource "aws_batch_scheduling_policy" "test" {
+  name = %[1]q
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A1*"
+      weight_factor    = 0.1
+    }
+
+    share_distribution {
+      share_identifier = "A2"
+      weight_factor    = 0.2
+    }
+  }
+
+  tags = {
+    "Name" = "Test Batch Scheduling Policy"
+  }
+}
+`, rName))
+}

--- a/internal/service/batch/scheduling_policy_test.go
+++ b/internal/service/batch/scheduling_policy_test.go
@@ -41,6 +41,22 @@ func testAccCheckBatchSchedulingPolicyExists(n string, sp *batch.SchedulingPolic
 	}
 }
 
+func testAccCheckBatchSchedulingPolicyDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_batch_scheduling_policy" {
+			continue
+		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BatchConn
+		sp, err := GetSchedulingPolicyNoContext(conn, rs.Primary.ID)
+		if err == nil {
+			if sp != nil {
+				return fmt.Errorf("Error: Scheduling Policy still exists")
+			}
+		}
+		return nil
+	}
+	return nil
+}
 
 func GetSchedulingPolicyNoContext(conn *batch.Batch, arn string) (*batch.SchedulingPolicyDetail, error) {
 	resp, err := conn.DescribeSchedulingPolicies(&batch.DescribeSchedulingPoliciesInput{

--- a/internal/service/batch/validate.go
+++ b/internal/service/batch/validate.go
@@ -20,3 +20,11 @@ func validPrefix(v interface{}, k string) (ws []string, errors []error) {
 	}
 	return
 }
+
+func validShareIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z0-9]{0,254}[a-zA-Z0-9*]?$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be limited to 255 alphanumeric characters, where the last character can be an asterisk (*).", k, v))
+	}
+	return
+}

--- a/internal/service/batch/validate_test.go
+++ b/internal/service/batch/validate_test.go
@@ -50,3 +50,29 @@ func TestValidPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestValidShareIdentifier(t *testing.T) {
+	validShareIdentifiers := []string{
+		"sample*",
+		"sample1",
+		strings.Repeat("W", 255),       // <= 255,
+		strings.Repeat("W", 254) + "*", // optional asterisk
+	}
+	for _, v := range validShareIdentifiers {
+		_, errors := validShareIdentifier(v, "share_identifier")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid share identifier: %q", v, errors)
+		}
+	}
+
+	invalidShareIdentifiers := []string{
+		"s@mple",
+		strings.Repeat("W", 256), // > 255
+	}
+	for _, v := range invalidShareIdentifiers {
+		_, errors := validShareIdentifier(v, "share_identifier")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be a invalid share identifier: %q", v, errors)
+		}
+	}
+}

--- a/website/docs/r/batch_scheduling_policy.html.markdown
+++ b/website/docs/r/batch_scheduling_policy.html.markdown
@@ -1,0 +1,72 @@
+---
+subcategory: "Batch"
+layout: "aws"
+page_title: "AWS: aws_batch_scheduling_policy"
+description: |-
+  Provides a Batch Scheduling Policy resource.
+---
+
+# Resource: aws_batch_scheduling_policy
+
+Provides a Batch Scheduling Policy resource.
+
+## Example Usage
+
+```terraform
+resource "aws_batch_scheduling_policy" "example" {
+  name = "example"
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A1*"
+      weight_factor    = 0.1
+    }
+
+    share_distribution {
+      share_identifier = "A2"
+      weight_factor    = 0.2
+    }
+  }
+
+  tags = {
+    "Name" = "Example Batch Scheduling Policy"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `fairshare_policy` - (Optional) A fairshare policy block specifies the `compute_reservation`, `share_delay_seconds`, and `share_distribution` of the scheduling policy. The `fairshare_policy` block is documented below.
+* `name` - (Required) Specifies the name of the scheduling policy.
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+A `fairshare_policy` block supports the following arguments:
+
+* `compute_reservation` - (Optional) A value used to reserve some of the available maximum vCPU for fair share identifiers that have not yet been used. For more information, see [FairsharePolicy](https://docs.aws.amazon.com/batch/latest/APIReference/API_FairsharePolicy.html).
+* `share_delay_seconds` - (Optional) The time period to use to calculate a fair share percentage for each fair share identifier in use, in seconds. For more information, see [FairsharePolicy](https://docs.aws.amazon.com/batch/latest/APIReference/API_FairsharePolicy.html).
+* `share_distribution` - (Optional) One or more share distribution blocks which define the weights for the fair share identifiers for the fair share policy. For more information, see [FairsharePolicy](https://docs.aws.amazon.com/batch/latest/APIReference/API_FairsharePolicy.html). The `share_distribution` block is documented below.
+
+A `share_distribution` block supports the following arguments:
+
+* `share_identifier` - (Required) A fair share identifier or fair share identifier prefix. For more information, see [ShareAttributes](https://docs.aws.amazon.com/batch/latest/APIReference/API_ShareAttributes.html).
+* `weight_factor` - (Optional) The weight factor for the fair share identifier. For more information, see [ShareAttributes](https://docs.aws.amazon.com/batch/latest/APIReference/API_ShareAttributes.html).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name of the scheduling policy.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Batch Scheduling Policy can be imported using the `arn`, e.g.,
+
+```
+$ terraform import aws_batch_scheduling_policy.test_policy arn:aws:batch:us-east-1:123456789012:scheduling-policy/sample
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #21755

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccBatchSchedulingPolicy PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchSchedulingPolicy' -timeout 180m
=== RUN   TestAccBatchSchedulingPolicy_basic
=== PAUSE TestAccBatchSchedulingPolicy_basic
=== RUN   TestAccBatchSchedulingPolicy_disappears
=== PAUSE TestAccBatchSchedulingPolicy_disappears
=== CONT  TestAccBatchSchedulingPolicy_basic
=== CONT  TestAccBatchSchedulingPolicy_disappears
--- PASS: TestAccBatchSchedulingPolicy_disappears (26.24s)
--- PASS: TestAccBatchSchedulingPolicy_basic (58.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      66.032s

...
```
