### PR TITLE
ecs/task_definition: Add `skip_destroy` argument

### DIFF
--- a/.changelog/22269.txt
+++ b/.changelog/22269.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_task_definition: Add `skip_destroy` argument to optionally prevent overwriting previous revision
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,7 @@ ifneq ($(origin PKG), undefined)
 endif
 
 ifneq ($(origin TESTS), undefined)
-	TESTARGS = -run='$(TESTS)'
+	RUNARGS = -run='$(TESTS)'
 endif
 
 default: build
@@ -42,7 +42,7 @@ testacc: fmtcheck
 		echo "See the contributing guide for more information: https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/running-and-writing-acceptance-tests.md"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+	TF_ACC=1 go test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -248,6 +248,11 @@ func ResourceTaskDefinition() *schema.Resource {
 					},
 				},
 			},
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"task_role_arn": {
@@ -695,6 +700,11 @@ func resourceTaskDefinitionUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceTaskDefinitionDelete(d *schema.ResourceData, meta interface{}) error {
+	if v, ok := d.GetOk("skip_destroy"); ok && v.(bool) {
+		log.Printf("[DEBUG] Retaining ECS Task Definition Revision %q", d.Id())
+		return nil
+	}
+
 	conn := meta.(*conns.AWSClient).ECSConn
 
 	_, err := conn.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -59,28 +59,6 @@ func ResourceTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"cpu": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"family": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexp.MustCompile("^[0-9A-Za-z_-]+$"), "see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html"),
-				),
-			},
-
-			"revision": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
 			"container_definitions": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -103,6 +81,11 @@ func ResourceTaskDefinition() *schema.Resource {
 				},
 				ValidateFunc: ValidTaskDefinitionContainerDefinitions,
 			},
+			"cpu": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"ephemeral_storage": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -119,26 +102,51 @@ func ResourceTaskDefinition() *schema.Resource {
 					},
 				},
 			},
-			"task_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-
 			"execution_role_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-
+			"family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile("^[0-9A-Za-z_-]+$"), "see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html"),
+				),
+			},
+			"inference_accelerator": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"device_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"ipc_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ecs.IpcMode_Values(), false),
+			},
 			"memory": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"network_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -146,188 +154,12 @@ func ResourceTaskDefinition() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(ecs.NetworkMode_Values(), false),
 			},
-
-			"runtime_platform": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"operating_system_family": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(ecs.OSFamily_Values(), false),
-						},
-						"cpu_architecture": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(ecs.CPUArchitecture_Values(), false),
-						},
-					},
-				},
+			"pid_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(ecs.PidMode_Values(), false),
 			},
-
-			"volume": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-
-						"host_path": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-
-						"docker_volume_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"scope": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										Computed:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice(ecs.Scope_Values(), false),
-									},
-									"autoprovision": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										ForceNew: true,
-										Default:  false,
-									},
-									"driver": {
-										Type:     schema.TypeString,
-										ForceNew: true,
-										Optional: true,
-									},
-									"driver_opts": {
-										Type:     schema.TypeMap,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-										ForceNew: true,
-										Optional: true,
-									},
-									"labels": {
-										Type:     schema.TypeMap,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-										ForceNew: true,
-										Optional: true,
-									},
-								},
-							},
-						},
-						"efs_volume_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"file_system_id": {
-										Type:     schema.TypeString,
-										ForceNew: true,
-										Required: true,
-									},
-									"root_directory": {
-										Type:     schema.TypeString,
-										ForceNew: true,
-										Optional: true,
-										Default:  "/",
-									},
-									"transit_encryption": {
-										Type:         schema.TypeString,
-										ForceNew:     true,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice(ecs.EFSTransitEncryption_Values(), false),
-									},
-									"transit_encryption_port": {
-										Type:         schema.TypeInt,
-										ForceNew:     true,
-										Optional:     true,
-										ValidateFunc: validation.IsPortNumber,
-									},
-									"authorization_config": {
-										Type:     schema.TypeList,
-										Optional: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"access_point_id": {
-													Type:     schema.TypeString,
-													ForceNew: true,
-													Optional: true,
-												},
-												"iam": {
-													Type:         schema.TypeString,
-													ForceNew:     true,
-													Optional:     true,
-													ValidateFunc: validation.StringInSlice(ecs.EFSAuthorizationConfigIAM_Values(), false),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						"fsx_windows_file_server_volume_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"file_system_id": {
-										Type:     schema.TypeString,
-										ForceNew: true,
-										Required: true,
-									},
-									"root_directory": {
-										Type:     schema.TypeString,
-										ForceNew: true,
-										Required: true,
-									},
-									"authorization_config": {
-										Type:     schema.TypeList,
-										Required: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"credentials_parameter": {
-													Type:         schema.TypeString,
-													ForceNew:     true,
-													Required:     true,
-													ValidateFunc: verify.ValidARN,
-												},
-												"domain": {
-													Type:     schema.TypeString,
-													ForceNew: true,
-													Required: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				Set: resourceTaskDefinitionVolumeHash,
-			},
-
 			"placement_constraints": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -335,49 +167,20 @@ func ResourceTaskDefinition() *schema.Resource {
 				MaxItems: 10,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"expression": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
 						"type": {
 							Type:         schema.TypeString,
 							ForceNew:     true,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice(ecs.TaskDefinitionPlacementConstraintType_Values(), false),
 						},
-						"expression": {
-							Type:     schema.TypeString,
-							ForceNew: true,
-							Optional: true,
-						},
 					},
 				},
 			},
-
-			"requires_compatibilities": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"EC2",
-						"FARGATE",
-						"EXTERNAL",
-					}, false),
-				},
-			},
-
-			"ipc_mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(ecs.IpcMode_Values(), false),
-			},
-
-			"pid_mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(ecs.PidMode_Values(), false),
-			},
-
 			"proxy_configuration": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -406,27 +209,207 @@ func ResourceTaskDefinition() *schema.Resource {
 					},
 				},
 			},
-
+			"requires_compatibilities": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"EC2",
+						"FARGATE",
+						"EXTERNAL",
+					}, false),
+				},
+			},
+			"revision": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"runtime_platform": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cpu_architecture": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(ecs.CPUArchitecture_Values(), false),
+						},
+						"operating_system_family": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(ecs.OSFamily_Values(), false),
+						},
+					},
+				},
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
-			"inference_accelerator": {
+			"task_role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"volume": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"device_name": {
+						"docker_volume_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"autoprovision": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+										Default:  false,
+									},
+									"driver": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Optional: true,
+									},
+									"driver_opts": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										ForceNew: true,
+										Optional: true,
+									},
+									"labels": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										ForceNew: true,
+										Optional: true,
+									},
+									"scope": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(ecs.Scope_Values(), false),
+									},
+								},
+							},
+						},
+						"efs_volume_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"authorization_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										ForceNew: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"access_point_id": {
+													Type:     schema.TypeString,
+													ForceNew: true,
+													Optional: true,
+												},
+												"iam": {
+													Type:         schema.TypeString,
+													ForceNew:     true,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(ecs.EFSAuthorizationConfigIAM_Values(), false),
+												},
+											},
+										},
+									},
+									"file_system_id": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Required: true,
+									},
+									"root_directory": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Optional: true,
+										Default:  "/",
+									},
+									"transit_encryption": {
+										Type:         schema.TypeString,
+										ForceNew:     true,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ecs.EFSTransitEncryption_Values(), false),
+									},
+									"transit_encryption_port": {
+										Type:         schema.TypeInt,
+										ForceNew:     true,
+										Optional:     true,
+										ValidateFunc: validation.IsPortNumber,
+									},
+								},
+							},
+						},
+						"fsx_windows_file_server_volume_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"authorization_config": {
+										Type:     schema.TypeList,
+										Required: true,
+										ForceNew: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"credentials_parameter": {
+													Type:         schema.TypeString,
+													ForceNew:     true,
+													Required:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"domain": {
+													Type:     schema.TypeString,
+													ForceNew: true,
+													Required: true,
+												},
+											},
+										},
+									},
+									"file_system_id": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Required: true,
+									},
+									"root_directory": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Required: true,
+									},
+								},
+							},
+						},
+						"host_path": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ForceNew: true,
 						},
-						"device_type": {
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
 					},
 				},
+				Set: resourceTaskDefinitionVolumeHash,
 			},
 		},
 	}

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -430,7 +430,7 @@ func TestAccECSTaskDefinition_fsxWinFileSystem(t *testing.T) {
 	domainName := acctest.RandomDomainName()
 
 	if testing.Short() {
-		t.Skip("skipping testing in short mode")
+		t.Skip("skipping ~3400s test in short mode")
 	}
 
 	if acctest.Partition() == "aws-us-gov" {

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -64,7 +64,7 @@ func TestAccECSTaskDefinition_basic(t *testing.T) {
 }
 
 // Regression for https://github.com/hashicorp/terraform/issues/2370
-func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
+func TestAccECSTaskDefinition_scratchVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -77,7 +77,7 @@ func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithScratchVolume(rName),
+				Config: testAccTaskDefinitionScratchVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 				),
@@ -93,7 +93,7 @@ func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
+func TestAccECSTaskDefinition_DockerVolume_basic(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -106,7 +106,7 @@ func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithDockerVolumes(rName),
+				Config: testAccTaskDefinitionDockerVolumes(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -136,7 +136,7 @@ func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
+func TestAccECSTaskDefinition_DockerVolume_minimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -149,7 +149,7 @@ func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithDockerVolumesMinimalConfig(rName),
+				Config: testAccTaskDefinitionDockerVolumesMinimalConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -171,7 +171,7 @@ func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
+func TestAccECSTaskDefinition_runtimePlatform(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -184,7 +184,7 @@ func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithRuntimePlatformMinimalConfig(rName),
+				Config: testAccTaskDefinitionRuntimePlatformMinimalConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "runtime_platform.#", "1"),
@@ -205,7 +205,7 @@ func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
+func TestAccECSTaskDefinition_Fargate_runtimePlatform(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -218,7 +218,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(rName, true, true),
+				Config: testAccFargateTaskDefinitionRuntimePlatformMinimalConfig(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "runtime_platform.#", "1"),
@@ -239,7 +239,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.T) {
+func TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -252,7 +252,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(rName, false, true),
+				Config: testAccFargateTaskDefinitionRuntimePlatformMinimalConfig(rName, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "runtime_platform.#", "1"),
@@ -272,7 +272,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.
 	})
 }
 
-func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
+func TestAccECSTaskDefinition_EFSVolume_minimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -285,7 +285,7 @@ func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEFSVolumeMinimal(rName),
+				Config: testAccTaskDefinitionEFSVolumeMinimal(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -307,7 +307,7 @@ func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
+func TestAccECSTaskDefinition_EFSVolume_basic(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -320,7 +320,7 @@ func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEFSVolume(rName, "/home/test"),
+				Config: testAccTaskDefinitionEFSVolume(rName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -343,7 +343,7 @@ func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
+func TestAccECSTaskDefinition_EFSVolume_transitEncryption(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -355,7 +355,7 @@ func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithTransitEncryptionEFSVolume(rName, "ENABLED", 2999),
+				Config: testAccTaskDefinitionTransitEncryptionEFSVolume(rName, "ENABLED", 2999),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -380,7 +380,7 @@ func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
+func TestAccECSTaskDefinition_EFSVolume_accessPoint(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -393,7 +393,7 @@ func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEFSAccessPoint(rName, "DISABLED"),
+				Config: testAccTaskDefinitionEFSAccessPoint(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -421,7 +421,7 @@ func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
+func TestAccECSTaskDefinition_fsxWinFileSystem(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -444,7 +444,7 @@ func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithFSxVolume(domainName, rName),
+				Config: testAccTaskDefinitionFSxVolume(domainName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
@@ -470,7 +470,7 @@ func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
+func TestAccECSTaskDefinition_DockerVolume_taskScoped(t *testing.T) {
 	var def ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -483,7 +483,7 @@ func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithTaskScopedDockerVolume(rName),
+				Config: testAccTaskDefinitionTaskScopedDockerVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					testAccCheckTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(&def),
@@ -502,12 +502,10 @@ func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 }
 
 // Regression for https://github.com/hashicorp/terraform/issues/2694
-func TestAccECSTaskDefinition_withECSService(t *testing.T) {
+func TestAccECSTaskDefinition_service(t *testing.T) {
 	var def ecs.TaskDefinition
 	var service ecs.Service
 
-	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	svcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
@@ -518,14 +516,14 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEcsService(clusterName, svcName, rName),
+				Config: testAccTaskDefinitionService(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					testAccCheckServiceExists("aws_ecs_service.test", &service),
 				),
 			},
 			{
-				Config: testAccTaskDefinitionWithEcsServiceModified(clusterName, svcName, rName),
+				Config: testAccTaskDefinitionServiceModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					testAccCheckServiceExists("aws_ecs_service.test", &service),
@@ -542,11 +540,9 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
+func TestAccECSTaskDefinition_taskRoleARN(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
@@ -557,7 +553,7 @@ func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithTaskRoleARN(roleName, policyName, rName),
+				Config: testAccTaskDefinitionTaskRoleARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 				),
@@ -573,11 +569,9 @@ func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
+func TestAccECSTaskDefinition_networkMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
@@ -588,7 +582,7 @@ func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithNetworkMode(roleName, policyName, rName),
+				Config: testAccTaskDefinitionNetworkMode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "network_mode", "bridge"),
@@ -605,11 +599,9 @@ func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
+func TestAccECSTaskDefinition_ipcMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
@@ -620,7 +612,7 @@ func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithIPcMode(roleName, policyName, rName),
+				Config: testAccTaskDefinitionIPcMode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "ipc_mode", "host"),
@@ -637,11 +629,9 @@ func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
+func TestAccECSTaskDefinition_pidMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
@@ -652,7 +642,7 @@ func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithPidMode(roleName, policyName, rName),
+				Config: testAccTaskDefinitionPIDMode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "pid_mode", "host"),
@@ -767,7 +757,7 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_fargate(t *testing.T) {
+func TestAccECSTaskDefinition_Fargate_basic(t *testing.T) {
 	var conf ecs.TaskDefinition
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -841,8 +831,6 @@ func TestAccECSTaskDefinition_Fargate_ephemeralStorage(t *testing.T) {
 func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
@@ -853,7 +841,7 @@ func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionExecutionRole(roleName, policyName, rName),
+				Config: testAccTaskDefinitionExecutionRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &conf),
 				),
@@ -1259,7 +1247,6 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
     name      = "jenkins-home"
     host_path = "/ecs/jenkins-home"
@@ -1317,7 +1304,6 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
     name      = "jenkins-home"
     host_path = "/ecs/jenkins-home"
@@ -1369,7 +1355,6 @@ resource "aws_ecs_task_definition" "test" {
 	}
 ]
 TASK_DEFINITION
-
 
   volume {
     name      = "jenkins-home"
@@ -1472,7 +1457,6 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
     name      = "vol1"
     host_path = "/host/vol1"
@@ -1547,7 +1531,7 @@ TASK_DEFINITION
 `, rName, portMappings)
 }
 
-func testAccTaskDefinitionExecutionRole(roleName, policyName, rName string) string {
+func testAccTaskDefinitionExecutionRole(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1570,7 +1554,7 @@ EOF
 }
 
 resource "aws_iam_policy" "test" {
-  name        = %[2]q
+  name        = %[1]q
   description = "A test policy"
 
   policy = <<EOF
@@ -1600,7 +1584,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family             = %[3]q
+  family             = %[1]q
   execution_role_arn = aws_iam_role.test.arn
 
   container_definitions = <<TASK_DEFINITION
@@ -1616,10 +1600,10 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 }
-`, roleName, policyName, rName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithScratchVolume(rName string) string {
+func testAccTaskDefinitionScratchVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1636,7 +1620,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q
@@ -1645,7 +1628,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccTaskDefinitionWithDockerVolumes(rName string) string {
+func testAccTaskDefinitionDockerVolumes(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1662,7 +1645,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q
@@ -1688,7 +1670,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccTaskDefinitionWithDockerVolumesMinimalConfig(rName string) string {
+func testAccTaskDefinitionDockerVolumesMinimalConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1706,7 +1688,6 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
     name = %[1]q
 
@@ -1718,7 +1699,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccTaskDefinitionWithRuntimePlatformMinimalConfig(rName string) string {
+func testAccTaskDefinitionRuntimePlatformMinimalConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family                = %[1]q
@@ -1742,7 +1723,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(rName string, architecture bool, osFamily bool) string {
+func testAccFargateTaskDefinitionRuntimePlatformMinimalConfig(rName string, architecture bool, osFamily bool) string {
 
 	var arch string
 	if architecture {
@@ -1787,7 +1768,7 @@ TASK_DEFINITION
 `, rName, arch, os)
 }
 
-func testAccTaskDefinitionWithTaskScopedDockerVolume(rName string) string {
+func testAccTaskDefinitionTaskScopedDockerVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1804,7 +1785,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q
@@ -1817,7 +1797,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccTaskDefinitionWithEFSVolumeMinimal(rName string) string {
+func testAccTaskDefinitionEFSVolumeMinimal(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1838,7 +1818,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q
@@ -1851,7 +1830,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccTaskDefinitionWithEFSVolume(rName, rDir string) string {
+func testAccTaskDefinitionEFSVolume(rName, rDir string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1872,7 +1851,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q
@@ -1886,7 +1864,7 @@ TASK_DEFINITION
 `, rName, rDir)
 }
 
-func testAccTaskDefinitionWithTransitEncryptionEFSVolume(rName, tEnc string, tEncPort int) string {
+func testAccTaskDefinitionTransitEncryptionEFSVolume(rName, tEnc string, tEncPort int) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1907,7 +1885,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q
@@ -1923,7 +1900,7 @@ TASK_DEFINITION
 `, rName, tEnc, tEncPort)
 }
 
-func testAccTaskDefinitionWithEFSAccessPoint(rName, useIam string) string {
+func testAccTaskDefinitionEFSAccessPoint(rName, useIam string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1953,7 +1930,6 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
     name = %[1]q
 
@@ -1971,7 +1947,7 @@ TASK_DEFINITION
 `, rName, useIam)
 }
 
-func testAccTaskDefinitionWithTaskRoleARN(roleName, policyName, rName string) string {
+func testAccTaskDefinitionTaskRoleARN(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1997,7 +1973,7 @@ EOF
 data "aws_partition" "current" {}
 
 resource "aws_iam_role_policy" "test" {
-  name = %[2]q
+  name = %[1]q
   role = aws_iam_role.test.id
 
   policy = <<EOF
@@ -2018,7 +1994,7 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = %[3]q
+  family        = %[1]q
   task_role_arn = aws_iam_role.test.arn
 
   container_definitions = <<TASK_DEFINITION
@@ -2034,15 +2010,14 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
-    name = %[3]q
+    name = %[1]q
   }
 }
-`, roleName, policyName, rName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithIPcMode(roleName, policyName, rName string) string {
+func testAccTaskDefinitionIPcMode(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2068,7 +2043,7 @@ EOF
 data "aws_partition" "current" {}
 
 resource "aws_iam_role_policy" "test" {
-  name = %[2]q
+  name = %[1]q
   role = aws_iam_role.test.id
 
   policy = <<EOF
@@ -2090,7 +2065,7 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = %[3]q
+  family        = %[1]q
   task_role_arn = aws_iam_role.test.arn
   network_mode  = "bridge"
   ipc_mode      = "host"
@@ -2108,15 +2083,14 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
-    name = %[3]q
+    name = %[1]q
   }
 }
-`, roleName, policyName, rName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithPidMode(roleName, policyName, rName string) string {
+func testAccTaskDefinitionPIDMode(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2142,7 +2116,7 @@ EOF
 data "aws_partition" "current" {}
 
 resource "aws_iam_role_policy" "test" {
-  name = %[2]q
+  name = %[1]q
   role = aws_iam_role.test.id
 
   policy = <<EOF
@@ -2164,7 +2138,7 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = %[3]q
+  family        = %[1]q
   task_role_arn = aws_iam_role.test.arn
   network_mode  = "bridge"
   pid_mode      = "host"
@@ -2182,15 +2156,14 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
-    name = %[3]q
+    name = %[1]q
   }
 }
-`, roleName, policyName, rName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithNetworkMode(roleName, policyName, rName string) string {
+func testAccTaskDefinitionNetworkMode(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2216,7 +2189,7 @@ EOF
 data "aws_partition" "current" {}
 
 resource "aws_iam_role_policy" "test" {
-  name = %[2]q
+  name = %[1]q
   role = aws_iam_role.test.id
 
   policy = <<EOF
@@ -2238,7 +2211,7 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = %[3]q
+  family        = %[1]q
   task_role_arn = aws_iam_role.test.arn
   network_mode  = "bridge"
 
@@ -2255,29 +2228,28 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
-    name = %[3]q
+    name = %[1]q
   }
 }
-`, roleName, policyName, rName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithEcsService(clusterName, svcName, rName string) string {
+func testAccTaskDefinitionService(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
 }
 
 resource "aws_ecs_service" "test" {
-  name            = %[2]q
+  name            = %[1]q
   cluster         = aws_ecs_cluster.test.id
   task_definition = aws_ecs_task_definition.test.arn
   desired_count   = 1
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[3]q
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -2292,29 +2264,28 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
-    name = %[3]q
+    name = %[1]q
   }
 }
-`, clusterName, svcName, rName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithEcsServiceModified(clusterName, svcName, rName string) string {
+func testAccTaskDefinitionServiceModified(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
 }
 
 resource "aws_ecs_service" "test" {
-  name            = %[2]q
+  name            = %[1]q
   cluster         = aws_ecs_cluster.test.id
   task_definition = aws_ecs_task_definition.test.arn
   desired_count   = 1
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[3]q
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -2329,12 +2300,11 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   volume {
-    name = %[3]q
+    name = %[1]q
   }
 }
-`, clusterName, svcName, rName)
+`, rName)
 }
 
 func testAccTaskDefinitionModified(rName string) string {
@@ -2380,7 +2350,6 @@ resource "aws_ecs_task_definition" "test" {
 	}
 ]
 TASK_DEFINITION
-
 
   volume {
     name      = "jenkins-home"
@@ -2507,7 +2476,6 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 
-
   inference_accelerator {
     device_name = "device_1"
     device_type = "eia1.medium"
@@ -2516,7 +2484,7 @@ TASK_DEFINITION
 `, rName)
 }
 
-func testAccTaskDefinitionWithFSxVolume(domain, rName string) string {
+func testAccTaskDefinitionFSxVolume(domain, rName string) string {
 	return acctest.ConfigCompose(
 		testAccFSxWindowsFileSystemSubnetIds1Config(domain),
 		fmt.Sprintf(`
@@ -2581,7 +2549,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
 
   volume {
     name = %[1]q

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -29,7 +29,7 @@ func testAccErrorCheckSkipECS(t *testing.T) resource.ErrorCheckFunc {
 func TestAccECSTaskDefinition_basic(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -39,14 +39,14 @@ func TestAccECSTaskDefinition_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinition(tdName),
+				Config: testAccTaskDefinition(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ecs", regexp.MustCompile(`task-definition/.+`)),
 				),
 			},
 			{
-				Config: testAccTaskDefinitionModified(tdName),
+				Config: testAccTaskDefinitionModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ecs", regexp.MustCompile(`task-definition/.+`)),
@@ -67,7 +67,7 @@ func TestAccECSTaskDefinition_basic(t *testing.T) {
 func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -77,7 +77,7 @@ func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithScratchVolume(tdName),
+				Config: testAccTaskDefinitionWithScratchVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 				),
@@ -96,7 +96,7 @@ func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -106,12 +106,12 @@ func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithDockerVolumes(tdName),
+				Config: testAccTaskDefinitionWithDockerVolumes(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
-						"name":                                             tdName,
+						"name":                                             rName,
 						"docker_volume_configuration.#":                    "1",
 						"docker_volume_configuration.0.driver":             "local",
 						"docker_volume_configuration.0.scope":              "shared",
@@ -139,7 +139,7 @@ func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -149,12 +149,12 @@ func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithDockerVolumesMinimalConfig(tdName),
+				Config: testAccTaskDefinitionWithDockerVolumesMinimalConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
-						"name":                          tdName,
+						"name":                          rName,
 						"docker_volume_configuration.#": "1",
 						"docker_volume_configuration.0.autoprovision": "true",
 					}),
@@ -174,7 +174,7 @@ func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -184,7 +184,7 @@ func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithRuntimePlatformMinimalConfig(tdName),
+				Config: testAccTaskDefinitionWithRuntimePlatformMinimalConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "runtime_platform.#", "1"),
@@ -208,7 +208,7 @@ func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -218,7 +218,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(tdName, true, true),
+				Config: testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "runtime_platform.#", "1"),
@@ -242,7 +242,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -252,7 +252,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(tdName, false, true),
+				Config: testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(rName, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "runtime_platform.#", "1"),
@@ -275,7 +275,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.
 func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -285,12 +285,12 @@ func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEFSVolumeMinimal(tdName),
+				Config: testAccTaskDefinitionWithEFSVolumeMinimal(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
-						"name":                       tdName,
+						"name":                       rName,
 						"efs_volume_configuration.#": "1",
 					}),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "volume.*.efs_volume_configuration.0.file_system_id", "aws_efs_file_system.test", "id"),
@@ -310,7 +310,7 @@ func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -320,12 +320,12 @@ func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEFSVolume(tdName, "/home/test"),
+				Config: testAccTaskDefinitionWithEFSVolume(rName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
-						"name":                       tdName,
+						"name":                       rName,
 						"efs_volume_configuration.#": "1",
 						"efs_volume_configuration.0.root_directory": "/home/test",
 					}),
@@ -346,7 +346,7 @@ func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -355,12 +355,12 @@ func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithTransitEncryptionEFSVolume(tdName, "ENABLED", 2999),
+				Config: testAccTaskDefinitionWithTransitEncryptionEFSVolume(rName, "ENABLED", 2999),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
-						"name":                       tdName,
+						"name":                       rName,
 						"efs_volume_configuration.#": "1",
 						"efs_volume_configuration.0.root_directory":          "/home/test",
 						"efs_volume_configuration.0.transit_encryption":      "ENABLED",
@@ -383,7 +383,7 @@ func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -393,12 +393,12 @@ func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEFSAccessPoint(tdName, "DISABLED"),
+				Config: testAccTaskDefinitionWithEFSAccessPoint(rName, "DISABLED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "volume.*", map[string]string{
-						"name":                       tdName,
+						"name":                       rName,
 						"efs_volume_configuration.#": "1",
 						"efs_volume_configuration.0.root_directory":             "/",
 						"efs_volume_configuration.0.transit_encryption":         "ENABLED",
@@ -473,7 +473,7 @@ func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
 func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -483,7 +483,7 @@ func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithTaskScopedDockerVolume(tdName),
+				Config: testAccTaskDefinitionWithTaskScopedDockerVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					testAccCheckTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(&def),
@@ -508,7 +508,7 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 
 	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	svcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -518,14 +518,14 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithEcsService(clusterName, svcName, tdName),
+				Config: testAccTaskDefinitionWithEcsService(clusterName, svcName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					testAccCheckServiceExists("aws_ecs_service.test", &service),
 				),
 			},
 			{
-				Config: testAccTaskDefinitionWithEcsServiceModified(clusterName, svcName, tdName),
+				Config: testAccTaskDefinitionWithEcsServiceModified(clusterName, svcName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					testAccCheckServiceExists("aws_ecs_service.test", &service),
@@ -547,7 +547,7 @@ func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 
 	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -557,7 +557,7 @@ func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithTaskRoleARN(roleName, policyName, tdName),
+				Config: testAccTaskDefinitionWithTaskRoleARN(roleName, policyName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 				),
@@ -578,7 +578,7 @@ func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 
 	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -588,7 +588,7 @@ func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithNetworkMode(roleName, policyName, tdName),
+				Config: testAccTaskDefinitionWithNetworkMode(roleName, policyName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "network_mode", "bridge"),
@@ -610,7 +610,7 @@ func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 
 	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -620,7 +620,7 @@ func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithIPcMode(roleName, policyName, tdName),
+				Config: testAccTaskDefinitionWithIPcMode(roleName, policyName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "ipc_mode", "host"),
@@ -642,7 +642,7 @@ func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 
 	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -652,7 +652,7 @@ func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionWithPidMode(roleName, policyName, tdName),
+				Config: testAccTaskDefinitionWithPidMode(roleName, policyName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "pid_mode", "host"),
@@ -672,7 +672,7 @@ func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 func TestAccECSTaskDefinition_constraint(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -682,7 +682,7 @@ func TestAccECSTaskDefinition_constraint(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinition_constraint(tdName),
+				Config: testAccTaskDefinition_constraint(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "placement_constraints.#", "1"),
@@ -704,7 +704,7 @@ func TestAccECSTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 	var before ecs.TaskDefinition
 	var after ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -714,13 +714,13 @@ func TestAccECSTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinition(tdName),
+				Config: testAccTaskDefinition(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &before),
 				),
 			},
 			{
-				Config: testAccTaskDefinitionUpdatedVolume(tdName),
+				Config: testAccTaskDefinitionUpdatedVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &after),
 					testAccCheckEcsTaskDefinitionRecreated(t, &before, &after),
@@ -742,7 +742,7 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 	var conf ecs.TaskDefinition
 	resourceName := "aws_ecs_task_definition.test"
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -751,7 +751,7 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionArrays(tdName),
+				Config: testAccTaskDefinitionArrays(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &conf),
 				),
@@ -770,7 +770,7 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 func TestAccECSTaskDefinition_fargate(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -780,7 +780,7 @@ func TestAccECSTaskDefinition_fargate(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionFargate(tdName, `[{"protocol": "tcp", "containerPort": 8000}]`),
+				Config: testAccTaskDefinitionFargate(rName, `[{"protocol": "tcp", "containerPort": 8000}]`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "requires_compatibilities.#", "1"),
@@ -798,7 +798,7 @@ func TestAccECSTaskDefinition_fargate(t *testing.T) {
 			{
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
-				Config:             testAccTaskDefinitionFargate(tdName, `[{"protocol": "tcp", "containerPort": 8000, "hostPort": 8000}]`),
+				Config:             testAccTaskDefinitionFargate(rName, `[{"protocol": "tcp", "containerPort": 8000, "hostPort": 8000}]`),
 			},
 		},
 	})
@@ -807,7 +807,7 @@ func TestAccECSTaskDefinition_fargate(t *testing.T) {
 func TestAccECSTaskDefinition_Fargate_ephemeralStorage(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -817,7 +817,7 @@ func TestAccECSTaskDefinition_Fargate_ephemeralStorage(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionFargateEphemeralStorage(tdName, `[{"protocol": "tcp", "containerPort": 8000}]`),
+				Config: testAccTaskDefinitionFargateEphemeralStorage(rName, `[{"protocol": "tcp", "containerPort": 8000}]`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "requires_compatibilities.#", "1"),
@@ -843,7 +843,7 @@ func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 
 	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -853,7 +853,7 @@ func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionExecutionRole(roleName, policyName, tdName),
+				Config: testAccTaskDefinitionExecutionRole(roleName, policyName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &conf),
 				),
@@ -873,7 +873,7 @@ func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 func TestAccECSTaskDefinition_disappears(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -883,7 +883,7 @@ func TestAccECSTaskDefinition_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinition(tdName),
+				Config: testAccTaskDefinition(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					acctest.CheckResourceDisappears(acctest.Provider, tfecs.ResourceTaskDefinition(), resourceName),
@@ -891,7 +891,7 @@ func TestAccECSTaskDefinition_disappears(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccTaskDefinition(tdName),
+				Config: testAccTaskDefinition(rName),
 				Check:  resource.TestCheckResourceAttr(resourceName, "revision", "2"), // should get re-created
 			},
 		},
@@ -987,7 +987,7 @@ func TestAccECSTaskDefinition_proxy(t *testing.T) {
 func TestAccECSTaskDefinition_inferenceAccelerator(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -997,7 +997,7 @@ func TestAccECSTaskDefinition_inferenceAccelerator(t *testing.T) {
 		CheckDestroy: testAccCheckTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTaskDefinitionInferenceAcceleratorConfig(tdName),
+				Config: testAccTaskDefinitionInferenceAcceleratorConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "inference_accelerator.#", "1"),
@@ -1215,7 +1215,7 @@ func testAccCheckTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(def *ec
 	}
 }
 
-func testAccTaskDefinition_constraint(tdName string) string {
+func testAccTaskDefinition_constraint(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
@@ -1270,10 +1270,10 @@ TASK_DEFINITION
     expression = "attribute:ecs.availability-zone in [${data.aws_availability_zones.available.names[0]}, ${data.aws_availability_zones.available.names[1]}]"
   }
 }
-`, tdName))
+`, rName))
 }
 
-func testAccTaskDefinition(tdName string) string {
+func testAccTaskDefinition(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
@@ -1323,10 +1323,10 @@ TASK_DEFINITION
     host_path = "/ecs/jenkins-home"
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionUpdatedVolume(tdName string) string {
+func testAccTaskDefinitionUpdatedVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
@@ -1376,10 +1376,10 @@ TASK_DEFINITION
     host_path = "/ecs/jenkins"
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionArrays(tdName string) string {
+func testAccTaskDefinitionArrays(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
@@ -1488,10 +1488,10 @@ TASK_DEFINITION
     host_path = "/host/vol3"
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionFargate(tdName, portMappings string) string {
+func testAccTaskDefinitionFargate(rName, portMappings string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family                   = "%s"
@@ -1514,10 +1514,10 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 }
-`, tdName, portMappings)
+`, rName, portMappings)
 }
 
-func testAccTaskDefinitionFargateEphemeralStorage(tdName, portMappings string) string {
+func testAccTaskDefinitionFargateEphemeralStorage(rName, portMappings string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family                   = "%s"
@@ -1544,10 +1544,10 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 }
-`, tdName, portMappings)
+`, rName, portMappings)
 }
 
-func testAccTaskDefinitionExecutionRole(roleName, policyName, tdName string) string {
+func testAccTaskDefinitionExecutionRole(roleName, policyName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = "%s"
@@ -1616,10 +1616,10 @@ resource "aws_ecs_task_definition" "test" {
 ]
 TASK_DEFINITION
 }
-`, roleName, policyName, tdName)
+`, roleName, policyName, rName)
 }
 
-func testAccTaskDefinitionWithScratchVolume(tdName string) string {
+func testAccTaskDefinitionWithScratchVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1642,10 +1642,10 @@ TASK_DEFINITION
     name = %[1]q
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithDockerVolumes(tdName string) string {
+func testAccTaskDefinitionWithDockerVolumes(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1685,10 +1685,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithDockerVolumesMinimalConfig(tdName string) string {
+func testAccTaskDefinitionWithDockerVolumesMinimalConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1715,10 +1715,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithRuntimePlatformMinimalConfig(tdName string) string {
+func testAccTaskDefinitionWithRuntimePlatformMinimalConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family                = %[1]q
@@ -1739,10 +1739,10 @@ TASK_DEFINITION
     cpu_architecture        = "X86_64"
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(tdName string, architecture bool, osFamily bool) string {
+func testAccFargateTaskDefinitionWithRuntimePlatformMinimalConfig(rName string, architecture bool, osFamily bool) string {
 
 	var arch string
 	if architecture {
@@ -1784,10 +1784,10 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
 }
-`, tdName, arch, os)
+`, rName, arch, os)
 }
 
-func testAccTaskDefinitionWithTaskScopedDockerVolume(tdName string) string {
+func testAccTaskDefinitionWithTaskScopedDockerVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
@@ -1814,10 +1814,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithEFSVolumeMinimal(tdName string) string {
+func testAccTaskDefinitionWithEFSVolumeMinimal(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1848,10 +1848,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithEFSVolume(tdName, rDir string) string {
+func testAccTaskDefinitionWithEFSVolume(rName, rDir string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1883,10 +1883,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName, rDir)
+`, rName, rDir)
 }
 
-func testAccTaskDefinitionWithTransitEncryptionEFSVolume(tdName, tEnc string, tEncPort int) string {
+func testAccTaskDefinitionWithTransitEncryptionEFSVolume(rName, tEnc string, tEncPort int) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1920,10 +1920,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName, tEnc, tEncPort)
+`, rName, tEnc, tEncPort)
 }
 
-func testAccTaskDefinitionWithEFSAccessPoint(tdName, useIam string) string {
+func testAccTaskDefinitionWithEFSAccessPoint(rName, useIam string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
@@ -1968,10 +1968,10 @@ TASK_DEFINITION
     }
   }
 }
-`, tdName, useIam)
+`, rName, useIam)
 }
 
-func testAccTaskDefinitionWithTaskRoleARN(roleName, policyName, tdName string) string {
+func testAccTaskDefinitionWithTaskRoleARN(roleName, policyName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2039,10 +2039,10 @@ TASK_DEFINITION
     name = %[3]q
   }
 }
-`, roleName, policyName, tdName)
+`, roleName, policyName, rName)
 }
 
-func testAccTaskDefinitionWithIPcMode(roleName, policyName, tdName string) string {
+func testAccTaskDefinitionWithIPcMode(roleName, policyName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2113,10 +2113,10 @@ TASK_DEFINITION
     name = %[3]q
   }
 }
-`, roleName, policyName, tdName)
+`, roleName, policyName, rName)
 }
 
-func testAccTaskDefinitionWithPidMode(roleName, policyName, tdName string) string {
+func testAccTaskDefinitionWithPidMode(roleName, policyName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2187,10 +2187,10 @@ TASK_DEFINITION
     name = %[3]q
   }
 }
-`, roleName, policyName, tdName)
+`, roleName, policyName, rName)
 }
 
-func testAccTaskDefinitionWithNetworkMode(roleName, policyName, tdName string) string {
+func testAccTaskDefinitionWithNetworkMode(roleName, policyName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2260,10 +2260,10 @@ TASK_DEFINITION
     name = %[3]q
   }
 }
-`, roleName, policyName, tdName)
+`, roleName, policyName, rName)
 }
 
-func testAccTaskDefinitionWithEcsService(clusterName, svcName, tdName string) string {
+func testAccTaskDefinitionWithEcsService(clusterName, svcName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
@@ -2297,10 +2297,10 @@ TASK_DEFINITION
     name = %[3]q
   }
 }
-`, clusterName, svcName, tdName)
+`, clusterName, svcName, rName)
 }
 
-func testAccTaskDefinitionWithEcsServiceModified(clusterName, svcName, tdName string) string {
+func testAccTaskDefinitionWithEcsServiceModified(clusterName, svcName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
@@ -2334,10 +2334,10 @@ TASK_DEFINITION
     name = %[3]q
   }
 }
-`, clusterName, svcName, tdName)
+`, clusterName, svcName, rName)
 }
 
-func testAccTaskDefinitionModified(tdName string) string {
+func testAccTaskDefinitionModified(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
@@ -2387,7 +2387,7 @@ TASK_DEFINITION
     host_path = "/ecs/jenkins-home"
   }
 }
-`, tdName)
+`, rName)
 }
 
 var testValidTaskDefinitionValidContainerDefinitions = `
@@ -2473,7 +2473,7 @@ DEFINITION
 `, rName, rName, tag1Key, tag1Value, tag2Key, tag2Value)
 }
 
-func testAccTaskDefinitionInferenceAcceleratorConfig(tdName string) string {
+func testAccTaskDefinitionInferenceAcceleratorConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
@@ -2513,10 +2513,10 @@ TASK_DEFINITION
     device_type = "eia1.medium"
   }
 }
-`, tdName)
+`, rName)
 }
 
-func testAccTaskDefinitionWithFSxVolume(domain, tdName string) string {
+func testAccTaskDefinitionWithFSxVolume(domain, rName string) string {
 	return acctest.ConfigCompose(
 		testAccFSxWindowsFileSystemSubnetIds1Config(domain),
 		fmt.Sprintf(`
@@ -2603,7 +2603,7 @@ TASK_DEFINITION
     aws_iam_role_policy_attachment.test3
   ]
 }
-`, tdName))
+`, rName))
 }
 
 func testAccTaskDefinitionImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -18,7 +18,6 @@ import (
 
 func init() {
 	acctest.RegisterServiceErrorCheckFunc(ecs.EndpointsID, testAccErrorCheckSkipECS)
-
 }
 
 func testAccErrorCheckSkipECS(t *testing.T) resource.ErrorCheckFunc {

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -1020,24 +1020,24 @@ func testAccTaskDefinitionProxyConfigurationConfig(rName string, containerName s
 
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family       = %q
+  family       = %[1]q
   network_mode = "awsvpc"
 
   proxy_configuration {
-    type           = %q
-    container_name = %q
+    type           = %[2]q
+    container_name = %[3]q
     properties = {
-      IgnoredUID         = %q
-      IgnoredGID         = %q
-      AppPorts           = %q
-      ProxyIngressPort   = %q
-      ProxyEgressPort    = %q
-      EgressIgnoredPorts = %q
-      EgressIgnoredIPs   = %q
+      IgnoredUID         = %[4]q
+      IgnoredGID         = %[5]q
+      AppPorts           = %[6]q
+      ProxyIngressPort   = %[7]q
+      ProxyEgressPort    = %[8]q
+      EgressIgnoredPorts = %[9]q
+      EgressIgnoredIPs   = %[10]q
     }
   }
 
@@ -1048,12 +1048,12 @@ resource "aws_ecs_task_definition" "test" {
     "essential": true,
     "image": "nginx:latest",
     "memory": 128,
-    "name": %q
+    "name": %[11]q
   }
 ]
 DEFINITION
 }
-`, rName, rName, proxyType, containerName, ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs, containerName)
+`, rName, proxyType, containerName, ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs, containerName)
 }
 
 func testAccCheckTaskDefinitionProxyConfiguration(after *ecs.TaskDefinition, containerName string, proxyType string,
@@ -1218,7 +1218,7 @@ func testAccCheckTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(def *ec
 func testAccTaskDefinition_constraint(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1276,7 +1276,7 @@ TASK_DEFINITION
 func testAccTaskDefinition(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1329,7 +1329,7 @@ TASK_DEFINITION
 func testAccTaskDefinitionUpdatedVolume(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1382,7 +1382,7 @@ TASK_DEFINITION
 func testAccTaskDefinitionArrays(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1494,7 +1494,7 @@ TASK_DEFINITION
 func testAccTaskDefinitionFargate(rName, portMappings string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family                   = "%s"
+  family                   = %[1]q
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = "256"
@@ -1509,7 +1509,7 @@ resource "aws_ecs_task_definition" "test" {
     "command": ["sleep","360"],
     "memory": 10,
     "essential": true,
-    "portMappings": %s
+    "portMappings": %[2]s
   }
 ]
 TASK_DEFINITION
@@ -1520,7 +1520,7 @@ TASK_DEFINITION
 func testAccTaskDefinitionFargateEphemeralStorage(rName, portMappings string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family                   = "%s"
+  family                   = %[1]q
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = "256"
@@ -1539,7 +1539,7 @@ resource "aws_ecs_task_definition" "test" {
     "command": ["sleep","360"],
     "memory": 10,
     "essential": true,
-    "portMappings": %s
+    "portMappings": %[2]s
   }
 ]
 TASK_DEFINITION
@@ -1550,7 +1550,7 @@ TASK_DEFINITION
 func testAccTaskDefinitionExecutionRole(roleName, policyName, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -1570,7 +1570,7 @@ EOF
 }
 
 resource "aws_iam_policy" "test" {
-  name        = "%s"
+  name        = %[2]q
   description = "A test policy"
 
   policy = <<EOF
@@ -1600,7 +1600,7 @@ resource "aws_iam_role_policy_attachment" "test" {
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family             = "%s"
+  family             = %[3]q
   execution_role_arn = aws_iam_role.test.arn
 
   container_definitions = <<TASK_DEFINITION
@@ -2340,7 +2340,7 @@ TASK_DEFINITION
 func testAccTaskDefinitionModified(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -2419,11 +2419,11 @@ var testValidTaskDefinitionInvalidCommandContainerDefinitions = `
 func testAccTaskDefinitionTags1Config(rName, tag1Key, tag1Value string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %q
+  family = %[1]q
 
   container_definitions = <<DEFINITION
 [
@@ -2438,20 +2438,20 @@ resource "aws_ecs_task_definition" "test" {
 DEFINITION
 
   tags = {
-    %q = %q
+    %[2]q = %[3]q
   }
 }
-`, rName, rName, tag1Key, tag1Value)
+`, rName, tag1Key, tag1Value)
 }
 
 func testAccTaskDefinitionTags2Config(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %q
+  family = %[1]q
 
   container_definitions = <<DEFINITION
 [
@@ -2466,17 +2466,17 @@ resource "aws_ecs_task_definition" "test" {
 DEFINITION
 
   tags = {
-    %q = %q
-    %q = %q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, rName, rName, tag1Key, tag1Value, tag2Key, tag2Value)
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value)
 }
 
 func testAccTaskDefinitionInferenceAcceleratorConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -29,7 +29,7 @@ func testAccErrorCheckSkipECS(t *testing.T) resource.ErrorCheckFunc {
 func TestAccECSTaskDefinition_basic(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-basic")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -53,10 +53,11 @@ func TestAccECSTaskDefinition_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -66,7 +67,7 @@ func TestAccECSTaskDefinition_basic(t *testing.T) {
 func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-scratch-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -82,10 +83,11 @@ func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -94,7 +96,7 @@ func TestAccECSTaskDefinition_withScratchVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-docker-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -124,10 +126,11 @@ func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -136,7 +139,7 @@ func TestAccECSTaskDefinition_withDockerVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-docker-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -158,10 +161,11 @@ func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -170,7 +174,7 @@ func TestAccECSTaskDefinition_withDockerVolumeMinimal(t *testing.T) {
 func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-runtime-platform")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -191,10 +195,11 @@ func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -203,7 +208,7 @@ func TestAccECSTaskDefinition_withRuntimePlatform(t *testing.T) {
 func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-runtime-platform")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -224,10 +229,11 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -236,7 +242,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatform(t *testing.T) {
 func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-runtime-platform")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -256,10 +262,11 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -268,7 +275,7 @@ func TestAccECSTaskDefinition_Fargate_withRuntimePlatformWithoutArch(t *testing.
 func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-efs-volume-min")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -290,10 +297,11 @@ func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -302,7 +310,7 @@ func TestAccECSTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-efs-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -325,10 +333,11 @@ func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -337,7 +346,7 @@ func TestAccECSTaskDefinition_withEFSVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-efs-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -361,10 +370,11 @@ func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -373,7 +383,7 @@ func TestAccECSTaskDefinition_withTransitEncryptionEFSVolume(t *testing.T) {
 func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-efs-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -401,10 +411,11 @@ func TestAccECSTaskDefinition_withEFSAccessPoint(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -417,6 +428,10 @@ func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
 	resourceName := "aws_ecs_task_definition.test"
 
 	domainName := acctest.RandomDomainName()
+
+	if testing.Short() {
+		t.Skip("skipping testing in short mode")
+	}
 
 	if acctest.Partition() == "aws-us-gov" {
 		t.Skip("Amazon FSx for Windows File Server volumes for ECS tasks are not supported in GovCloud partition")
@@ -445,10 +460,11 @@ func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -457,7 +473,7 @@ func TestAccECSTaskDefinition_withFSxWinFileSystem(t *testing.T) {
 func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-docker-volume")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -475,10 +491,11 @@ func TestAccECSTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -489,9 +506,9 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 	var def ecs.TaskDefinition
 	var service ecs.Service
 
-	clusterName := sdkacctest.RandomWithPrefix("tf-acc-cluster-with-ecs-service")
-	svcName := sdkacctest.RandomWithPrefix("tf-acc-td-with-ecs-service")
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-ecs-service")
+	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	svcName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -515,10 +532,11 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -527,9 +545,9 @@ func TestAccECSTaskDefinition_withECSService(t *testing.T) {
 func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix("tf-acc-role-ecs-td-with-task-role-arn")
-	policyName := sdkacctest.RandomWithPrefix("tf-acc-policy-ecs-td-with-task-role-arn")
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-task-role-arn")
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -545,10 +563,11 @@ func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -557,9 +576,9 @@ func TestAccECSTaskDefinition_withTaskRoleARN(t *testing.T) {
 func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix("tf-acc-ecs-td-with-network-mode")
-	policyName := sdkacctest.RandomWithPrefix("tf-acc-ecs-td-with-network-mode")
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-network-mode")
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -576,10 +595,11 @@ func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -588,9 +608,9 @@ func TestAccECSTaskDefinition_withNetworkMode(t *testing.T) {
 func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix("tf-acc-ecs-td-with-ipc-mode")
-	policyName := sdkacctest.RandomWithPrefix("tf-acc-ecs-td-with-ipc-mode")
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-ipc-mode")
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -607,10 +627,11 @@ func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -619,9 +640,9 @@ func TestAccECSTaskDefinition_withIPCMode(t *testing.T) {
 func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix("tf-acc-ecs-td-with-pid-mode")
-	policyName := sdkacctest.RandomWithPrefix("tf-acc-ecs-td-with-pid-mode")
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-with-pid-mode")
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -638,10 +659,11 @@ func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -650,7 +672,7 @@ func TestAccECSTaskDefinition_withPidMode(t *testing.T) {
 func TestAccECSTaskDefinition_constraint(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-constraint")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -668,10 +690,11 @@ func TestAccECSTaskDefinition_constraint(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -681,7 +704,7 @@ func TestAccECSTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 	var before ecs.TaskDefinition
 	var after ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-change-vol-forces-new-resource")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -704,10 +727,11 @@ func TestAccECSTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -718,7 +742,7 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 	var conf ecs.TaskDefinition
 	resourceName := "aws_ecs_task_definition.test"
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-arrays")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -733,10 +757,11 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -745,7 +770,7 @@ func TestAccECSTaskDefinition_arrays(t *testing.T) {
 func TestAccECSTaskDefinition_fargate(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-fargate")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -764,10 +789,11 @@ func TestAccECSTaskDefinition_fargate(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 			{
 				ExpectNonEmptyPlan: false,
@@ -781,7 +807,7 @@ func TestAccECSTaskDefinition_fargate(t *testing.T) {
 func TestAccECSTaskDefinition_Fargate_ephemeralStorage(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-fargate")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -802,10 +828,11 @@ func TestAccECSTaskDefinition_Fargate_ephemeralStorage(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -814,9 +841,9 @@ func TestAccECSTaskDefinition_Fargate_ephemeralStorage(t *testing.T) {
 func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	roleName := sdkacctest.RandomWithPrefix("tf-acc-role-ecs-td-execution-role")
-	policyName := sdkacctest.RandomWithPrefix("tf-acc-policy-ecs-td-execution-role")
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-execution-role")
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -832,10 +859,11 @@ func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -845,7 +873,7 @@ func TestAccECSTaskDefinition_executionRole(t *testing.T) {
 func TestAccECSTaskDefinition_disappears(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-basic")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -890,10 +918,11 @@ func TestAccECSTaskDefinition_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 			{
 				Config: testAccTaskDefinitionTags2Config(rName, "key1", "value1updated", "key2", "value2"),
@@ -945,10 +974,11 @@ func TestAccECSTaskDefinition_proxy(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -957,7 +987,7 @@ func TestAccECSTaskDefinition_proxy(t *testing.T) {
 func TestAccECSTaskDefinition_inferenceAccelerator(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	tdName := sdkacctest.RandomWithPrefix("tf-acc-td-basic")
+	tdName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -974,10 +1004,11 @@ func TestAccECSTaskDefinition_inferenceAccelerator(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #258
Closes #11506
Relates #4198
Relates #6314
Relates #11997

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS='TestAccECSTaskDefinition_' PKG=ecs TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_' -short -timeout 180m
--- SKIP: TestAccECSTaskDefinition_fsxWinFileSystem (0.00s)
--- PASS: TestAccECSTaskDefinition_arrays (24.10s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (24.13s)
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (24.23s)
--- PASS: TestAccECSTaskDefinition_constraint (24.88s)
--- PASS: TestAccECSTaskDefinition_ipcMode (28.09s)
--- PASS: TestAccECSTaskDefinition_networkMode (28.38s)
--- PASS: TestAccECSTaskDefinition_pidMode (28.43s)
--- PASS: TestAccECSTaskDefinition_executionRole (28.47s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (28.48s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (34.93s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (37.64s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (37.95s)
--- PASS: TestAccECSTaskDefinition_disappears (38.00s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (38.10s)
--- PASS: TestAccECSTaskDefinition_proxy (38.29s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (41.58s)
--- PASS: TestAccECSTaskDefinition_basic (41.73s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (43.02s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (21.67s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (22.78s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (22.76s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (22.16s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (20.25s)
--- PASS: TestAccECSTaskDefinition_runtimePlatform (20.43s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (20.77s)
--- PASS: TestAccECSTaskDefinition_tags (60.77s)
--- PASS: TestAccECSTaskDefinition_service (120.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	122.071s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS='TestAccECSTaskDefinition_' PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_'  -timeout 180m
--- SKIP: TestAccECSTaskDefinition_fsxWinFileSystem (0.00s)
--- SKIP: TestAccECSTaskDefinition_runtimePlatform (1.34s)
--- SKIP: TestAccECSTaskDefinition_inferenceAccelerator (12.32s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (29.91s)
--- PASS: TestAccECSTaskDefinition_arrays (29.94s)
--- SKIP: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (0.00s)
--- SKIP: TestAccECSTaskDefinition_Fargate_runtimePlatform (0.00s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (30.00s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (30.02s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (30.02s)
--- PASS: TestAccECSTaskDefinition_executionRole (34.90s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (34.98s)
--- PASS: TestAccECSTaskDefinition_networkMode (35.14s)
--- PASS: TestAccECSTaskDefinition_constraint (25.04s)
--- PASS: TestAccECSTaskDefinition_proxy (39.67s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (40.00s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (40.11s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (40.15s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (41.10s)
--- PASS: TestAccECSTaskDefinition_disappears (41.33s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (45.01s)
--- PASS: TestAccECSTaskDefinition_basic (45.03s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (43.82s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (20.00s)
--- PASS: TestAccECSTaskDefinition_ipcMode (24.77s)
--- PASS: TestAccECSTaskDefinition_pidMode (24.95s)
--- PASS: TestAccECSTaskDefinition_tags (63.56s)
--- PASS: TestAccECSTaskDefinition_service (118.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	119.481s
```