### PR TITLE
r/aws_sns_platform_application: Skip errors in unsupported regions

### DIFF
--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -149,7 +149,7 @@ func SkipSweepError(err error) bool {
 		return true
 	}
 	// Ignore unsupported API calls
-	if tfawserr.ErrMessageContains(err, "UnsupportedOperation", "") {
+	if tfawserr.ErrCodeEquals(err, "UnsupportedOperation") {
 		return true
 	}
 	// Ignore more unsupported API calls
@@ -165,11 +165,15 @@ func SkipSweepError(err error) bool {
 	// AccessDeniedException:
 	// Since acceptance test sweepers are best effort and this response is very common,
 	// we allow bypassing this error globally instead of individual test sweeper fixes.
-	if tfawserr.ErrMessageContains(err, "AccessDeniedException", "") {
+	if tfawserr.ErrCodeEquals(err, "AccessDeniedException") {
 		return true
 	}
 	// Example: BadRequestException: vpc link not supported for region us-gov-west-1
 	if tfawserr.ErrMessageContains(err, "BadRequestException", "not supported") {
+		return true
+	}
+	// Example: InvalidAction: InvalidAction: Operation (ListPlatformApplications) is not supported in this region
+	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not supported in this region") {
 		return true
 	}
 	// Example: InvalidAction: The action DescribeTransitGatewayAttachments is not valid for this web service


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Currently the `aws_sns_platform_application` sweeper fails in `us-east-2` with:

```console
% make sweep SWEEPARGS=-sweep-run=aws_sns_platform_application SWEEP=us-east-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-2 -sweep-run=aws_sns_platform_application -timeout 60m
2021/12/17 11:23:58 [DEBUG] Running Sweepers for region (us-east-2):
2021/12/17 11:23:58 [DEBUG] Running Sweeper (aws_sns_platform_application) in region (us-east-2)
2021/12/17 11:23:58 [INFO] AWS Auth provider used: "EnvProvider"
2021/12/17 11:23:58 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/12/17 11:23:58 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/12/17 11:23:58 [DEBUG] Completed Sweeper (aws_sns_platform_application) in region (us-east-2) in 822.767995ms
2021/12/17 11:23:58 [ERROR] Error running Sweeper (aws_sns_platform_application) in region (us-east-2): 1 error occurred:
	* error retrieving SNS Platform Applications: InvalidAction: Operation (ListPlatformApplications) is not supported in this region
	status code: 400, request id: a25b03dc-4db4-5365-b267-59eaf66a7dcc

FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	6.051s
FAIL
make: *** [sweep] Error 1
```

Now:

```console
% make sweep SWEEPARGS=-sweep-run=aws_sns_platform_application SWEEP=us-east-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-2 -sweep-run=aws_sns_platform_application -timeout 60m
2021/12/17 11:29:13 [DEBUG] Running Sweepers for region (us-east-2):
2021/12/17 11:29:13 [DEBUG] Running Sweeper (aws_sns_platform_application) in region (us-east-2)
2021/12/17 11:29:13 [INFO] AWS Auth provider used: "EnvProvider"
2021/12/17 11:29:13 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/12/17 11:29:14 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2021/12/17 11:29:14 [WARN] Skipping SNS Platform Applications sweep for us-east-2: InvalidAction: Operation (ListPlatformApplications) is not supported in this region
	status code: 400, request id: fc065aa3-0884-52f0-8c79-0095b59e5dc0
2021/12/17 11:29:14 [DEBUG] Completed Sweeper (aws_sns_platform_application) in region (us-east-2) in 958.846744ms
2021/12/17 11:29:14 Completed Sweepers for region (us-east-2) in 959.056387ms
2021/12/17 11:29:14 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_sns_platform_application
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	5.799s
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
