### PR TITLE
Increase rules and destination limits for aws_ecr_replication_configuration

### DIFF
--- a/.changelog/22281.txt
+++ b/.changelog/22281.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+resource/aws_ecr_replication_configuration: increase rules and destinations
+```

--- a/.changelog/22281.txt
+++ b/.changelog/22281.txt
@@ -1,3 +1,3 @@
-```release-note:feature
-resource/aws_ecr_replication_configuration: increase rules and destinations
+```release-note:enhancement
+resource/aws_ecr_replication_configuration: Increase `MaxItems` for `rule` to `10` and for `destination` to `25`
 ```

--- a/internal/service/ecr/replication_configuration.go
+++ b/internal/service/ecr/replication_configuration.go
@@ -36,12 +36,13 @@ func ResourceReplicationConfiguration() *schema.Resource {
 						"rule": {
 							Type:     schema.TypeList,
 							Required: true,
-							MaxItems: 1,
+							MaxItems: 10,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"destination": {
 										Type:     schema.TypeList,
 										Required: true,
+										MaxItems: 25,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"region": {

--- a/website/docs/r/ecr_replication_configuration.html.markdown
+++ b/website/docs/r/ecr_replication_configuration.html.markdown
@@ -85,11 +85,11 @@ The following arguments are supported:
 
 ### Replication Configuration
 
-* `rule` - (Required) The replication rules for a replication configuration. See [Rule](#rule).
+* `rule` - (Required) The replication rules for a replication configuration. A maximum of 10 are allowed per `replication_configuration`. See [Rule](#rule)
 
 ### Rule
 
-* `destination` - (Required) the details of a replication destination. See [Destination](#destination).
+* `destination` - (Required) the details of a replication destination. A maximum of 25 are allowed per `rule`. See [Destination](#destination).
 * `repository_filter` - (Optional) filters for a replication rule. See [Repository Filter](#repository-filter).
 
 ### Destination


### PR DESCRIPTION
### Description
This Pull Request increases the rules and destination limits for the `aws_ecr_replication_configuration`. The replication configuration can contain up to 10 rules, and each rule can contain up to 25 destinations.

* [AWS ECR API Documentation for ReplicationConfig Rule limits](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ReplicationConfiguration.html)
* [AWS ECR API Documentation for ReplicationRule Destination Limits](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ReplicationRule.html)

This PR only encompasses resource schema updates to allow us to match the limits that have been declared by the AWS API.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes [#21898](https://github.com/hashicorp/terraform-provider-aws/issues/21898)

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccECRReplicationConfiguration_' PKG_NAME=internal/service/ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run=TestAccECRReplicationConfiguration_ -timeout 180m
=== RUN   TestAccECRReplicationConfiguration_basic
=== PAUSE TestAccECRReplicationConfiguration_basic
=== CONT  TestAccECRReplicationConfiguration_basic
--- PASS: TestAccECRReplicationConfiguration_basic (43.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        54.523s
```
### Example Usage of Multiple Replication Rules with Multiple Destinations
#### Terraform Configuration

```
data "aws_caller_identity" "current" {}

resource "aws_ecr_replication_configuration" "example" {
  replication_configuration {
    rule {
      destination {
        region      = "us-west-1"
        registry_id = data.aws_caller_identity.current.account_id
      }
      destination {
        region      = "us-west-2"
        registry_id = data.aws_caller_identity.current.account_id
      }
    }
    rule {
      destination {
        region      = "eu-west-1"
        registry_id = data.aws_caller_identity.current.account_id
      }
      destination {
        region      = "eu-west-2"
        registry_id = data.aws_caller_identity.current.account_id
      }
    }
  }
}
```
#### Apply Output
```
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_replication_configuration.example will be created
  + resource "aws_ecr_replication_configuration" "example" {
      + id          = (known after apply)
      + registry_id = (known after apply)

      + replication_configuration {
          + rule {
              + destination {
                  + region      = "us-west-1"
                  + registry_id = "562177434340"
                }
              + destination {
                  + region      = "us-west-2"
                  + registry_id = "562177434340"
                }
            }
          + rule {
              + destination {
                  + region      = "eu-west-1"
                  + registry_id = "562177434340"
                }
              + destination {
                  + region      = "eu-west-2"
                  + registry_id = "562177434340"
                }
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_ecr_replication_configuration.example: Creating...
aws_ecr_replication_configuration.example: Creation complete after 1s [id=562177434340]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```