### PR TITLE
Resource/aws_sqs_queue added redrive policy

### DIFF
--- a/internal/attrmap/attrmap.go
+++ b/internal/attrmap/attrmap.go
@@ -1,4 +1,4 @@
-package create
+package attrmap
 
 import (
 	"fmt"
@@ -6,20 +6,24 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // AttributeMap represents a map of Terraform resource attribute name to AWS API attribute name.
 // Useful for SQS Queue or SNS Topic attribute handling.
 type attributeInfo struct {
-	apiAttributeName   string
-	tfType             schema.ValueType
-	tfOptionalComputed bool
+	apiAttributeName string
+	tfType           schema.ValueType
+	tfComputed       bool
+	tfOptional       bool
+	isIAMPolicy      bool
 }
 
 type AttributeMap map[string]attributeInfo
 
-// AttrMap returns a new AttributeMap from the specified Terraform resource attribute name to AWS API attribute name map and resource schema.
-func AttrMap(attrMap map[string]string, schemaMap map[string]*schema.Schema) AttributeMap {
+// New returns a new AttributeMap from the specified Terraform resource attribute name to AWS API attribute name map and resource schema.
+func New(attrMap map[string]string, schemaMap map[string]*schema.Schema) AttributeMap {
 	attributeMap := make(AttributeMap)
 
 	for tfAttributeName, apiAttributeName := range attrMap {
@@ -29,9 +33,8 @@ func AttrMap(attrMap map[string]string, schemaMap map[string]*schema.Schema) Att
 				tfType:           s.Type,
 			}
 
-			if s.Optional && s.Computed {
-				attributeInfo.tfOptionalComputed = true
-			}
+			attributeInfo.tfComputed = s.Computed
+			attributeInfo.tfOptional = s.Optional
 
 			attributeMap[tfAttributeName] = attributeInfo
 		} else {
@@ -64,6 +67,16 @@ func (m AttributeMap) ApiAttributesToResourceData(apiAttributes map[string]strin
 				}
 			case schema.TypeString:
 				tfAttributeValue = v
+
+				if attributeInfo.isIAMPolicy {
+					policy, err := verify.PolicyToSet(d.Get(tfAttributeName).(string), tfAttributeValue.(string))
+
+					if err != nil {
+						return err
+					}
+
+					tfAttributeValue = policy
+				}
 			default:
 				return fmt.Errorf("attribute %s is of unsupported type: %d", tfAttributeName, t)
 			}
@@ -85,7 +98,13 @@ func (m AttributeMap) ResourceDataToApiAttributesCreate(d *schema.ResourceData) 
 	apiAttributes := map[string]string{}
 
 	for tfAttributeName, attributeInfo := range m {
+		// Purely Computed values aren't specified on creation.
+		if attributeInfo.tfComputed && !attributeInfo.tfOptional {
+			continue
+		}
+
 		var apiAttributeValue string
+		tfOptionalComputed := attributeInfo.tfComputed && attributeInfo.tfOptional
 
 		switch v, t := d.Get(tfAttributeName), attributeInfo.tfType; t {
 		case schema.TypeBool:
@@ -94,11 +113,21 @@ func (m AttributeMap) ResourceDataToApiAttributesCreate(d *schema.ResourceData) 
 			}
 		case schema.TypeInt:
 			// On creation don't specify any zero Optional/Computed attribute integer values.
-			if v := v.(int); !attributeInfo.tfOptionalComputed || v != 0 {
+			if v := v.(int); !tfOptionalComputed || v != 0 {
 				apiAttributeValue = strconv.Itoa(v)
 			}
 		case schema.TypeString:
 			apiAttributeValue = v.(string)
+
+			if attributeInfo.isIAMPolicy && apiAttributeValue != "" {
+				policy, err := structure.NormalizeJsonString(apiAttributeValue)
+
+				if err != nil {
+					return nil, fmt.Errorf("policy (%s) is invalid JSON: %w", apiAttributeValue, err)
+				}
+
+				apiAttributeValue = policy
+			}
 		default:
 			return nil, fmt.Errorf("attribute %s is of unsupported type: %d", tfAttributeName, t)
 		}
@@ -117,6 +146,11 @@ func (m AttributeMap) ResourceDataToApiAttributesUpdate(d *schema.ResourceData) 
 	apiAttributes := map[string]string{}
 
 	for tfAttributeName, attributeInfo := range m {
+		// Purely Computed values aren't specified on update.
+		if attributeInfo.tfComputed && !attributeInfo.tfOptional {
+			continue
+		}
+
 		if d.HasChange(tfAttributeName) {
 			v := d.Get(tfAttributeName)
 
@@ -129,6 +163,16 @@ func (m AttributeMap) ResourceDataToApiAttributesUpdate(d *schema.ResourceData) 
 				apiAttributeValue = strconv.Itoa(v.(int))
 			case schema.TypeString:
 				apiAttributeValue = v.(string)
+
+				if attributeInfo.isIAMPolicy {
+					policy, err := structure.NormalizeJsonString(apiAttributeValue)
+
+					if err != nil {
+						return nil, fmt.Errorf("policy (%s) is invalid JSON: %w", apiAttributeValue, err)
+					}
+
+					apiAttributeValue = policy
+				}
 			default:
 				return nil, fmt.Errorf("attribute %s is of unsupported type: %d", tfAttributeName, t)
 			}
@@ -149,4 +193,15 @@ func (m AttributeMap) ApiAttributeNames() []string {
 	}
 
 	return apiAttributeNames
+}
+
+// WithIAMPolicyAttribute marks the specified Terraform attribute as holding an AWS IAM policy.
+// AWS IAM policies get special handling.
+// This method is intended to be chained with other similar helper methods in a builder pattern.
+func (m AttributeMap) WithIAMPolicyAttribute(tfAttributeName string) AttributeMap {
+	if attributeInfo, ok := m[tfAttributeName]; ok {
+		attributeInfo.isIAMPolicy = true
+	}
+
+	return m
 }

--- a/internal/service/sns/consts.go
+++ b/internal/service/sns/consts.go
@@ -3,3 +3,70 @@ package sns
 const (
 	FIFOTopicNameSuffix = ".fifo"
 )
+
+const (
+	SubscriptionProtocolApplication = "application"
+	SubscriptionProtocolEmail       = "email"
+	SubscriptionProtocolEmailJSON   = "email-json"
+	SubscriptionProtocolFirehose    = "firehose"
+	SubscriptionProtocolHTTP        = "http"
+	SubscriptionProtocolHTTPS       = "https"
+	SubscriptionProtocolLambda      = "lambda"
+	SubscriptionProtocolSMS         = "sms"
+	SubscriptionProtocolSQS         = "sqs"
+)
+
+func SubscriptionProtocol_Values() []string {
+	return []string{
+		SubscriptionProtocolApplication,
+		SubscriptionProtocolEmail,
+		SubscriptionProtocolEmailJSON,
+		SubscriptionProtocolFirehose,
+		SubscriptionProtocolHTTP,
+		SubscriptionProtocolHTTPS,
+		SubscriptionProtocolLambda,
+		SubscriptionProtocolSMS,
+		SubscriptionProtocolSQS,
+	}
+}
+
+const (
+	SubscriptionAttributeNameConfirmationWasAuthenticated = "ConfirmationWasAuthenticated"
+	SubscriptionAttributeNameDeliveryPolicy               = "DeliveryPolicy"
+	SubscriptionAttributeNameEndpoint                     = "Endpoint"
+	SubscriptionAttributeNameFilterPolicy                 = "FilterPolicy"
+	SubscriptionAttributeNameOwner                        = "Owner"
+	SubscriptionAttributeNamePendingConfirmation          = "PendingConfirmation"
+	SubscriptionAttributeNameProtocol                     = "Protocol"
+	SubscriptionAttributeNameRawMessageDelivery           = "RawMessageDelivery"
+	SubscriptionAttributeNameRedrivePolicy                = "RedrivePolicy"
+	SubscriptionAttributeNameSubscriptionArn              = "SubscriptionArn"
+	SubscriptionAttributeNameSubscriptionRoleArn          = "SubscriptionRoleArn"
+	SubscriptionAttributeNameTopicArn                     = "TopicArn"
+)
+
+const (
+	TopicAttributeNameApplicationFailureFeedbackRoleArn    = "ApplicationFailureFeedbackRoleArn"
+	TopicAttributeNameApplicationSuccessFeedbackRoleArn    = "ApplicationSuccessFeedbackRoleArn"
+	TopicAttributeNameApplicationSuccessFeedbackSampleRate = "ApplicationSuccessFeedbackSampleRate"
+	TopicAttributeNameContentBasedDeduplication            = "ContentBasedDeduplication"
+	TopicAttributeNameDeliveryPolicy                       = "DeliveryPolicy"
+	TopicAttributeNameDisplayName                          = "DisplayName"
+	TopicAttributeNameFifoTopic                            = "FifoTopic"
+	TopicAttributeNameFirehoseFailureFeedbackRoleArn       = "FirehoseFailureFeedbackRoleArn"
+	TopicAttributeNameFirehoseSuccessFeedbackRoleArn       = "FirehoseSuccessFeedbackRoleArn"
+	TopicAttributeNameFirehoseSuccessFeedbackSampleRate    = "FirehoseSuccessFeedbackSampleRate"
+	TopicAttributeNameHTTPFailureFeedbackRoleArn           = "HTTPFailureFeedbackRoleArn"
+	TopicAttributeNameHTTPSuccessFeedbackRoleArn           = "HTTPSuccessFeedbackRoleArn"
+	TopicAttributeNameHTTPSuccessFeedbackSampleRate        = "HTTPSuccessFeedbackSampleRate"
+	TopicAttributeNameKmsMasterKeyId                       = "KmsMasterKeyId"
+	TopicAttributeNameLambdaFailureFeedbackRoleArn         = "LambdaFailureFeedbackRoleArn"
+	TopicAttributeNameLambdaSuccessFeedbackRoleArn         = "LambdaSuccessFeedbackRoleArn"
+	TopicAttributeNameLambdaSuccessFeedbackSampleRate      = "LambdaSuccessFeedbackSampleRate"
+	TopicAttributeNameOwner                                = "Owner"
+	TopicAttributeNamePolicy                               = "Policy"
+	TopicAttributeNameSQSFailureFeedbackRoleArn            = "SQSFailureFeedbackRoleArn"
+	TopicAttributeNameSQSSuccessFeedbackRoleArn            = "SQSSuccessFeedbackRoleArn"
+	TopicAttributeNameSQSSuccessFeedbackSampleRate         = "SQSSuccessFeedbackSampleRate"
+	TopicAttributeNameTopicArn                             = "TopicArn"
+)

--- a/internal/service/sns/find.go
+++ b/internal/service/sns/find.go
@@ -4,23 +4,56 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func FindSubscriptionByARN(conn *sns.SNS, id string) (*sns.GetSubscriptionAttributesOutput, error) {
-	output, err := conn.GetSubscriptionAttributes(&sns.GetSubscriptionAttributesInput{
-		SubscriptionArn: aws.String(id),
-	})
+func FindSubscriptionAttributesByARN(conn *sns.SNS, arn string) (map[string]string, error) {
+	input := &sns.GetSubscriptionAttributesInput{
+		SubscriptionArn: aws.String(arn),
+	}
+
+	output, err := conn.GetSubscriptionAttributes(input)
+
 	if tfawserr.ErrCodeEquals(err, sns.ErrCodeNotFoundException) {
-		return nil, nil
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || output.Attributes == nil || len(output.Attributes) == 0 {
-		return nil, nil
+	if output == nil || len(output.Attributes) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return output, nil
+	return aws.StringValueMap(output.Attributes), nil
+}
+
+func FindTopicAttributesByARN(conn *sns.SNS, arn string) (map[string]string, error) {
+	input := &sns.GetTopicAttributesInput{
+		TopicArn: aws.String(arn),
+	}
+
+	output, err := conn.GetTopicAttributes(input)
+
+	if tfawserr.ErrCodeEquals(err, sns.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Attributes) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return aws.StringValueMap(output.Attributes), nil
 }

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/attrmap"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 )
 
 func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
@@ -114,7 +114,7 @@ var (
 		},
 	}
 
-	SMSPreferencesAttributeMap = create.AttrMap(map[string]string{
+	SMSPreferencesAttributeMap = attrmap.New(map[string]string{
 		"default_sender_id":                     "DefaultSenderID",
 		"default_sms_type":                      "DefaultSMSType",
 		"delivery_status_iam_role_arn":          "DeliveryStatusIAMRole",

--- a/internal/service/sns/status.go
+++ b/internal/service/sns/status.go
@@ -1,22 +1,23 @@
 package sns
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func statusSubscriptionPendingConfirmation(conn *sns.SNS, id string) resource.StateRefreshFunc {
+func statusSubscriptionPendingConfirmation(conn *sns.SNS, arn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindSubscriptionByARN(conn, id)
+		output, err := FindSubscriptionAttributesByARN(conn, arn)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
 		if err != nil {
 			return nil, "", err
 		}
 
-		if output == nil {
-			return nil, "", nil
-		}
-
-		return output, aws.StringValue(output.Attributes["PendingConfirmation"]), nil
+		return output, output[SubscriptionAttributeNamePendingConfirmation], nil
 	}
 }

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -5,21 +5,192 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/attrmap"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+var (
+	topicSchema = map[string]*schema.Schema{
+		"application_failure_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"application_success_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"application_success_feedback_sample_rate": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 100),
+		},
+		"arn": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"content_based_deduplication": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"delivery_policy": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ForceNew:         false,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+			StateFunc: func(v interface{}) string {
+				json, _ := structure.NormalizeJsonString(v)
+				return json
+			},
+		},
+		"display_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"fifo_topic": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+			ForceNew: true,
+		},
+		"firehose_failure_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"firehose_success_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"firehose_success_feedback_sample_rate": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 100),
+		},
+		"http_failure_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"http_success_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"http_success_feedback_sample_rate": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 100),
+		},
+		"kms_master_key_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"lambda_failure_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"lambda_success_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"lambda_success_feedback_sample_rate": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 100),
+		},
+		"name": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"name_prefix"},
+		},
+		"name_prefix": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"name"},
+		},
+		"owner": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"policy": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+			StateFunc: func(v interface{}) string {
+				json, _ := structure.NormalizeJsonString(v)
+				return json
+			},
+		},
+		"sqs_failure_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"sqs_success_feedback_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"sqs_success_feedback_sample_rate": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 100),
+		},
+		"tags":     tftags.TagsSchema(),
+		"tags_all": tftags.TagsSchemaComputed(),
+	}
+
+	topicAttributeMap = attrmap.New(map[string]string{
+		"application_failure_feedback_role_arn":    TopicAttributeNameApplicationFailureFeedbackRoleArn,
+		"application_success_feedback_role_arn":    TopicAttributeNameApplicationSuccessFeedbackRoleArn,
+		"application_success_feedback_sample_rate": TopicAttributeNameApplicationSuccessFeedbackSampleRate,
+		"arn":                                   TopicAttributeNameTopicArn,
+		"content_based_deduplication":           TopicAttributeNameContentBasedDeduplication,
+		"delivery_policy":                       TopicAttributeNameDeliveryPolicy,
+		"display_name":                          TopicAttributeNameDisplayName,
+		"fifo_topic":                            TopicAttributeNameFifoTopic,
+		"firehose_failure_feedback_role_arn":    TopicAttributeNameFirehoseFailureFeedbackRoleArn,
+		"firehose_success_feedback_role_arn":    TopicAttributeNameFirehoseSuccessFeedbackRoleArn,
+		"firehose_success_feedback_sample_rate": TopicAttributeNameFirehoseSuccessFeedbackSampleRate,
+		"http_failure_feedback_role_arn":        TopicAttributeNameHTTPFailureFeedbackRoleArn,
+		"http_success_feedback_role_arn":        TopicAttributeNameHTTPSuccessFeedbackRoleArn,
+		"http_success_feedback_sample_rate":     TopicAttributeNameHTTPSuccessFeedbackSampleRate,
+		"kms_master_key_id":                     TopicAttributeNameKmsMasterKeyId,
+		"lambda_failure_feedback_role_arn":      TopicAttributeNameLambdaFailureFeedbackRoleArn,
+		"lambda_success_feedback_role_arn":      TopicAttributeNameLambdaSuccessFeedbackRoleArn,
+		"lambda_success_feedback_sample_rate":   TopicAttributeNameLambdaSuccessFeedbackSampleRate,
+		"owner":                                 TopicAttributeNameOwner,
+		"policy":                                TopicAttributeNamePolicy,
+		"sqs_failure_feedback_role_arn":         TopicAttributeNameSQSFailureFeedbackRoleArn,
+		"sqs_success_feedback_role_arn":         TopicAttributeNameSQSSuccessFeedbackRoleArn,
+		"sqs_success_feedback_sample_rate":      TopicAttributeNameSQSSuccessFeedbackSampleRate,
+	}, topicSchema).WithIAMPolicyAttribute("policy")
 )
 
 func ResourceTopic() *schema.Resource {
@@ -36,148 +207,7 @@ func ResourceTopic() *schema.Resource {
 			verify.SetTagsDiff,
 		),
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"name_prefix"},
-			},
-			"name_prefix": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"name"},
-			},
-			"display_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
-				},
-			},
-			"delivery_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         false,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
-				},
-			},
-			"application_success_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"application_success_feedback_sample_rate": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			"application_failure_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"http_success_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"http_success_feedback_sample_rate": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			"http_failure_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"kms_master_key_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"fifo_topic": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-			"content_based_deduplication": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"firehose_success_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"firehose_success_feedback_sample_rate": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			"firehose_failure_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"lambda_success_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"lambda_success_feedback_sample_rate": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			"lambda_failure_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"sqs_success_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"sqs_success_feedback_sample_rate": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
-			},
-			"sqs_failure_feedback_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
-		},
+		Schema: topicSchema,
 	}
 }
 
@@ -188,322 +218,48 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var name string
 	fifoTopic := d.Get("fifo_topic").(bool)
-
 	if fifoTopic {
 		name = create.NameWithSuffix(d.Get("name").(string), d.Get("name_prefix").(string), FIFOTopicNameSuffix)
 	} else {
 		name = create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	}
 
-	attributes := make(map[string]*string)
-	// If FifoTopic is true, then the attribute must be passed into the call to CreateTopic
-	if fifoTopic {
-		attributes["FifoTopic"] = aws.String(strconv.FormatBool(fifoTopic))
-	}
-
-	log.Printf("[DEBUG] SNS create topic: %s", name)
-
-	req := &sns.CreateTopicInput{
+	input := &sns.CreateTopicInput{
 		Name: aws.String(name),
-		Tags: Tags(tags.IgnoreAWS()),
 	}
 
-	if len(attributes) > 0 {
-		req.Attributes = attributes
+	attributes, err := topicAttributeMap.ResourceDataToApiAttributesCreate(d)
+
+	if err != nil {
+		return err
 	}
 
-	output, err := conn.CreateTopic(req)
+	// The FifoTopic attribute must be passed in the call to CreateTopic.
+	if v, ok := attributes[TopicAttributeNameFifoTopic]; ok {
+		input.Attributes = aws.StringMap(map[string]string{
+			TopicAttributeNameFifoTopic: v,
+		})
+
+		delete(attributes, TopicAttributeNameFifoTopic)
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	log.Printf("[DEBUG] Creating SNS Topic: %s", input)
+	output, err := conn.CreateTopic(input)
+
 	if err != nil {
 		return fmt.Errorf("error creating SNS Topic (%s): %w", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.TopicArn))
 
-	// update mutable attributes
-	if d.HasChange("application_failure_feedback_role_arn") {
-		_, v := d.GetChange("application_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "ApplicationFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("application_success_feedback_role_arn") {
-		_, v := d.GetChange("application_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "ApplicationSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("arn") {
-		_, v := d.GetChange("arn")
-		if err := updateTopicAttribute(d.Id(), "TopicArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("delivery_policy") {
-		_, v := d.GetChange("delivery_policy")
-		if err := updateTopicAttribute(d.Id(), "DeliveryPolicy", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("display_name") {
-		_, v := d.GetChange("display_name")
-		if err := updateTopicAttribute(d.Id(), "DisplayName", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("http_failure_feedback_role_arn") {
-		_, v := d.GetChange("http_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "HTTPFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("http_success_feedback_role_arn") {
-		_, v := d.GetChange("http_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "HTTPSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("kms_master_key_id") {
-		_, v := d.GetChange("kms_master_key_id")
-		if err := updateTopicAttribute(d.Id(), "KmsMasterKeyId", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("content_based_deduplication") {
-		_, v := d.GetChange("content_based_deduplication")
-		if err := updateTopicAttribute(d.Id(), "ContentBasedDeduplication", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("lambda_failure_feedback_role_arn") {
-		_, v := d.GetChange("lambda_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "LambdaFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("lambda_success_feedback_role_arn") {
-		_, v := d.GetChange("lambda_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "LambdaSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("policy") {
-		_, v := d.GetChange("policy")
+	err = putTopicAttributes(conn, d.Id(), attributes)
 
-		policy, err := structure.NormalizeJsonString(v.(string))
-
-		if err != nil {
-			return fmt.Errorf("policy (%s) is invalid JSON: %w", v.(string), err)
-		}
-
-		if err := updateTopicAttribute(d.Id(), "Policy", policy, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("sqs_failure_feedback_role_arn") {
-		_, v := d.GetChange("sqs_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "SQSFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("sqs_success_feedback_role_arn") {
-		_, v := d.GetChange("sqs_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "SQSSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("application_success_feedback_sample_rate") {
-		_, v := d.GetChange("application_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "ApplicationSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("http_success_feedback_sample_rate") {
-		_, v := d.GetChange("http_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "HTTPSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("lambda_success_feedback_sample_rate") {
-		_, v := d.GetChange("lambda_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "LambdaSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("sqs_success_feedback_sample_rate") {
-		_, v := d.GetChange("sqs_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "SQSSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("firehose_failure_feedback_role_arn") {
-		_, v := d.GetChange("firehose_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "FirehoseFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("firehose_success_feedback_role_arn") {
-		_, v := d.GetChange("firehose_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "FirehoseSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("firehose_success_feedback_sample_rate") {
-		_, v := d.GetChange("firehose_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "FirehoseSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-
-	return resourceTopicRead(d, meta)
-}
-
-func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).SNSConn
-
-	// update mutable attributes
-	if d.HasChange("application_failure_feedback_role_arn") {
-		_, v := d.GetChange("application_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "ApplicationFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("application_success_feedback_role_arn") {
-		_, v := d.GetChange("application_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "ApplicationSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("arn") {
-		_, v := d.GetChange("arn")
-		if err := updateTopicAttribute(d.Id(), "TopicArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("delivery_policy") {
-		_, v := d.GetChange("delivery_policy")
-		if err := updateTopicAttribute(d.Id(), "DeliveryPolicy", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("display_name") {
-		_, v := d.GetChange("display_name")
-		if err := updateTopicAttribute(d.Id(), "DisplayName", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("http_failure_feedback_role_arn") {
-		_, v := d.GetChange("http_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "HTTPFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("http_success_feedback_role_arn") {
-		_, v := d.GetChange("http_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "HTTPSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("kms_master_key_id") {
-		_, v := d.GetChange("kms_master_key_id")
-		if err := updateTopicAttribute(d.Id(), "KmsMasterKeyId", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("content_based_deduplication") {
-		_, v := d.GetChange("content_based_deduplication")
-		if err := updateTopicAttribute(d.Id(), "ContentBasedDeduplication", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("lambda_failure_feedback_role_arn") {
-		_, v := d.GetChange("lambda_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "LambdaFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("lambda_success_feedback_role_arn") {
-		_, v := d.GetChange("lambda_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "LambdaSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("policy") {
-		o, n := d.GetChange("policy")
-
-		if equivalent, err := awspolicy.PoliciesAreEquivalent(o.(string), n.(string)); err != nil || !equivalent {
-			policy, err := structure.NormalizeJsonString(n.(string))
-
-			if err != nil {
-				return fmt.Errorf("policy contains an invalid JSON: %s", err)
-			}
-
-			if err := updateTopicAttribute(d.Id(), "Policy", policy, conn); err != nil {
-				return err
-			}
-		}
-	}
-
-	if d.HasChange("sqs_failure_feedback_role_arn") {
-		_, v := d.GetChange("sqs_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "SQSFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("sqs_success_feedback_role_arn") {
-		_, v := d.GetChange("sqs_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "SQSSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("application_success_feedback_sample_rate") {
-		_, v := d.GetChange("application_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "ApplicationSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("http_success_feedback_sample_rate") {
-		_, v := d.GetChange("http_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "HTTPSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("lambda_success_feedback_sample_rate") {
-		_, v := d.GetChange("lambda_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "LambdaSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("sqs_success_feedback_sample_rate") {
-		_, v := d.GetChange("sqs_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "SQSSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("firehose_failure_feedback_role_arn") {
-		_, v := d.GetChange("firehose_failure_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "FirehoseFailureFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("firehose_success_feedback_role_arn") {
-		_, v := d.GetChange("firehose_success_feedback_role_arn")
-		if err := updateTopicAttribute(d.Id(), "FirehoseSuccessFeedbackRoleArn", v, conn); err != nil {
-			return err
-		}
-	}
-	if d.HasChange("firehose_success_feedback_sample_rate") {
-		_, v := d.GetChange("firehose_success_feedback_sample_rate")
-		if err := updateTopicAttribute(d.Id(), "FirehoseSuccessFeedbackSampleRate", v, conn); err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %w", err)
-		}
+	if err != nil {
+		return err
 	}
 
 	return resourceTopicRead(d, meta)
@@ -514,12 +270,9 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	log.Printf("[DEBUG] Reading SNS Topic Attributes for %s", d.Id())
-	attributeOutput, err := conn.GetTopicAttributes(&sns.GetTopicAttributesInput{
-		TopicArn: aws.String(d.Id()),
-	})
+	attributes, err := FindTopicAttributesByARN(conn, d.Id())
 
-	if tfawserr.ErrMessageContains(err, sns.ErrCodeNotFoundException, "") {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SNS Topic (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -529,96 +282,11 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading SNS Topic (%s): %w", d.Id(), err)
 	}
 
-	fifoTopic := false
+	err = topicAttributeMap.ApiAttributesToResourceData(attributes, d)
 
-	// set the mutable attributes
-	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
-		// set the string values
-		d.Set("application_failure_feedback_role_arn", attributeOutput.Attributes["ApplicationFailureFeedbackRoleArn"])
-		d.Set("application_success_feedback_role_arn", attributeOutput.Attributes["ApplicationSuccessFeedbackRoleArn"])
-		d.Set("arn", attributeOutput.Attributes["TopicArn"])
-		d.Set("delivery_policy", attributeOutput.Attributes["DeliveryPolicy"])
-		d.Set("display_name", attributeOutput.Attributes["DisplayName"])
-		d.Set("http_failure_feedback_role_arn", attributeOutput.Attributes["HTTPFailureFeedbackRoleArn"])
-		d.Set("http_success_feedback_role_arn", attributeOutput.Attributes["HTTPSuccessFeedbackRoleArn"])
-		d.Set("kms_master_key_id", attributeOutput.Attributes["KmsMasterKeyId"])
-		d.Set("lambda_failure_feedback_role_arn", attributeOutput.Attributes["LambdaFailureFeedbackRoleArn"])
-		d.Set("lambda_success_feedback_role_arn", attributeOutput.Attributes["LambdaSuccessFeedbackRoleArn"])
-		d.Set("sqs_failure_feedback_role_arn", attributeOutput.Attributes["SQSFailureFeedbackRoleArn"])
-		d.Set("sqs_success_feedback_role_arn", attributeOutput.Attributes["SQSSuccessFeedbackRoleArn"])
-		d.Set("firehose_success_feedback_role_arn", attributeOutput.Attributes["FirehoseSuccessFeedbackRoleArn"])
-		d.Set("firehose_failure_feedback_role_arn", attributeOutput.Attributes["FirehoseFailureFeedbackRoleArn"])
-		d.Set("owner", attributeOutput.Attributes["Owner"])
-
-		policyToSet, policyErr := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(attributeOutput.Attributes["Policy"]))
-
-		if policyErr != nil {
-			return err
-		}
-
-		d.Set("policy", policyToSet)
-
-		// set the boolean values
-		if v, ok := attributeOutput.Attributes["FifoTopic"]; ok && aws.StringValue(v) == "true" {
-			fifoTopic = true
-		}
-		d.Set("content_based_deduplication", false)
-		if v, ok := attributeOutput.Attributes["ContentBasedDeduplication"]; ok && aws.StringValue(v) == "true" {
-			d.Set("content_based_deduplication", true)
-		}
-
-		// set the number values
-		var vStr string
-		var v int64
-		var err error
-
-		vStr = aws.StringValue(attributeOutput.Attributes["ApplicationSuccessFeedbackSampleRate"])
-		if vStr != "" {
-			v, err = strconv.ParseInt(vStr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("error parsing integer attribute 'ApplicationSuccessFeedbackSampleRate': %w", err)
-			}
-			d.Set("application_success_feedback_sample_rate", v)
-		}
-
-		vStr = aws.StringValue(attributeOutput.Attributes["HTTPSuccessFeedbackSampleRate"])
-		if vStr != "" {
-			v, err = strconv.ParseInt(vStr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("error parsing integer attribute 'HTTPSuccessFeedbackSampleRate': %w", err)
-			}
-			d.Set("http_success_feedback_sample_rate", v)
-		}
-
-		vStr = aws.StringValue(attributeOutput.Attributes["LambdaSuccessFeedbackSampleRate"])
-		if vStr != "" {
-			v, err = strconv.ParseInt(vStr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("error parsing integer attribute 'LambdaSuccessFeedbackSampleRate': %w", err)
-			}
-			d.Set("lambda_success_feedback_sample_rate", v)
-		}
-
-		vStr = aws.StringValue(attributeOutput.Attributes["SQSSuccessFeedbackSampleRate"])
-		if vStr != "" {
-			v, err = strconv.ParseInt(vStr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("error parsing integer attribute 'SQSSuccessFeedbackSampleRate': %w", err)
-			}
-			d.Set("sqs_success_feedback_sample_rate", v)
-		}
-
-		vStr = aws.StringValue(attributeOutput.Attributes["FirehoseSuccessFeedbackSampleRate"])
-		if vStr != "" {
-			v, err = strconv.ParseInt(vStr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("error parsing integer attribute 'FirehoseSuccessFeedbackSampleRate': %w", err)
-			}
-			d.Set("firehose_success_feedback_sample_rate", v)
-		}
+	if err != nil {
+		return err
 	}
-
-	d.Set("fifo_topic", fifoTopic)
 
 	arn, err := arn.Parse(d.Id())
 
@@ -628,7 +296,7 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 
 	name := arn.Resource
 	d.Set("name", name)
-	if fifoTopic {
+	if d.Get("fifo_topic").(bool) {
 		d.Set("name_prefix", create.NamePrefixFromNameWithSuffix(name, FIFOTopicNameSuffix))
 	} else {
 		d.Set("name_prefix", create.NamePrefixFromName(name))
@@ -654,18 +322,46 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
+func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SNSConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		attributes, err := topicAttributeMap.ResourceDataToApiAttributesUpdate(d)
+
+		if err != nil {
+			return err
+		}
+
+		err = putTopicAttributes(conn, d.Id(), attributes)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %w", err)
+		}
+	}
+
+	return resourceTopicRead(d, meta)
+}
+
 func resourceTopicDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	log.Printf("[DEBUG] SNS Delete Topic: %s", d.Id())
+	log.Printf("[DEBUG] Deleting SNS Topic: %s", d.Id())
 	_, err := conn.DeleteTopic(&sns.DeleteTopicInput{
 		TopicArn: aws.String(d.Id()),
 	})
 
+	if tfawserr.ErrCodeEquals(err, sns.ErrCodeNotFoundException) {
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, sns.ErrCodeNotFoundException, "") {
-			return nil
-		}
 		return fmt.Errorf("error deleting SNS Topic (%s): %w", d.Id(), err)
 	}
 
@@ -708,29 +404,37 @@ func resourceTopicCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, me
 	return nil
 }
 
-func updateTopicAttribute(topicArn, name string, value interface{}, conn *sns.SNS) error {
-	// Ignore an empty policy
-	if name == "Policy" && value == "" {
-		return nil
-	}
-	log.Printf("[DEBUG] Updating SNS Topic Attribute: %s", name)
+func putTopicAttributes(conn *sns.SNS, arn string, attributes map[string]string) error {
+	for name, value := range attributes {
+		// Ignore an empty policy.
+		if name == TopicAttributeNamePolicy && value == "" {
+			continue
+		}
 
-	// Make API call to update attributes
-	req := sns.SetTopicAttributesInput{
-		TopicArn:       aws.String(topicArn),
+		err := putTopicAttribute(conn, arn, name, value)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func putTopicAttribute(conn *sns.SNS, arn string, name, value string) error {
+	input := &sns.SetTopicAttributesInput{
 		AttributeName:  aws.String(name),
-		AttributeValue: aws.String(fmt.Sprintf("%v", value)),
+		AttributeValue: aws.String(value),
+		TopicArn:       aws.String(arn),
 	}
 
-	// Retry the update in the event of an eventually consistent style of
-	// error, where say an IAM resource is successfully created but not
-	// actually available. See https://github.com/hashicorp/terraform/issues/3660
-	_, err := verify.RetryOnAWSCode(sns.ErrCodeInvalidParameterException, func() (interface{}, error) {
-		return conn.SetTopicAttributes(&req)
-	})
+	log.Printf("[DEBUG] Setting SNS Topic attribute: %s", input)
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(topicPutAttributeTimeout, func() (interface{}, error) {
+		return conn.SetTopicAttributes(input)
+	}, sns.ErrCodeInvalidParameterException)
 
 	if err != nil {
-		return fmt.Errorf("error setting SNS Topic (%s) attributes: %w", topicArn, err)
+		return fmt.Errorf("error setting SNS Topic (%s) attribute (%s): %w", arn, name, err)
 	}
 
 	return nil

--- a/internal/service/sns/topic_policy.go
+++ b/internal/service/sns/topic_policy.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -32,6 +31,10 @@ func ResourceTopicPolicy() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"policy": {
 				Type:             schema.TypeString,
 				Required:         true,
@@ -42,16 +45,12 @@ func ResourceTopicPolicy() *schema.Resource {
 					return json
 				},
 			},
-			"owner": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
 
 func resourceTopicPolicyUpsert(d *schema.ResourceData, meta interface{}) error {
-	arn := d.Get("arn").(string)
+	conn := meta.(*conns.AWSClient).SNSConn
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
 
@@ -59,23 +58,16 @@ func resourceTopicPolicyUpsert(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
 	}
 
-	req := sns.SetTopicAttributesInput{
-		TopicArn:       aws.String(arn),
-		AttributeName:  aws.String("Policy"),
-		AttributeValue: aws.String(policy),
-	}
+	arn := d.Get("arn").(string)
 
-	d.SetId(arn)
+	err = putTopicPolicy(conn, arn, policy)
 
-	// Retry the update in the event of an eventually consistent style of
-	// error, where say an IAM resource is successfully created but not
-	// actually available. See https://github.com/hashicorp/terraform/issues/3660
-	conn := meta.(*conns.AWSClient).SNSConn
-	_, err = verify.RetryOnAWSCode("InvalidParameter", func() (interface{}, error) {
-		return conn.SetTopicAttributes(&req)
-	})
 	if err != nil {
 		return err
+	}
+
+	if d.IsNewResource() {
+		d.SetId(arn)
 	}
 
 	return resourceTopicPolicyRead(d, meta)
@@ -84,69 +76,57 @@ func resourceTopicPolicyUpsert(d *schema.ResourceData, meta interface{}) error {
 func resourceTopicPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	attributeOutput, err := conn.GetTopicAttributes(&sns.GetTopicAttributesInput{
-		TopicArn: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrMessageContains(err, sns.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] SNS Topic (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
+	attributes, err := FindTopicAttributesByARN(conn, d.Id())
+
+	var policy string
+
+	if err == nil {
+		policy = attributes[TopicAttributeNamePolicy]
+
+		if policy == "" {
+			err = tfresource.NewEmptyResultError(d.Id())
 		}
-
-		return err
 	}
 
-	if attributeOutput.Attributes == nil {
-		log.Printf("[WARN] SNS Topic (%q) attributes not found (nil), removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-	attrmap := attributeOutput.Attributes
-
-	policy, ok := attrmap["Policy"]
-	if !ok {
-		log.Printf("[WARN] SNS Topic (%q) policy not found in attributes, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SNS Topic Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(policy))
+	if err != nil {
+		return fmt.Errorf("error reading SNS Topic Policy (%s): %w", d.Id(), err)
+	}
+
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
 
 	if err != nil {
 		return err
 	}
 
+	d.Set("arn", attributes[TopicAttributeNameTopicArn])
+	d.Set("owner", attributes[TopicAttributeNameOwner])
 	d.Set("policy", policyToSet)
-
-	d.Set("arn", attrmap["TopicArn"])
-	d.Set("owner", attrmap["Owner"])
 
 	return nil
 }
 
 func resourceTopicPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	req := sns.SetTopicAttributesInput{
-		TopicArn:      aws.String(d.Id()),
-		AttributeName: aws.String("Policy"),
-		// It is impossible to delete a policy or set to empty
-		// (confirmed by AWS Support representative)
-		// so we instead set it back to the default one
-		AttributeValue: aws.String(buildDefaultSnsTopicPolicy(d.Id(), d.Get("owner").(string))),
+	conn := meta.(*conns.AWSClient).SNSConn
+
+	// It is impossible to delete a policy or set to empty
+	// (confirmed by AWS Support representative)
+	// so we instead set it back to the default one.
+	err := putTopicPolicy(conn, d.Id(), defaultSNSTopicPolicy(d.Id(), d.Get("owner").(string)))
+
+	if err != nil {
+		return err
 	}
 
-	// Retry the update in the event of an eventually consistent style of
-	// error, where say an IAM resource is successfully created but not
-	// actually available. See https://github.com/hashicorp/terraform/issues/3660
-	log.Printf("[DEBUG] Resetting SNS Topic Policy to default: %s", req)
-	conn := meta.(*conns.AWSClient).SNSConn
-	_, err := verify.RetryOnAWSCode("InvalidParameter", func() (interface{}, error) {
-		return conn.SetTopicAttributes(&req)
-	})
-	return err
+	return nil
 }
 
-func buildDefaultSnsTopicPolicy(topicArn, accountId string) string {
+func defaultSNSTopicPolicy(topicArn, accountId string) string {
 	return fmt.Sprintf(`{
   "Version": "2008-10-17",
   "Id": "__default_policy_ID",
@@ -168,14 +148,18 @@ func buildDefaultSnsTopicPolicy(topicArn, accountId string) string {
         "SNS:Publish",
         "SNS:Receive"
       ],
-      "Resource": "%s",
+      "Resource": %[1]q,
       "Condition": {
         "StringEquals": {
-          "AWS:SourceOwner": "%s"
+          "AWS:SourceOwner": %[2]q
         }
       }
     }
   ]
 }
 `, topicArn, accountId)
+}
+
+func putTopicPolicy(conn *sns.SNS, arn string, policy string) error {
+	return putTopicAttribute(conn, arn, TopicAttributeNamePolicy, policy)
 }

--- a/internal/service/sns/topic_policy_test.go
+++ b/internal/service/sns/topic_policy_test.go
@@ -5,19 +5,18 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsns "github.com/hashicorp/terraform-provider-aws/internal/service/sns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccSNSTopicPolicy_basic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -30,7 +29,7 @@ func TestAccSNSTopicPolicy_basic(t *testing.T) {
 			{
 				Config: testAccTopicPolicyBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists("aws_sns_topic.test", attributes),
+					testAccCheckTopicExists("aws_sns_topic.test", &attributes),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
@@ -47,7 +46,7 @@ func TestAccSNSTopicPolicy_basic(t *testing.T) {
 }
 
 func TestAccSNSTopicPolicy_updated(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -60,7 +59,7 @@ func TestAccSNSTopicPolicy_updated(t *testing.T) {
 			{
 				Config: testAccTopicPolicyBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists("aws_sns_topic.test", attributes),
+					testAccCheckTopicExists("aws_sns_topic.test", &attributes),
 					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
 				),
@@ -73,7 +72,7 @@ func TestAccSNSTopicPolicy_updated(t *testing.T) {
 			{
 				Config: testAccTopicPolicyUpdatedConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists("aws_sns_topic.test", attributes),
+					testAccCheckTopicExists("aws_sns_topic.test", &attributes),
 					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
 					resource.TestMatchResourceAttr(resourceName, "policy",
@@ -85,7 +84,7 @@ func TestAccSNSTopicPolicy_updated(t *testing.T) {
 }
 
 func TestAccSNSTopicPolicy_Disappears_topic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	topicResourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -98,7 +97,7 @@ func TestAccSNSTopicPolicy_Disappears_topic(t *testing.T) {
 			{
 				Config: testAccTopicPolicyBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(topicResourceName, attributes),
+					testAccCheckTopicExists(topicResourceName, &attributes),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsns.ResourceTopic(), topicResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -108,7 +107,7 @@ func TestAccSNSTopicPolicy_Disappears_topic(t *testing.T) {
 }
 
 func TestAccSNSTopicPolicy_disappears(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -121,7 +120,7 @@ func TestAccSNSTopicPolicy_disappears(t *testing.T) {
 			{
 				Config: testAccTopicPolicyBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists("aws_sns_topic.test", attributes),
+					testAccCheckTopicExists("aws_sns_topic.test", &attributes),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsns.ResourceTopicPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -131,7 +130,7 @@ func TestAccSNSTopicPolicy_disappears(t *testing.T) {
 }
 
 func TestAccSNSTopicPolicy_ignoreEquivalent(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -144,7 +143,7 @@ func TestAccSNSTopicPolicy_ignoreEquivalent(t *testing.T) {
 			{
 				Config: testAccTopicPolicyEquivalentConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists("aws_sns_topic.test", attributes),
+					testAccCheckTopicExists("aws_sns_topic.test", &attributes),
 					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile(fmt.Sprintf("\"Sid\":\"%[1]s\"", rName))),
@@ -167,18 +166,17 @@ func testAccCheckTopicPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Check if the topic policy exists by fetching its attributes
-		params := &sns.GetTopicAttributesInput{
-			TopicArn: aws.String(rs.Primary.ID),
+		_, err := tfsns.FindTopicAttributesByARN(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
-		_, err := conn.GetTopicAttributes(params)
+
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, sns.ErrCodeNotFoundException, "") {
-				return nil
-			}
 			return err
 		}
-		return fmt.Errorf("SNS Topic Policy (%s) exists when it should be destroyed", rs.Primary.ID)
+
+		return fmt.Errorf("SNS Topic Policy %s still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/internal/service/sns/topic_subscription.go
+++ b/internal/service/sns/topic_subscription.go
@@ -12,13 +12,108 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/attrmap"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+var (
+	subscriptionSchema = map[string]*schema.Schema{
+		"arn": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"confirmation_timeout_in_minutes": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  1,
+		},
+		"confirmation_was_authenticated": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"delivery_policy": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: SuppressEquivalentTopicSubscriptionDeliveryPolicy,
+		},
+		"endpoint": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"endpoint_auto_confirms": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"filter_policy": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+			StateFunc: func(v interface{}) string {
+				json, _ := structure.NormalizeJsonString(v)
+				return json
+			},
+		},
+		"owner_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"pending_confirmation": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"protocol": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(SubscriptionProtocol_Values(), false),
+		},
+		"raw_message_delivery": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"redrive_policy": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+		},
+		"subscription_role_arn": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+		"topic_arn": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: verify.ValidARN,
+		},
+	}
+
+	subscriptionAttributeMap = attrmap.New(map[string]string{
+		"arn":                            SubscriptionAttributeNameSubscriptionArn,
+		"confirmation_was_authenticated": SubscriptionAttributeNameConfirmationWasAuthenticated,
+		"delivery_policy":                SubscriptionAttributeNameDeliveryPolicy,
+		"endpoint":                       SubscriptionAttributeNameEndpoint,
+		"filter_policy":                  SubscriptionAttributeNameFilterPolicy,
+		"owner_id":                       SubscriptionAttributeNameOwner,
+		"pending_confirmation":           SubscriptionAttributeNamePendingConfirmation,
+		"protocol":                       SubscriptionAttributeNameProtocol,
+		"raw_message_delivery":           SubscriptionAttributeNameRawMessageDelivery,
+		"redrive_policy":                 SubscriptionAttributeNameRedrivePolicy,
+		"subscription_role_arn":          SubscriptionAttributeNameSubscriptionRoleArn,
+		"topic_arn":                      SubscriptionAttributeNameTopicArn,
+	}, subscriptionSchema)
 )
 
 func ResourceTopicSubscription() *schema.Resource {
@@ -31,115 +126,37 @@ func ResourceTopicSubscription() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"confirmation_timeout_in_minutes": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  1,
-			},
-			"confirmation_was_authenticated": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"delivery_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: SuppressEquivalentTopicSubscriptionDeliveryPolicy,
-			},
-			"endpoint": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"endpoint_auto_confirms": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"filter_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
-				},
-			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"pending_confirmation": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"protocol": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"application",
-					"email-json",
-					"email",
-					"firehose",
-					"http",
-					"https",
-					"lambda",
-					"sms",
-					"sqs",
-				}, false),
-			},
-			"raw_message_delivery": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"redrive_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-			},
-			"subscription_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"topic_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-		},
+		Schema: subscriptionSchema,
 	}
 }
 
 func resourceTopicSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
+	attributes, err := subscriptionAttributeMap.ResourceDataToApiAttributesCreate(d)
+
+	if err != nil {
+		return err
+	}
+
+	// Endpoint, Protocol and TopicArn are not passed in Attributes.
+	delete(attributes, SubscriptionAttributeNameEndpoint)
+	delete(attributes, SubscriptionAttributeNameProtocol)
+	delete(attributes, SubscriptionAttributeNameTopicArn)
+
 	input := &sns.SubscribeInput{
-		Attributes:            expandSNSSubscriptionAttributes(d),
+		Attributes:            aws.StringMap(attributes),
 		Endpoint:              aws.String(d.Get("endpoint").(string)),
 		Protocol:              aws.String(d.Get("protocol").(string)),
 		ReturnSubscriptionArn: aws.Bool(true), // even if not confirmed, will get ARN
 		TopicArn:              aws.String(d.Get("topic_arn").(string)),
 	}
 
+	log.Printf("[DEBUG] Creating SNS Topic Subscription: %s", input)
 	output, err := conn.Subscribe(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating SNS topic subscription: %w", err)
-	}
-
-	if output == nil || output.SubscriptionArn == nil || aws.StringValue(output.SubscriptionArn) == "" {
-		return fmt.Errorf("error creating SNS topic subscription: empty response")
+		return fmt.Errorf("error creating SNS Topic Subscription: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.SubscriptionArn))
@@ -160,8 +177,8 @@ func resourceTopicSubscriptionCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if waitForConfirmation {
-		if _, err := waitSubscriptionConfirmed(conn, d.Id(), "false", timeout); err != nil {
-			return fmt.Errorf("waiting for SNS topic subscription (%s) confirmation: %w", d.Id(), err)
+		if _, err := waitSubscriptionConfirmed(conn, d.Id(), timeout); err != nil {
+			return fmt.Errorf("error waiting for SNS Topic Subscription (%s) confirmation: %w", d.Id(), err)
 		}
 	}
 
@@ -171,69 +188,26 @@ func resourceTopicSubscriptionCreate(d *schema.ResourceData, meta interface{}) e
 func resourceTopicSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	var output *sns.GetSubscriptionAttributesOutput
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(subscriptionCreateTimeout, func() (interface{}, error) {
+		return FindSubscriptionAttributesByARN(conn, d.Id())
+	}, d.IsNewResource())
 
-	err := resource.Retry(subscriptionCreateTimeout, func() *resource.RetryError {
-		var err error
-
-		output, err = FindSubscriptionByARN(conn, d.Id())
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		if d.IsNewResource() && output == nil {
-			return resource.RetryableError(&resource.NotFoundError{
-				LastError: fmt.Errorf("SNS Topic Subscription Attributes (%s) not found", d.Id()),
-			})
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		output, err = FindSubscriptionByARN(conn, d.Id())
-	}
-
-	if err != nil {
-		return fmt.Errorf("error getting SNS Topic Subscription Attributes (%s): %w", d.Id(), err)
-	}
-
-	if output == nil {
-		if d.IsNewResource() {
-			return fmt.Errorf("error getting SNS Topic Subscription Attributes (%s): not found after creation", d.Id())
-		}
-
-		log.Printf("[WARN] SNS Topic Subscription Attributes (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SNS Topic Subscription %s not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	attributes := output.Attributes
-
-	d.Set("arn", attributes["SubscriptionArn"])
-	d.Set("delivery_policy", attributes["DeliveryPolicy"])
-	d.Set("endpoint", attributes["Endpoint"])
-	d.Set("filter_policy", attributes["FilterPolicy"])
-	d.Set("owner_id", attributes["Owner"])
-	d.Set("protocol", attributes["Protocol"])
-	d.Set("redrive_policy", attributes["RedrivePolicy"])
-	d.Set("subscription_role_arn", attributes["SubscriptionRoleArn"])
-	d.Set("topic_arn", attributes["TopicArn"])
-
-	d.Set("confirmation_was_authenticated", false)
-	if v, ok := attributes["ConfirmationWasAuthenticated"]; ok && aws.StringValue(v) == "true" {
-		d.Set("confirmation_was_authenticated", true)
+	if err != nil {
+		return fmt.Errorf("error reading SNS Topic Subscription (%s): %w", d.Id(), err)
 	}
 
-	d.Set("pending_confirmation", false)
-	if v, ok := attributes["PendingConfirmation"]; ok && aws.StringValue(v) == "true" {
-		d.Set("pending_confirmation", true)
-	}
+	attributes := outputRaw.(map[string]string)
 
-	d.Set("raw_message_delivery", false)
-	if v, ok := attributes["RawMessageDelivery"]; ok && aws.StringValue(v) == "true" {
-		d.Set("raw_message_delivery", true)
+	err = subscriptionAttributeMap.ApiAttributesToResourceData(attributes, d)
+
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -242,50 +216,16 @@ func resourceTopicSubscriptionRead(d *schema.ResourceData, meta interface{}) err
 func resourceTopicSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	if d.HasChange("raw_message_delivery") {
-		if err := snsSubscriptionAttributeUpdate(conn, d.Id(), "RawMessageDelivery", fmt.Sprintf("%t", d.Get("raw_message_delivery").(bool))); err != nil {
-			return err
-		}
+	attributes, err := subscriptionAttributeMap.ResourceDataToApiAttributesUpdate(d)
+
+	if err != nil {
+		return err
 	}
 
-	if d.HasChange("filter_policy") {
-		filterPolicy := d.Get("filter_policy").(string)
+	err = putSubscriptionAttributes(conn, d.Id(), attributes)
 
-		// https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html#message-filtering-policy-remove
-		if filterPolicy == "" {
-			filterPolicy = "{}"
-		}
-
-		if err := snsSubscriptionAttributeUpdate(conn, d.Id(), "FilterPolicy", filterPolicy); err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("delivery_policy") {
-		if err := snsSubscriptionAttributeUpdate(conn, d.Id(), "DeliveryPolicy", d.Get("delivery_policy").(string)); err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("subscription_role_arn") {
-		protocol := d.Get("protocol").(string)
-		subscriptionRoleARN := d.Get("subscription_role_arn").(string)
-		if strings.Contains(protocol, "firehose") && subscriptionRoleARN == "" {
-			return fmt.Errorf("protocol firehose must contain subscription_role_arn!")
-		}
-		if !strings.Contains(protocol, "firehose") && subscriptionRoleARN != "" {
-			return fmt.Errorf("only protocol firehose supports subscription_role_arn!")
-		}
-
-		if err := snsSubscriptionAttributeUpdate(conn, d.Id(), "SubscriptionRoleArn", subscriptionRoleARN); err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("redrive_policy") {
-		if err := snsSubscriptionAttributeUpdate(conn, d.Id(), "RedrivePolicy", d.Get("redrive_policy").(string)); err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	return resourceTopicSubscriptionRead(d, meta)
@@ -294,79 +234,60 @@ func resourceTopicSubscriptionUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceTopicSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SNSConn
 
-	log.Printf("[DEBUG] SNS delete topic subscription: %s", d.Id())
+	log.Printf("[DEBUG] Deleting SNS Topic Subscription: %s", d.Id())
 	_, err := conn.Unsubscribe(&sns.UnsubscribeInput{
 		SubscriptionArn: aws.String(d.Id()),
 	})
 
 	if tfawserr.ErrMessageContains(err, sns.ErrCodeInvalidParameterException, "Cannot unsubscribe a subscription that is pending confirmation") {
-		log.Printf("[WARN] Removing unconfirmed SNS topic subscription (%s) from Terraform state but failed to remove it from AWS!", d.Id())
-		d.SetId("")
+		log.Printf("[WARN] Removing unconfirmed SNS Topic Subscription (%s) from Terraform state but failed to remove it from AWS!", d.Id())
 		return nil
 	}
 
 	if _, err := waitSubscriptionDeleted(conn, d.Id()); err != nil {
-		if tfawserr.ErrCodeEquals(err, sns.ErrCodeNotFoundException) {
-			return nil
-		}
-		return fmt.Errorf("error waiting for SNS topic subscription (%s) deletion: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for SNS Topic Subscription (%s) deletion: %w", d.Id(), err)
 	}
 
 	return err
 }
 
-// Assembles supplied attributes into a single map - empty/default values are excluded from the map
-func expandSNSSubscriptionAttributes(d *schema.ResourceData) (output map[string]*string) {
-	deliveryPolicy := d.Get("delivery_policy").(string)
-	filterPolicy := d.Get("filter_policy").(string)
-	rawMessageDelivery := d.Get("raw_message_delivery").(bool)
-	redrivePolicy := d.Get("redrive_policy").(string)
-	subscriptionRoleARN := d.Get("subscription_role_arn").(string)
+func putSubscriptionAttributes(conn *sns.SNS, arn string, attributes map[string]string) error {
+	for name, value := range attributes {
+		err := putSubscriptionAttribute(conn, arn, name, value)
 
-	// Collect attributes if available
-	attributes := map[string]*string{}
-
-	if deliveryPolicy != "" {
-		attributes["DeliveryPolicy"] = aws.String(deliveryPolicy)
+		if err != nil {
+			return err
+		}
 	}
 
-	if filterPolicy != "" {
-		attributes["FilterPolicy"] = aws.String(filterPolicy)
-	}
-
-	if rawMessageDelivery {
-		attributes["RawMessageDelivery"] = aws.String(fmt.Sprintf("%t", rawMessageDelivery))
-	}
-
-	if subscriptionRoleARN != "" {
-		attributes["SubscriptionRoleArn"] = aws.String(subscriptionRoleARN)
-	}
-
-	if redrivePolicy != "" {
-		attributes["RedrivePolicy"] = aws.String(redrivePolicy)
-	}
-
-	return attributes
+	return nil
 }
 
-func snsSubscriptionAttributeUpdate(conn *sns.SNS, subscriptionArn, attributeName, attributeValue string) error {
-	req := &sns.SetSubscriptionAttributesInput{
-		SubscriptionArn: aws.String(subscriptionArn),
-		AttributeName:   aws.String(attributeName),
-		AttributeValue:  aws.String(attributeValue),
+func putSubscriptionAttribute(conn *sns.SNS, arn string, name, value string) error {
+	// https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html#message-filtering-policy-remove
+	if name == SubscriptionAttributeNameFilterPolicy && value == "" {
+		value = "{}"
+	}
+
+	input := &sns.SetSubscriptionAttributesInput{
+		AttributeName:   aws.String(name),
+		AttributeValue:  aws.String(value),
+		SubscriptionArn: aws.String(arn),
 	}
 
 	// The AWS API requires a non-empty string value or nil for the RedrivePolicy attribute,
-	// else throws an InvalidParameter error
-	if attributeName == "RedrivePolicy" && attributeValue == "" {
-		req.AttributeValue = nil
+	// else throws an InvalidParameter error.
+	if name == SubscriptionAttributeNameRedrivePolicy && value == "" {
+		input.AttributeValue = nil
 	}
 
-	_, err := conn.SetSubscriptionAttributes(req)
+	log.Printf("[DEBUG] Setting SNS Topic Subscription attribute: %s", input)
+	_, err := conn.SetSubscriptionAttributes(input)
 
 	if err != nil {
-		return fmt.Errorf("error setting subscription (%s) attribute (%s): %s", subscriptionArn, attributeName, err)
+		return fmt.Errorf("error setting SNS Topic Subscription (%s) attribute (%s): %w", arn, name, err)
 	}
+
 	return nil
 }
 

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/sns"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -19,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsns "github.com/hashicorp/terraform-provider-aws/internal/service/sns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy(t *testing.T) {
@@ -68,7 +68,7 @@ func TestSuppressEquivalentSnsTopicSubscriptionDeliveryPolicy(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_basic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -81,7 +81,7 @@ func TestAccSNSTopicSubscription_basic(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", sns.ServiceName, regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
 					resource.TestCheckResourceAttr(resourceName, "confirmation_was_authenticated", "true"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
@@ -107,7 +107,7 @@ func TestAccSNSTopicSubscription_basic(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	filterPolicy1 := `{"key1": ["val1"], "key2": ["val2"]}`
 	filterPolicy2 := `{"key3": ["val3"], "key4": ["val4"]}`
@@ -122,7 +122,7 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_filterPolicy(rName, strconv.Quote(filterPolicy1)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", filterPolicy1),
 				),
 			},
@@ -139,7 +139,7 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_filterPolicy(rName, strconv.Quote(filterPolicy2)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", filterPolicy2),
 				),
 			},
@@ -147,7 +147,7 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", ""),
 				),
 			},
@@ -156,7 +156,7 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_deliveryPolicy(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -169,8 +169,8 @@ func TestAccSNSTopicSubscription_deliveryPolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_deliveryPolicy(rName, strconv.Quote(`{"healthyRetryPolicy":{"minDelayTarget":5,"maxDelayTarget":20,"numRetries": 5}}`)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
-					testAccCheckTopicSubscriptionDeliveryPolicyAttribute(attributes, &tfsns.TopicSubscriptionDeliveryPolicy{
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					testAccCheckTopicSubscriptionDeliveryPolicyAttribute(&attributes, &tfsns.TopicSubscriptionDeliveryPolicy{
 						HealthyRetryPolicy: &tfsns.TopicSubscriptionDeliveryPolicyHealthyRetryPolicy{
 							MaxDelayTarget: 20,
 							MinDelayTarget: 5,
@@ -192,8 +192,8 @@ func TestAccSNSTopicSubscription_deliveryPolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_deliveryPolicy(rName, strconv.Quote(`{"healthyRetryPolicy":{"minDelayTarget":3,"maxDelayTarget":78,"numRetries": 11}}`)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
-					testAccCheckTopicSubscriptionDeliveryPolicyAttribute(attributes, &tfsns.TopicSubscriptionDeliveryPolicy{
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					testAccCheckTopicSubscriptionDeliveryPolicyAttribute(&attributes, &tfsns.TopicSubscriptionDeliveryPolicy{
 						HealthyRetryPolicy: &tfsns.TopicSubscriptionDeliveryPolicyHealthyRetryPolicy{
 							MaxDelayTarget: 78,
 							MinDelayTarget: 3,
@@ -206,7 +206,7 @@ func TestAccSNSTopicSubscription_deliveryPolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
 				),
 			},
@@ -215,7 +215,7 @@ func TestAccSNSTopicSubscription_deliveryPolicy(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_redrivePolicy(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	dlqName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	updatedDlqName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -230,8 +230,8 @@ func TestAccSNSTopicSubscription_redrivePolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_redrivePolicy(rName, dlqName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
-					testAccCheckTopicSubscriptionRedrivePolicyAttribute(attributes, dlqName),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					testAccCheckTopicSubscriptionRedrivePolicyAttribute(&attributes, dlqName),
 				),
 			},
 			{
@@ -247,8 +247,8 @@ func TestAccSNSTopicSubscription_redrivePolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_redrivePolicy(rName, updatedDlqName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
-					testAccCheckTopicSubscriptionRedrivePolicyAttribute(attributes, updatedDlqName),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					testAccCheckTopicSubscriptionRedrivePolicyAttribute(&attributes, updatedDlqName),
 				),
 			},
 			{
@@ -264,7 +264,7 @@ func TestAccSNSTopicSubscription_redrivePolicy(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
 				),
 			},
@@ -273,7 +273,7 @@ func TestAccSNSTopicSubscription_redrivePolicy(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_rawMessageDelivery(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -286,7 +286,7 @@ func TestAccSNSTopicSubscription_rawMessageDelivery(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_rawMessageDelivery(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "raw_message_delivery", "true"),
 				),
 			},
@@ -303,7 +303,7 @@ func TestAccSNSTopicSubscription_rawMessageDelivery(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_rawMessageDelivery(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "raw_message_delivery", "false"),
 				),
 			},
@@ -311,7 +311,7 @@ func TestAccSNSTopicSubscription_rawMessageDelivery(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "raw_message_delivery", "false"),
 				),
 			},
@@ -320,7 +320,7 @@ func TestAccSNSTopicSubscription_rawMessageDelivery(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_autoConfirmingEndpoint(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -333,7 +333,7 @@ func TestAccSNSTopicSubscription_autoConfirmingEndpoint(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_autoConfirmingEndpoint(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 				),
 			},
 			{
@@ -350,7 +350,7 @@ func TestAccSNSTopicSubscription_autoConfirmingEndpoint(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -363,7 +363,7 @@ func TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_autoConfirmingSecuredEndpoint(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 				),
 			},
 			{
@@ -380,7 +380,7 @@ func TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_email(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -393,7 +393,7 @@ func TestAccSNSTopicSubscription_email(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionEmailConfig(rName, acctest.DefaultEmailAddress),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", sns.ServiceName, regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
 					resource.TestCheckResourceAttr(resourceName, "confirmation_was_authenticated", "false"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
@@ -410,7 +410,7 @@ func TestAccSNSTopicSubscription_email(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_firehose(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -423,7 +423,7 @@ func TestAccSNSTopicSubscription_firehose(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig_firehose(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", sns.ServiceName, regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint", "aws_kinesis_firehose_delivery_stream.test_stream", "arn"),
@@ -439,7 +439,7 @@ func TestAccSNSTopicSubscription_firehose(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_disappears(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -452,7 +452,7 @@ func TestAccSNSTopicSubscription_disappears(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsns.ResourceTopicSubscription(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -462,7 +462,7 @@ func TestAccSNSTopicSubscription_disappears(t *testing.T) {
 }
 
 func TestAccSNSTopicSubscription_Disappears_topic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic_subscription.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -475,7 +475,7 @@ func TestAccSNSTopicSubscription_Disappears_topic(t *testing.T) {
 			{
 				Config: testAccTopicSubscriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicSubscriptionExists(resourceName, attributes),
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsns.ResourceTopic(), "aws_sns_topic.test"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -492,22 +492,27 @@ func testAccCheckTopicSubscriptionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		output, err := tfsns.FindSubscriptionByARN(conn, rs.Primary.ID)
+		output, err := tfsns.FindSubscriptionAttributesByARN(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
-			return fmt.Errorf("SNS topic subscription still exists, can't continue.")
+			return err
 		}
 
-		if output == nil || aws.StringValue(output.Attributes["Protocol"]) == "email" {
-			return nil
+		if output["Protocol"] == "email" {
+			continue
 		}
 
-		return fmt.Errorf("SNS topic Subscription (%s) exists when it should be destroyed", rs.Primary.ID)
+		return fmt.Errorf("SNS Topic Subscription %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckTopicSubscriptionExists(n string, attributes map[string]string) resource.TestCheckFunc {
+func testAccCheckTopicSubscriptionExists(n string, v *map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -515,23 +520,26 @@ func testAccCheckTopicSubscriptionExists(n string, attributes map[string]string)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No SNS subscription with that ARN exists")
+			return fmt.Errorf("No SNS Topic Subscription ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SNSConn
 
-		output, err := tfsns.FindSubscriptionByARN(conn, rs.Primary.ID)
-		for k, v := range output.Attributes {
-			attributes[k] = aws.StringValue(v)
+		output, err := tfsns.FindSubscriptionAttributesByARN(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
 		}
 
-		return err
+		*v = output
+
+		return nil
 	}
 }
 
-func testAccCheckTopicSubscriptionDeliveryPolicyAttribute(attributes map[string]string, expectedDeliveryPolicy *tfsns.TopicSubscriptionDeliveryPolicy) resource.TestCheckFunc {
+func testAccCheckTopicSubscriptionDeliveryPolicyAttribute(attributes *map[string]string, expectedDeliveryPolicy *tfsns.TopicSubscriptionDeliveryPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		apiDeliveryPolicyJSONString, ok := attributes["DeliveryPolicy"]
+		apiDeliveryPolicyJSONString, ok := (*attributes)["DeliveryPolicy"]
 
 		if !ok {
 			return fmt.Errorf("DeliveryPolicy attribute not found in attributes: %s", attributes)
@@ -550,9 +558,9 @@ func testAccCheckTopicSubscriptionDeliveryPolicyAttribute(attributes map[string]
 	}
 }
 
-func testAccCheckTopicSubscriptionRedrivePolicyAttribute(attributes map[string]string, expectedRedrivePolicyResource string) resource.TestCheckFunc {
+func testAccCheckTopicSubscriptionRedrivePolicyAttribute(attributes *map[string]string, expectedRedrivePolicyResource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		apiRedrivePolicyJSONString, ok := attributes["RedrivePolicy"]
+		apiRedrivePolicyJSONString, ok := (*attributes)["RedrivePolicy"]
 
 		if !ok {
 			return fmt.Errorf("RedrivePolicy attribute not found in attributes: %s", attributes)

--- a/internal/service/sns/topic_test.go
+++ b/internal/service/sns/topic_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfsns "github.com/hashicorp/terraform-provider-aws/internal/service/sns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -32,7 +32,7 @@ func testAccErrorCheckSkipSNS(t *testing.T) resource.ErrorCheckFunc {
 }
 
 func TestAccSNSTopic_basic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -44,11 +44,33 @@ func TestAccSNSTopic_basic(t *testing.T) {
 			{
 				Config: testAccTopicNameGeneratedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "application_failure_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "application_success_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "application_success_feedback_sample_rate", "0"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "sns", regexp.MustCompile(`terraform-\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "false"),
+					resource.TestCheckResourceAttr(resourceName, "firehose_failure_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "firehose_success_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "firehose_success_feedback_sample_rate", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http_failure_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "http_success_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "http_success_feedback_sample_rate", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "lambda_failure_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "lambda_success_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "lambda_success_feedback_sample_rate", "0"),
 					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
-					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "false"),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+					resource.TestCheckResourceAttr(resourceName, "sqs_failure_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "sqs_success_feedback_role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "sqs_success_feedback_sample_rate", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -61,7 +83,7 @@ func TestAccSNSTopic_basic(t *testing.T) {
 }
 
 func TestAccSNSTopic_name(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -74,7 +96,7 @@ func TestAccSNSTopic_name(t *testing.T) {
 			{
 				Config: testAccTopicNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "false"),
 				),
@@ -89,7 +111,7 @@ func TestAccSNSTopic_name(t *testing.T) {
 }
 
 func TestAccSNSTopic_namePrefix(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := "tf-acc-test-prefix-"
 
@@ -102,7 +124,7 @@ func TestAccSNSTopic_namePrefix(t *testing.T) {
 			{
 				Config: testAccTopicNamePrefixConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
 					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "false"),
@@ -118,7 +140,7 @@ func TestAccSNSTopic_namePrefix(t *testing.T) {
 }
 
 func TestAccSNSTopic_policy(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandString(10)
 	expectedPolicy := fmt.Sprintf(`{"Statement":[{"Sid":"Stmt1445931846145","Effect":"Allow","Principal":{"AWS":"*"},"Action":"sns:Publish","Resource":"arn:%s:sns:%s::example"}],"Version":"2012-10-17","Id":"Policy1445931846145"}`, acctest.Partition(), acctest.Region())
@@ -132,7 +154,7 @@ func TestAccSNSTopic_policy(t *testing.T) {
 			{
 				Config: testAccTopicWithPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					testAccCheckNSTopicHasPolicy(resourceName, expectedPolicy),
 				),
 			},
@@ -146,7 +168,7 @@ func TestAccSNSTopic_policy(t *testing.T) {
 }
 
 func TestAccSNSTopic_withIAMRole(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandString(10)
 
@@ -159,7 +181,7 @@ func TestAccSNSTopic_withIAMRole(t *testing.T) {
 			{
 				Config: testAccTopicConfig_withIAMRole(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 				),
 			},
 			{
@@ -188,7 +210,7 @@ func TestAccSNSTopic_withFakeIAMRole(t *testing.T) {
 }
 
 func TestAccSNSTopic_withDeliveryPolicy(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandString(10)
 	expectedPolicy := `{"http":{"defaultHealthyRetryPolicy": {"minDelayTarget": 20,"maxDelayTarget": 20,"numMaxDelayRetries": 0,"numRetries": 3,"numNoDelayRetries": 0,"numMinDelayRetries": 0,"backoffFunction": "linear"},"disableSubscriptionOverrides": false}}`
@@ -202,7 +224,7 @@ func TestAccSNSTopic_withDeliveryPolicy(t *testing.T) {
 			{
 				Config: testAccTopicConfig_withDeliveryPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					testAccCheckNSTopicHasDeliveryPolicy(resourceName, expectedPolicy),
 				),
 			},
@@ -216,7 +238,7 @@ func TestAccSNSTopic_withDeliveryPolicy(t *testing.T) {
 }
 
 func TestAccSNSTopic_deliveryStatus(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	iamRoleResourceName := "aws_iam_role.example"
 
@@ -231,7 +253,7 @@ func TestAccSNSTopic_deliveryStatus(t *testing.T) {
 			{
 				Config: testAccTopicConfig_deliveryStatus(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttrPair(resourceName, "application_success_feedback_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "application_success_feedback_sample_rate", "100"),
 					resource.TestCheckResourceAttrPair(resourceName, "application_failure_feedback_role_arn", iamRoleResourceName, "arn"),
@@ -259,7 +281,7 @@ func TestAccSNSTopic_deliveryStatus(t *testing.T) {
 }
 
 func TestAccSNSTopic_NameGenerated_fifoTopic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -271,7 +293,7 @@ func TestAccSNSTopic_NameGenerated_fifoTopic(t *testing.T) {
 			{
 				Config: testAccTopicNameGeneratedFIFOTopicConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					create.TestCheckResourceAttrNameWithSuffixGenerated(resourceName, "name", tfsns.FIFOTopicNameSuffix),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
 					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "true"),
@@ -287,7 +309,7 @@ func TestAccSNSTopic_NameGenerated_fifoTopic(t *testing.T) {
 }
 
 func TestAccSNSTopic_Name_fifoTopic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix) + tfsns.FIFOTopicNameSuffix
 
@@ -300,7 +322,7 @@ func TestAccSNSTopic_Name_fifoTopic(t *testing.T) {
 			{
 				Config: testAccTopicNameFIFOTopicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "true"),
 				),
@@ -315,7 +337,7 @@ func TestAccSNSTopic_Name_fifoTopic(t *testing.T) {
 }
 
 func TestAccSNSTopic_NamePrefix_fifoTopic(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := "tf-acc-test-prefix-"
 
@@ -328,7 +350,7 @@ func TestAccSNSTopic_NamePrefix_fifoTopic(t *testing.T) {
 			{
 				Config: testAccTopicNamePrefixFIFOTopicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					create.TestCheckResourceAttrNameWithSuffixFromPrefix(resourceName, "name", rName, tfsns.FIFOTopicNameSuffix),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", rName),
 					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "true"),
@@ -344,7 +366,7 @@ func TestAccSNSTopic_NamePrefix_fifoTopic(t *testing.T) {
 }
 
 func TestAccSNSTopic_fifoWithContentBasedDeduplication(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandString(10)
 
@@ -357,7 +379,7 @@ func TestAccSNSTopic_fifoWithContentBasedDeduplication(t *testing.T) {
 			{
 				Config: testAccTopicWithFIFOContentBasedDeduplicationConfig(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "fifo_topic", "true"),
 					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "true"),
 				),
@@ -371,7 +393,7 @@ func TestAccSNSTopic_fifoWithContentBasedDeduplication(t *testing.T) {
 			{
 				Config: testAccTopicWithFIFOContentBasedDeduplicationConfig(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
 				),
 			},
@@ -396,7 +418,7 @@ func TestAccSNSTopic_fifoExpectContentBasedDeduplicationError(t *testing.T) {
 }
 
 func TestAccSNSTopic_encryption(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -409,7 +431,7 @@ func TestAccSNSTopic_encryption(t *testing.T) {
 			{
 				Config: testAccTopicConfig_withEncryption(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", "alias/aws/sns"),
 				),
 			},
@@ -421,7 +443,7 @@ func TestAccSNSTopic_encryption(t *testing.T) {
 			{
 				Config: testAccTopicNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
 				),
 			},
@@ -430,7 +452,7 @@ func TestAccSNSTopic_encryption(t *testing.T) {
 }
 
 func TestAccSNSTopic_tags(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 	rName := sdkacctest.RandString(10)
 
@@ -443,7 +465,7 @@ func TestAccSNSTopic_tags(t *testing.T) {
 			{
 				Config: testAccTopicTags1Config(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -456,7 +478,7 @@ func TestAccSNSTopic_tags(t *testing.T) {
 			{
 				Config: testAccTopicTags2Config(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -465,7 +487,7 @@ func TestAccSNSTopic_tags(t *testing.T) {
 			{
 				Config: testAccTopicTags1Config(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -475,7 +497,7 @@ func TestAccSNSTopic_tags(t *testing.T) {
 }
 
 func TestAccSNSTopic_disappears(t *testing.T) {
-	attributes := make(map[string]string)
+	var attributes map[string]string
 	resourceName := "aws_sns_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -487,7 +509,7 @@ func TestAccSNSTopic_disappears(t *testing.T) {
 			{
 				Config: testAccTopicNameGeneratedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTopicExists(resourceName, attributes),
+					testAccCheckTopicExists(resourceName, &attributes),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsns.ResourceTopic(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -594,24 +616,23 @@ func testAccCheckTopicDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Check if the topic exists by fetching its attributes
-		params := &sns.GetTopicAttributesInput{
-			TopicArn: aws.String(rs.Primary.ID),
+		_, err := tfsns.FindTopicAttributesByARN(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
-		_, err := conn.GetTopicAttributes(params)
+
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, sns.ErrCodeNotFoundException, "") {
-				return nil
-			}
 			return err
 		}
-		return fmt.Errorf("SNS topic (%s) exists when it should be destroyed", rs.Primary.ID)
+
+		return fmt.Errorf("SNS Topic %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckTopicExists(n string, attributes map[string]string) resource.TestCheckFunc {
+func testAccCheckTopicExists(n string, v *map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -619,23 +640,18 @@ func testAccCheckTopicExists(n string, attributes map[string]string) resource.Te
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No SNS topic with that ARN exists")
+			return fmt.Errorf("No SNS Topic ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SNSConn
 
-		params := &sns.GetTopicAttributesInput{
-			TopicArn: aws.String(rs.Primary.ID),
-		}
-		out, err := conn.GetTopicAttributes(params)
+		output, err := tfsns.FindTopicAttributesByARN(conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		for k, v := range out.Attributes {
-			attributes[k] = aws.StringValue(v)
-		}
+		*v = output
 
 		return nil
 	}

--- a/internal/service/sns/topic_test.go
+++ b/internal/service/sns/topic_test.go
@@ -48,7 +48,7 @@ func TestAccSNSTopic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "application_failure_feedback_role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "application_success_feedback_role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "application_success_feedback_sample_rate", "0"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "sns", regexp.MustCompile(`terraform-\d+$`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "sns", regexp.MustCompile(`terraform-.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "content_based_deduplication", "false"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, "display_name", ""),

--- a/internal/service/sns/topic_test.go
+++ b/internal/service/sns/topic_test.go
@@ -21,7 +21,6 @@ import (
 
 func init() {
 	acctest.RegisterServiceErrorCheckFunc(sns.EndpointsID, testAccErrorCheckSkipSNS)
-
 }
 
 func testAccErrorCheckSkipSNS(t *testing.T) resource.ErrorCheckFunc {

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/attrmap"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -166,7 +167,7 @@ var (
 		"tags_all": tftags.TagsSchemaComputed(),
 	}
 
-	sqsQueueAttributeMap = create.AttrMap(map[string]string{
+	sqsQueueAttributeMap = attrmap.New(map[string]string{
 		"delay_seconds":                     sqs.QueueAttributeNameDelaySeconds,
 		"max_message_size":                  sqs.QueueAttributeNameMaximumMessageSize,
 		"message_retention_seconds":         sqs.QueueAttributeNameMessageRetentionPeriod,

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -140,6 +140,30 @@ var (
 			},
 		},
 
+		"redrive_allow_policy": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"redrive_permission": {
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{"allowAll", "denyAll", "byQueue"}, false),
+						Default:      "allowAll",
+						Optional:     true,
+					},
+					"source_queue_arns": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type:         schema.TypeString,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
+		},
+
 		"url": {
 			Type:     schema.TypeString,
 			Computed: true,

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -141,26 +141,12 @@ var (
 		},
 
 		"redrive_allow_policy": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"redrive_permission": {
-						Type:         schema.TypeString,
-						ValidateFunc: validation.StringInSlice([]string{"allowAll", "denyAll", "byQueue"}, false),
-						Default:      "allowAll",
-						Optional:     true,
-					},
-					"source_queue_arns": {
-						Type:     schema.TypeSet,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Schema{
-							Type:         schema.TypeString,
-							ValidateFunc: verify.ValidARN,
-						},
-					},
-				},
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsJSON,
+			StateFunc: func(v interface{}) string {
+				json, _ := structure.NormalizeJsonString(v)
+				return json
 			},
 		},
 
@@ -188,6 +174,7 @@ var (
 		"visibility_timeout_seconds":        sqs.QueueAttributeNameVisibilityTimeout,
 		"policy":                            sqs.QueueAttributeNamePolicy,
 		"redrive_policy":                    sqs.QueueAttributeNameRedrivePolicy,
+		"redrive_allow_policy":              sqs.QueueAttributeNameRedriveAllowPolicy,
 		"arn":                               sqs.QueueAttributeNameQueueArn,
 		"fifo_queue":                        sqs.QueueAttributeNameFifoQueue,
 		"content_based_deduplication":       sqs.QueueAttributeNameContentBasedDeduplication,

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -18,6 +18,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(sqs.EndpointsID, testAccErrorCheckSkipSQS)
+}
+
+func testAccErrorCheckSkipSQS(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"Unknown Attribute RedriveAllowPolicy",
+	)
+}
+
 func TestAccSQSQueue_basic(t *testing.T) {
 	var queueAttributes map[string]string
 	resourceName := "aws_sqs_queue.test"

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -48,6 +48,7 @@ func TestAccSQSQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy", ""),
 					resource.TestCheckResourceAttr(resourceName, "receive_wait_time_seconds", strconv.Itoa(tfsqs.DefaultQueueReceiveMessageWaitTimeSeconds)),
 					resource.TestCheckResourceAttr(resourceName, "redrive_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "redrive_allow_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "url", resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_timeout_seconds", strconv.Itoa(tfsqs.DefaultQueueVisibilityTimeout)),
@@ -466,6 +467,8 @@ func TestAccSQSQueue_redrivePolicy(t *testing.T) {
 		},
 	})
 }
+
+///ADD TEST HERE
 
 func TestAccSQSQueue_fifoQueue(t *testing.T) {
 	var queueAttributes map[string]string

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -1052,7 +1052,7 @@ resource "aws_sqs_queue" "test" {
   delay_seconds              = 0
   visibility_timeout_seconds = 300
 
-	redrive_allow_policy = <<EOF
+  redrive_allow_policy = <<EOF
 {
   "redrivePermission": "byQueue",
   "sourceQueueArns": ["${aws_sqs_queue.dlq.arn}"]

--- a/internal/service/sqs/status.go
+++ b/internal/service/sqs/status.go
@@ -56,11 +56,7 @@ func statusQueueAttributeState(conn *sqs.SQS, url string, expected map[string]st
 					if !equivalent {
 						return queuePolicyStateNotEqual
 					}
-				case sqs.QueueAttributeNameRedrivePolicy:
-					if !StringsEquivalent(g, e) {
-						return queuePolicyStateNotEqual
-					}
-				case sqs.QueueAttributeNameRedriveAllowPolicy:
+				case sqs.QueueAttributeNameRedriveAllowPolicy, sqs.QueueAttributeNameRedrivePolicy:
 					if !StringsEquivalent(g, e) {
 						return queuePolicyStateNotEqual
 					}

--- a/internal/service/sqs/status.go
+++ b/internal/service/sqs/status.go
@@ -60,6 +60,10 @@ func statusQueueAttributeState(conn *sqs.SQS, url string, expected map[string]st
 					if !StringsEquivalent(g, e) {
 						return queuePolicyStateNotEqual
 					}
+				case sqs.QueueAttributeNameRedriveAllowPolicy:
+					if !StringsEquivalent(g, e) {
+						return queuePolicyStateNotEqual
+					}
 				default:
 					if g != e {
 						return queuePolicyStateNotEqual

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -21,6 +21,10 @@ resource "aws_sqs_queue" "terraform_queue" {
     deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
     maxReceiveCount     = 4
   })
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = ["${aws_sqs_queue.terraform_queue_deadletter.arn}"]
+  })
 
   tags = {
     Environment = "production"
@@ -83,6 +87,7 @@ The following arguments are supported:
 * `receive_wait_time_seconds` - (Optional) The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately.
 * `policy` - (Optional) The JSON policy for the SQS queue. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 * `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html). **Note:** when specifying `maxReceiveCount`, you must specify it as an integer (`5`), and not a string (`"5"`).
+* `redrive_allow_policy` - (Optional) The JSON policy to set up the Dead Letter Queue redrive permission, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html).
 * `fifo_queue` - (Optional) Boolean designating a FIFO queue. If not set, it defaults to `false` making it standard.
 * `content_based_deduplication` - (Optional) Enables content-based deduplication for FIFO queues. For more information, see the [related documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
 * `sqs_managed_sse_enabled` - (Optional) Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys. Defaults to `false`. See [Encryption at rest](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22249.
Closes #22275.
Closes #11993.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccSQSQueue_redriveAllowPolicy' PKG_NAME='internal/service/sqs'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run=TestAccSQSQueue_redriveAllowPolicy -timeout 180m
=== RUN   TestAccSQSQueue_redriveAllowPolicy
=== PAUSE TestAccSQSQueue_redriveAllowPolicy
=== CONT  TestAccSQSQueue_redriveAllowPolicy
--- PASS: TestAccSQSQueue_redriveAllowPolicy (82.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	82.896s

```
