### PR TITLE
Illustrate SecretsManager secret policy with a safer example

### DIFF
--- a/website/docs/r/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/r/secretsmanager_secret_policy.html.markdown
@@ -27,10 +27,10 @@ resource "aws_secretsmanager_secret_policy" "example" {
   "Version": "2012-10-17",
   "Statement": [
 	{
-	  "Sid": "EnableAllPermissions",
+	  "Sid": "EnableAnotherAWSAccountToReadTheSecret",
 	  "Effect": "Allow",
 	  "Principal": {
-		"AWS": "*"
+		"AWS": "arn:aws:iam::111122223333:root"
 	  },
 	  "Action": "secretsmanager:GetSecretValue",
 	  "Resource": "*"

--- a/website/docs/r/secretsmanager_secret_policy.html.markdown
+++ b/website/docs/r/secretsmanager_secret_policy.html.markdown
@@ -30,7 +30,7 @@ resource "aws_secretsmanager_secret_policy" "example" {
 	  "Sid": "EnableAnotherAWSAccountToReadTheSecret",
 	  "Effect": "Allow",
 	  "Principal": {
-		"AWS": "arn:aws:iam::111122223333:root"
+		"AWS": "arn:aws:iam::123456789012:root"
 	  },
 	  "Action": "secretsmanager:GetSecretValue",
 	  "Resource": "*"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

## Context and background

Such policies are generally considered dangerous, as they allow access by any principal in the account, or outside the account that has permissions on the KMS key. Generally, it's a bad idea to illustrate security features with insecure examples, so I'm proposing this change.