### PR TITLE
r/aws_batch_job_queue - new attribute

### DIFF
--- a/.changelog/22298.txt
+++ b/.changelog/22298.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_batch_job_queue: Add `scheduling_policy_arn` attribute
+```

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -46,6 +46,11 @@ func ResourceJobQueue() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			"scheduling_policy_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"state": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -72,6 +77,10 @@ func resourceJobQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		JobQueueName:            aws.String(d.Get("name").(string)),
 		Priority:                aws.Int64(int64(d.Get("priority").(int))),
 		State:                   aws.String(d.Get("state").(string)),
+	}
+
+	if v, ok := d.GetOk("scheduling_policy_arn"); ok {
+		input.SchedulingPolicyArn = aws.String(v.(string))
 	}
 
 	if len(tags) > 0 {
@@ -138,6 +147,7 @@ func resourceJobQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", jq.JobQueueName)
 	d.Set("priority", jq.Priority)
+	d.Set("scheduling_policy_arn", jq.SchedulingPolicyArn)
 	d.Set("state", jq.State)
 
 	tags := KeyValueTags(jq.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -157,7 +167,7 @@ func resourceJobQueueRead(d *schema.ResourceData, meta interface{}) error {
 func resourceJobQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).BatchConn
 
-	if d.HasChanges("compute_environments", "priority", "state") {
+	if d.HasChanges("compute_environments", "priority", "scheduling_policy_arn", "state") {
 		name := d.Get("name").(string)
 		updateInput := &batch.UpdateJobQueueInput{
 			ComputeEnvironmentOrder: createComputeEnvironmentOrder(d.Get("compute_environments").([]interface{})),
@@ -165,6 +175,18 @@ func resourceJobQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 			Priority:                aws.Int64(int64(d.Get("priority").(int))),
 			State:                   aws.String(d.Get("state").(string)),
 		}
+		// After a job queue is created, you can replace but can't remove the fair share scheduling policy
+		// https://docs.aws.amazon.com/sdk-for-go/api/service/batch/#CreateJobQueueInput
+		if d.HasChange("scheduling_policy_arn") {
+			if v, ok := d.GetOk("scheduling_policy_arn"); ok {
+				updateInput.SchedulingPolicyArn = aws.String(v.(string))
+			} else {
+				return fmt.Errorf("Cannot remove the fair share scheduling policy")
+			}
+		} else {
+			updateInput.SchedulingPolicyArn = aws.String(d.Get("scheduling_policy_arn").(string))
+		}
+
 		_, err := conn.UpdateJobQueue(updateInput)
 		if err != nil {
 			return err

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -184,7 +184,11 @@ func resourceJobQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Cannot remove the fair share scheduling policy")
 			}
 		} else {
-			updateInput.SchedulingPolicyArn = aws.String(d.Get("scheduling_policy_arn").(string))
+			// if a queue is a FIFO queue, SchedulingPolicyArn should not be set. Error is "Only fairshare queue can have scheduling policy"
+			// hence, check for scheduling_policy_arn and set it in the inputs only if it exists already
+			if v, ok := d.GetOk("scheduling_policy_arn"); ok {
+				updateInput.SchedulingPolicyArn = aws.String(v.(string))
+			}
 		}
 
 		_, err := conn.UpdateJobQueue(updateInput)

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -134,6 +134,44 @@ func TestAccBatchJobQueue_priority(t *testing.T) {
 	})
 }
 
+func TestAccBatchJobQueue_schedulingPolicy(t *testing.T) {
+	var jobQueue1, jobQueue2 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	schedulingPolicyName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	schedulingPolicyName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, batch.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBatchJobQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				// last variable selects the scheduling policy's arn. In this case, the first scheduling policy's arn.
+				Config: testAccBatchJobQueueConfigSchedulingPolicy(rName, schedulingPolicyName1, schedulingPolicyName2, "first"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue1),
+					resource.TestCheckResourceAttrSet(resourceName, "scheduling_policy_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// test switching the scheduling_policy_arn by changing the last variable to select the second scheduling policy's arn.
+				Config: testAccBatchJobQueueConfigSchedulingPolicy(rName, schedulingPolicyName1, schedulingPolicyName2, "second"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue2),
+					resource.TestCheckResourceAttrSet(resourceName, "scheduling_policy_arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBatchJobQueue_state(t *testing.T) {
 	var jobQueue1, jobQueue2 batch.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
@@ -414,6 +452,53 @@ resource "aws_batch_job_queue" "test" {
   state                = "ENABLED"
 }
 `, rName, priority))
+}
+
+func testAccBatchJobQueueSchedulingPolicy(rName string, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_scheduling_policy" "test1" {
+  name = %[1]q
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A1*"
+      weight_factor    = 0.1
+    }
+  }
+}
+
+resource "aws_batch_scheduling_policy" "test2" {
+  name = %[2]q
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A2"
+      weight_factor    = 0.2
+    }
+  }
+}
+`, rName, rName2)
+}
+
+func testAccBatchJobQueueConfigSchedulingPolicy(rName string, schedulingPolicyName1 string, schedulingPolicyName2 string, selectSchedulingPolicy string) string {
+	return acctest.ConfigCompose(
+		testAccBatchJobQueueConfigBase(rName),
+		testAccBatchJobQueueSchedulingPolicy(schedulingPolicyName1, schedulingPolicyName2),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments  = [aws_batch_compute_environment.test.arn]
+  name                  = %[1]q
+  priority              = 1
+  scheduling_policy_arn = %[2]q == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
+  state                 = "ENABLED"
+}
+`, rName, selectSchedulingPolicy))
 }
 
 func testAccBatchJobQueueConfigState(rName string, state string) string {

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -495,7 +495,7 @@ resource "aws_batch_job_queue" "test" {
   compute_environments  = [aws_batch_compute_environment.test.arn]
   name                  = %[1]q
   priority              = 1
-  scheduling_policy_arn = %[2]q == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
+  scheduling_policy_arn = "%[2]q" == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
   state                 = "ENABLED"
 }
 `, rName, selectSchedulingPolicy))

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -492,14 +492,14 @@ func testAccBatchJobQueueConfigSchedulingPolicy(rName string, schedulingPolicyNa
 		testAccBatchJobQueueSchedulingPolicy(schedulingPolicyName1, schedulingPolicyName2),
 		fmt.Sprintf(`
 locals {
-  selectSchedulingPolicy = %[2]q
+  select_scheduling_policy = %[2]q
 }
 
 resource "aws_batch_job_queue" "test" {
   compute_environments  = [aws_batch_compute_environment.test.arn]
   name                  = %[1]q
   priority              = 1
-  scheduling_policy_arn = local.selectSchedulingPolicy == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
+  scheduling_policy_arn = local.select_scheduling_policy == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
   state                 = "ENABLED"
 }
 `, rName, selectSchedulingPolicy))

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -491,11 +491,15 @@ func testAccBatchJobQueueConfigSchedulingPolicy(rName string, schedulingPolicyNa
 		testAccBatchJobQueueConfigBase(rName),
 		testAccBatchJobQueueSchedulingPolicy(schedulingPolicyName1, schedulingPolicyName2),
 		fmt.Sprintf(`
+locals {
+  selectSchedulingPolicy = %[2]q
+}
+
 resource "aws_batch_job_queue" "test" {
   compute_environments  = [aws_batch_compute_environment.test.arn]
   name                  = %[1]q
   priority              = 1
-  scheduling_policy_arn = "%[2]q" == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
+  scheduling_policy_arn = local.selectSchedulingPolicy == "first" ? aws_batch_scheduling_policy.test1.arn : aws_batch_scheduling_policy.test2.arn
   state                 = "ENABLED"
 }
 `, rName, selectSchedulingPolicy))

--- a/internal/service/batch/sweep.go
+++ b/internal/service/batch/sweep.go
@@ -39,6 +39,14 @@ func init() {
 		Name: "aws_batch_job_queue",
 		F:    sweepJobQueues,
 	})
+
+	resource.AddTestSweepers("aws_batch_scheduling_policy", &resource.Sweeper{
+		Name: "aws_batch_scheduling_policy",
+		F:    sweepSchedulingPolicies,
+		Dependencies: []string{
+			"aws_batch_job_queue",
+		},
+	})
 }
 
 func sweepComputeEnvironments(region string) error {
@@ -242,4 +250,46 @@ func sweepJobQueues(region string) error {
 	}
 
 	return nil
+}
+
+func sweepSchedulingPolicies(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).BatchConn
+	input := &batch.ListSchedulingPoliciesInput{}
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListSchedulingPolicies(input, func(page *batch.ListSchedulingPoliciesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, schedulingPolicy := range page.SchedulingPolicies {
+			arn := aws.StringValue(schedulingPolicy.Arn)
+
+			log.Printf("[INFO] Deleting Batch Scheduling Policy: %s", arn)
+			_, err := conn.DeleteSchedulingPolicy(&batch.DeleteSchedulingPolicyInput{
+				Arn: aws.String(arn),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Batch Scheduling Policy (%s): %w", arn, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Batch Scheduling Policies sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Batch Scheduling Policies: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
 }

--- a/internal/service/batch/sweep.go
+++ b/internal/service/batch/sweep.go
@@ -261,7 +261,7 @@ func sweepSchedulingPolicies(region string) error {
 	input := &batch.ListSchedulingPoliciesInput{}
 	var sweeperErrs *multierror.Error
 
-	err = conn.ListSchedulingPolicies(input, func(page *batch.ListSchedulingPoliciesOutput, lastPage bool) bool {
+	err = conn.ListSchedulingPoliciesPages(input, func(page *batch.ListSchedulingPoliciesOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -12,11 +12,44 @@ Provides a Batch Job Queue resource.
 
 ## Example Usage
 
+### Basic Job Queue
+
 ```terraform
 resource "aws_batch_job_queue" "test_queue" {
   name     = "tf-test-batch-job-queue"
   state    = "ENABLED"
   priority = 1
+  compute_environments = [
+    aws_batch_compute_environment.test_environment_1.arn,
+    aws_batch_compute_environment.test_environment_2.arn,
+  ]
+}
+```
+
+### Job Queue with a fair share scheduling policy
+
+```terraform
+resource "aws_batch_scheduling_policy" "example" {
+  name = "example"
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A1*"
+      weight_factor    = 0.1
+    }
+  }
+}
+
+resource "aws_batch_job_queue" "example" {
+  name = "tf-test-batch-job-queue"
+
+  scheduling_policy_arn = aws_batch_scheduling_policy.example.arn
+  state                 = "ENABLED"
+  priority              = 1
+
   compute_environments = [
     aws_batch_compute_environment.test_environment_1.arn,
     aws_batch_compute_environment.test_environment_2.arn,
@@ -34,6 +67,7 @@ The following arguments are supported:
     in the list will dictate the order.
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.
+* `scheduling_policy_arn` - (Optional) The ARN of the fair share scheduling policy. If this parameter is specified, the job queue uses a fair share scheduling policy. If this parameter isn't specified, the job queue uses a first in, first out (FIFO) scheduling policy. After a job queue is created, you can replace but can't remove the fair share scheduling policy.
 * `state` - (Required) The state of the job queue. Must be one of: `ENABLED` or `DISABLED`
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21755

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccBatchSchedulingPolicy PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchSchedulingPolicy' -timeout 180m
=== RUN   TestAccBatchSchedulingPolicy_basic
=== PAUSE TestAccBatchSchedulingPolicy_basic
=== RUN   TestAccBatchSchedulingPolicy_disappears
=== PAUSE TestAccBatchSchedulingPolicy_disappears
=== CONT  TestAccBatchSchedulingPolicy_basic
=== CONT  TestAccBatchSchedulingPolicy_disappears
--- PASS: TestAccBatchSchedulingPolicy_disappears (30.25s)
--- PASS: TestAccBatchSchedulingPolicy_basic (65.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      73.201s

...
```

## Changes made

- Uses the `aws_batch_scheduling_policy` resource from #22262
- Add sweeper for `aws_batch_scheduling_policy` that was missed in the earlier PR
- Add `scheduling_policy_arn` to `aws_batch_job_queue`
- Test creation of job queue with `scheduling_policy_arn` and then updating the ARN to an ARN of another `aws_batch_scheduling_policy` resource 

## Notes

- After a job queue is created, you can replace but can't remove the fair share scheduling policy. Reference: https://docs.aws.amazon.com/sdk-for-go/api/service/batch/#CreateJobQueueInput. As such, some conditions are added within the main `HasChanges` to check if `scheduling_policy_arn` has changed and whether that change was a removal or an actual update. If it was a removal, throw an error. If it was an update, proceed.
- If a queue is a FIFO queue (meaning that it was created without `scheduling_policy_arn`), SchedulingPolicyArn should not be set. Error is "Only fairshare queue can have scheduling policy" if we set this value after the creation of the queue. A conditional check was used to fix this error.