### PR TITLE
resource/aws_connect_contact_flow: add delete function

### DIFF
--- a/.changelog/22303.txt
+++ b/.changelog/22303.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_connect_contact_flow: add delete function
+```

--- a/internal/service/connect/contact_flow.go
+++ b/internal/service/connect/contact_flow.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/connect"
@@ -27,7 +28,7 @@ func ResourceContactFlow() *schema.Resource {
 		CreateContext: resourceContactFlowCreate,
 		ReadContext:   resourceContactFlowRead,
 		UpdateContext: resourceContactFlowUpdate,
-		DeleteContext: schema.NoopContext,
+		DeleteContext: resourceContactFlowDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -258,31 +259,30 @@ func resourceContactFlowUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceContactFlowRead(ctx, d, meta)
 }
 
-//Contact Flows do not support deletion today. We will NoOp the Delete method. Users can rename their flows manually if they want.
-// func resourceContactFlowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-// 	conn := meta.(*conns.AWSClient).ConnectConn
+func resourceContactFlowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ConnectConn
 
-// 	instanceID, contactFlowID, err := ContactFlowParseID(d.Id())
+	instanceID, contactFlowID, err := ContactFlowParseID(d.Id())
 
-// 	if err != nil {
-// 		return diag.FromErr(err)
-// 	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-// 	input := &connect.UpdateContactFlowNameInput{
-// 		ContactFlowId: aws.String(contactFlowID),
-// 		InstanceId:    aws.String(instanceID),
-// 		Name:          aws.String(fmt.Sprintf("%s:%s:%d", "zzTrash", d.Get("name").(string), time.Now().Unix())),
-// 		Description:   aws.String("DELETED"),
-// 	}
+	input := &connect.UpdateContactFlowNameInput{
+		ContactFlowId: aws.String(contactFlowID),
+		InstanceId:    aws.String(instanceID),
+		Name:          aws.String(fmt.Sprintf("%s:%s:%d", "zzTrash", d.Get("name").(string), time.Now().Unix())),
+		Description:   aws.String("DELETED"),
+	}
 
-// 	_, delerr := conn.UpdateContactFlowNameWithContext(ctx, input)
+	_, delerr := conn.UpdateContactFlowNameWithContext(ctx, input)
 
-// 	if delerr != nil {
-// 		return diag.FromErr(fmt.Errorf("Unable to delete contact flow: %s", delerr))
-// 	}
+	if delerr != nil {
+		return diag.FromErr(fmt.Errorf("Unable to delete contact flow: %s", delerr))
+	}
 
-// 	return nil
-// }
+	return nil
+}
 
 func ContactFlowParseID(id string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)

--- a/internal/service/connect/contact_flow.go
+++ b/internal/service/connect/contact_flow.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/connect"
@@ -268,17 +267,17 @@ func resourceContactFlowDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	input := &connect.UpdateContactFlowNameInput{
+	log.Printf("[DEBUG] Deleting Connect Contact Flow : %s", contactFlowID)
+
+	input := &connect.DeleteContactFlowInput{
 		ContactFlowId: aws.String(contactFlowID),
 		InstanceId:    aws.String(instanceID),
-		Name:          aws.String(fmt.Sprintf("%s:%s:%d", "zzTrash", d.Get("name").(string), time.Now().Unix())),
-		Description:   aws.String("DELETED"),
 	}
 
-	_, delerr := conn.UpdateContactFlowNameWithContext(ctx, input)
+	_, deleteContactFlowErr := conn.DeleteContactFlowWithContext(ctx, input)
 
-	if delerr != nil {
-		return diag.FromErr(fmt.Errorf("Unable to delete contact flow: %s", delerr))
+	if deleteContactFlowErr != nil {
+		return diag.FromErr(fmt.Errorf("error deleting Connect Contact Flow (%s): %w", d.Id(), deleteContactFlowErr))
 	}
 
 	return nil

--- a/internal/service/connect/contact_flow_test.go
+++ b/internal/service/connect/contact_flow_test.go
@@ -20,7 +20,7 @@ func TestAccConnectContactFlow_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":      testAccContactFlow_basic,
 		"filename":   testAccContactFlow_filename,
-		"disappears": testAccContactFlow_disappears_ConnectInstance,
+		"disappears": testAccContactFlow_disappears,
 	}
 
 	for name, tc := range testCases {
@@ -131,13 +131,12 @@ func testAccContactFlow_filename(t *testing.T) {
 	})
 }
 
-func testAccContactFlow_disappears_ConnectInstance(t *testing.T) {
+func testAccContactFlow_disappears(t *testing.T) {
 	var v connect.DescribeContactFlowOutput
 	// var v2 connect.DescribeInstanceOutput
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_contact_flow.test"
-	instanceResourceName := "aws_connect_instance.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -149,7 +148,7 @@ func testAccContactFlow_disappears_ConnectInstance(t *testing.T) {
 				Config: testAccContactFlowBasicConfig(rName, rName2, "Disappear"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContactFlowExists(resourceName, &v),
-					acctest.CheckResourceDisappears(acctest.Provider, tfconnect.ResourceInstance(), instanceResourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfconnect.ResourceContactFlow(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/connect/contact_flow_test.go
+++ b/internal/service/connect/contact_flow_test.go
@@ -131,7 +131,6 @@ func testAccContactFlow_filename(t *testing.T) {
 	})
 }
 
-// Can't delete an contact flow. Test deletion of entire connect instance
 func testAccContactFlow_disappears_ConnectInstance(t *testing.T) {
 	var v connect.DescribeContactFlowOutput
 	// var v2 connect.DescribeInstanceOutput

--- a/website/docs/r/connect_contact_flow.html.markdown
+++ b/website/docs/r/connect_contact_flow.html.markdown
@@ -17,7 +17,6 @@ This resource embeds or references Contact Flows specified in Amazon Connect Con
 !> **WARN:** Contact Flows exported from the Console [Contact Flow import/export](https://docs.aws.amazon.com/connect/latest/adminguide/contact-flow-import-export.html) are not in the Amazon Connect Contact Flow Language and can not be used with this resource. Instead, the recommendation is to use the AWS CLI [`describe-contact-flow`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/connect/describe-contact-flow.html).
 See [example](#with-external-content) below which uses `jq` to extract the `Content` attribute and saves it to a local file.
 
-~> **NOTE:** Due to The behaviour of Amazon Connect you cannot delete contact flows. The [recommendation](https://docs.aws.amazon.com/connect/latest/adminguide/create-contact-flow.html#before-create-contact-flow) is to prefix the Contact Flow with `zzTrash_` to get obsolete contact flows out of the way.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #21935

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccConnectContactFlow_serial' PKG_NAME=internal/service/connect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run=TestAccConnectContactFlow_serial -timeout 180m
=== RUN   TestAccConnectContactFlow_serial
=== RUN   TestAccConnectContactFlow_serial/basic
=== RUN   TestAccConnectContactFlow_serial/filename
=== RUN   TestAccConnectContactFlow_serial/disappears
--- PASS: TestAccConnectContactFlow_serial (436.99s)
    --- PASS: TestAccConnectContactFlow_serial/basic (166.09s)
    --- PASS: TestAccConnectContactFlow_serial/filename (166.40s)
    --- PASS: TestAccConnectContactFlow_serial/disappears (104.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    440.123s
...
```

we evaluated the acceptance tests and determined that no changes were required. would love feedback on this decision

