### PR TITLE
datasource aws_ses_active_receipt_rule_set

### DIFF
--- a/.changelog/22310.txt
+++ b/.changelog/22310.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ses_active_receipt_rule_set
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -621,6 +621,8 @@ func Provider() *schema.Provider {
 
 			"aws_ram_resource_share": ram.DataSourceResourceShare(),
 
+			"aws_ses_active_receipt_rule_set": ses.DataSourceActiveReceiptRuleSet(),
+
 			"aws_db_cluster_snapshot":       rds.DataSourceClusterSnapshot(),
 			"aws_db_event_categories":       rds.DataSourceEventCategories(),
 			"aws_db_instance":               rds.DataSourceInstance(),

--- a/internal/service/ses/active_receipt_rule_set_data_source.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source.go
@@ -1,0 +1,50 @@
+package ses
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceActiveReceiptRuleSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceActiveReceiptRuleSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rule_set_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceActiveReceiptRuleSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SESConn
+	data, err := conn.DescribeActiveReceiptRuleSet(&ses.DescribeActiveReceiptRuleSetInput{})
+	if err != nil {
+		if tfawserr.ErrMessageContains(err, ses.ErrCodeRuleSetDoesNotExistException, "") {
+			return fmt.Errorf("SES Active Receipt Rule Set not found: %s", err)
+		}
+		return fmt.Errorf("Error getting SES Active Receipt Rule Set: %s", err)
+	}
+	d.SetId(*data.Metadata.Name)
+	d.Set("rule_set_name", data.Metadata.Name)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ses",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("receipt-rule-set/%s", *data.Metadata.Name),
+	}.String()
+	d.Set("arn", arn)
+	return nil
+}

--- a/internal/service/ses/active_receipt_rule_set_data_source.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source.go
@@ -3,6 +3,7 @@ package ses
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
@@ -36,14 +37,15 @@ func dataSourceActiveReceiptRuleSetRead(d *schema.ResourceData, meta interface{}
 		}
 		return fmt.Errorf("Error getting SES Active Receipt Rule Set: %s", err)
 	}
-	d.SetId(*data.Metadata.Name)
-	d.Set("rule_set_name", data.Metadata.Name)
+	name := aws.StringValue(data.Metadata.Name)
+	d.SetId(name)
+	d.Set("rule_set_name", name)
 	arn := arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition,
 		Service:   "ses",
 		Region:    meta.(*conns.AWSClient).Region,
 		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("receipt-rule-set/%s", *data.Metadata.Name),
+		Resource:  fmt.Sprintf("receipt-rule-set/%s", name),
 	}.String()
 	d.Set("arn", arn)
 	return nil

--- a/internal/service/ses/active_receipt_rule_set_data_source.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ses"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
@@ -30,13 +29,13 @@ func DataSourceActiveReceiptRuleSet() *schema.Resource {
 
 func dataSourceActiveReceiptRuleSetRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).SESConn
+
 	data, err := conn.DescribeActiveReceiptRuleSet(&ses.DescribeActiveReceiptRuleSetInput{})
+
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, ses.ErrCodeRuleSetDoesNotExistException, "") {
-			return fmt.Errorf("SES Active Receipt Rule Set not found: %s", err)
-		}
-		return fmt.Errorf("Error getting SES Active Receipt Rule Set: %s", err)
+		return fmt.Errorf("error reading SES Active Receipt Rule Set: %s", err)
 	}
+
 	name := aws.StringValue(data.Metadata.Name)
 	d.SetId(name)
 	d.Set("rule_set_name", name)
@@ -48,5 +47,6 @@ func dataSourceActiveReceiptRuleSetRead(d *schema.ResourceData, meta interface{}
 		Resource:  fmt.Sprintf("receipt-rule-set/%s", name),
 	}.String()
 	d.Set("arn", arn)
+
 	return nil
 }

--- a/internal/service/ses/active_receipt_rule_set_data_source_test.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source_test.go
@@ -1,0 +1,51 @@
+package ses_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ses"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func testAccActiveReceiptRuleSetDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "data.aws_ses_active_receipt_rule_set.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			testAccPreCheckSESReceiptRule(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, ses.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSESActiveReceiptRuleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccActiveReceiptRuleSetDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckActiveReceiptRuleSetExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-rule-set/%s", rName)),
+				),
+			},
+		},
+	})
+}
+
+func testAccActiveReceiptRuleSetDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_receipt_rule_set" "test" {
+  rule_set_name = %[1]q
+}
+
+resource "aws_ses_active_receipt_rule_set" "test" {
+  rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
+}
+data "aws_ses_active_receipt_rule_set" "test" {
+  depends_on = [aws_ses_active_receipt_rule_set.test]
+}
+`, name)
+}

--- a/internal/service/ses/active_receipt_rule_set_data_source_test.go
+++ b/internal/service/ses/active_receipt_rule_set_data_source_test.go
@@ -44,6 +44,7 @@ resource "aws_ses_receipt_rule_set" "test" {
 resource "aws_ses_active_receipt_rule_set" "test" {
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
 }
+
 data "aws_ses_active_receipt_rule_set" "test" {
   depends_on = [aws_ses_active_receipt_rule_set.test]
 }

--- a/internal/service/ses/active_receipt_rule_set_test.go
+++ b/internal/service/ses/active_receipt_rule_set_test.go
@@ -18,8 +18,9 @@ import (
 // locally and in TeamCity.
 func TestAccSESActiveReceiptRuleSet_serial(t *testing.T) {
 	testFuncs := map[string]func(t *testing.T){
-		"basic":      testAccActiveReceiptRuleSet_basic,
-		"disappears": testAccActiveReceiptRuleSet_disappears,
+		"basic":       testAccActiveReceiptRuleSet_basic,
+		"disappears":  testAccActiveReceiptRuleSet_disappears,
+		"data_source": testAccActiveReceiptRuleSet_data_source,
 	}
 
 	for name, testFunc := range testFuncs {
@@ -82,6 +83,31 @@ func testAccActiveReceiptRuleSet_disappears(t *testing.T) {
 	})
 }
 
+func testAccActiveReceiptRuleSet_data_source(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "data.aws_ses_active_receipt_rule_set.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			testAccPreCheck(t)
+			testAccPreCheckSESReceiptRule(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, ses.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSESActiveReceiptRuleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccActiveReceiptRuleSetConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckActiveReceiptRuleSetExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-rule-set/%s", rName)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSESActiveReceiptRuleSetDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).SESConn
 
@@ -139,6 +165,21 @@ resource "aws_ses_receipt_rule_set" "test" {
 
 resource "aws_ses_active_receipt_rule_set" "test" {
   rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
+}
+`, name)
+}
+
+func testAccActiveReceiptRuleSetConfigDataSource(name string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_receipt_rule_set" "test" {
+  rule_set_name = %[1]q
+}
+
+resource "aws_ses_active_receipt_rule_set" "test" {
+  rule_set_name = aws_ses_receipt_rule_set.test.rule_set_name
+}
+data "aws_ses_active_receipt_rule_set" "test" {
+  depends_on = [aws_ses_active_receipt_rule_set.test]
 }
 `, name)
 }

--- a/website/docs/d/ses_active_receipt_rule_set.html.markdown
+++ b/website/docs/d/ses_active_receipt_rule_set.html.markdown
@@ -1,0 +1,24 @@
+---
+subcategory: "SES"
+layout: "aws"
+page_title: "AWS: aws_ses_active_receipt_rule_set"
+description: |-
+  Retrieve the active SES receipt rule set
+---
+
+# Data Source: aws_ses_active_receipt_rule_set
+
+Retrieve the active SES receipt rule set
+
+## Example Usage
+
+```terraform
+data "aws_ses_active_receipt_rule_set" "main" {}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The SES receipt rule set ARN.
+* `rule_set_name` - The name of the rule set


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #20318

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccSESActiveReceiptRuleSet_serial" PKG_NAME="./internal/service/ses" ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/ses/... -v -count 1 -parallel 3 -run=TestAccSESActiveReceiptRuleSet_serial -timeout 180m
=== RUN   TestAccSESActiveReceiptRuleSet_serial
=== RUN   TestAccSESActiveReceiptRuleSet_serial/data_source
=== RUN   TestAccSESActiveReceiptRuleSet_serial/basic
=== RUN   TestAccSESActiveReceiptRuleSet_serial/disappears
--- PASS: TestAccSESActiveReceiptRuleSet_serial (76.31s)
    --- PASS: TestAccSESActiveReceiptRuleSet_serial/data_source (28.22s)
    --- PASS: TestAccSESActiveReceiptRuleSet_serial/basic (24.30s)
    --- PASS: TestAccSESActiveReceiptRuleSet_serial/disappears (23.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	77.839s
```
