### PR TITLE
fix: change the type from array to slice to prevent a panic

### DIFF
--- a/.changelog/22315.txt
+++ b/.changelog/22315.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_traffic_mirror_filter_rule: Prevent crash during resource read
+```

--- a/internal/service/ec2/traffic_mirror_filter_rule.go
+++ b/internal/service/ec2/traffic_mirror_filter_rule.go
@@ -356,7 +356,7 @@ func buildTrafficMirrorFilterRulePortRangeSchema(portRange *ec2.TrafficMirrorPor
 		return nil
 	}
 
-	var out [1]interface{}
+	out := make([]interface{}, 1)
 	elem := make(map[string]interface{})
 	elem["from_port"] = portRange.FromPort
 	elem["to_port"] = portRange.ToPort


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #22312.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTS=TestAccEC2TrafficMirrorFilterRule PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2TrafficMirrorFilterRule' -timeout 180m
=== RUN   TestAccEC2TrafficMirrorFilterRule_basic
=== PAUSE TestAccEC2TrafficMirrorFilterRule_basic
=== RUN   TestAccEC2TrafficMirrorFilterRule_disappears
=== PAUSE TestAccEC2TrafficMirrorFilterRule_disappears
=== CONT  TestAccEC2TrafficMirrorFilterRule_basic
=== CONT  TestAccEC2TrafficMirrorFilterRule_disappears
--- PASS: TestAccEC2TrafficMirrorFilterRule_disappears (52.83s)
--- PASS: TestAccEC2TrafficMirrorFilterRule_basic (141.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	143.856s
```
