### PR TITLE
data_source `aws_ses_domain_identity` `aws_ses_email_identity`

### DIFF
--- a/.changelog/22321.txt
+++ b/.changelog/22321.txt
@@ -1,0 +1,4 @@
+```release-note:new-data-source
+aws_ses_domain_identity
+aws_ses_email_identity
+```

--- a/.changelog/22321.txt
+++ b/.changelog/22321.txt
@@ -1,4 +1,7 @@
 ```release-note:new-data-source
 aws_ses_domain_identity
+```
+
+```release-note:new-data-source
 aws_ses_email_identity
 ```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -631,6 +631,8 @@ func Provider() *schema.Provider {
 			"aws_ram_resource_share": ram.DataSourceResourceShare(),
 
 			"aws_ses_active_receipt_rule_set": ses.DataSourceActiveReceiptRuleSet(),
+			"aws_ses_domain_identity":         ses.DataSourceDomainIdentity(),
+			"aws_ses_email_identity":          ses.DataSourceEmailIdentity(),
 
 			"aws_db_cluster_snapshot":       rds.DataSourceClusterSnapshot(),
 			"aws_db_event_categories":       rds.DataSourceEventCategories(),

--- a/internal/service/ses/domain_identity_data_source.go
+++ b/internal/service/ses/domain_identity_data_source.go
@@ -1,0 +1,69 @@
+package ses
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceDomainIdentity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDomainIdentityRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+			},
+			"verification_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDomainIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SESConn
+
+	domainName := d.Get("domain").(string)
+	d.SetId(domainName)
+	d.Set("domain", domainName)
+
+	readOpts := &ses.GetIdentityVerificationAttributesInput{
+		Identities: []*string{
+			aws.String(domainName),
+		},
+	}
+
+	response, err := conn.GetIdentityVerificationAttributes(readOpts)
+	if err != nil {
+		return fmt.Errorf("[WARN] Error fetching identity verification attributes for %s: %s", domainName, err)
+	}
+
+	verificationAttrs, ok := response.VerificationAttributes[domainName]
+	if !ok {
+		return fmt.Errorf("[WARN] Domain not listed in response when fetching verification attributes for %s", domainName)
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ses",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("identity/%s", domainName),
+	}.String()
+	d.Set("arn", arn)
+	d.Set("verification_token", verificationAttrs.VerificationToken)
+	return nil
+}

--- a/internal/service/ses/domain_identity_data_source_test.go
+++ b/internal/service/ses/domain_identity_data_source_test.go
@@ -1,0 +1,43 @@
+package ses_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccSESDomainIdentityDataSource_basic(t *testing.T) {
+	domain := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ses.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDomainIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainIdentityDataSourceConfig(domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainIdentityExists("aws_ses_domain_identity.test"),
+					testAccCheckDomainIdentityARN("data.aws_ses_domain_identity.test", domain),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainIdentityDataSourceConfig(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_domain_identity" "test" {
+  domain = "%s"
+}
+
+data "aws_ses_domain_identity" "test" {
+  depends_on = [aws_ses_domain_identity.test]
+  domain     = "%s"
+}
+`, domain, domain)
+}

--- a/internal/service/ses/email_identity_data_dource_test.go
+++ b/internal/service/ses/email_identity_data_dource_test.go
@@ -1,0 +1,64 @@
+package ses_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccSESEmailIdentityDataSource_basic(t *testing.T) {
+	email := acctest.DefaultEmailAddress
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ses.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityDataSourceConfig(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityExists("aws_ses_email_identity.test"),
+					acctest.MatchResourceAttrRegionalARN("data.aws_ses_email_identity.test", "arn", "ses", regexp.MustCompile(fmt.Sprintf("identity/%s$", regexp.QuoteMeta(email)))),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSESEmailIdentityDataSource_trailingPeriod(t *testing.T) {
+	email := fmt.Sprintf("%s.", acctest.DefaultEmailAddress)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ses.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityDataSourceConfig(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityExists("aws_ses_email_identity.test"),
+					acctest.MatchResourceAttrRegionalARN("data.aws_ses_email_identity.test", "arn", "ses", regexp.MustCompile(fmt.Sprintf("identity/%s$", regexp.QuoteMeta(strings.TrimSuffix(email, "."))))),
+				),
+			},
+		},
+	})
+}
+
+func testAccEmailIdentityDataSourceConfig(email string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_email_identity" "test" {
+  email = %q
+}
+data "aws_ses_email_identity" "test" {
+  depends_on = [aws_ses_email_identity.test]
+  email      = %q
+}
+`, email, email)
+}

--- a/internal/service/ses/email_identity_data_source.go
+++ b/internal/service/ses/email_identity_data_source.go
@@ -1,0 +1,67 @@
+package ses
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceEmailIdentity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceEmailIdentityRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(v interface{}) string {
+					return strings.TrimSuffix(v.(string), ".")
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEmailIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SESConn
+
+	email := d.Get("email").(string)
+	email = strings.TrimSuffix(email, ".")
+
+	d.SetId(email)
+	d.Set("email", email)
+
+	readOpts := &ses.GetIdentityVerificationAttributesInput{
+		Identities: []*string{
+			aws.String(email),
+		},
+	}
+
+	response, err := conn.GetIdentityVerificationAttributes(readOpts)
+	if err != nil {
+		return fmt.Errorf("[WARN] Error fetching identity verification attributes for %s: %s", email, err)
+	}
+
+	_, ok := response.VerificationAttributes[email]
+	if !ok {
+		return fmt.Errorf("[WARN] Email not listed in response when fetching verification attributes for %s", d.Id())
+	}
+
+	arn := arn.ARN{
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Partition: meta.(*conns.AWSClient).Partition,
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("identity/%s", email),
+		Service:   "ses",
+	}.String()
+	d.Set("arn", arn)
+	return nil
+}

--- a/website/docs/d/ses_domain_identity.markdown
+++ b/website/docs/d/ses_domain_identity.markdown
@@ -1,0 +1,27 @@
+---
+subcategory: "SES"
+layout: "aws"
+page_title: "AWS: aws_ses_domain_identity"
+description: |-
+  Retrieve the SES domain identity
+---
+
+# Data Source: aws_ses_domain_identity
+
+Retrieve the SES domain identity
+
+## Example Usage
+
+```terraform
+data "aws_ses_domain_identity" "example" {
+  domain = "example.com"
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The ARN of the domain identity.
+* `domain` - The name of the domain
+* `verification_token` - A code which when added to the domain as a TXT record will signal to SES that the owner of the domain has authorized SES to act on their behalf.

--- a/website/docs/d/ses_email_identity.markdown
+++ b/website/docs/d/ses_email_identity.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "SES"
+layout: "aws"
+page_title: "AWS: aws_ses_email_identity"
+description: |-
+  Retrieve the active SES email identity
+---
+
+# Data Source: aws_ses_email_identity
+
+Retrieve the active SES email identity
+
+## Example Usage
+
+```terraform
+data "aws_ses_email_identity" "example" {
+  email = "awesome@example.com"
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` -  The ARN of the email identity.
+* `email` - The email identity.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #16878

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS="-run=TestAccSESDomainIdentityDataSource_basic" PKG_NAME="./internal/service/ses" ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/ses/... -v -count 1 -parallel 3 -run=TestAccSESDomainIdentityDataSource_basic TestAccSESEmailIdentityDataSource_basic TestAccSESEmailIdentityDataSource_trailingPeriod -timeout 180m
=== RUN   TestAccSESDomainIdentityDataSource_basic
=== PAUSE TestAccSESDomainIdentityDataSource_basic
=== CONT  TestAccSESDomainIdentityDataSource_basic
--- PASS: TestAccSESDomainIdentityDataSource_basic (23.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	25.080s
$ make testacc TESTARGS="-run=TestAccSESEmailIdentityDataSource_basic" PKG_NAME="./internal/service/ses" ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/ses/... -v -count 1 -parallel 3 -run=TestAccSESEmailIdentityDataSource_basic -timeout 180m
=== RUN   TestAccSESEmailIdentityDataSource_basic
=== PAUSE TestAccSESEmailIdentityDataSource_basic
=== CONT  TestAccSESEmailIdentityDataSource_basic
--- PASS: TestAccSESEmailIdentityDataSource_basic (22.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	23.743s
$ make testacc TESTARGS="-run=TestAccSESEmailIdentityDataSource_trailingPeriod" PKG_NAME="./internal/service/ses" ACCTEST_PARALLELISM=3   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/ses/... -v -count 1 -parallel 3 -run=TestAccSESEmailIdentityDataSource_trailingPeriod -timeout 180m
=== RUN   TestAccSESEmailIdentityDataSource_trailingPeriod
=== PAUSE TestAccSESEmailIdentityDataSource_trailingPeriod
=== CONT  TestAccSESEmailIdentityDataSource_trailingPeriod
--- PASS: TestAccSESEmailIdentityDataSource_trailingPeriod (22.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	23.651s
...
```
