### PR TITLE
Timestream actions in IoT Rules

### DIFF
--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -533,6 +533,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"cloudwatch_metric": {
@@ -585,6 +586,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"dynamodb": {
@@ -657,6 +659,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"dynamodbv2": {
@@ -701,6 +704,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"elasticsearch": {
@@ -749,6 +753,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"firehose": {
@@ -789,6 +794,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"iot_analytics": {
@@ -824,6 +830,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"iot_events": {
@@ -863,6 +870,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"kinesis": {
@@ -902,6 +910,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"lambda": {
@@ -933,6 +942,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"republish": {
@@ -974,6 +984,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"s3": {
@@ -1013,6 +1024,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"step_functions": {
@@ -1052,6 +1064,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"sns": {
@@ -1093,6 +1106,7 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 						"sqs": {
@@ -1132,6 +1146,69 @@ func ResourceTopicRule() *schema.Resource {
 								"error_action.0.step_functions",
 								"error_action.0.sns",
 								"error_action.0.sqs",
+								"error_action.0.timestream",
+							},
+						},
+						"timestream": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"database_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"dimension": {
+										Type:     schema.TypeSet,
+										Required: true,
+										Elem:     timestreamDimensionResource,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: verify.ValidARN,
+									},
+									"table_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"timestamp": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"unit": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+								"error_action.0.timestream",
 							},
 						},
 					},
@@ -2174,6 +2251,16 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{StepFunctions: action}
 				}
+			case "timestream":
+				for _, tfMapRaw := range v.([]interface{}) {
+					action := expandIotTimestreamAction([]interface{}{tfMapRaw})
+
+					if action == nil {
+						continue
+					}
+
+					iotErrorAction = &iot.Action{Timestream: action}
+				}
 			}
 		}
 	}
@@ -2866,6 +2953,10 @@ func flattenIotErrorAction(errorAction *iot.Action) []map[string]interface{} {
 	}
 	if errorAction.StepFunctions != nil {
 		results = append(results, map[string]interface{}{"step_functions": flattenIotStepFunctionsActions(input)})
+		return results
+	}
+	if errorAction.Timestream != nil {
+		results = append(results, map[string]interface{}{"timestream": flattenIotTimestreamActions(input)})
 		return results
 	}
 

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -474,6 +474,12 @@ func ResourceTopicRule() *schema.Resource {
 									"unit": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"SECONDS",
+											"MILLISECONDS",
+											"MICROSECONDS",
+											"NANOSECONDS",
+										}, false),
 									},
 									"value": {
 										Type:     schema.TypeString,
@@ -1182,6 +1188,12 @@ func ResourceTopicRule() *schema.Resource {
 												"unit": {
 													Type:     schema.TypeString,
 													Required: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														"SECONDS",
+														"MILLISECONDS",
+														"MICROSECONDS",
+														"NANOSECONDS",
+													}, false),
 												},
 												"value": {
 													Type:     schema.TypeString,

--- a/internal/service/iot/topic_rule_test.go
+++ b/internal/service/iot/topic_rule_test.go
@@ -425,6 +425,31 @@ func TestAccIoTTopicRule_Step_functions(t *testing.T) {
 	})
 }
 
+func TestAccIoTTopicRule_Timestream(t *testing.T) {
+	rName := sdkacctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, iot.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckTopicRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTopicRule_timestream(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccIoTTopicRule_IoT_analytics(t *testing.T) {
 	rName := sdkacctest.RandString(5)
 
@@ -1014,6 +1039,36 @@ resource "aws_iot_topic_rule" "rule" {
     execution_name_prefix = "myprefix"
     state_machine_name    = "mystatemachine"
     role_arn              = aws_iam_role.iot_role.arn
+  }
+}
+`, rName))
+}
+
+func testAccTopicRule_timestream(rName string) string {
+	return acctest.ConfigCompose(
+		testAccTopicRuleRole(rName),
+		fmt.Sprintf(`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  timestream {
+    database_name = "TestDB"
+    role_arn      = aws_iam_role.iot_role.arn
+    table_name    = "test_table"
+
+    dimension {
+      name  = "dim"
+      value = "$${dim}"
+    }
+
+    timestamp {
+      unit = "MILLISECONDS"
+      value = "$${time}"
+    }
   }
 }
 `, rName))

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -88,7 +88,7 @@ EOF
 * `enabled` - (Required) Specifies whether the rule is enabled.
 * `sql` - (Required) The SQL statement used to query the topic. For more information, see AWS IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference) in the AWS IoT Developer Guide.
 * `sql_version` - (Required) The version of the SQL rules engine to use when evaluating the rule.
-* `error_action` - (Optional) Configuration block with error action to be associated with the rule. See the documentation for `cloudwatch_alarm`, `cloudwatch_metric`, `dynamodb`, `dynamodbv2`, `elasticsearch`, `firehose`, `iot_analytics`, `iot_events`, `kinesis`, `lambda`, `republish`, `s3`, `step_functions`, `sns`, `sqs` configuration blocks for further configuration details.
+* `error_action` - (Optional) Configuration block with error action to be associated with the rule. See the documentation for `cloudwatch_alarm`, `cloudwatch_metric`, `dynamodb`, `dynamodbv2`, `elasticsearch`, `firehose`, `iot_analytics`, `iot_events`, `kinesis`, `lambda`, `republish`, `s3`, `step_functions`, `sns`, `sqs`, `timestream` configuration blocks for further configuration details.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `cloudwatch_alarm` object takes the following arguments:
@@ -179,6 +179,18 @@ The `step_functions` object takes the following arguments:
 * `execution_name_prefix` - (Optional) The prefix used to generate, along with a UUID, the unique state machine execution name.
 * `state_machine_name` - (Required) The name of the Step Functions state machine whose execution will be started.
 * `role_arn` - (Required) The ARN of the IAM role that grants access to start execution of the state machine.
+
+The `timestream` object takes the following arguments:
+
+* `database_name` - (Required) The name of an Amazon Timestream database.
+* `dimension` - (Required) Configuration blocks with metadata attributes of the time series that are written in each measure record. Nested arguments below.
+    * `name` - (Required) The metadata dimension name. This is the name of the column in the Amazon Timestream database table record.
+    * `value` - (Required) The value to write in this column of the database record.
+* `role_arn` - (Required) The ARN of the role that grants permission to write to the Amazon Timestream database table.
+* `table_name` - (Required) The name of the database table into which to write the measure records.
+* `timestamp` - (Optional) Configuration block specifying an application-defined value to replace the default value assigned to the Timestream record's timestamp in the time column. Nested arguments below.
+    * `unit` - (Required) The precision of the timestamp value that results from the expression described in value. Valid values: `SECONDS`, `MILLISECONDS`, `MICROSECONDS`, `NANOSECONDS`.
+    * `value` - (Required) An expression that returns a long epoch time value.
 
 The `iot_analytics` object takes the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

This PR adds support for Timestream actions in IoT rules. Both for main output and as error actions.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19904

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccIoTTopicRule PKG=iot            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTTopicRule' -timeout 180m
=== RUN   TestAccIoTTopicRule_basic
=== PAUSE TestAccIoTTopicRule_basic
=== RUN   TestAccIoTTopicRule_cloudWatchAlarm
=== PAUSE TestAccIoTTopicRule_cloudWatchAlarm
=== RUN   TestAccIoTTopicRule_cloudWatchMetric
=== PAUSE TestAccIoTTopicRule_cloudWatchMetric
=== RUN   TestAccIoTTopicRule_dynamoDB
=== PAUSE TestAccIoTTopicRule_dynamoDB
=== RUN   TestAccIoTTopicRule_dynamoDBv2
=== PAUSE TestAccIoTTopicRule_dynamoDBv2
=== RUN   TestAccIoTTopicRule_elasticSearch
=== PAUSE TestAccIoTTopicRule_elasticSearch
=== RUN   TestAccIoTTopicRule_firehose
=== PAUSE TestAccIoTTopicRule_firehose
=== RUN   TestAccIoTTopicRule_Firehose_separator
=== PAUSE TestAccIoTTopicRule_Firehose_separator
=== RUN   TestAccIoTTopicRule_kinesis
=== PAUSE TestAccIoTTopicRule_kinesis
=== RUN   TestAccIoTTopicRule_lambda
=== PAUSE TestAccIoTTopicRule_lambda
=== RUN   TestAccIoTTopicRule_republish
=== PAUSE TestAccIoTTopicRule_republish
=== RUN   TestAccIoTTopicRule_republishWithQos
=== PAUSE TestAccIoTTopicRule_republishWithQos
=== RUN   TestAccIoTTopicRule_s3
=== PAUSE TestAccIoTTopicRule_s3
=== RUN   TestAccIoTTopicRule_sns
=== PAUSE TestAccIoTTopicRule_sns
=== RUN   TestAccIoTTopicRule_sqs
=== PAUSE TestAccIoTTopicRule_sqs
=== RUN   TestAccIoTTopicRule_Step_functions
=== PAUSE TestAccIoTTopicRule_Step_functions
=== RUN   TestAccIoTTopicRule_Timestream
=== PAUSE TestAccIoTTopicRule_Timestream
=== RUN   TestAccIoTTopicRule_IoT_analytics
=== PAUSE TestAccIoTTopicRule_IoT_analytics
=== RUN   TestAccIoTTopicRule_IoT_events
=== PAUSE TestAccIoTTopicRule_IoT_events
=== RUN   TestAccIoTTopicRule_tags
=== PAUSE TestAccIoTTopicRule_tags
=== RUN   TestAccIoTTopicRule_errorAction
=== PAUSE TestAccIoTTopicRule_errorAction
=== RUN   TestAccIoTTopicRule_updateKinesisErrorAction
=== PAUSE TestAccIoTTopicRule_updateKinesisErrorAction
=== CONT  TestAccIoTTopicRule_basic
=== CONT  TestAccIoTTopicRule_republishWithQos
=== CONT  TestAccIoTTopicRule_updateKinesisErrorAction
=== CONT  TestAccIoTTopicRule_errorAction
=== CONT  TestAccIoTTopicRule_tags
=== CONT  TestAccIoTTopicRule_IoT_events
=== CONT  TestAccIoTTopicRule_IoT_analytics
=== CONT  TestAccIoTTopicRule_Timestream
=== CONT  TestAccIoTTopicRule_Step_functions
=== CONT  TestAccIoTTopicRule_sqs
=== CONT  TestAccIoTTopicRule_sns
=== CONT  TestAccIoTTopicRule_s3
=== CONT  TestAccIoTTopicRule_firehose
=== CONT  TestAccIoTTopicRule_republish
=== CONT  TestAccIoTTopicRule_lambda
=== CONT  TestAccIoTTopicRule_kinesis
=== CONT  TestAccIoTTopicRule_Firehose_separator
=== CONT  TestAccIoTTopicRule_dynamoDB
=== CONT  TestAccIoTTopicRule_elasticSearch
=== CONT  TestAccIoTTopicRule_dynamoDBv2
--- PASS: TestAccIoTTopicRule_basic (37.89s)
=== CONT  TestAccIoTTopicRule_cloudWatchMetric
--- PASS: TestAccIoTTopicRule_lambda (50.21s)
=== CONT  TestAccIoTTopicRule_cloudWatchAlarm
--- PASS: TestAccIoTTopicRule_IoT_analytics (54.03s)
--- PASS: TestAccIoTTopicRule_sqs (63.18s)
--- PASS: TestAccIoTTopicRule_firehose (63.26s)
--- PASS: TestAccIoTTopicRule_errorAction (63.27s)
--- PASS: TestAccIoTTopicRule_republish (64.01s)
--- PASS: TestAccIoTTopicRule_dynamoDBv2 (68.44s)
--- PASS: TestAccIoTTopicRule_IoT_events (68.47s)
--- PASS: TestAccIoTTopicRule_republishWithQos (73.77s)
--- PASS: TestAccIoTTopicRule_Step_functions (73.97s)
--- PASS: TestAccIoTTopicRule_elasticSearch (73.99s)
--- PASS: TestAccIoTTopicRule_Timestream (74.00s)
--- PASS: TestAccIoTTopicRule_s3 (74.10s)
--- PASS: TestAccIoTTopicRule_kinesis (74.20s)
--- PASS: TestAccIoTTopicRule_sns (74.61s)
--- PASS: TestAccIoTTopicRule_cloudWatchMetric (45.85s)
--- PASS: TestAccIoTTopicRule_Firehose_separator (92.01s)
--- PASS: TestAccIoTTopicRule_tags (94.13s)
--- PASS: TestAccIoTTopicRule_updateKinesisErrorAction (104.55s)
--- PASS: TestAccIoTTopicRule_dynamoDB (105.84s)
--- PASS: TestAccIoTTopicRule_cloudWatchAlarm (55.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        106.034s
```
