### PR TITLE
r/ebs_snapshot - support storage tier + sweeper

### DIFF
--- a/.changelog/22342.txt
+++ b/.changelog/22342.txt
@@ -1,13 +1,13 @@
 ```release-note:enhancement
-resource/aws_ebs_snapshot: Add `outpost_arn`, `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
+resource/aws_ebs_snapshot: Add `outpost_arn`, `storage_tier`, `permanent_restore`, `temporary_restore_days` arguments
 ```
 
 ```release-note:enhancement
-resource/aws_ebs_snapshot_copy: Add `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
+resource/aws_ebs_snapshot_copy: Add `storage_tier`, `permanent_restore`, `temporary_restore_days` arguments
 ```
 
 ```release-note:enhancement
-resource/aws_ebs_snapshot_import: Add `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
+resource/aws_ebs_snapshot_import: Add `storage_tier`, `permanent_restore`, `temporary_restore_days` arguments
 ```
 
 ```release-note:enhancement

--- a/.changelog/22342.txt
+++ b/.changelog/22342.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_ebs_snapshot: Add `outpost_arn`, `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
+```
+
+```release-note:enhancement
+resource/aws_ebs_snapshot_copy: Add `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
+```
+
+```release-note:enhancement
+resource/aws_ebs_snapshot_import: Add `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
+```

--- a/.changelog/22342.txt
+++ b/.changelog/22342.txt
@@ -9,3 +9,7 @@ resource/aws_ebs_snapshot_copy: Add `storage_tier`, `permenent_restore`, `tempor
 ```release-note:enhancement
 resource/aws_ebs_snapshot_import: Add `storage_tier`, `permenent_restore`, `temporary_restore_days` arguments
 ```
+
+```release-note:enhancement
+data-source/aws_ebs_snapshot: Add `storage_tier` and `outpost_arn` attributes.
+```

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -193,6 +193,7 @@ func resourceEBSSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("kms_key_id", snapshot.KmsKeyId)
 	d.Set("volume_size", snapshot.VolumeSize)
 	d.Set("storage_tier", snapshot.StorageTier)
+	d.Set("volume_id", snapshot.VolumeId)
 
 	if snapshot.OutpostArn != nil {
 		d.Set("outpost_arn", snapshot.OutpostArn)

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -89,7 +89,7 @@ func ResourceEBSSnapshot() *schema.Resource {
 					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
-			"permenent_restore": {
+			"permanent_restore": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
@@ -245,7 +245,7 @@ func resourceEBSSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
 				SnapshotId: aws.String(d.Id()),
 			}
 
-			if v, ok := d.GetOk("permenent_restore"); ok {
+			if v, ok := d.GetOk("permanent_restore"); ok {
 				input.PermanentRestore = aws.Bool(v.(bool))
 			}
 

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -86,7 +86,7 @@ func ResourceEBSSnapshot() *schema.Resource {
 				Computed: true,
 				ValidateFunc: validation.Any(
 					validation.StringInSlice(ec2.TargetStorageTier_Values(), false),
-					validation.StringInSlice([]string{"standard"}, false), //Does not include `standard` type.
+					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
 			"permenent_restore": {

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -40,15 +40,22 @@ func ResourceEBSSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"volume_id": {
+			"data_encryption_key_id": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+			"encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"outpost_arn": {
 				Type:         schema.TypeString,
@@ -56,29 +63,17 @@ func ResourceEBSSnapshot() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"owner_alias": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"encrypted": {
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permanent_restore": {
 				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"volume_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"kms_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"data_encryption_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 			"storage_tier": {
 				Type:     schema.TypeString,
@@ -89,16 +84,21 @@ func ResourceEBSSnapshot() *schema.Resource {
 					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
-			"permanent_restore": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
 			"temporary_restore_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -185,19 +185,16 @@ func resourceEBSSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading EBS Snapshot (%s): %w", d.Id(), err)
 	}
 
-	d.Set("description", snapshot.Description)
-	d.Set("owner_id", snapshot.OwnerId)
-	d.Set("encrypted", snapshot.Encrypted)
-	d.Set("owner_alias", snapshot.OwnerAlias)
 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
+	d.Set("description", snapshot.Description)
+	d.Set("encrypted", snapshot.Encrypted)
 	d.Set("kms_key_id", snapshot.KmsKeyId)
-	d.Set("volume_size", snapshot.VolumeSize)
+	d.Set("outpost_arn", snapshot.OutpostArn)
+	d.Set("owner_alias", snapshot.OwnerAlias)
+	d.Set("owner_id", snapshot.OwnerId)
 	d.Set("storage_tier", snapshot.StorageTier)
 	d.Set("volume_id", snapshot.VolumeId)
-
-	if snapshot.OutpostArn != nil {
-		d.Set("outpost_arn", snapshot.OutpostArn)
-	}
+	d.Set("volume_size", snapshot.VolumeSize)
 
 	tags := KeyValueTags(snapshot.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -193,8 +193,11 @@ func resourceEBSSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
 	d.Set("kms_key_id", snapshot.KmsKeyId)
 	d.Set("volume_size", snapshot.VolumeSize)
-	d.Set("outpost_arn", snapshot.OutpostArn)
 	d.Set("storage_tier", snapshot.StorageTier)
+
+	if snapshot.OutpostArn != nil {
+		d.Set("outpost_arn", snapshot.OutpostArn)
+	}
 
 	tags := KeyValueTags(snapshot.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -189,7 +189,6 @@ func resourceEBSSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("owner_id", snapshot.OwnerId)
 	d.Set("encrypted", snapshot.Encrypted)
 	d.Set("owner_alias", snapshot.OwnerAlias)
-	d.Set("volume_id", snapshot.VolumeId)
 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
 	d.Set("kms_key_id", snapshot.KmsKeyId)
 	d.Set("volume_size", snapshot.VolumeSize)

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -2,27 +2,21 @@ package ec2
 
 import (
 	"fmt"
-	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceEBSSnapshotCopy() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceEBSSnapshotCopyCreate,
-		Read:   resourceEBSSnapshotCopyRead,
-		Update: resourceEBSSnapshotCopyUpdate,
-		Delete: resourceEBSSnapshotCopyDelete,
+		Read:   resourceEBSSnapshotRead,
+		Update: resourceEBSSnapshotUpdate,
+		Delete: resourceEBSSnapshotDelete,
 
 		CustomizeDiff: verify.SetTagsDiff,
 
@@ -109,119 +103,121 @@ func resourceEBSSnapshotCopyCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(aws.StringValue(res.SnapshotId))
 
-	err = resourceEBSSnapshotCopyWaitForAvailable(d.Id(), conn)
+	err = resourceEBSSnapshotWaitForAvailable(d, conn)
 	if err != nil {
 		return err
 	}
 
-	return resourceEBSSnapshotCopyRead(d, meta)
-}
+	if v, ok := d.GetOk("storage_tier"); ok && v.(string) == ec2.TargetStorageTierArchive {
+		_, err = conn.ModifySnapshotTier(&ec2.ModifySnapshotTierInput{
+			SnapshotId:  aws.String(d.Id()),
+			StorageTier: aws.String(v.(string)),
+		})
 
-func resourceEBSSnapshotCopyRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).EC2Conn
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	req := &ec2.DescribeSnapshotsInput{
-		SnapshotIds: []*string{aws.String(d.Id())},
-	}
-	res, err := conn.DescribeSnapshots(req)
-	if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
-		log.Printf("Snapshot %q Not found - removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error describing EC2 Snapshot (%s): %w", d.Id(), err)
-	}
-
-	snapshot := res.Snapshots[0]
-
-	d.Set("description", snapshot.Description)
-	d.Set("owner_id", snapshot.OwnerId)
-	d.Set("encrypted", snapshot.Encrypted)
-	d.Set("owner_alias", snapshot.OwnerAlias)
-	d.Set("volume_id", snapshot.VolumeId)
-	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
-	d.Set("kms_key_id", snapshot.KmsKeyId)
-	d.Set("volume_size", snapshot.VolumeSize)
-
-	tags := KeyValueTags(snapshot.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
-	}
-
-	snapshotArn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Region:    meta.(*conns.AWSClient).Region,
-		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
-		Service:   ec2.ServiceName,
-	}.String()
-
-	d.Set("arn", snapshotArn)
-
-	return nil
-}
-
-func resourceEBSSnapshotCopyDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).EC2Conn
-	input := &ec2.DeleteSnapshotInput{
-		SnapshotId: aws.String(d.Id()),
-	}
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteSnapshot(input)
-		if err == nil {
-			return nil
+		if err != nil {
+			return fmt.Errorf("error setting EBS Snapshot (%s) Storage Tier: %w", d.Id(), err)
 		}
 
-		if tfawserr.ErrMessageContains(err, "SnapshotInUse", "") {
-			return resource.RetryableError(fmt.Errorf("EBS SnapshotInUse - trying again while it detaches"))
-		}
-
-		if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
-			return nil
-		}
-
-		return resource.NonRetryableError(err)
-	})
-	if tfresource.TimedOut(err) {
-		_, err = conn.DeleteSnapshot(input)
-		if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
-			return nil
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("Error deleting EBS snapshot copy: %s", err)
-	}
-	return nil
-}
-
-func resourceEBSSnapshotCopyUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).EC2Conn
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+		_, err = WaitEBSSnapshotTierArchive(conn, d.Id())
+		if err != nil {
+			return fmt.Errorf("Error waiting for EBS Snapshot (%s) Storage Tier to be archived: %w", d.Id(), err)
 		}
 	}
 
 	return resourceEBSSnapshotRead(d, meta)
 }
 
-func resourceEBSSnapshotCopyWaitForAvailable(id string, conn *ec2.EC2) error {
-	log.Printf("Waiting for Snapshot %s to become available...", id)
+// func resourceEBSSnapshotCopyRead(d *schema.ResourceData, meta interface{}) error {
+// 	conn := meta.(*conns.AWSClient).EC2Conn
+// 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+// 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	req := &ec2.DescribeSnapshotsInput{
-		SnapshotIds: []*string{aws.String(id)},
-	}
-	err := conn.WaitUntilSnapshotCompleted(req)
-	return err
-}
+// 	snapshot, err := FindSnapshotById(conn, d.Id())
+
+// 	if !d.IsNewResource() && tfresource.NotFound(err) {
+// 		log.Printf("[WARN] EBS Snapshot (%s) Not found - removing from state", d.Id())
+// 		d.SetId("")
+// 		return nil
+// 	}
+
+// 	if err != nil {
+// 		return fmt.Errorf("error reading EBS Snapshot (%s): %w", d.Id(), err)
+// 	}
+
+// 	d.Set("description", snapshot.Description)
+// 	d.Set("owner_id", snapshot.OwnerId)
+// 	d.Set("encrypted", snapshot.Encrypted)
+// 	d.Set("owner_alias", snapshot.OwnerAlias)
+// 	d.Set("volume_id", snapshot.VolumeId)
+// 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
+// 	d.Set("kms_key_id", snapshot.KmsKeyId)
+// 	d.Set("volume_size", snapshot.VolumeSize)
+
+// 	tags := KeyValueTags(snapshot.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+// 	//lintignore:AWSR002
+// 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+// 		return fmt.Errorf("error setting tags: %w", err)
+// 	}
+
+// 	if err := d.Set("tags_all", tags.Map()); err != nil {
+// 		return fmt.Errorf("error setting tags_all: %w", err)
+// 	}
+
+// 	snapshotArn := arn.ARN{
+// 		Partition: meta.(*conns.AWSClient).Partition,
+// 		Region:    meta.(*conns.AWSClient).Region,
+// 		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
+// 		Service:   ec2.ServiceName,
+// 	}.String()
+
+// 	d.Set("arn", snapshotArn)
+
+// 	return nil
+// }
+
+// func resourceEBSSnapshotCopyDelete(d *schema.ResourceData, meta interface{}) error {
+// 	conn := meta.(*conns.AWSClient).EC2Conn
+// 	input := &ec2.DeleteSnapshotInput{
+// 		SnapshotId: aws.String(d.Id()),
+// 	}
+// 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+// 		_, err := conn.DeleteSnapshot(input)
+// 		if err == nil {
+// 			return nil
+// 		}
+
+// 		if tfawserr.ErrMessageContains(err, "SnapshotInUse", "") {
+// 			return resource.RetryableError(fmt.Errorf("EBS SnapshotInUse - trying again while it detaches"))
+// 		}
+
+// 		if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
+// 			return nil
+// 		}
+
+// 		return resource.NonRetryableError(err)
+// 	})
+// 	if tfresource.TimedOut(err) {
+// 		_, err = conn.DeleteSnapshot(input)
+// 		if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
+// 			return nil
+// 		}
+// 	}
+// 	if err != nil {
+// 		return fmt.Errorf("Error deleting EBS snapshot copy: %s", err)
+// 	}
+// 	return nil
+// }
+
+// func resourceEBSSnapshotCopyUpdate(d *schema.ResourceData, meta interface{}) error {
+// 	conn := meta.(*conns.AWSClient).EC2Conn
+
+// 	if d.HasChange("tags_all") {
+// 		o, n := d.GetChange("tags_all")
+// 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+// 			return fmt.Errorf("error updating tags: %s", err)
+// 		}
+// 	}
+
+// 	return resourceEBSSnapshotRead(d, meta)
+// }

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -70,6 +71,23 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"storage_tier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.Any(
+					validation.StringInSlice(ec2.TargetStorageTier_Values(), false),
+					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
+				),
+			},
+			"permenent_restore": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"temporary_restore_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -115,109 +133,14 @@ func resourceEBSSnapshotCopyCreate(d *schema.ResourceData, meta interface{}) err
 		})
 
 		if err != nil {
-			return fmt.Errorf("error setting EBS Snapshot (%s) Storage Tier: %w", d.Id(), err)
+			return fmt.Errorf("error setting EBS Snapshot Copy (%s) Storage Tier: %w", d.Id(), err)
 		}
 
 		_, err = WaitEBSSnapshotTierArchive(conn, d.Id())
 		if err != nil {
-			return fmt.Errorf("Error waiting for EBS Snapshot (%s) Storage Tier to be archived: %w", d.Id(), err)
+			return fmt.Errorf("Error waiting for EBS Snapshot Copy (%s) Storage Tier to be archived: %w", d.Id(), err)
 		}
 	}
 
 	return resourceEBSSnapshotRead(d, meta)
 }
-
-// func resourceEBSSnapshotCopyRead(d *schema.ResourceData, meta interface{}) error {
-// 	conn := meta.(*conns.AWSClient).EC2Conn
-// 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-// 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-// 	snapshot, err := FindSnapshotById(conn, d.Id())
-
-// 	if !d.IsNewResource() && tfresource.NotFound(err) {
-// 		log.Printf("[WARN] EBS Snapshot (%s) Not found - removing from state", d.Id())
-// 		d.SetId("")
-// 		return nil
-// 	}
-
-// 	if err != nil {
-// 		return fmt.Errorf("error reading EBS Snapshot (%s): %w", d.Id(), err)
-// 	}
-
-// 	d.Set("description", snapshot.Description)
-// 	d.Set("owner_id", snapshot.OwnerId)
-// 	d.Set("encrypted", snapshot.Encrypted)
-// 	d.Set("owner_alias", snapshot.OwnerAlias)
-// 	d.Set("volume_id", snapshot.VolumeId)
-// 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
-// 	d.Set("kms_key_id", snapshot.KmsKeyId)
-// 	d.Set("volume_size", snapshot.VolumeSize)
-
-// 	tags := KeyValueTags(snapshot.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-// 	//lintignore:AWSR002
-// 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-// 		return fmt.Errorf("error setting tags: %w", err)
-// 	}
-
-// 	if err := d.Set("tags_all", tags.Map()); err != nil {
-// 		return fmt.Errorf("error setting tags_all: %w", err)
-// 	}
-
-// 	snapshotArn := arn.ARN{
-// 		Partition: meta.(*conns.AWSClient).Partition,
-// 		Region:    meta.(*conns.AWSClient).Region,
-// 		Resource:  fmt.Sprintf("snapshot/%s", d.Id()),
-// 		Service:   ec2.ServiceName,
-// 	}.String()
-
-// 	d.Set("arn", snapshotArn)
-
-// 	return nil
-// }
-
-// func resourceEBSSnapshotCopyDelete(d *schema.ResourceData, meta interface{}) error {
-// 	conn := meta.(*conns.AWSClient).EC2Conn
-// 	input := &ec2.DeleteSnapshotInput{
-// 		SnapshotId: aws.String(d.Id()),
-// 	}
-// 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-// 		_, err := conn.DeleteSnapshot(input)
-// 		if err == nil {
-// 			return nil
-// 		}
-
-// 		if tfawserr.ErrMessageContains(err, "SnapshotInUse", "") {
-// 			return resource.RetryableError(fmt.Errorf("EBS SnapshotInUse - trying again while it detaches"))
-// 		}
-
-// 		if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
-// 			return nil
-// 		}
-
-// 		return resource.NonRetryableError(err)
-// 	})
-// 	if tfresource.TimedOut(err) {
-// 		_, err = conn.DeleteSnapshot(input)
-// 		if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
-// 			return nil
-// 		}
-// 	}
-// 	if err != nil {
-// 		return fmt.Errorf("Error deleting EBS snapshot copy: %s", err)
-// 	}
-// 	return nil
-// }
-
-// func resourceEBSSnapshotCopyUpdate(d *schema.ResourceData, meta interface{}) error {
-// 	conn := meta.(*conns.AWSClient).EC2Conn
-
-// 	if d.HasChange("tags_all") {
-// 		o, n := d.GetChange("tags_all")
-// 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-// 			return fmt.Errorf("error updating tags: %s", err)
-// 		}
-// 	}
-
-// 	return resourceEBSSnapshotRead(d, meta)
-// }

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -80,7 +80,7 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
-			"permenent_restore": {
+			"permanent_restore": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -45,6 +45,10 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"owner_alias": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -26,7 +26,7 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"volume_id": {
+			"data_encryption_key_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -35,31 +35,27 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"encrypted": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-			},
-			"volume_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
 			},
 			"kms_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"data_encryption_key_id": {
+			"owner_alias": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permanent_restore": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"source_region": {
 				Type:     schema.TypeString,
@@ -80,16 +76,20 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
-			"permanent_restore": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
 			"temporary_restore_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/service/ec2/ebs_snapshot_copy_test.go
+++ b/internal/service/ec2/ebs_snapshot_copy_test.go
@@ -275,7 +275,7 @@ data "aws_availability_zones" "alternate_available" {
     values = ["opt-in-not-required"]
   }
 }
-	
+
 data "aws_region" "alternate" {
   provider = "awsalternate"
 }

--- a/internal/service/ec2/ebs_snapshot_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_data_source.go
@@ -23,19 +23,41 @@ func DataSourceEBSSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			//selection criteria
+			"data_encryption_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"filter": DataSourceFiltersSchema(),
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"most_recent": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-			"owners": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
-			"snapshot_ids": {
+			"owner_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owners": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -45,44 +67,16 @@ func DataSourceEBSSnapshot() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			//Computed values returned
 			"snapshot_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"volume_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"snapshot_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"state": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"encrypted": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"volume_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"kms_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"data_encryption_key_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -90,11 +84,15 @@ func DataSourceEBSSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"outpost_arn": {
+			"tags": tftags.TagsSchemaComputed(),
+			"volume_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": tftags.TagsSchemaComputed(),
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/service/ec2/ebs_snapshot_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_data_source.go
@@ -86,6 +86,14 @@ func DataSourceEBSSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"storage_tier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
@@ -155,6 +163,8 @@ func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot *ec2.Snapsho
 	d.Set("state", snapshot.State)
 	d.Set("owner_id", snapshot.OwnerId)
 	d.Set("owner_alias", snapshot.OwnerAlias)
+	d.Set("storage_tier", snapshot.StorageTier)
+	d.Set("outpost_arn", snapshot.OutpostArn)
 
 	if err := d.Set("tags", KeyValueTags(snapshot.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/internal/service/ec2/ebs_snapshot_data_source_test.go
+++ b/internal/service/ec2/ebs_snapshot_data_source_test.go
@@ -33,6 +33,7 @@ func TestAccEC2EBSSnapshotDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "volume_id", resourceName, "volume_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "volume_size", resourceName, "volume_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "storage_tier", resourceName, "storage_tier"),
 				),
 			},
 		},

--- a/internal/service/ec2/ebs_snapshot_import.go
+++ b/internal/service/ec2/ebs_snapshot_import.go
@@ -134,6 +134,10 @@ func ResourceEBSSnapshotImport() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"owner_alias": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -166,6 +170,10 @@ func ResourceEBSSnapshotImport() *schema.Resource {
 			"temporary_restore_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"volume_size": {
 				Type:     schema.TypeInt,
@@ -280,7 +288,7 @@ func resourceEBSSnapshotImportCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	return resourceEBSSnapshotRead(d, meta)
+	return resourceEBSSnapshotImportRead(d, meta)
 }
 
 func resourceEBSSnapshotImportRead(d *schema.ResourceData, meta interface{}) error {

--- a/internal/service/ec2/ebs_snapshot_import.go
+++ b/internal/service/ec2/ebs_snapshot_import.go
@@ -66,6 +66,10 @@ func ResourceEBSSnapshotImport() *schema.Resource {
 					},
 				},
 			},
+			"data_encryption_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -120,37 +124,33 @@ func ResourceEBSSnapshotImport() *schema.Resource {
 					},
 				},
 			},
-			"owner_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner_alias": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"encrypted": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-			},
-			"volume_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
 			},
 			"kms_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
+			"owner_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permanent_restore": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"role_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  "vmimport",
-			},
-			"data_encryption_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 			"storage_tier": {
 				Type:     schema.TypeString,
@@ -161,16 +161,16 @@ func ResourceEBSSnapshotImport() *schema.Resource {
 					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
-			"permanent_restore": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
 			"temporary_restore_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/service/ec2/ebs_snapshot_import.go
+++ b/internal/service/ec2/ebs_snapshot_import.go
@@ -227,7 +227,6 @@ func resourceEBSSnapshotImportCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		var resp *ec2.ImportSnapshotOutput
 		resp, err := conn.ImportSnapshot(request)
 
 		if tfawserr.ErrMessageContains(err, "InvalidParameter", "provided does not exist or does not have sufficient permissions") {
@@ -242,7 +241,7 @@ func resourceEBSSnapshotImportCreate(d *schema.ResourceData, meta interface{}) e
 
 		res, err := WaitEBSSnapshotImportComplete(conn, importTaskId)
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error waiting for snapshot (%s) to be imported: %s", d.Id(), err))
+			return resource.NonRetryableError(fmt.Errorf("Error waiting for snapshot (%s) to be imported: %s", importTaskId, err))
 		}
 
 		d.SetId(aws.StringValue(res.SnapshotId))

--- a/internal/service/ec2/ebs_snapshot_import.go
+++ b/internal/service/ec2/ebs_snapshot_import.go
@@ -161,7 +161,7 @@ func ResourceEBSSnapshotImport() *schema.Resource {
 					validation.StringInSlice([]string{"standard"}, false), //Enum slice does not include `standard` type.
 				),
 			},
-			"permenent_restore": {
+			"permanent_restore": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},

--- a/internal/service/ec2/ebs_snapshot_import_test.go
+++ b/internal/service/ec2/ebs_snapshot_import_test.go
@@ -166,7 +166,7 @@ func TestAccEC2EBSSnapshotImport_Disappears_s3BucketObject(t *testing.T) {
 func testAccEBSSnapshotImportConfig_Base(t *testing.T) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "images" {
-  bucket_prefix = "images-"
+  bucket_prefix = "tf-acc-test-"
   force_destroy = true
 }
 

--- a/internal/service/ec2/ebs_snapshot_test.go
+++ b/internal/service/ec2/ebs_snapshot_test.go
@@ -5,15 +5,14 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccEC2EBSSnapshot_basic(t *testing.T) {
@@ -34,6 +33,73 @@ func TestAccEC2EBSSnapshot_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "storage_tier", "standard"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccEC2EBSSnapshot_storageTier(t *testing.T) {
+	var v ec2.Snapshot
+	rName := fmt.Sprintf("tf-acc-ebs-snapshot-basic-%s", sdkacctest.RandString(7))
+	resourceName := "aws_ebs_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEBSSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEBSSnapshotStorageTierConfig(rName, "archive"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "storage_tier", "archive"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"permenent_restore"},
+			},
+			{
+				Config: testAccEBSSnapshotStorageTierConfig(rName, "standard"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName, &v),
+					// Restoring a snapshot takes 24-72 hours so state will reamin (https://aws.amazon.com/blogs/aws/new-amazon-ebs-snapshots-archive/)
+					resource.TestCheckResourceAttr(resourceName, "storage_tier", "archive"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2EBSSnapshot_outpost(t *testing.T) {
+	var v ec2.Snapshot
+	outpostDataSourceName := "data.aws_outposts_outpost.test"
+	resourceName := "aws_ebs_snapshot.test"
+	rName := fmt.Sprintf("tf-acc-ebs-snapshot-basic-%s", sdkacctest.RandString(7))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckOutpostsOutposts(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckEBSSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEBSSnapshotOutpostConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "outpost_arn", outpostDataSourceName, "arn"),
 				),
 			},
 			{
@@ -180,19 +246,15 @@ func testAccCheckSnapshotExists(n string, v *ec2.Snapshot) resource.TestCheckFun
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+		output, err := tfec2.FindSnapshotById(conn, rs.Primary.ID)
 
-		request := &ec2.DescribeSnapshotsInput{
-			SnapshotIds: []*string{aws.String(rs.Primary.ID)},
+		if err != nil {
+			return err
 		}
 
-		response, err := conn.DescribeSnapshots(request)
-		if err == nil {
-			if response.Snapshots != nil && len(response.Snapshots) > 0 {
-				*v = *response.Snapshots[0]
-				return nil
-			}
-		}
-		return fmt.Errorf("Error finding EC2 Snapshot %s", rs.Primary.ID)
+		*v = *output
+
+		return nil
 	}
 }
 
@@ -203,36 +265,25 @@ func testAccCheckEBSSnapshotDestroy(s *terraform.State) error {
 		if rs.Type != "aws_ebs_snapshot" {
 			continue
 		}
-		input := &ec2.DescribeSnapshotsInput{
-			SnapshotIds: []*string{aws.String(rs.Primary.ID)},
+
+		_, err := tfec2.FindSnapshotById(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		output, err := conn.DescribeSnapshots(input)
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, "InvalidSnapshot.NotFound", "") {
-				continue
-			}
 			return err
 		}
-		if output != nil && len(output.Snapshots) > 0 && aws.StringValue(output.Snapshots[0].SnapshotId) == rs.Primary.ID {
-			return fmt.Errorf("EBS Snapshot %q still exists", rs.Primary.ID)
-		}
+
+		return fmt.Errorf("EBS Snapshot %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccEBSSnapshotBasicConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+func testAccEBSSnapshotBaseConfig(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
@@ -241,7 +292,11 @@ resource "aws_ebs_volume" "test" {
     Name = %[1]q
   }
 }
+`, rName))
+}
 
+func testAccEBSSnapshotBasicConfig(rName string) string {
+	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), `
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 
@@ -250,25 +305,46 @@ resource "aws_ebs_snapshot" "test" {
     delete = "10m"
   }
 }
-`, rName)
+`)
+}
+
+func testAccEBSSnapshotStorageTierConfig(rName, tier string) string {
+	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
+resource "aws_ebs_snapshot" "test" {
+  volume_id    = aws_ebs_volume.test.id
+  storage_tier      = %[1]q
+  permenent_restore = true
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+}
+`, tier))
+}
+
+func testAccEBSSnapshotOutpostConfig(rName string) string {
+	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), `
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+resource "aws_ebs_snapshot" "test" {
+  volume_id   = aws_ebs_volume.test.id
+  outpost_arn = data.aws_outposts_outpost.test.arn  
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+}
+`)
 }
 
 func testAccEBSSnapshotBasicTags1Config(rName, tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_ebs_volume" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  size              = 1
-}
-
+	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 
@@ -282,25 +358,11 @@ resource "aws_ebs_snapshot" "test" {
     delete = "10m"
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccEBSSnapshotBasicTags2Config(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_ebs_volume" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  size              = 1
-}
-
+	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 
@@ -315,43 +377,20 @@ resource "aws_ebs_snapshot" "test" {
     delete = "10m"
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccEBSSnapshotWithDescriptionConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_ebs_volume" "description_test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  size              = 1
-}
-
+	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
-  volume_id   = aws_ebs_volume.description_test.id
+  volume_id   = aws_ebs_volume.test.id
   description = %[1]q
 }
-`, rName)
+`, rName))
 }
 
 func testAccEBSSnapshotWithKMSConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
@@ -374,5 +413,5 @@ resource "aws_ebs_volume" "test" {
 resource "aws_ebs_snapshot" "test" {
   volume_id = aws_ebs_volume.test.id
 }
-`, rName)
+`, rName))
 }

--- a/internal/service/ec2/ebs_snapshot_test.go
+++ b/internal/service/ec2/ebs_snapshot_test.go
@@ -323,7 +323,7 @@ data "aws_outposts_outpost" "test" {
 
 resource "aws_ebs_snapshot" "test" {
   volume_id   = aws_ebs_volume.test.id
-  outpost_arn = data.aws_outposts_outpost.test.arn  
+  outpost_arn = data.aws_outposts_outpost.test.arn
 
   timeouts {
     create = "10m"

--- a/internal/service/ec2/ebs_snapshot_test.go
+++ b/internal/service/ec2/ebs_snapshot_test.go
@@ -66,18 +66,9 @@ func TestAccEC2EBSSnapshot_storageTier(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"permenent_restore"},
-			},
-			{
-				Config: testAccEBSSnapshotStorageTierConfig(rName, "standard"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotExists(resourceName, &v),
-					// Restoring a snapshot takes 24-72 hours so state will reamin (https://aws.amazon.com/blogs/aws/new-amazon-ebs-snapshots-archive/)
-					resource.TestCheckResourceAttr(resourceName, "storage_tier", "archive"),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -312,8 +303,7 @@ func testAccEBSSnapshotStorageTierConfig(rName, tier string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot" "test" {
   volume_id    = aws_ebs_volume.test.id
-  storage_tier      = %[1]q
-  permenent_restore = true
+  storage_tier = %[1]q
 
   timeouts {
     create = "10m"

--- a/internal/service/ec2/enum.go
+++ b/internal/service/ec2/enum.go
@@ -31,7 +31,7 @@ const (
 	EBSSnapshotImportStateDeleted    = "deleted"
 	EBSSnapshotImportStateUpdating   = "updating"
 	EBSSnapshotImportStateValidating = "validating"
-	EBSSnapshotImportStateValidd     = "validated"
+	EBSSnapshotImportStateValidated  = "validated"
 	EBSSnapshotImportStateConverting = "converting"
 	EBSSnapshotImportStateCompleted  = "completed"
 )

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -51,6 +51,7 @@ const (
 	ErrCodeInvalidVpcPeeringConnectionIDNotFound  = "InvalidVpcPeeringConnectionID.NotFound"
 	ErrCodeInvalidVpnGatewayAttachmentNotFound    = "InvalidVpnGatewayAttachment.NotFound"
 	ErrCodeInvalidVpnGatewayIDNotFound            = "InvalidVpnGatewayID.NotFound"
+	ErrCodeInvalidSnapshotNotFound                = "InvalidSnapshot.NotFound"
 )
 
 func UnsuccessfulItemError(apiObject *ec2.UnsuccessfulItemError) error {

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -727,3 +727,19 @@ func statusVPCEndpointConnectionVPCEndpointState(conn *ec2.EC2, serviceID, vpcEn
 		return output, aws.StringValue(output.VpcEndpointState), nil
 	}
 }
+
+func StatusSnapshotTierStatus(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindSnapshotTierStatusById(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.StorageTier), nil
+	}
+}

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -51,6 +51,11 @@ func init() {
 		F: sweepEBSVolumes,
 	})
 
+	resource.AddTestSweepers("aws_ebs_snapshot", &resource.Sweeper{
+		Name: "aws_ebs_snapshot",
+		F:    sweepEBSnapshots,
+	})
+
 	resource.AddTestSweepers("aws_egress_only_internet_gateway", &resource.Sweeper{
 		Name: "aws_egress_only_internet_gateway",
 		F:    sweepEgressOnlyInternetGateways,
@@ -548,6 +553,50 @@ func sweepEBSVolumes(region string) error {
 	}
 
 	return nil
+}
+
+func sweepEBSnapshots(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).EC2Conn
+	sweepResources := make([]*sweep.SweepResource, 0)
+	var errs *multierror.Error
+
+	input := &ec2.DescribeSnapshotsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("owner-id"),
+				Values: aws.StringSlice([]string{client.(*conns.AWSClient).AccountID}),
+			},
+		},
+	}
+
+	err = conn.DescribeSnapshotsPages(input, func(page *ec2.DescribeSnapshotsOutput, lastPage bool) bool {
+		for _, volume := range page.Snapshots {
+			id := aws.StringValue(volume.SnapshotId)
+
+			r := ResourceEBSSnapshot()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping EC2 EBS Snapshots for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping EC2 EBS Snapshot sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
 }
 
 func sweepEgressOnlyInternetGateways(region string) error {

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1165,3 +1165,20 @@ func waitVPCEndpointConnectionAccepted(conn *ec2.EC2, serviceID, vpcEndpointID s
 
 	return nil, err
 }
+
+func WaitEBSSnapshotTierArchive(conn *ec2.EC2, id string) (*ec2.SnapshotTierStatus, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"standard"},
+		Target:  []string{ec2.TargetStorageTierArchive},
+		Refresh: StatusSnapshotTierStatus(conn, id),
+		Timeout: 60 * time.Minute,
+		Delay:   10 * time.Second,
+	}
+
+	detail, err := stateConf.WaitForState()
+	if err != nil {
+		return nil, err
+	} else {
+		return detail.(*ec2.SnapshotTierStatus), nil
+	}
+}

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1127,10 +1127,11 @@ func WaitVPCEndpointRouteTableAssociationReady(conn *ec2.EC2, vpcEndpointID, rou
 
 func WaitEBSSnapshotImportComplete(conn *ec2.EC2, importTaskID string) (*ec2.SnapshotTaskDetail, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{EBSSnapshotImportStateActive,
+		Pending: []string{
+			EBSSnapshotImportStateActive,
 			EBSSnapshotImportStateUpdating,
 			EBSSnapshotImportStateValidating,
-			EBSSnapshotImportStateValidd,
+			EBSSnapshotImportStateValidated,
 			EBSSnapshotImportStateConverting,
 		},
 		Target:  []string{EBSSnapshotImportStateCompleted},
@@ -1139,12 +1140,15 @@ func WaitEBSSnapshotImportComplete(conn *ec2.EC2, importTaskID string) (*ec2.Sna
 		Delay:   10 * time.Second,
 	}
 
-	detail, err := stateConf.WaitForState()
-	if err != nil {
-		return nil, err
-	} else {
-		return detail.(*ec2.SnapshotTaskDetail), nil
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.SnapshotTaskDetail); ok {
+		tfresource.SetLastError(err, errors.New(aws.StringValue(output.StatusMessage)))
+
+		return output, err
 	}
+
+	return nil, err
 }
 
 func waitVPCEndpointConnectionAccepted(conn *ec2.EC2, serviceID, vpcEndpointID string, timeout time.Duration) (*ec2.VpcEndpointConnection, error) {

--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -62,6 +62,8 @@ In addition to all arguments above, the following attributes are exported:
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
 * `state` - The snapshot state.
+* `storage_tier` - The storage tier in which the snapshot is stored.
+* `outpost_arn` - The ARN of the Outpost on which the snapshot is stored.
 * `tags` - A map of tags for the resource.
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-snapshots.html

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -63,7 +63,6 @@ In addition to all arguments above, the following attributes are exported:
 * `volume_size` - The size of the drive in GiBs.
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
-* `tags` - A map of tags for the snapshot.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `description` - (Optional) A description of what the snapshot is.
 * `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost on which to create a local snapshot.
 * `storage_tier` - (Optional) The name of the storage tier. Valid values are `archive` and `standard`. Default value is `standard`.
-* `permenent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
+* `permanent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
 * `temporary_restore_days` - (Optional) Specifies the number of days for which to temporarily restore an archived snapshot. Required for temporary restores only. The snapshot will be automatically re-archived after this period.
 * `tags` - (Optional) A map of tags to assign to the snapshot. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -37,6 +37,10 @@ The following arguments are supported:
 
 * `volume_id` - (Required) The Volume ID of which to make a snapshot.
 * `description` - (Optional) A description of what the snapshot is.
+* `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost on which to create a local snapshot.
+* `storage_tier` - (Optional) The name of the storage tier. Valid values are `archive` and `standard`. Default value is `standard`.
+* `permenent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
+* `temporary_restore_days` - (Optional) Specifies the number of days for which to temporarily restore an archived snapshot. Required for temporary restores only. The snapshot will be automatically re-archived after this period.
 * `tags` - (Optional) A map of tags to assign to the snapshot. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Timeouts

--- a/website/docs/r/ebs_snapshot_copy.html.markdown
+++ b/website/docs/r/ebs_snapshot_copy.html.markdown
@@ -62,11 +62,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The snapshot ID (e.g., snap-59fcb34e).
 * `owner_id` - The AWS account ID of the snapshot owner.
 * `owner_alias` - Value from an Amazon-maintained list (`amazon`, `aws-marketplace`, `microsoft`) of snapshot owners.
-* `encrypted` - Whether the snapshot is encrypted.
 * `volume_size` - The size of the drive in GiBs.
-* `kms_key_id` - The ARN for the KMS encryption key.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
-* `source_snapshot_id` The ARN of the copied snapshot.
-* `source_region` The region of the source snapshot.
-* `tags` - A map of tags for the snapshot.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/ebs_snapshot_copy.html.markdown
+++ b/website/docs/r/ebs_snapshot_copy.html.markdown
@@ -49,6 +49,9 @@ The following arguments are supported:
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `source_snapshot_id` The ARN for the snapshot to be copied.
 * `source_region` The region of the source snapshot.
+* `storage_tier` - (Optional) The name of the storage tier. Valid values are `archive` and `standard`. Default value is `standard`.
+* `permenent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
+* `temporary_restore_days` - (Optional) Specifies the number of days for which to temporarily restore an archived snapshot. Required for temporary restores only. The snapshot will be automatically re-archived after this period.
 * `tags` - A map of tags for the snapshot. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/ebs_snapshot_copy.html.markdown
+++ b/website/docs/r/ebs_snapshot_copy.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `source_snapshot_id` The ARN for the snapshot to be copied.
 * `source_region` The region of the source snapshot.
 * `storage_tier` - (Optional) The name of the storage tier. Valid values are `archive` and `standard`. Default value is `standard`.
-* `permenent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
+* `permanent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
 * `temporary_restore_days` - (Optional) Specifies the number of days for which to temporarily restore an archived snapshot. Required for temporary restores only. The snapshot will be automatically re-archived after this period.
 * `tags` - A map of tags for the snapshot. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -40,6 +40,9 @@ The following arguments are supported:
 * `disk_container` - (Required) Information about the disk container. Detailed below.
 * `encrypted` - (Optional) Specifies whether the destination snapshot of the imported image should be encrypted. The default KMS key for EBS is used unless you specify a non-default KMS key using KmsKeyId.
 * `kms_key_id` - (Optional) An identifier for the symmetric KMS key to use when creating the encrypted snapshot. This parameter is only required if you want to use a non-default KMS key; if this parameter is not specified, the default KMS key for EBS is used. If a KmsKeyId is specified, the Encrypted flag must also be set.
+* `storage_tier` - (Optional) The name of the storage tier. Valid values are `archive` and `standard`. Default value is `standard`.
+* `permenent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
+* `temporary_restore_days` - (Optional) Specifies the number of days for which to temporarily restore an archived snapshot. Required for temporary restores only. The snapshot will be automatically re-archived after this period.
 * `role_name` - (Optional) The name of the IAM Role the VM Import/Export service will assume. This role needs certain permissions. See https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role. Default: `vmimport`
 * `tags` - (Optional) A map of tags to assign to the snapshot.
 

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -83,5 +83,4 @@ In addition to all arguments above, the following attributes are exported:
 * `owner_alias` - Value from an Amazon-maintained list (`amazon`, `aws-marketplace`, `microsoft`) of snapshot owners.
 * `volume_size` - The size of the drive in GiBs.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
-* `tags` - A map of tags for the snapshot.
-
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).

--- a/website/docs/r/ebs_snapshot_import.html.markdown
+++ b/website/docs/r/ebs_snapshot_import.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `encrypted` - (Optional) Specifies whether the destination snapshot of the imported image should be encrypted. The default KMS key for EBS is used unless you specify a non-default KMS key using KmsKeyId.
 * `kms_key_id` - (Optional) An identifier for the symmetric KMS key to use when creating the encrypted snapshot. This parameter is only required if you want to use a non-default KMS key; if this parameter is not specified, the default KMS key for EBS is used. If a KmsKeyId is specified, the Encrypted flag must also be set.
 * `storage_tier` - (Optional) The name of the storage tier. Valid values are `archive` and `standard`. Default value is `standard`.
-* `permenent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
+* `permanent_restore` - (Optional) Indicates whether to permanently restore an archived snapshot.
 * `temporary_restore_days` - (Optional) Specifies the number of days for which to temporarily restore an archived snapshot. Required for temporary restores only. The snapshot will be automatically re-archived after this period.
 * `role_name` - (Optional) The name of the IAM Role the VM Import/Export service will assume. This role needs certain permissions. See https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role. Default: `vmimport`
 * `tags` - (Optional) A map of tags to assign to the snapshot.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #17491.
Supersedes #17730.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2EBSSnapshot_ PKG=ec2

--- PASS: TestAccEC2EBSSnapshot_disappears (115.47s)
--- PASS: TestAccEC2EBSSnapshot_withDescription (128.47s)
--- PASS: TestAccEC2EBSSnapshot_basic (130.41s)
--- PASS: TestAccEC2EBSSnapshot_withKMS (150.40s)
--- PASS: TestAccEC2EBSSnapshot_storageTier (181.11s)
--- PASS: TestAccEC2EBSSnapshot_tags (227.18s)
```

```
$ make testacc TESTS=TestAccEC2EBSSnapshotImport_ PKG=ec2
--- PASS: TestAccEC2EBSSnapshotCopy_withRegions (91.20s)
--- PASS: TestAccEC2EBSSnapshotCopy_disappears (97.67s)--- PASS: TestAccEC2EBSSnapshotCopy_withDescription (97.85s)
--- PASS: TestAccEC2EBSSnapshotCopy_basic (98.01s)
--- PASS: TestAccEC2EBSSnapshotCopy_withKMS (99.05s)
--- PASS: TestAccEC2EBSSnapshotCopy_storageTier (157.43s)
--- PASS: TestAccEC2EBSSnapshotCopy_tags (180.89s)
```

```
$ make testacc TESTS=TestAccEC2EBSSnapshotCopy_ PKG=ec2
--- PASS: TestAccEC2EBSSnapshotImport_basic (202.33s)
--- PASS: TestAccEC2EBSSnapshotImport_disappears (207.32s)
--- PASS: TestAccEC2EBSSnapshotImport_Disappears_s3BucketObject (207.59s)
--- PASS: TestAccEC2EBSSnapshotImport_storageTier (314.20s)
--- PASS: TestAccEC2EBSSnapshotImport_tags (350.19s)
```

```
$ make testacc TESTS=TestAccEC2EBSSnapshotDataSource_ PKG=ec2
--- PASS: TestAccEC2EBSSnapshotDataSource_basic (86.74s)
--- PASS: TestAccEC2EBSSnapshotDataSource_filter (88.47s)
--- PASS: TestAccEC2EBSSnapshotDataSource_mostRecent (106.08s)
```
