### PR TITLE
r/codebuild_source_credential - finder, sweeper and disappears test

### DIFF
--- a/internal/service/codebuild/source_credential.go
+++ b/internal/service/codebuild/source_credential.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func ResourceSourceCredential() *schema.Resource {
@@ -28,23 +29,16 @@ func ResourceSourceCredential() *schema.Resource {
 				Computed: true,
 			},
 			"auth_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					codebuild.AuthTypeBasicAuth,
-					codebuild.AuthTypePersonalAccessToken,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(codebuild.AuthType_Values(), false),
 			},
 			"server_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					codebuild.ServerTypeGithub,
-					codebuild.ServerTypeBitbucket,
-					codebuild.ServerTypeGithubEnterprise,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(codebuild.ServerType_Values(), false),
 			},
 			"token": {
 				Type:      schema.TypeString,
@@ -78,7 +72,7 @@ func resourceSourceCredentialCreate(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := conn.ImportSourceCredentials(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error importing source credentials: %s", err)
+		return fmt.Errorf("Error importing source credentials: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Arn))
@@ -89,29 +83,20 @@ func resourceSourceCredentialCreate(d *schema.ResourceData, meta interface{}) er
 func resourceSourceCredentialRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).CodeBuildConn
 
-	resp, err := conn.ListSourceCredentials(&codebuild.ListSourceCredentialsInput{})
-	if err != nil {
-		return fmt.Errorf("Error List CodeBuild Source Credential: %s", err)
-	}
-
-	var info *codebuild.SourceCredentialsInfo
-
-	for _, sourceCredentialsInfo := range resp.SourceCredentialsInfos {
-		if d.Id() == aws.StringValue(sourceCredentialsInfo.Arn) {
-			info = sourceCredentialsInfo
-			break
-		}
-	}
-
-	if info == nil {
+	resp, err := FindSourceCredentialByARN(conn, d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CodeBuild Source Credential (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("arn", info.Arn)
-	d.Set("auth_type", info.AuthType)
-	d.Set("server_type", info.ServerType)
+	if err != nil {
+		return fmt.Errorf("error reading CodeBuild Source Credential (%s): %w", d.Id(), err)
+	}
+
+	d.Set("arn", resp.Arn)
+	d.Set("auth_type", resp.AuthType)
+	d.Set("server_type", resp.ServerType)
 
 	return nil
 }
@@ -127,7 +112,7 @@ func resourceSourceCredentialDelete(d *schema.ResourceData, meta interface{}) er
 		if tfawserr.ErrMessageContains(err, codebuild.ErrCodeResourceNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Source Credentials(%s): %s", d.Id(), err)
+		return fmt.Errorf("Error deleting CodeBuild Source Credentials(%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/codebuild/source_credential_test.go
+++ b/internal/service/codebuild/source_credential_test.go
@@ -157,6 +157,8 @@ func testAccCheckSourceCredentialExists(name string, sourceCredential *codebuild
 			return fmt.Errorf("CodeBuild Source Credential (%s) not found", rs.Primary.ID)
 		}
 
+		*sourceCredential = *output
+
 		return nil
 	}
 }

--- a/internal/service/codebuild/source_credential_test.go
+++ b/internal/service/codebuild/source_credential_test.go
@@ -104,7 +104,7 @@ func TestAccCodeBuildSourceCredential_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckSourceCredentialDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB", token),
+				Config: testAccSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB_ENTERPRISE", token),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceSourceCredential(), resourceName),

--- a/internal/service/codebuild/source_credential_test.go
+++ b/internal/service/codebuild/source_credential_test.go
@@ -5,13 +5,14 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codebuild"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfcodebuild "github.com/hashicorp/terraform-provider-aws/internal/service/codebuild"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccCodeBuildSourceCredential_basic(t *testing.T) {
@@ -91,6 +92,30 @@ func TestAccCodeBuildSourceCredential_basicAuth(t *testing.T) {
 	})
 }
 
+func TestAccCodeBuildSourceCredential_disappears(t *testing.T) {
+	var sourceCredentialsInfo codebuild.SourceCredentialsInfo
+	token := sdkacctest.RandomWithPrefix("token")
+	resourceName := "aws_codebuild_source_credential.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, codebuild.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSourceCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB", token),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSourceCredentialExists(resourceName, &sourceCredentialsInfo),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceSourceCredential(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcodebuild.ResourceSourceCredential(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckSourceCredentialDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).CodeBuildConn
 
@@ -99,20 +124,17 @@ func testAccCheckSourceCredentialDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, err := conn.ListSourceCredentials(&codebuild.ListSourceCredentialsInput{})
+		_, err := tfcodebuild.FindSourceCredentialByARN(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
 			return err
 		}
 
-		if len(resp.SourceCredentialsInfos) == 0 {
-			return nil
-		}
-
-		for _, sourceCredentialsInfo := range resp.SourceCredentialsInfos {
-			if rs.Primary.ID == aws.StringValue(sourceCredentialsInfo.Arn) {
-				return fmt.Errorf("Found Source Credential %s", rs.Primary.ID)
-			}
-		}
+		return fmt.Errorf("CodeBuild Source Credential %s still exists", rs.Primary.ID)
 	}
 	return nil
 }
@@ -126,23 +148,16 @@ func testAccCheckSourceCredentialExists(name string, sourceCredential *codebuild
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeBuildConn
 
-		resp, err := conn.ListSourceCredentials(&codebuild.ListSourceCredentialsInput{})
+		output, err := tfcodebuild.FindSourceCredentialByARN(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		if len(resp.SourceCredentialsInfos) == 0 {
-			return fmt.Errorf("Source Credential %s not found", rs.Primary.ID)
+		if output == nil {
+			return fmt.Errorf("CodeBuild Source Credential (%s) not found", rs.Primary.ID)
 		}
 
-		for _, sourceCredentialsInfo := range resp.SourceCredentialsInfos {
-			if rs.Primary.ID == aws.StringValue(sourceCredentialsInfo.Arn) {
-				*sourceCredential = *sourceCredentialsInfo
-				return nil
-			}
-		}
-
-		return fmt.Errorf("Source Credential %s not found", rs.Primary.ID)
+		return nil
 	}
 }
 

--- a/internal/service/codebuild/sweep.go
+++ b/internal/service/codebuild/sweep.go
@@ -25,6 +25,11 @@ func init() {
 		Name: "aws_codebuild_project",
 		F:    sweepProjects,
 	})
+
+	resource.AddTestSweepers("aws_codebuild_source_credential", &resource.Sweeper{
+		Name: "aws_codebuild_source_credential",
+		F:    sweepSourceCredentials,
+	})
 }
 
 func sweepReportGroups(region string) error {
@@ -115,6 +120,46 @@ func sweepProjects(region string) error {
 
 	if err != nil {
 		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving CodeBuild Projects: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func sweepSourceCredentials(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).CodeBuildConn
+	input := &codebuild.ListSourceCredentialsInput{}
+	var sweeperErrs *multierror.Error
+
+	creds, err := conn.ListSourceCredentials(input)
+
+	for _, cred := range creds.SourceCredentialsInfos {
+		id := aws.StringValue(cred.Arn)
+		r := ResourceSourceCredential()
+		d := r.Data(nil)
+		d.SetId(id)
+
+		err := r.Delete(d, client)
+		if err != nil {
+			sweeperErr := fmt.Errorf("error deleting CodeBuild Source Credential (%s): %w", id, err)
+			log.Printf("[ERROR] %s", sweeperErr)
+			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+			continue
+		}
+	}
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping CodeBuild Source Credential sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil()
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving CodeBuild Source Credentials: %w", err))
 	}
 
 	return sweeperErrs.ErrorOrNil()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13826

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCodeBuildSourceCredential_ PKG=codebuild
--- PASS: TestAccCodeBuildSourceCredential_disappears (48.68s)
--- PASS: TestAccCodeBuildSourceCredential_basic (94.34s)
--- PASS: TestAccCodeBuildSourceCredential_basicAuth (96.39s)
```