### PR TITLE
r/datasync_location_fsx_lustre_file_system - new resource

### DIFF
--- a/.changelog/22346.txt
+++ b/.changelog/22346.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_datasync_location_fsx_lustre
+```

--- a/.changelog/22346.txt
+++ b/.changelog/22346.txt
@@ -1,3 +1,3 @@
 ```release-note:new-resource
-aws_datasync_location_fsx_lustre
+aws_datasync_location_fsx_lustre_file_system
 ```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -977,6 +977,7 @@ func Provider() *schema.Provider {
 
 			"aws_datasync_agent":                            datasync.ResourceAgent(),
 			"aws_datasync_location_efs":                     datasync.ResourceLocationEFS(),
+			"aws_datasync_location_fsx_lustre_file_system":  datasync.ResourceLocationFSxLustreFileSystem(),
 			"aws_datasync_location_fsx_windows_file_system": datasync.ResourceLocationFSxWindowsFileSystem(),
 			"aws_datasync_location_nfs":                     datasync.ResourceLocationNFS(),
 			"aws_datasync_location_s3":                      datasync.ResourceLocationS3(),

--- a/internal/service/datasync/find.go
+++ b/internal/service/datasync/find.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/datasync"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func FindAgentByARN(conn *datasync.DataSync, arn string) (*datasync.DescribeAgentOutput, error) {
@@ -58,6 +59,31 @@ func FindTaskByARN(conn *datasync.DataSync, arn string) (*datasync.DescribeTaskO
 			Message:     "Empty result",
 			LastRequest: input,
 		}
+	}
+
+	return output, nil
+}
+
+func FindFsxLustreLocationByARN(conn *datasync.DataSync, arn string) (*datasync.DescribeLocationFsxLustreOutput, error) {
+	input := &datasync.DescribeLocationFsxLustreInput{
+		LocationArn: aws.String(arn),
+	}
+
+	output, err := conn.DescribeLocationFsxLustre(input)
+
+	if tfawserr.ErrMessageContains(err, datasync.ErrCodeInvalidRequestException, "not found") {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/internal/service/datasync/location_fsx_lustre_file_system.go
+++ b/internal/service/datasync/location_fsx_lustre_file_system.go
@@ -1,0 +1,204 @@
+package datasync
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceLocationFSxLustreFileSystem() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLocationFSxLustreFileSystemCreate,
+		Read:   resourceLocationFSxLustreFileSystemRead,
+		Update: resourceLocationFSxLustreFileSystemUpdate,
+		Delete: resourceLocationFSxLustreFileSystemDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "#")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected DataSyncLocationArn#FsxArn", d.Id())
+				}
+
+				DSArn := idParts[0]
+				FSxArn := idParts[1]
+
+				d.Set("fsx_filesystem_arn", FSxArn)
+				d.SetId(DSArn)
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fsx_filesystem_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"security_group_arns": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				MinItems: 1,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: verify.ValidARN,
+				},
+			},
+			"subdirectory": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 4096),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceLocationFSxLustreFileSystemCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DataSyncConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+	fsxArn := d.Get("fsx_filesystem_arn").(string)
+
+	input := &datasync.CreateLocationFsxLustreInput{
+		FsxFilesystemArn:  aws.String(fsxArn),
+		SecurityGroupArns: flex.ExpandStringSet(d.Get("security_group_arns").(*schema.Set)),
+		Tags:              Tags(tags.IgnoreAWS()),
+	}
+
+	if v, ok := d.GetOk("subdirectory"); ok {
+		input.Subdirectory = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating DataSync Location Fsx Lustre File System: %#v", input)
+	output, err := conn.CreateLocationFsxLustre(input)
+	if err != nil {
+		return fmt.Errorf("error creating DataSync Location Fsx Lustre File System: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.LocationArn))
+
+	return resourceLocationFSxLustreFileSystemRead(d, meta)
+}
+
+func resourceLocationFSxLustreFileSystemRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DataSyncConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	output, err := FindFsxLustreLocationByARN(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DataSync Location Fsx Lustre (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading DataSync Location Fsx Lustre (%s): %w", d.Id(), err)
+	}
+
+	subdirectory, err := SubdirectoryFromLocationURI(aws.StringValue(output.LocationUri))
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("arn", output.LocationArn)
+	d.Set("subdirectory", subdirectory)
+	d.Set("uri", output.LocationUri)
+
+	if err := d.Set("security_group_arns", flex.FlattenStringSet(output.SecurityGroupArns)); err != nil {
+		return fmt.Errorf("error setting security_group_arns: %w", err)
+	}
+
+	if err := d.Set("creation_time", output.CreationTime.Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("error setting creation_time: %w", err)
+	}
+
+	tags, err := ListTags(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for DataSync Location Fsx Lustre (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceLocationFSxLustreFileSystemUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DataSyncConn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating DataSync Location Fsx Lustre File System (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceLocationFSxLustreFileSystemRead(d, meta)
+}
+
+func resourceLocationFSxLustreFileSystemDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DataSyncConn
+
+	input := &datasync.DeleteLocationInput{
+		LocationArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DataSync Location Fsx Lustre File System: %#v", input)
+	_, err := conn.DeleteLocation(input)
+
+	if tfawserr.ErrMessageContains(err, datasync.ErrCodeInvalidRequestException, "not found") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting DataSync Location Fsx Lustre (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/datasync/location_fsx_lustre_file_system_test.go
+++ b/internal/service/datasync/location_fsx_lustre_file_system_test.go
@@ -1,0 +1,307 @@
+package datasync_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdatasync "github.com/hashicorp/terraform-provider-aws/internal/service/datasync"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccDataSyncLocationFSxLustreFileSystem_basic(t *testing.T) {
+	var locationFsxLustre1 datasync.DescribeLocationFsxLustreOutput
+	resourceName := "aws_datasync_location_fsx_lustre_file_system.test"
+	fsResourceName := "aws_fsx_lustre_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(fsx.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, datasync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLocationFSxLustreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationFSxLustreConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationFSxLustreExists(resourceName, &locationFsxLustre1),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "datasync", regexp.MustCompile(`location/loc-.+`)),
+					resource.TestCheckResourceAttrPair(resourceName, "fsx_filesystem_arn", fsResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestMatchResourceAttr(resourceName, "uri", regexp.MustCompile(`^fsxl://.+/`)),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWSDataSyncLocationFsxLustreImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccDataSyncLocationFSxLustreFileSystem_disappears(t *testing.T) {
+	var locationFsxLustre1 datasync.DescribeLocationFsxLustreOutput
+	resourceName := "aws_datasync_location_fsx_lustre_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(fsx.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, datasync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLocationFSxLustreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationFSxLustreConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationFSxLustreExists(resourceName, &locationFsxLustre1),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdatasync.ResourceLocationFSxLustreFileSystem(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdatasync.ResourceLocationFSxLustreFileSystem(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDataSyncLocationFSxLustreFileSystem_subdirectory(t *testing.T) {
+	var locationFsxLustre1 datasync.DescribeLocationFsxLustreOutput
+	resourceName := "aws_datasync_location_fsx_lustre_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(fsx.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, datasync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLocationFSxLustreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationFSxLustreSubdirectoryConfig("/subdirectory1/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationFSxLustreExists(resourceName, &locationFsxLustre1),
+					resource.TestCheckResourceAttr(resourceName, "subdirectory", "/subdirectory1/"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWSDataSyncLocationFsxLustreImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccDataSyncLocationFSxLustreFileSystem_tags(t *testing.T) {
+	var locationFsxLustre1 datasync.DescribeLocationFsxLustreOutput
+	resourceName := "aws_datasync_location_fsx_lustre_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(fsx.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, datasync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckLocationFSxLustreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLocationFSxLustreTags1Config("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationFSxLustreExists(resourceName, &locationFsxLustre1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWSDataSyncLocationFsxLustreImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccLocationFSxLustreTags2Config("key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationFSxLustreExists(resourceName, &locationFsxLustre1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccLocationFSxLustreTags1Config("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocationFSxLustreExists(resourceName, &locationFsxLustre1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLocationFSxLustreDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DataSyncConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_datasync_location_fsx_lustre_file_system" {
+			continue
+		}
+
+		_, err := tfdatasync.FindFsxLustreLocationByARN(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("DataSync Task %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckLocationFSxLustreExists(resourceName string, locationFsxLustre *datasync.DescribeLocationFsxLustreOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataSyncConn
+		output, err := tfdatasync.FindFsxLustreLocationByARN(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil {
+			return fmt.Errorf("Location %q does not exist", rs.Primary.ID)
+		}
+
+		*locationFsxLustre = *output
+
+		return nil
+	}
+}
+
+func testAccWSDataSyncLocationFsxLustreImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s#%s", rs.Primary.ID, rs.Primary.Attributes["fsx_filesystem_arn"]), nil
+	}
+}
+
+func testAccLocationFSxLustreConfig() string {
+	return acctest.ConfigCompose(testAccFSxLustreFileSystemBaseConfig(), `
+resource "aws_datasync_location_fsx_lustre_file_system" "test" {
+  fsx_filesystem_arn  = aws_fsx_lustre_file_system.test.arn
+  security_group_arns = [aws_security_group.test.arn]
+}
+`)
+}
+
+func testAccLocationFSxLustreSubdirectoryConfig(subdirectory string) string {
+	return acctest.ConfigCompose(testAccFSxLustreFileSystemBaseConfig(), fmt.Sprintf(`
+resource "aws_datasync_location_fsx_lustre_file_system" "test" {
+  fsx_filesystem_arn  = aws_fsx_lustre_file_system.test.arn
+  security_group_arns = [aws_security_group.test.arn]
+  subdirectory        = %[1]q
+}
+`, subdirectory))
+}
+
+func testAccLocationFSxLustreTags1Config(key1, value1 string) string {
+	return acctest.ConfigCompose(testAccFSxLustreFileSystemBaseConfig(), fmt.Sprintf(`
+resource "aws_datasync_location_fsx_lustre_file_system" "test" {
+  fsx_filesystem_arn  = aws_fsx_lustre_file_system.test.arn
+  security_group_arns = [aws_security_group.test.arn]
+
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, key1, value1))
+}
+
+func testAccLocationFSxLustreTags2Config(key1, value1, key2, value2 string) string {
+	return acctest.ConfigCompose(testAccFSxLustreFileSystemBaseConfig(), fmt.Sprintf(`
+resource "aws_datasync_location_fsx_lustre_file_system" "test" {
+  fsx_filesystem_arn  = aws_fsx_lustre_file_system.test.arn
+  security_group_arns = [aws_security_group.test.arn]
+
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, key1, value1, key2, value2))
+}
+
+func testAccFSxLustreFileSystemBaseConfig() string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
+data "aws_partition" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+
+resource "aws_security_group" "test" {
+  description = "security group for FSx testing"
+  vpc_id      = aws_vpc.test.id
+
+  ingress {
+    cidr_blocks = [aws_vpc.test.cidr_block]
+    from_port   = 0
+    protocol    = -1
+    to_port     = 0
+  }
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+}
+
+resource "aws_fsx_lustre_file_system" "test" {
+  security_group_ids = [aws_security_group.test.id]
+  storage_capacity   = 1200
+  subnet_ids         = [aws_subnet.test.id]
+  deployment_type    = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
+}
+`)
+}

--- a/internal/service/datasync/uri.go
+++ b/internal/service/datasync/uri.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	locationURIPattern                      = regexp.MustCompile(`^(efs|nfs|s3|smb|fsxw)://(.+)$`)
+	locationURIPattern                      = regexp.MustCompile(`^(efs|nfs|s3|smb|fsxw|fsxl)://(.+)$`)
 	locationURIGlobalIDAndSubdirPattern     = regexp.MustCompile(`^([a-zA-Z0-9.\-]+)(/.*)$`)
 	s3OutpostsAccessPointARNResourcePattern = regexp.MustCompile(`^outpost/.*/accesspoint/.*?(/.*)$`)
 )

--- a/website/docs/r/datasync_location_fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/datasync_location_fsx_lustre_file_system.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "DataSync"
+layout: "aws"
+page_title: "AWS: aws_datasync_location_fsx_lustre_file_system"
+description: |-
+  Manages an FSx Lustre Location within AWS DataSync.
+---
+
+# Resource: aws_datasync_location_fsx_lustre_file_system
+
+Manages an AWS DataSync FSx Lustre Location.
+
+## Example Usage
+
+```terraform
+resource "aws_datasync_location_fsx_lustre_file_system" "example" {
+  fsx_filesystem_arn  = aws_fsx_lustre_file_system.example.arn
+  security_group_arns = [aws_security_group.example.arn]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `fsx_filesystem_arn` - (Required) The Amazon Resource Name (ARN) for the FSx for Lustre file system.
+* `security_group_arns` - (Optional) The Amazon Resource Names (ARNs) of the security groups that are to use to configure the FSx for Lustre file system.
+* `subdirectory` - (Optional) Subdirectory to perform actions as source or destination.
+* `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Location. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Amazon Resource Name (ARN) of the DataSync Location.
+* `arn` - Amazon Resource Name (ARN) of the DataSync Location.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `uri` - The URL of the FSx for Lustre location that was described.
+* `creation_time` - The time that the FSx for Lustre location was created.
+
+## Import
+
+`aws_datasync_location_fsx_lustre_file_system` can be imported by using the `DataSync-ARN#FSx-Lustre-ARN`, e.g.,
+
+```
+$ terraform import aws_datasync_location_fsx_lustre_file_system.example arn:aws:datasync:us-west-2:123456789012:location/loc-12345678901234567#arn:aws:fsx:us-west-2:476956259333:file-system/fs-08e04cd442c1bb94a
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDataSyncLocationFSxLustreFileSystem PKG=datasync
--- PASS: TestAccDataSyncLocationFSxLustreFileSystem_disappears (676.21s)
--- PASS: TestAccDataSyncLocationFSxLustreFileSystem_subdirectory (698.12s)
--- PASS: TestAccDataSyncLocationFSxLustreFileSystem_basic (777.55s)
--- PASS: TestAccDataSyncLocationFSxLustreFileSystem_tags (843.65s)
```
