### PR TITLE
d/aws_batch_job_queue - new attribute

### DIFF
--- a/.changelog/22348.txt
+++ b/.changelog/22348.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_batch_job_queue: Add `scheduling_policy_arn` attribute
+```

--- a/internal/service/batch/job_queue_data_source.go
+++ b/internal/service/batch/job_queue_data_source.go
@@ -26,6 +26,11 @@ func DataSourceJobQueue() *schema.Resource {
 				Computed: true,
 			},
 
+			"scheduling_policy_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -94,6 +99,7 @@ func dataSourceJobQueueRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(aws.StringValue(jobQueue.JobQueueArn))
 	d.Set("arn", jobQueue.JobQueueArn)
 	d.Set("name", jobQueue.JobQueueName)
+	d.Set("scheduling_policy_arn", jobQueue.SchedulingPolicyArn)
 	d.Set("status", jobQueue.Status)
 	d.Set("status_reason", jobQueue.StatusReason)
 	d.Set("state", jobQueue.State)

--- a/internal/service/batch/job_queue_data_source_test.go
+++ b/internal/service/batch/job_queue_data_source_test.go
@@ -27,6 +27,7 @@ func TestAccBatchJobQueueDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "compute_environment_order.#", resourceName, "compute_environments.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "priority", resourceName, "priority"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scheduling_policy_arn", resourceName, "scheduling_policy_arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "state", resourceName, "state"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 				),

--- a/internal/service/batch/job_queue_data_source_test.go
+++ b/internal/service/batch/job_queue_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccBatchJobQueueDataSource_basic(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobQueueDataSourceConfig(rName),
+				Config: testAccJobQueueDataSourceConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "compute_environment_order.#", resourceName, "compute_environments.#"),
@@ -35,7 +35,7 @@ func TestAccBatchJobQueueDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccJobQueueDataSourceConfig(rName string) string {
+func testAccJobQueueDataSourceConfigBase(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -133,7 +133,13 @@ resource "aws_batch_compute_environment" "sample" {
   type         = "MANAGED"
   depends_on   = [aws_iam_role_policy_attachment.aws_batch_service_role]
 }
+`, rName)
+}
 
+func testAccJobQueueDataSourceConfigBasic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccJobQueueDataSourceConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_batch_job_queue" "test" {
   name                 = "%[1]s"
   state                = "ENABLED"
@@ -151,5 +157,5 @@ resource "aws_batch_job_queue" "wrong" {
 data "aws_batch_job_queue" "by_name" {
   name = aws_batch_job_queue.test.name
 }
-`, rName)
+`, rName))
 }

--- a/internal/service/batch/job_queue_data_source_test.go
+++ b/internal/service/batch/job_queue_data_source_test.go
@@ -36,6 +36,32 @@ func TestAccBatchJobQueueDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccBatchJobQueueDataSource_schedulingPolicy(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("tf_acc_test_")
+	resourceName := "aws_batch_job_queue.test"
+	datasourceName := "data.aws_batch_job_queue.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, batch.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobQueueDataSourceConfigSchedulingPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "compute_environment_order.#", resourceName, "compute_environments.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "priority", resourceName, "priority"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scheduling_policy_arn", resourceName, "scheduling_policy_arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "state", resourceName, "state"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
 func testAccJobQueueDataSourceConfigBase(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
@@ -156,6 +182,38 @@ resource "aws_batch_job_queue" "wrong" {
 }
 
 data "aws_batch_job_queue" "by_name" {
+  name = aws_batch_job_queue.test.name
+}
+`, rName))
+}
+
+func testAccJobQueueDataSourceConfigSchedulingPolicy(rName string) string {
+	return acctest.ConfigCompose(
+		testAccJobQueueDataSourceConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_scheduling_policy" "test" {
+  name = %[1]q
+
+  fair_share_policy {
+    compute_reservation = 1
+    share_decay_seconds = 3600
+
+    share_distribution {
+      share_identifier = "A1*"
+      weight_factor    = 0.1
+    }
+  }
+}
+
+resource "aws_batch_job_queue" "test" {
+  name                  = %[1]q
+  scheduling_policy_arn = aws_batch_scheduling_policy.test.arn
+  state                 = "ENABLED"
+  priority              = 1
+  compute_environments  = [aws_batch_compute_environment.sample.arn]
+}
+
+data "aws_batch_job_queue" "test" {
   name = aws_batch_job_queue.test.name
 }
 `, rName))

--- a/website/docs/d/batch_job_queue.html.markdown
+++ b/website/docs/d/batch_job_queue.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the job queue.
+* `scheduling_policy_arn` - The ARN of the fair share scheduling policy. If this attribute has a value, the job queue uses a fair share scheduling policy. If this attribute does not have a value, the job queue uses a first in, first out (FIFO) scheduling policy.
 * `status` - The current status of the job queue (for example, `CREATING` or `VALID`).
 * `status_reason` - A short, human-readable string to provide additional details about the current status
     of the job queue.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21755

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccBatchJobQueueDataSource PKG=batch 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobQueueDataSource' -timeout 180m
=== RUN   TestAccBatchJobQueueDataSource_basic
=== PAUSE TestAccBatchJobQueueDataSource_basic
=== RUN   TestAccBatchJobQueueDataSource_schedulingPolicy
=== PAUSE TestAccBatchJobQueueDataSource_schedulingPolicy
=== CONT  TestAccBatchJobQueueDataSource_basic
=== CONT  TestAccBatchJobQueueDataSource_schedulingPolicy
--- PASS: TestAccBatchJobQueueDataSource_basic (174.88s)
--- PASS: TestAccBatchJobQueueDataSource_schedulingPolicy (176.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      185.282s

...
```
