### PR TITLE
r/aws_connect_contact_flow_module

### DIFF
--- a/.changelog/22349.txt
+++ b/.changelog/22349.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_connect_contact_flow_module
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -967,6 +967,7 @@ func Provider() *schema.Provider {
 
 			"aws_connect_bot_association":             connect.ResourceBotAssociation(),
 			"aws_connect_contact_flow":                connect.ResourceContactFlow(),
+			"aws_connect_contact_flow_module":         connect.ResourceContactFlowModule(),
 			"aws_connect_instance":                    connect.ResourceInstance(),
 			"aws_connect_hours_of_operation":          connect.ResourceHoursOfOperation(),
 			"aws_connect_lambda_function_association": connect.ResourceLambdaFunctionAssociation(),

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -86,6 +86,68 @@ func ResourceContactFlowModule() *schema.Resource {
 	}
 }
 
+
+func resourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ConnectConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	instanceID, contactFlowModuleID, err := ContactFlowModuleParseID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := conn.DescribeContactFlowModuleWithContext(ctx, &connect.DescribeContactFlowModuleInput{
+		ContactFlowModuleId: aws.String(contactFlowModuleID),
+		InstanceId:          aws.String(instanceID),
+	})
+
+	if !d.IsNewResource() && tfawserr.ErrMessageContains(err, connect.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Connect Contact Flow Module (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting Connect Contact Flow Module (%s): %w", d.Id(), err))
+	}
+
+	if resp == nil || resp.ContactFlowModule == nil {
+		return diag.FromErr(fmt.Errorf("error getting Connect Contact Flow Module (%s): empty response", d.Id()))
+	}
+
+	d.Set("arn", resp.ContactFlowModule.Arn)
+	d.Set("contact_flow_module_id", resp.ContactFlowModule.Id)
+	d.Set("instance_id", instanceID)
+	d.Set("name", resp.ContactFlowModule.Name)
+	d.Set("description", resp.ContactFlowModule.Description)
+	d.Set("content", resp.ContactFlowModule.Content)
+
+	tags := KeyValueTags(resp.ContactFlowModule.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+	}
+
+	return nil
+}
+
+func ContactFlowModuleParseID(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected instanceID:contactFlowModuleID", id)
+	}
+
+	return parts[0], parts[1], nil
+}
+
 func resourceContactFlowModuleLoadFileContent(filename string) (string, error) {
 	filename, err := homedir.Expand(filename)
 	if err != nil {

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -31,10 +31,6 @@ func ResourceContactFlowModule() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(connectContactFlowModuleCreateTimeout),
-			Update: schema.DefaultTimeout(connectContactFlowModuleUpdateTimeout),
-		},
 		CustomizeDiff: verify.SetTagsDiff,
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -252,6 +252,26 @@ func resourceContactFlowModuleUpdate(ctx context.Context, d *schema.ResourceData
 	return resourceContactFlowModuleRead(ctx, d, meta)
 }
 
+func resourceContactFlowModuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ConnectConn
+
+	instanceID, contactFlowModuleID, err := ContactFlowModuleParseID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	log.Printf("[DEBUG] Deleting Connect Contact Flow Module : %s", contactFlowModuleID)
+	input := &connect.DeleteContactFlowModuleInput{
+		ContactFlowModuleId: aws.String(contactFlowModuleID),
+		InstanceId:          aws.String(instanceID),
+	}
+
+	_, deleteContactFlowModuleErr := conn.DeleteContactFlowModuleWithContext(ctx, input)
+	if deleteContactFlowModuleErr != nil {
+		return diag.FromErr(fmt.Errorf("error deleting Connect Contact Flow Module (%s): %w", d.Id(), deleteContactFlowModuleErr))
+	}
+	return nil
+}
+
 func ContactFlowModuleParseID(id string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)
 

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -86,3 +86,14 @@ func ResourceContactFlowModule() *schema.Resource {
 	}
 }
 
+func resourceContactFlowModuleLoadFileContent(filename string) (string, error) {
+	filename, err := homedir.Expand(filename)
+	if err != nil {
+		return "", err
+	}
+	fileContent, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return string(fileContent), nil
+}

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -1,0 +1,88 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/connect"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/mitchellh/go-homedir"
+)
+
+const awsMutexConnectContactFlowModuleKey = `aws_connect_contact_flow_module`
+
+func ResourceContactFlowModule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceContactFlowModuleCreate,
+		ReadContext:   resourceContactFlowModuleRead,
+		UpdateContext: resourceContactFlowModuleUpdate,
+		DeleteContext: resourceContactFlowModuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(connectContactFlowModuleCreateTimeout),
+			Update: schema.DefaultTimeout(connectContactFlowModuleUpdateTimeout),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"contact_flow_module_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				ConflictsWith:    []string{"filename"},
+				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
+			"content_hash": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 500),
+			},
+			"filename": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"content"},
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 127),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+

--- a/internal/service/connect/contact_flow_module_test.go
+++ b/internal/service/connect/contact_flow_module_test.go
@@ -16,6 +16,54 @@ import (
 )
 
 
+func testAccContactFlowModule_basic(t *testing.T) {
+	var v connect.DescribeContactFlowModuleOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_contact_flow_module.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckContactFlowModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContactFlowModuleConfig_basic(rName, rName2, "Created"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContactFlowModuleExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "contact_flow_module_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "content"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContactFlowModuleConfig_basic(rName, rName2, "Updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckContactFlowModuleExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "contact_flow_module_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "content"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+
 func testAccCheckContactFlowModuleExists(resourceName string, function *connect.DescribeContactFlowModuleOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/service/connect/contact_flow_module_test.go
+++ b/internal/service/connect/contact_flow_module_test.go
@@ -63,6 +63,55 @@ func testAccContactFlowModule_basic(t *testing.T) {
 	})
 }
 
+func testAccContactFlowModule_filename(t *testing.T) {
+	var v connect.DescribeContactFlowModuleOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_contact_flow_module.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckContactFlowModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContactFlowModuleConfig_filename(rName, rName2, "Created", "test-fixtures/connect_contact_flow_module.json"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContactFlowModuleExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "contact_flow_module_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"content_hash",
+					"filename",
+				},
+			},
+			{
+				Config: testAccContactFlowModuleConfig_filename(rName, rName2, "Updated", "test-fixtures/connect_contact_flow_module_updated.json"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckContactFlowModuleExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "contact_flow_module_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
 
 func testAccCheckContactFlowModuleExists(resourceName string, function *connect.DescribeContactFlowModuleOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/service/connect/contact_flow_module_test.go
+++ b/internal/service/connect/contact_flow_module_test.go
@@ -1,0 +1,107 @@
+package connect_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/connect"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfconnect "github.com/hashicorp/terraform-provider-aws/internal/service/connect"
+)
+
+
+func testAccContactFlowModuleBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+}
+`, rName)
+}
+
+func testAccContactFlowModuleConfig_basic(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccContactFlowModuleBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_contact_flow_module" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = %[1]q
+  description = %[2]q
+
+  content = <<JSON
+    {
+		"Version": "2019-10-30",
+		"StartAction": "12345678-1234-1234-1234-123456789012",
+		"Actions": [
+			{
+				"Identifier": "12345678-1234-1234-1234-123456789012",
+				"Parameters": {
+					"Text": "Hello contact flow module"
+				},
+				"Transitions": {
+					"NextAction": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+					"Errors": [],
+					"Conditions": []
+				},
+				"Type": "MessageParticipant"
+			},
+			{
+				"Identifier": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+				"Type": "DisconnectParticipant",
+				"Parameters": {},
+				"Transitions": {}
+			}
+		],
+		"Settings": {
+			"InputParameters": [],
+			"OutputParameters": [],
+			"Transitions": [
+				{
+					"DisplayName": "Success",
+					"ReferenceName": "Success",
+					"Description": ""
+				},
+				{
+					"DisplayName": "Error",
+					"ReferenceName": "Error",
+					"Description": ""
+				}
+			]
+		}
+	}
+    JSON
+
+  tags = {
+    "Name"   = "Test Contact Flow Module",
+    "Method" = %[2]q
+  }
+}
+`, rName2, label))
+}
+
+func testAccContactFlowModuleConfig_filename(rName, rName2 string, label string, filepath string) string {
+	return acctest.ConfigCompose(
+		testAccContactFlowModuleBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_contact_flow_module" "test" {
+  instance_id  = aws_connect_instance.test.id
+  name         = %[1]q
+  description  = %[2]q
+  filename     = %[3]q
+  content_hash = filebase64sha256(%[3]q)
+
+  tags = {
+    "Name"   = "Test Contact Flow Module",
+    "Method" = %[2]q
+  }
+}
+`, rName2, label, filepath))
+}

--- a/internal/service/connect/contact_flow_module_test.go
+++ b/internal/service/connect/contact_flow_module_test.go
@@ -16,6 +16,41 @@ import (
 )
 
 
+func testAccCheckContactFlowModuleExists(resourceName string, function *connect.DescribeContactFlowModuleOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Connect Contact Flow Module not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Connect Contact Flow Module ID not set")
+		}
+		instanceID, contactFlowModuleID, err := tfconnect.ContactFlowModuleParseID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ConnectConn
+
+		params := &connect.DescribeContactFlowModuleInput{
+			ContactFlowModuleId: aws.String(contactFlowModuleID),
+			InstanceId:          aws.String(instanceID),
+		}
+
+		getFunction, err := conn.DescribeContactFlowModule(params)
+		if err != nil {
+			return err
+		}
+
+		*function = *getFunction
+
+		return nil
+	}
+}
+
+
 func testAccContactFlowModuleBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_connect_instance" "test" {

--- a/internal/service/connect/contact_flow_module_test.go
+++ b/internal/service/connect/contact_flow_module_test.go
@@ -15,6 +15,21 @@ import (
 	tfconnect "github.com/hashicorp/terraform-provider-aws/internal/service/connect"
 )
 
+// Serialized acceptance tests due to Connect account limits (max 2 parallel tests)
+func TestAccConnectContactFlowModule_serial(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccContactFlowModule_basic,
+		"filename":   testAccContactFlowModule_filename,
+		"disappears": testAccContactFlowModule_disappears,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
 
 func testAccContactFlowModule_basic(t *testing.T) {
 	var v connect.DescribeContactFlowModuleOutput

--- a/internal/service/connect/contact_flow_module_test.go
+++ b/internal/service/connect/contact_flow_module_test.go
@@ -112,6 +112,29 @@ func testAccContactFlowModule_filename(t *testing.T) {
 	})
 }
 
+func testAccContactFlowModule_disappears(t *testing.T) {
+	var v connect.DescribeContactFlowModuleOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_contact_flow_module.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckContactFlowModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContactFlowModuleConfig_basic(rName, rName2, "Disappear"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContactFlowModuleExists(resourceName, &v),
+					acctest.CheckResourceDisappears(acctest.Provider, tfconnect.ResourceContactFlowModule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
 func testAccCheckContactFlowModuleExists(resourceName string, function *connect.DescribeContactFlowModuleOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/service/connect/test-fixtures/connect_contact_flow_module.json
+++ b/internal/service/connect/test-fixtures/connect_contact_flow_module.json
@@ -1,0 +1,40 @@
+{
+    "Version": "2019-10-30",
+    "StartAction": "12345678-1234-1234-1234-123456789012",
+    "Actions": [
+        {
+            "Identifier": "12345678-1234-1234-1234-123456789012",
+            "Parameters": {
+                "Text": "Hello contact flow module"
+            },
+            "Transitions": {
+                "NextAction": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+                "Errors": [],
+                "Conditions": []
+            },
+            "Type": "MessageParticipant"
+        },
+        {
+            "Identifier": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+            "Type": "DisconnectParticipant",
+            "Parameters": {},
+            "Transitions": {}
+        }
+    ],
+    "Settings": {
+        "InputParameters": [],
+        "OutputParameters": [],
+        "Transitions": [
+            {
+                "DisplayName": "Success",
+                "ReferenceName": "Success",
+                "Description": ""
+            },
+            {
+                "DisplayName": "Error",
+                "ReferenceName": "Error",
+                "Description": ""
+            }
+        ]
+    }
+}

--- a/internal/service/connect/test-fixtures/connect_contact_flow_module_updated.json
+++ b/internal/service/connect/test-fixtures/connect_contact_flow_module_updated.json
@@ -1,0 +1,40 @@
+{
+    "Version": "2019-10-30",
+    "StartAction": "12345678-1234-1234-1234-123456789012",
+    "Actions": [
+        {
+            "Identifier": "12345678-1234-1234-1234-123456789012",
+            "Parameters": {
+                "Text": "Hello contact flow module updated"
+            },
+            "Transitions": {
+                "NextAction": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+                "Errors": [],
+                "Conditions": []
+            },
+            "Type": "MessageParticipant"
+        },
+        {
+            "Identifier": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+            "Type": "DisconnectParticipant",
+            "Parameters": {},
+            "Transitions": {}
+        }
+    ],
+    "Settings": {
+        "InputParameters": [],
+        "OutputParameters": [],
+        "Transitions": [
+            {
+                "DisplayName": "Success",
+                "ReferenceName": "Success",
+                "Description": ""
+            },
+            {
+                "DisplayName": "Error",
+                "ReferenceName": "Error",
+                "Description": ""
+            }
+        ]
+    }
+}

--- a/internal/service/connect/wait.go
+++ b/internal/service/connect/wait.go
@@ -16,9 +16,6 @@ const (
 	connectContactFlowCreateTimeout = 5 * time.Minute
 	connectContactFlowUpdateTimeout = 5 * time.Minute
 
-	connectContactFlowModuleCreateTimeout = 5 * time.Minute
-	connectContactFlowModuleUpdateTimeout = 5 * time.Minute
-
 	connectBotAssociationCreateTimeout = 5 * time.Minute
 
 	connectHoursOfOperationCreatedTimeout = 5 * time.Minute

--- a/internal/service/connect/wait.go
+++ b/internal/service/connect/wait.go
@@ -16,6 +16,9 @@ const (
 	connectContactFlowCreateTimeout = 5 * time.Minute
 	connectContactFlowUpdateTimeout = 5 * time.Minute
 
+	connectContactFlowModuleCreateTimeout = 5 * time.Minute
+	connectContactFlowModuleUpdateTimeout = 5 * time.Minute
+
 	connectBotAssociationCreateTimeout = 5 * time.Minute
 
 	connectHoursOfOperationCreatedTimeout = 5 * time.Minute

--- a/website/docs/r/connect_contact_flow_module.html.markdown
+++ b/website/docs/r/connect_contact_flow_module.html.markdown
@@ -1,0 +1,141 @@
+---
+subcategory: "Connect"
+layout: "aws"
+page_title: "AWS: aws_connect_contact_flow_module"
+description: |-
+  Provides details about a specific Amazon Connect Contact Flow Module.
+---
+
+# Resource: aws_connect_contact_flow_module
+
+Provides an Amazon Connect Contact Flow Module resource. For more information see
+[Amazon Connect: Getting Started](https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-get-started.html)
+
+This resource embeds or references Contact Flows Modules specified in Amazon Connect Contact Flow Language. For more information see
+[Amazon Connect Flow language](https://docs.aws.amazon.com/connect/latest/adminguide/flow-language.html)
+
+!> **WARN:** Contact Flow Modules exported from the Console [See Contact Flow import/export which is the same for Contact Flow Modules](https://docs.aws.amazon.com/connect/latest/adminguide/contact-flow-import-export.html) are not in the Amazon Connect Contact Flow Language and can not be used with this resource. Instead, the recommendation is to use the AWS CLI [`describe-contact-flow-module`](https://docs.aws.amazon.com/cli/latest/reference/connect/describe-contact-flow-module.html).
+See [example](#with-external-content) below which uses `jq` to extract the `Content` attribute and saves it to a local file.
+
+## Example Usage
+
+### Basic
+
+```hcl
+resource "aws_connect_contact_flow_module" "example" {
+  instance_id = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name        = "Example"
+  description = "Example Contact Flow Module Description"
+
+  content = <<JSON
+    {
+		"Version": "2019-10-30",
+		"StartAction": "12345678-1234-1234-1234-123456789012",
+		"Actions": [
+			{
+				"Identifier": "12345678-1234-1234-1234-123456789012",
+				"Parameters": {
+					"Text": "Hello contact flow module"
+				},
+				"Transitions": {
+					"NextAction": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+					"Errors": [],
+					"Conditions": []
+				},
+				"Type": "MessageParticipant"
+			},
+			{
+				"Identifier": "abcdef-abcd-abcd-abcd-abcdefghijkl",
+				"Type": "DisconnectParticipant",
+				"Parameters": {},
+				"Transitions": {}
+			}
+		],
+		"Settings": {
+			"InputParameters": [],
+			"OutputParameters": [],
+			"Transitions": [
+				{
+					"DisplayName": "Success",
+					"ReferenceName": "Success",
+					"Description": ""
+				},
+				{
+					"DisplayName": "Error",
+					"ReferenceName": "Error",
+					"Description": ""
+				}
+			]
+		}
+	}
+    JSON
+
+  tags = {
+    "Name"        = "Example Contact Flow Module",
+    "Application" = "Terraform",
+    "Method"      = "Create"
+  }
+}
+```
+
+### With External Content
+
+Use the AWS CLI to extract Contact Flow Content:
+
+```shell
+$ aws connect describe-contact-flow-module --instance-id 1b3c5d8-1b3c-1b3c-1b3c-1b3c5d81b3c5 --contact-flow-module-id c1d4e5f6-1b3c-1b3c-1b3c-c1d4e5f6c1d4e5 --region us-west-2 | jq '.ContactFlowModule.Content | fromjson' > contact_flow_module.json
+```
+
+Use the generated file as input:
+
+```hcl
+resource "aws_connect_contact_flow_module" "example" {
+  instance_id  = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name         = "Example"
+  description  = "Example Contact Flow Module Description"
+  filename     = "contact_flow_module.json"
+  content_hash = filebase64sha256("contact_flow_module.json")
+
+  tags = {
+    "Name"        = "Example Contact Flow Module",
+    "Application" = "Terraform",
+    "Method"      = "Create"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `content` - (Optional) Specifies the content of the Contact Flow Module, provided as a JSON string, written in Amazon Connect Contact Flow Language. If defined, the `filename` argument cannot be used.
+* `content_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the Contact Flow Module source specified with `filename`. The usual way to set this is filebase64sha256("contact_flow_module.json") (Terraform 0.11.12 and later) or base64sha256(file("contact_flow_module.json")) (Terraform 0.11.11 and earlier), where "contact_flow_module.json" is the local filename of the Contact Flow Module source.
+* `description` - (Optional) Specifies the description of the Contact Flow Module.
+* `filename` - (Optional) The path to the Contact Flow Module source within the local filesystem. Conflicts with `content`.
+* `instance_id` - (Required) Specifies the identifier of the hosting Amazon Connect Instance.
+* `name` - (Required) Specifies the name of the Contact Flow Module.
+* `tags` - (Optional) Tags to apply to the Contact Flow Module. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the Contact Flow Module.
+* `id` - The identifier of the hosting Amazon Connect Instance and identifier of the Contact Flow Module separated by a colon (`:`).
+* `contact_flow_module_id` - The identifier of the Contact Flow Module.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 5 min) Used when creating the Contact Flow Module.
+* `update` - (Defaults to 5 min) Used when updating the Contact Flow Module.
+
+## Import
+
+Amazon Connect Contact Flow Modules can be imported using the `instance_id` and `contact_flow_module_id` separated by a colon (`:`), e.g.,
+
+```
+$ terraform import aws_connect_contact_flow_module.example f1288a1f-6193-445a-b47e-af739b2:c1d4e5f6-1b3c-1b3c-1b3c-c1d4e5f6c1d4e5
+```

--- a/website/docs/r/connect_contact_flow_module.html.markdown
+++ b/website/docs/r/connect_contact_flow_module.html.markdown
@@ -125,13 +125,6 @@ In addition to all arguments above, the following attributes are exported:
 * `contact_flow_module_id` - The identifier of the Contact Flow Module.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 
-### Timeouts
-
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
-
-* `create` - (Defaults to 5 min) Used when creating the Contact Flow Module.
-* `update` - (Defaults to 5 min) Used when updating the Contact Flow Module.
-
 ## Import
 
 Amazon Connect Contact Flow Modules can be imported using the `instance_id` and `contact_flow_module_id` separated by a colon (`:`), e.g.,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22340

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccConnectContactFlowModule_serial PKG=connect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnectContactFlowModule_serial' -timeout 180m
=== RUN   TestAccConnectContactFlowModule_serial
=== RUN   TestAccConnectContactFlowModule_serial/basic
=== RUN   TestAccConnectContactFlowModule_serial/filename
=== RUN   TestAccConnectContactFlowModule_serial/disappears
--- PASS: TestAccConnectContactFlowModule_serial (459.82s)
    --- PASS: TestAccConnectContactFlowModule_serial/basic (185.60s)
    --- PASS: TestAccConnectContactFlowModule_serial/filename (167.39s)
    --- PASS: TestAccConnectContactFlowModule_serial/disappears (106.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    467.348s

...
```
