### PR TITLE
LocalStack update s3 integration with terraform docs with virtual-host style access 

### DIFF
--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -377,6 +377,43 @@ An example provider configuration:
 provider "aws" {
   access_key                  = "mock_access_key"
   region                      = "us-east-1"
+  s3_force_path_style         = false
+  secret_key                  = "mock_secret_key"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    apigateway     = "http://localhost:4566"
+    cloudformation = "http://localhost:4566"
+    cloudwatch     = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    es             = "http://localhost:4566"
+    firehose       = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    kinesis        = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    redshift       = "http://localhost:4566"
+    s3             = "http://s3.localhost.localstack.cloud:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    stepfunctions  = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}
+```
+
+In case of DNS issues resolving `s3.localhost.localstack.cloud`, the alternative is to fallback to the `http://localhost:4566` endpoint in combination with `s3_force_path_style = true`:
+
+```terraform
+
+provider "aws" {
+  access_key                  = "mock_access_key"
+  region                      = "us-east-1"
   s3_force_path_style         = true
   secret_key                  = "mock_secret_key"
   skip_credentials_validation = true

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -407,7 +407,7 @@ provider "aws" {
 }
 ```
 
-In case of DNS issues resolving `s3.localhost.localstack.cloud`, the alternative is to fallback to the `http://localhost:4566` endpoint in combination with `s3_force_path_style = true`:
+In case of DNS issues resolving `s3.localhost.localstack.cloud`, the alternative is to fallback to the `http://localhost:4566` endpoint in combination with `s3_force_path_style = true`, e.g.,
 
 ```terraform
 


### PR DESCRIPTION
Since AWS is deprecating the path-based style access for hosting s3 buckets, we want to incentivise users to use the virtual-host style first and make it more prominent in the documentation.