### PR TITLE
r/aws_ses_event_destination: fix cloudwatch_destination more contains

### DIFF
--- a/.changelog/22359.txt
+++ b/.changelog/22359.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_event_destination: Allow `.` and `@` characters in `cloudwatch_destination.default_value` argument
+```

--- a/internal/service/ses/event_destination.go
+++ b/internal/service/ses/event_destination.go
@@ -55,13 +55,9 @@ func ResourceEventDestination() *schema.Resource {
 							),
 						},
 						"value_source": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								ses.DimensionValueSourceMessageTag,
-								ses.DimensionValueSourceEmailHeader,
-								ses.DimensionValueSourceLinkTag,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(ses.DimensionValueSource_Values(), false),
 						},
 					},
 				},
@@ -104,17 +100,8 @@ func ResourceEventDestination() *schema.Resource {
 				ForceNew: true,
 				Set:      schema.HashString,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						ses.EventTypeSend,
-						ses.EventTypeReject,
-						ses.EventTypeBounce,
-						ses.EventTypeComplaint,
-						ses.EventTypeDelivery,
-						ses.EventTypeOpen,
-						ses.EventTypeClick,
-						ses.EventTypeRenderingFailure,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(ses.EventType_Values(), false),
 				},
 			},
 			"name": {

--- a/internal/service/ses/event_destination.go
+++ b/internal/service/ses/event_destination.go
@@ -86,7 +86,7 @@ func ResourceEventDestination() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.All(
 								validation.StringLenBetween(1, 256),
-								validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-\.@]+$`), "must contain only alphanumeric, underscore, hyphen, period, and at signs characters"),
+								validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_\-\.@]+$`), "must contain only alphanumeric, underscore, hyphen, period, and at signs characters"),
 							),
 						},
 

--- a/internal/service/ses/event_destination.go
+++ b/internal/service/ses/event_destination.go
@@ -86,7 +86,7 @@ func ResourceEventDestination() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.All(
 								validation.StringLenBetween(1, 256),
-								validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-]+$`), "must contain only alphanumeric, underscore, and hyphen characters"),
+								validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_-\.@]+$`), "must contain only alphanumeric, underscore, hyphen, period, and at signs characters"),
 							),
 						},
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #21150.

`cloudwatch_destination.default_value` can contain more the following characters

* period
* at signs (@)

Amazon SES Documentation > Developers Guide
https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-add-event-destination-cloudwatch.html#event-publishing-add-event-destination-cloudwatch-dimensions

> 10. For Default Value, type the value of the dimension. 
>
> Dimension values can contain only ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), dashes (-), at signs (@), and periods (.). Spaces, accented characters, non-Latin characters, and other special characters are not allowed. 

I also confirmed register on the Management Console,
but I can't terraform-apply include above characters now.

Please adding to the matches of the providers internal validation.