### PR TITLE
r/timestreamwrite_table - add `magnetic_store_write_properties` block

### DIFF
--- a/.changelog/22363.txt
+++ b/.changelog/22363.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_timestreamwrite_table: Add `magnetic_store_write_properties` argument.
+```

--- a/internal/service/timestreamwrite/table.go
+++ b/internal/service/timestreamwrite/table.go
@@ -44,6 +44,57 @@ func ResourceTable() *schema.Resource {
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
 				),
 			},
+			"magnetic_store_write_properties": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_magnetic_store_writes": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"magnetic_store_rejected_data_location": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"s3_configuration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"bucket_name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"encryption_option": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(timestreamwrite.S3EncryptionOption_Values(), false),
+												},
+												"kms_key_id": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"object_key_prefix": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 
 			"retention_properties": {
 				Type:     schema.TypeList,
@@ -99,6 +150,10 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("retention_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
 		input.RetentionProperties = expandTimestreamWriteRetentionProperties(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("magnetic_store_write_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
+		input.MagneticStoreWriteProperties = expandTimestreamWriteMagneticStoreWriteProperties(v.([]interface{}))
 	}
 
 	if len(tags) > 0 {
@@ -158,6 +213,10 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(fmt.Errorf("error setting retention_properties: %w", err))
 	}
 
+	if err := d.Set("magnetic_store_write_properties", flattenTimestreamWriteMagneticStoreWriteProperties(table.MagneticStoreWriteProperties)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting magnetic_store_write_properties: %w", err))
+	}
+
 	d.Set("table_name", table.TableName)
 
 	tags, err := ListTags(conn, arn)
@@ -183,7 +242,7 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).TimestreamWriteConn
 
-	if d.HasChange("retention_properties") {
+	if d.HasChangesExcept("tags", "tags_all") {
 		tableName, databaseName, err := TableParseID(d.Id())
 
 		if err != nil {
@@ -191,9 +250,16 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		input := &timestreamwrite.UpdateTableInput{
-			DatabaseName:        aws.String(databaseName),
-			RetentionProperties: expandTimestreamWriteRetentionProperties(d.Get("retention_properties").([]interface{})),
-			TableName:           aws.String(tableName),
+			DatabaseName: aws.String(databaseName),
+			TableName:    aws.String(tableName),
+		}
+
+		if d.HasChange("retention_properties") {
+			input.RetentionProperties = expandTimestreamWriteRetentionProperties(d.Get("retention_properties").([]interface{}))
+		}
+
+		if d.HasChange("magnetic_store_write_properties") {
+			input.MagneticStoreWriteProperties = expandTimestreamWriteMagneticStoreWriteProperties(d.Get("magnetic_store_write_properties").([]interface{}))
 		}
 
 		_, err = conn.UpdateTableWithContext(ctx, input)
@@ -273,6 +339,120 @@ func flattenTimestreamWriteRetentionProperties(rp *timestreamwrite.RetentionProp
 	m := map[string]interface{}{
 		"magnetic_store_retention_period_in_days": aws.Int64Value(rp.MagneticStoreRetentionPeriodInDays),
 		"memory_store_retention_period_in_hours":  aws.Int64Value(rp.MemoryStoreRetentionPeriodInHours),
+	}
+
+	return []interface{}{m}
+}
+
+func expandTimestreamWriteMagneticStoreWriteProperties(l []interface{}) *timestreamwrite.MagneticStoreWriteProperties {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	rp := &timestreamwrite.MagneticStoreWriteProperties{
+		EnableMagneticStoreWrites: aws.Bool(tfMap["enable_magnetic_store_writes"].(bool)),
+	}
+
+	if v, ok := tfMap["magnetic_store_rejected_data_location"].([]interface{}); ok && len(v) > 0 {
+		rp.MagneticStoreRejectedDataLocation = expandTimestreamWriteMagneticStoreRejectedDataLocation(v)
+	}
+
+	return rp
+}
+
+func flattenTimestreamWriteMagneticStoreWriteProperties(rp *timestreamwrite.MagneticStoreWriteProperties) []interface{} {
+	if rp == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enable_magnetic_store_writes":          aws.BoolValue(rp.EnableMagneticStoreWrites),
+		"magnetic_store_rejected_data_location": flattenTimestreamWriteMagneticStoreRejectedDataLocation(rp.MagneticStoreRejectedDataLocation),
+	}
+
+	return []interface{}{m}
+}
+
+func expandTimestreamWriteMagneticStoreRejectedDataLocation(l []interface{}) *timestreamwrite.MagneticStoreRejectedDataLocation {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	rp := &timestreamwrite.MagneticStoreRejectedDataLocation{}
+
+	if v, ok := tfMap["s3_configuration"].([]interface{}); ok && len(v) > 0 {
+		rp.S3Configuration = expandTimestreamWriteS3Configuration(v)
+	}
+
+	return rp
+}
+
+func flattenTimestreamWriteMagneticStoreRejectedDataLocation(rp *timestreamwrite.MagneticStoreRejectedDataLocation) []interface{} {
+	if rp == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"s3_configuration": flattenTimestreamWriteS3Configuration(rp.S3Configuration),
+	}
+
+	return []interface{}{m}
+}
+
+func expandTimestreamWriteS3Configuration(l []interface{}) *timestreamwrite.S3Configuration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	rp := &timestreamwrite.S3Configuration{}
+
+	if v, ok := tfMap["bucket_name"].(string); ok && v != "" {
+		rp.BucketName = aws.String(v)
+	}
+
+	if v, ok := tfMap["object_key_prefix"].(string); ok && v != "" {
+		rp.ObjectKeyPrefix = aws.String(v)
+	}
+
+	if v, ok := tfMap["kms_key_id"].(string); ok && v != "" {
+		rp.KmsKeyId = aws.String(v)
+	}
+
+	if v, ok := tfMap["encryption_option"].(string); ok && v != "" {
+		rp.EncryptionOption = aws.String(v)
+	}
+
+	return rp
+}
+
+func flattenTimestreamWriteS3Configuration(rp *timestreamwrite.S3Configuration) []interface{} {
+	if rp == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"bucket_name":       aws.StringValue(rp.BucketName),
+		"object_key_prefix": aws.StringValue(rp.ObjectKeyPrefix),
+		"kms_key_id":        aws.StringValue(rp.KmsKeyId),
+		"encryption_option": aws.StringValue(rp.EncryptionOption),
 	}
 
 	return []interface{}{m}

--- a/internal/service/timestreamwrite/table_test.go
+++ b/internal/service/timestreamwrite/table_test.go
@@ -34,8 +34,134 @@ func TestAccTimestreamWriteTable_basic(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "timestream", fmt.Sprintf("database/%[1]s/table/%[1]s", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "database_name", dbResourceName, "database_name"),
 					resource.TestCheckResourceAttr(resourceName, "retention_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "false"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "table_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTimestreamWriteTable_magneticStoreWriteProperties(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_timestreamwrite_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, timestreamwrite.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableMagneticStoreWritePropertiesConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "true"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTableMagneticStoreWritePropertiesConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "false"),
+				),
+			},
+			{
+				Config: testAccTableMagneticStoreWritePropertiesConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTimestreamWriteTable_magneticStoreWriteProperties_s3Config(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_timestreamwrite_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, timestreamwrite.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableMagneticStoreWritePropertiesS3Config(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "true"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.bucket_name", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.object_key_prefix", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTableMagneticStoreWritePropertiesS3Config(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "true"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.bucket_name", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.object_key_prefix", rNameUpdated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTimestreamWriteTable_magneticStoreWriteProperties_s3KmsConfig(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_timestreamwrite_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, timestreamwrite.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableMagneticStoreWritePropertiesS3KmsConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.enable_magnetic_store_writes", "true"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.bucket_name", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttrPair(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.object_key_prefix", rName),
+					resource.TestCheckResourceAttr(resourceName, "magnetic_store_write_properties.0.magnetic_store_rejected_data_location.0.s3_configuration.0.encryption_option", "SSE_KMS"),
 				),
 			},
 			{
@@ -61,6 +187,7 @@ func TestAccTimestreamWriteTable_disappears(t *testing.T) {
 				Config: testAccTableBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTableExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tftimestreamwrite.ResourceTable(), resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tftimestreamwrite.ResourceTable(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -260,6 +387,82 @@ func testAccTableBasicConfig(rName string) string {
 resource "aws_timestreamwrite_table" "test" {
   database_name = aws_timestreamwrite_database.test.database_name
   table_name    = %q
+}
+`, rName))
+}
+
+func testAccTableMagneticStoreWritePropertiesConfig(rName string, enable bool) string {
+	return acctest.ConfigCompose(
+		testAccTableBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_timestreamwrite_table" "test" {
+  database_name = aws_timestreamwrite_database.test.database_name
+  table_name    = %q
+
+  magnetic_store_write_properties {
+    enable_magnetic_store_writes = %t
+  }
+}
+`, rName, enable))
+}
+
+func testAccTableMagneticStoreWritePropertiesS3Config(rName, prefix string) string {
+	return acctest.ConfigCompose(
+		testAccTableBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_timestreamwrite_table" "test" {
+  database_name = aws_timestreamwrite_database.test.database_name
+  table_name    = %[1]q
+
+  magnetic_store_write_properties {
+    enable_magnetic_store_writes = true
+
+    magnetic_store_rejected_data_location {
+      s3_configuration {
+        bucket_name       = aws_s3_bucket.test.bucket
+        object_key_prefix = %[2]q
+	  }
+	}
+  }
+}
+`, rName, prefix))
+}
+
+func testAccTableMagneticStoreWritePropertiesS3KmsConfig(rName string) string {
+	return acctest.ConfigCompose(
+		testAccTableBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  description             = %[1]q
+}
+
+resource "aws_timestreamwrite_table" "test" {
+  database_name = aws_timestreamwrite_database.test.database_name
+  table_name    = %[1]q
+
+  magnetic_store_write_properties {
+    enable_magnetic_store_writes = true
+
+    magnetic_store_rejected_data_location {
+      s3_configuration {
+        bucket_name       = aws_s3_bucket.test.bucket
+        object_key_prefix = %[1]q
+		kms_key_id        = aws_kms_key.test.arn
+		encryption_option = "SSE_KMS"
+	  }
+	}
+  }
 }
 `, rName))
 }

--- a/internal/service/timestreamwrite/table_test.go
+++ b/internal/service/timestreamwrite/table_test.go
@@ -426,8 +426,8 @@ resource "aws_timestreamwrite_table" "test" {
       s3_configuration {
         bucket_name       = aws_s3_bucket.test.bucket
         object_key_prefix = %[2]q
-	  }
-	}
+      }
+    }
   }
 }
 `, rName, prefix))
@@ -458,10 +458,10 @@ resource "aws_timestreamwrite_table" "test" {
       s3_configuration {
         bucket_name       = aws_s3_bucket.test.bucket
         object_key_prefix = %[1]q
-		kms_key_id        = aws_kms_key.test.arn
-		encryption_option = "SSE_KMS"
-	  }
-	}
+        kms_key_id        = aws_kms_key.test.arn
+        encryption_option = "SSE_KMS"
+      }
+    }
   }
 }
 `, rName))

--- a/website/docs/r/timestreamwrite_table.html.markdown
+++ b/website/docs/r/timestreamwrite_table.html.markdown
@@ -44,9 +44,32 @@ resource "aws_timestreamwrite_table" "example" {
 The following arguments are supported:
 
 * `database_name` – (Required) The name of the Timestream database.
+* `magnetic_store_write_properties` - (Optional) Contains properties to set on the table when enabling magnetic store writes. See [Magnetic Store Write Properties](#magnetic-store-write-properties) below for more details.
 * `retention_properties` - (Optional) The retention duration for the memory store and magnetic store. See [Retention Properties](#retention-properties) below for more details. If not provided, `magnetic_store_retention_period_in_days` default to 73000 and `memory_store_retention_period_in_hours` defaults to 6.
 * `table_name` - (Required) The name of the Timestream table.
 * `tags` - (Optional) Map of tags to assign to this resource. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Magnetic Store Write Properties
+
+The `magnetic_store_write_properties` block supports the following arguments:
+
+* `enable_magnetic_store_writes` - (Required) A flag to enable magnetic store writes.
+* `magnetic_store_rejected_data_location` - (Optional) The location to write error reports for records rejected asynchronously during magnetic store writes. See [Magnetic Store Rejected Data Location](#magnetic-store-rejected-data-location) below for more details.
+
+#### Magnetic Store Rejected Data Location
+
+The `magnetic_store_rejected_data_location` block supports the following arguments:
+
+* `s3_configuration` - (Optional) Configuration of an S3 location to write error reports for records rejected, asynchronously, during magnetic store writes. See [S3 Configuration](#s3-configuration) below for more details.
+
+##### S3 Configuration
+
+The `s3_configuration` block supports the following arguments:
+
+* `bucket_name` - (Optional) Bucket name of the customer S3 bucket.
+* `encryption_option` - (Optional) Encryption option for the customer s3 location. Options are S3 server side encryption with an S3-managed key or KMS managed key. Valid values are `SSE_KMS` and `SSE_S3`.
+* `kms_key_id` - (Optional) KMS key arn for the customer s3 location when encrypting with a KMS managed key.
+* `object_key_prefix` - (Optional) Object key prefix for the customer S3 location.
 
 ### Retention Properties
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccTimestreamWriteTable_ PKG=timestreamwrite
--- PASS: TestAccTimestreamWriteTable_disappears (91.68s)
--- PASS: TestAccTimestreamWriteTable_basic (109.46s)
--- PASS: TestAccTimestreamWriteTable_magneticStoreWriteProperties_s3KmsConfig (131.78s)
--- PASS: TestAccTimestreamWriteTable_magneticStoreWriteProperties_s3Config (208.52s)
--- PASS: TestAccTimestreamWriteTable_retentionProperties (218.61s)
--- PASS: TestAccTimestreamWriteTable_magneticStoreWriteProperties (219.66s)
--- PASS: TestAccTimestreamWriteTable_tags (219.74s)
```
