### PR TITLE
Add `testAccIPAMPreCheck` to check for IPAM service-linked role

### DIFF
--- a/internal/service/ec2/vpc_byoip_test.go
+++ b/internal/service/ec2/vpc_byoip_test.go
@@ -53,7 +53,7 @@ func TestAccVPCIpam_ByoipIPv6(t *testing.T) {
 	netmaskLength := 56
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIPv6CIDRBlockAssociationDestroy,

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
@@ -22,7 +22,7 @@ func TestAccVPCIpamPoolAllocation_ipv4Basic(t *testing.T) {
 	cidr := "172.2.0.0/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamPoolAllocationDestroy,
@@ -52,7 +52,7 @@ func TestAccVPCIpamPoolAllocation_ipv4BasicNetmask(t *testing.T) {
 	netmask := "28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamPoolAllocationDestroy,

--- a/internal/service/ec2/vpc_ipam_pool_cidr_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_test.go
@@ -19,7 +19,7 @@ func TestAccVPCIpamPoolCidr_ipv4Basic(t *testing.T) {
 	cidr_range := "10.0.0.0/24"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamProvisionedPoolCidrDestroy,

--- a/internal/service/ec2/vpc_ipam_pool_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceVPCIpamPool_basic(t *testing.T) {
 	dataSourceName := "data.aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { acctest.PreCheck(t) },
+		PreCheck:   func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck: acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/vpc_ipam_pool_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_test.go
@@ -18,7 +18,7 @@ func TestAccVPCIpamPool_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamPoolDestroy,
@@ -60,7 +60,7 @@ func TestAccVPCIpamPool_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamPoolDestroy,
@@ -96,32 +96,12 @@ func TestAccVPCIpamPool_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckVPCIpamPoolExists(n string, pool *ec2.IpamPool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		id := rs.Primary.ID
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
-		found_pool, err := tfec2.FindIpamPoolById(conn, id)
-
-		if err != nil {
-			return err
-		}
-		*pool = *found_pool
-
-		return nil
-	}
-}
-
 func TestAccVPCIpamPool_ipv6Basic(t *testing.T) {
 	var pool ec2.IpamPool
 	resourceName := "aws_vpc_ipam_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamPoolDestroy,
@@ -143,6 +123,26 @@ func TestAccVPCIpamPool_ipv6Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckVPCIpamPoolExists(n string, pool *ec2.IpamPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		id := rs.Primary.ID
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+		found_pool, err := tfec2.FindIpamPoolById(conn, id)
+
+		if err != nil {
+			return err
+		}
+		*pool = *found_pool
+
+		return nil
+	}
 }
 
 func testAccCheckVPCIpamPoolDestroy(s *terraform.State) error {

--- a/internal/service/ec2/vpc_ipam_scope_test.go
+++ b/internal/service/ec2/vpc_ipam_scope_test.go
@@ -19,7 +19,7 @@ func TestAccVPCIpamScope_basic(t *testing.T) {
 	ipamName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamScopeDestroy,
@@ -55,7 +55,7 @@ func TestAccVPCIpamScope_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam_scope.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamScopeDestroy,

--- a/internal/service/ec2/vpc_ipam_test.go
+++ b/internal/service/ec2/vpc_ipam_test.go
@@ -16,11 +16,15 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func testAccIPAMPreCheck(t *testing.T) {
+	acctest.PreCheckIAMServiceLinkedRole(t, "/aws-service-role/ipam.amazonaws.com")
+}
+
 func TestAccVPCIpam_basic(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamDestroy,
@@ -52,6 +56,7 @@ func TestAccVPCIpam_modifyRegion(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			testAccIPAMPreCheck(t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
 		ErrorCheck:        acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -89,7 +94,7 @@ func TestAccVPCIpam_tags(t *testing.T) {
 	resourceName := "aws_vpc_ipam.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIpamDestroy,

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
@@ -51,7 +51,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_IpamBasic(t *testing.T) {
 	netmaskLength := "28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIPv4CIDRBlockAssociationDestroy,
@@ -72,7 +72,7 @@ func TestAccVPCIPv4CIDRBlockAssociation_IpamBasicExplicitCIDR(t *testing.T) {
 	cidr := "172.2.0.32/28"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVPCIPv4CIDRBlockAssociationDestroy,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22386.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Service-linked role defined

```console
% AWS_DEFAULT_REGION=us-east-2 make testacc TESTS=TestAccVPCIpam_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCIpam_basic' -timeout 180m
=== RUN   TestAccVPCIpam_basic
=== PAUSE TestAccVPCIpam_basic
=== CONT  TestAccVPCIpam_basic
--- PASS: TestAccVPCIpam_basic (28.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	31.889s
```

#### Service-linked role not defined

```console
% AWS_DEFAULT_REGION=us-east-2 make testacc TESTS=TestAccVPCIpam_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCIpam_basic' -timeout 180m
=== RUN   TestAccVPCIpam_basic
=== PAUSE TestAccVPCIpam_basic
=== CONT  TestAccVPCIpam_basic
    acctest.go:749: skipping tests; missing IAM service-linked role /aws-service-role/ipam.amazonaws.com. Please create the role and retry
--- SKIP: TestAccVPCIpam_basic (0.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	4.434s
```
