### PR TITLE
New resource/aws_vpc_ipam_organization_admin_account

### DIFF
--- a/.changelog/22394.txt
+++ b/.changelog/22394.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_vpc_ipam_organization_admin_account
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1120,6 +1120,7 @@ func Provider() *schema.Provider {
 			"aws_vpc_endpoint_service_allowed_principal":          ec2.ResourceVPCEndpointServiceAllowedPrincipal(),
 			"aws_vpc_endpoint_subnet_association":                 ec2.ResourceVPCEndpointSubnetAssociation(),
 			"aws_vpc_ipam":                                        ec2.ResourceVPCIpam(),
+			"aws_vpc_ipam_organization_account_admin":             ec2.ResourceVPCIpamOrganizationAdminAccount(),
 			"aws_vpc_ipam_pool":                                   ec2.ResourceVPCIpamPool(),
 			"aws_vpc_ipam_pool_cidr_allocation":                   ec2.ResourceVPCIpamPoolCidrAllocation(),
 			"aws_vpc_ipam_pool_cidr":                              ec2.ResourceVPCIpamPoolCidr(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1120,7 +1120,7 @@ func Provider() *schema.Provider {
 			"aws_vpc_endpoint_service_allowed_principal":          ec2.ResourceVPCEndpointServiceAllowedPrincipal(),
 			"aws_vpc_endpoint_subnet_association":                 ec2.ResourceVPCEndpointSubnetAssociation(),
 			"aws_vpc_ipam":                                        ec2.ResourceVPCIpam(),
-			"aws_vpc_ipam_organization_account_admin":             ec2.ResourceVPCIpamOrganizationAdminAccount(),
+			"aws_vpc_ipam_organization_admin_account":             ec2.ResourceVPCIpamOrganizationAdminAccount(),
 			"aws_vpc_ipam_pool":                                   ec2.ResourceVPCIpamPool(),
 			"aws_vpc_ipam_pool_cidr_allocation":                   ec2.ResourceVPCIpamPoolCidrAllocation(),
 			"aws_vpc_ipam_pool_cidr":                              ec2.ResourceVPCIpamPoolCidr(),

--- a/internal/service/ec2/vpc_ipam_organization_admin_account.go
+++ b/internal/service/ec2/vpc_ipam_organization_admin_account.go
@@ -1,0 +1,119 @@
+package ec2
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceVPCIpamOrganizationAdminAccount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVPCIpamOrganizationAdminAccountCreate,
+		Read:   resourceVPCIpamOrganizationAdminAccountRead,
+		// TODO: validate update is possible
+		// Update: resourceVPCIpamOrganizationAdminAccountUpdate,
+		Delete: resourceVPCIpamOrganizationAdminAccountDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"delegated_admin_account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				// ForceNew = true if cannot update in place - see L21
+				// ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+		},
+	}
+}
+
+const (
+	ipam_service_principal = "ipam.amazonaws.com"
+)
+
+func resourceVPCIpamOrganizationAdminAccountCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	adminAccountID := d.Get("delegated_admin_account_id").(string)
+
+	input := &ec2.EnableIpamOrganizationAdminAccountInput{
+		DelegatedAdminAccountId: aws.String(adminAccountID),
+	}
+
+	output, err := conn.EnableIpamOrganizationAdminAccount(input)
+
+	if err != nil {
+		return fmt.Errorf("error enabling IPAM Organization Admin Account (%s): %w", adminAccountID, err)
+	}
+	if !aws.BoolValue(output.Success) {
+		return fmt.Errorf("error enabling IPAM Organization Admin Account (%s): %w", adminAccountID, err)
+	}
+
+	d.SetId(encodeIpamOrgAdminId(adminAccountID))
+
+	return resourceVPCIpamOrganizationAdminAccountRead(d, meta)
+}
+
+func resourceVPCIpamOrganizationAdminAccountRead(d *schema.ResourceData, meta interface{}) error {
+	org_conn := meta.(*conns.AWSClient).OrganizationsConn
+	// ListDelegatedAdministratorsInput
+
+	// if err != nil {
+	// 	return fmt.Errorf("error reading VPCIpam Organization Admin Account (%s): %w", d.Id(), err)
+	// }
+
+	// if adminAccount == nil {
+	// 	log.Printf("[WARN] VPCIpam Organization Admin Account (%s) not found, removing from state", d.Id())
+	// 	d.SetId("")
+	// 	return nil
+	// }
+
+	return nil
+}
+
+func resourceVPCIpamOrganizationAdminAccountUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+	// need to check if its possbile to overwrite
+	// likely youll just run the same steps from Create()
+	return nil
+}
+
+func resourceVPCIpamOrganizationAdminAccountDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	account_id, _, err := DecodeIpamPoolCidrID(d.Id())
+
+	input := &ec2.DisableIpamOrganizationAdminAccountInput{
+		DelegatedAdminAccountId: aws.String(account_id),
+	}
+
+	output, err := conn.DisableIpamOrganizationAdminAccount(input)
+
+	if err != nil {
+		return fmt.Errorf("error disabling IPAM Organization Admin Account (%s): %w", account_id, err)
+	}
+	if !aws.BoolValue(output.Success) {
+		return fmt.Errorf("error disabling IPAM Organization Admin Account (%s): %w", account_id, err)
+	}
+	return nil
+}
+
+func encodeIpamOrgAdminId(account_id string) string {
+	return fmt.Sprintf("%s_%s", account_id, ipam_service_principal)
+}
+
+func DecodeIpamOrgAdminId(id string) (string, string, error) {
+	idParts := strings.Split(id, "_")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return "", "", fmt.Errorf("expected ID in the form of <account_id>_<service_principal>, given: %q", id)
+	}
+	return idParts[0], idParts[1], nil
+}

--- a/internal/service/ec2/vpc_ipam_organization_admin_account.go
+++ b/internal/service/ec2/vpc_ipam_organization_admin_account.go
@@ -1,6 +1,7 @@
 package ec2
 
-import (
+// ec2 has no action for Describe() to see if IPAM delegated admin has already been assigned
+import ( // nosemgrep: aws-sdk-go-multiple-service-imports
 	"fmt"
 	"log"
 

--- a/internal/service/ec2/vpc_ipam_organization_admin_account_test.go
+++ b/internal/service/ec2/vpc_ipam_organization_admin_account_test.go
@@ -115,7 +115,7 @@ func testAccCheckVPCIpamOrganizationAdminAccountExists(n string, org *organizati
 }
 
 func testAccVPCIpamOrganizationAdminAccountConfig() string {
-	return acctest.ConfigAlternateAccountProvider() + `
+	return acctest.ConfigCompose(acctest.ConfigAlternateAccountProvider() + `
 data "aws_caller_identity" "delegated" {
   provider = "awsalternate"
 }
@@ -123,5 +123,5 @@ data "aws_caller_identity" "delegated" {
 resource "aws_vpc_ipam_organization_admin_account" "test" {
   delegated_admin_account_id = data.aws_caller_identity.delegated.account_id
 }
-`
+`)
 }

--- a/internal/service/ec2/vpc_ipam_organization_admin_account_test.go
+++ b/internal/service/ec2/vpc_ipam_organization_admin_account_test.go
@@ -1,0 +1,137 @@
+package ec2_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
+)
+
+func TestAccVPCIpamOrganizationAdminAccount_basic(t *testing.T) {
+	// var providers []*schema.Provider
+	var organization organizations.DelegatedAdministrator
+	resourceName := "aws_vpc_ipam_organization_account_admin.test"
+	// servicePrincipal := "ipam.amazonaws.com"
+	dataSourceIdentity := "data.aws_caller_identity.delegated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			// acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck: acctest.ErrorCheck(t, organizations.EndpointsID),
+		// ProviderFactories: acctest.FactoriesAlternate(&providers),
+		CheckDestroy: testAccCheckVPCIpamOrganizationAdminAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCIpamOrganizationAdminAccountConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCIpamOrganizationAdminAccountExists(resourceName, &organization),
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceIdentity, "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "service_principal", tfec2.Ipam_service_principal),
+					acctest.MatchResourceAttrGlobalARNNoAccount(resourceName, "arn", "organizations", regexp.MustCompile("account/.+")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVPCIpamOrganizationAdminAccountDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_vpc_ipam_organization_account_admin" {
+			continue
+		}
+		id := rs.Primary.ID
+
+		input := &organizations.ListDelegatedAdministratorsInput{
+			ServicePrincipal: aws.String(tfec2.Ipam_service_principal),
+		}
+
+		output, err := conn.ListDelegatedAdministrators(input)
+
+		if err != nil {
+			return fmt.Errorf("error finding IPAM organization delegated account: (%s): %w", id, err)
+		}
+
+		if aws.StringValue(output.DelegatedAdministrators[0].Id) == id {
+			return fmt.Errorf("organization DelegatedAdministrator still exists: %q", id)
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckVPCIpamOrganizationAdminAccountExists(n string, org *organizations.DelegatedAdministrator) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Organization ID not set")
+		}
+
+		accountID, servicePrincipal, err := tforganizations.DecodeOrganizationDelegatedAdministratorID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsConn
+		input := &organizations.ListDelegatedAdministratorsInput{
+			ServicePrincipal: aws.String(servicePrincipal),
+		}
+
+		exists := false
+		var resp *organizations.DelegatedAdministrator
+		err = conn.ListDelegatedAdministratorsPages(input, func(page *organizations.ListDelegatedAdministratorsOutput, lastPage bool) bool {
+			for _, delegated := range page.DelegatedAdministrators {
+				if aws.StringValue(delegated.Id) == accountID {
+					exists = true
+					resp = delegated
+				}
+			}
+
+			return !lastPage
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return fmt.Errorf("organization DelegatedAdministrator %q does not exist", rs.Primary.ID)
+		}
+
+		*org = *resp
+
+		return nil
+	}
+}
+
+const testAccVPCIpamOrganizationAdminAccountConfig = `
+	// data "aws_caller_identity" "delegated" {
+	//   provider = "awsalternate"
+	// }
+
+	resource "aws_vpc_ipam_organization_account_admin" "test" {
+		delegated_admin_account_id =  "034799157163" #data.aws_caller_identity.delegated.account_id
+	}
+	`
+
+//acctest.ConfigAlternateAccountProvider()

--- a/internal/service/ec2/vpc_ipam_organization_admin_account_test.go
+++ b/internal/service/ec2/vpc_ipam_organization_admin_account_test.go
@@ -18,7 +18,7 @@ import (
 func TestAccVPCIpamOrganizationAdminAccount_basic(t *testing.T) {
 	var providers []*schema.Provider
 	var organization organizations.DelegatedAdministrator
-	resourceName := "aws_vpc_ipam_organization_account_admin.test"
+	resourceName := "aws_vpc_ipam_organization_admin_account.test"
 	dataSourceIdentity := "data.aws_caller_identity.delegated"
 
 	resource.Test(t, resource.TestCase{
@@ -52,7 +52,7 @@ func testAccCheckVPCIpamOrganizationAdminAccountDestroy(s *terraform.State) erro
 	conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsConn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_vpc_ipam_organization_account_admin" {
+		if rs.Type != "aws_vpc_ipam_organization_admin_account" {
 			continue
 		}
 		id := rs.Primary.ID
@@ -117,11 +117,11 @@ func testAccCheckVPCIpamOrganizationAdminAccountExists(n string, org *organizati
 func testAccVPCIpamOrganizationAdminAccountConfig() string {
 	return acctest.ConfigAlternateAccountProvider() + `
 data "aws_caller_identity" "delegated" {
-	provider = "awsalternate"
+  provider = "awsalternate"
 }
 
-resource "aws_vpc_ipam_organization_account_admin" "test" {
-	delegated_admin_account_id = data.aws_caller_identity.delegated.account_id
+resource "aws_vpc_ipam_organization_admin_account" "test" {
+  delegated_admin_account_id = data.aws_caller_identity.delegated.account_id
 }
 `
 }

--- a/website/docs/r/vpc_ipam_organization_account_admin.html.markdown
+++ b/website/docs/r/vpc_ipam_organization_account_admin.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_vpc_ipam_organization_account_admin"
+description: |-
+  Enables the IPAM Service and promotes an account to delegated administrator for the service.
+---
+
+# Resource: aws_vpc_ipam_organization_account_admin
+
+Enables the IPAM Service and promotes a delegated administrator.
+
+## Example Usage
+
+Basic usage:
+
+```terraform
+data "aws_caller_identity" "delegated" {
+  provider = "awsalternate"
+}
+
+resource "aws_vpc_ipam_organization_account_admin" "example" {
+  delegated_admin_account_id =  data.aws_caller_identity.delegated.account_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `delegated_admin_account_id` - (Required)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Organizations ARN for the delegate account.
+* `id` - The Organizations member account ID that you want to enable as the IPAM account.
+* `email` - The Organizations email for the delegate account.
+* `name` - The Organizations name for the delegate account.
+* `service_principal` - The AWS service principal.
+
+## Import
+
+IPAMs can be imported using the `delegate account id`, e.g.
+
+```
+$ terraform import aws_vpc_ipam_organization_account_admin.example 12345678901
+```

--- a/website/docs/r/vpc_ipam_organization_admin_account.html.markdown
+++ b/website/docs/r/vpc_ipam_organization_admin_account.html.markdown
@@ -20,7 +20,7 @@ data "aws_caller_identity" "delegated" {
 }
 
 resource "aws_vpc_ipam_organization_admin_account" "example" {
-  delegated_admin_account_id =  data.aws_caller_identity.delegated.account_id
+  delegated_admin_account_id = data.aws_caller_identity.delegated.account_id
 }
 ```
 

--- a/website/docs/r/vpc_ipam_organization_admin_account.html.markdown
+++ b/website/docs/r/vpc_ipam_organization_admin_account.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "VPC"
 layout: "aws"
-page_title: "AWS: aws_vpc_ipam_organization_account_admin"
+page_title: "AWS: aws_vpc_ipam_organization_admin_account"
 description: |-
   Enables the IPAM Service and promotes an account to delegated administrator for the service.
 ---
 
-# Resource: aws_vpc_ipam_organization_account_admin
+# Resource: aws_vpc_ipam_organization_admin_account
 
 Enables the IPAM Service and promotes a delegated administrator.
 
@@ -19,7 +19,7 @@ data "aws_caller_identity" "delegated" {
   provider = "awsalternate"
 }
 
-resource "aws_vpc_ipam_organization_account_admin" "example" {
+resource "aws_vpc_ipam_organization_admin_account" "example" {
   delegated_admin_account_id =  data.aws_caller_identity.delegated.account_id
 }
 ```
@@ -45,5 +45,5 @@ In addition to all arguments above, the following attributes are exported:
 IPAMs can be imported using the `delegate account id`, e.g.
 
 ```
-$ terraform import aws_vpc_ipam_organization_account_admin.example 12345678901
+$ terraform import aws_vpc_ipam_organization_admin_account.example 12345678901
 ```

--- a/website/docs/r/vpc_ipam_pool_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr.html.markdown
@@ -12,6 +12,9 @@ Provisions a CIDR from an IPAM address pool.
 
 ~> **NOTE:** Provisioning Public IPv4 or Public IPv6 require [steps outside the scope of this resource](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-byoip.html#prepare-for-byoip). The resource accepts `message` and `signature` as part of the `cidr_authorization_context` attribute but those must be generated ahead of time. Public IPv6 CIDRs that are provisioned into a Pool with `publicly_advertisable = true` and all public IPv4 CIDRs also require creating a Route Origin Authorization (ROA) object in your Regional Internet Registry (RIR).
 
+~> **NOTE:** In order to deprovision CIDRs all Allocations must be released. Allocations created by a VPC take up to 30 minutes to be released. However, for IPAM to properly manage the removal of allocation records created by VPCs and other resources, you must [grant it permissions](https://docs.aws.amazon.com/vpc/latest/ipam/choose-single-user-or-orgs-ipam.html) in
+either a single account or organizationally. If you are unable to deprovision a cidr after waiting over 30 minutes, you may be missing the Service Linked Role.
+
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #22092

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccVPCIpamOrganizationAdminAccount_basic' PKG_NAME='./internal/service/ec2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/ec2/... -v -count 1 -parallel 20 -run=TestAccVPCIpamOrganizationAdminAccount_basic -timeout 180m
=== RUN   TestAccVPCIpamOrganizationAdminAccount_basic
--- PASS: TestAccVPCIpamOrganizationAdminAccount_basic (15.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        18.537s
```

Also included note in docs for `aws_vpc_ipam_pool_cidr` to explain if the resource is unable to be deleted, users should have some context as to why and how to resolve
