### PR TITLE
r/appstream_fleet: correctly create resource with `stream_view` argument

### DIFF
--- a/.changelog/22395.txt
+++ b/.changelog/22395.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_fleet: Correctly create resource with `stream_view` argument
+```

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -241,6 +241,10 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		input.MaxUserDurationInSeconds = aws.Int64(int64(v.(int)))
 	}
 
+	if v, ok := d.GetOk("stream_view"); ok {
+		input.StreamView = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("vpc_config"); ok {
 		input.VpcConfig = expandVpcConfig(v.([]interface{}))
 	}

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -50,6 +50,7 @@ func TestAccAppStreamFleet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", instanceType),
 					resource.TestCheckResourceAttr(resourceName, "state", appstream.FleetStateRunning),
+					resource.TestCheckResourceAttr(resourceName, "stream_view", appstream.StreamViewApp),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 				),
 			},
@@ -117,6 +118,7 @@ func TestAccAppStreamFleet_completeWithStop(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_type", instanceType),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view", appstream.StreamViewDesktop),
 				),
 			},
 			{
@@ -128,6 +130,7 @@ func TestAccAppStreamFleet_completeWithStop(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_type", instanceTypeUpdate),
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdated),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view", appstream.StreamViewDesktop),
 				),
 			},
 			{
@@ -347,6 +350,7 @@ resource "aws_appstream_fleet" "test" {
   fleet_type                         = %[3]q
   instance_type                      = %[4]q
   max_user_duration_in_seconds       = 1000
+  stream_view                        = "DESKTOP"
 
   vpc_config {
     subnet_ids = aws_subnet.test.*.id

--- a/website/docs/r/appstream_fleet.html.markdown
+++ b/website/docs/r/appstream_fleet.html.markdown
@@ -59,7 +59,7 @@ The following arguments are optional:
 * `idle_disconnect_timeout_in_seconds` - (Optional) Amount of time that users can be idle (inactive) before they are disconnected from their streaming session and the `disconnect_timeout_in_seconds` time interval begins.
 * `image_name` - (Optional) Name of the image used to create the fleet.
 * `image_arn` - (Optional) ARN of the public, private, or shared image to use.
-* `stream_view` - (Optional) AppStream 2.0 view that is displayed to your users when they stream from the fleet. When `APP` is specified, only the windows of applications opened by users display. When `DESKTOP` is specified, the standard desktop that is provided by the operating system displays.
+* `stream_view` - (Optional) AppStream 2.0 view that is displayed to your users when they stream from the fleet. When `APP` is specified, only the windows of applications opened by users display. When `DESKTOP` is specified, the standard desktop that is provided by the operating system displays. If not specified, defaults to `APP`.
 * `max_user_duration_in_seconds` - (Optional) Maximum amount of time that a streaming session can remain active, in seconds.
 * `vpc_config` - (Optional) Configuration block for the VPC configuration for the image builder. See below.
 * `tags` - (Optional) Map of tags to attach to AppStream instances.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21718

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAppStreamFleet_basic (819.92s)
--- PASS: TestAccAppStreamFleet_completeWithStop (2087.37s)
--- PASS: TestAccAppStreamFleet_completeWithoutStop (912.51s)
```
