### PR TITLE
r/aws_dax_cluster - new attribute

### DIFF
--- a/.changelog/22396.txt
+++ b/.changelog/22396.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dax_cluster: Add `cluster_endpoint_encryption_type` attribute
+```

--- a/.changelog/22396.txt
+++ b/.changelog/22396.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_dax_cluster: Add `cluster_endpoint_encryption_type` attribute
+resource/aws_dax_cluster: Add `cluster_endpoint_encryption_type` argument
 ```

--- a/internal/service/dax/cluster.go
+++ b/internal/service/dax/cluster.go
@@ -43,6 +43,20 @@ func ResourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"cluster_endpoint_encryption_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(dax.ClusterEndpointEncryptionType_Values(), false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// API returns "NONE" by default.
+					if old == ClusterEndpointEncryptionTypeNone && new == "" {
+						return true
+					}
+
+					return old == new
+				},
+			},
 			"cluster_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -209,6 +223,10 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		req.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("cluster_endpoint_encryption_type"); ok {
+		req.ClusterEndpointEncryptionType = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("parameter_group_name"); ok {
 		req.ParameterGroupName = aws.String(v.(string))
 	}
@@ -307,6 +325,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	c := res.Clusters[0]
 	d.Set("arn", c.ClusterArn)
 	d.Set("cluster_name", c.ClusterName)
+	d.Set("cluster_endpoint_encryption_type", c.ClusterEndpointEncryptionType)
 	d.Set("description", c.Description)
 	d.Set("iam_role_arn", c.IamRoleArn)
 	d.Set("node_type", c.NodeType)

--- a/internal/service/dax/cluster.go
+++ b/internal/service/dax/cluster.go
@@ -50,7 +50,7 @@ func ResourceCluster() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(dax.ClusterEndpointEncryptionType_Values(), false),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// API returns "NONE" by default.
-					if old == ClusterEndpointEncryptionTypeNone && new == "" {
+					if old == dax.ClusterEndpointEncryptionTypeNone && new == "" {
 						return true
 					}
 

--- a/internal/service/dax/cluster_test.go
+++ b/internal/service/dax/cluster_test.go
@@ -32,6 +32,8 @@ func TestAccDAXCluster_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName, &dc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dax", regexp.MustCompile("cache/.+")),
+					resource.TestCheckResourceAttr(
+						resourceName, "cluster_endpoint_encryption_type", "NONE"),
 					resource.TestMatchResourceAttr(
 						resourceName, "cluster_name", regexp.MustCompile(`^tf-\w+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, "iam_role_arn", iamRoleResourceName, "arn"),

--- a/internal/service/dax/cluster_test.go
+++ b/internal/service/dax/cluster_test.go
@@ -323,6 +323,23 @@ resource "aws_dax_cluster" "test" {
 `, baseConfig, rString, enabled)
 }
 
+func testAccClusterWithEndpointEncryptionConfig(rString string, encryptionType string) string {
+	return fmt.Sprintf(`%s
+resource "aws_dax_cluster" "test" {
+  cluster_name                     = "tf-%s"
+  cluster_endpoint_encryption_type = "%s"
+  iam_role_arn                     = aws_iam_role.test.arn
+  node_type                        = "dax.t2.small"
+  replication_factor               = 1
+  description                      = "test cluster"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, baseConfig, rString, encryptionType)
+}
+
 func testAccClusterResizeConfig_singleNode(rString string) string {
 	return fmt.Sprintf(`%s
 resource "aws_dax_cluster" "test" {

--- a/internal/service/dax/cluster_test.go
+++ b/internal/service/dax/cluster_test.go
@@ -184,6 +184,74 @@ func TestAccDAXCluster_Encryption_enabled(t *testing.T) {
 	})
 }
 
+func TestAccDAXCluster_EndpointEncryption_disabled(t *testing.T) {
+	var dc dax.Cluster
+	rString := sdkacctest.RandString(10)
+	resourceName := "aws_dax_cluster.test"
+	clusterEndpointEncryptionType := "NONE"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dax.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterWithEndpointEncryptionConfig(rString, clusterEndpointEncryptionType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &dc),
+					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint_encryption_type", clusterEndpointEncryptionType),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Ensure it shows no difference when removing cluster_endpoint_encryption_type configuration
+			{
+				Config:             testAccClusterConfig(rString),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccDAXCluster_EndpointEncryption_enabled(t *testing.T) {
+	var dc dax.Cluster
+	rString := sdkacctest.RandString(10)
+	resourceName := "aws_dax_cluster.test"
+	clusterEndpointEncryptionType := "TLS"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, dax.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterWithEndpointEncryptionConfig(rString, clusterEndpointEncryptionType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &dc),
+					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint_encryption_type", clusterEndpointEncryptionType),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Ensure it shows a difference when removing cluster_endpoint_encryption_type configuration
+			{
+				Config:             testAccClusterConfig(rString),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckClusterDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).DAXConn
 

--- a/internal/service/dax/consts.go
+++ b/internal/service/dax/consts.go
@@ -1,5 +1,0 @@
-package dax
-
-const (
-	ClusterEndpointEncryptionTypeNone = "NONE"
-)

--- a/internal/service/dax/consts.go
+++ b/internal/service/dax/consts.go
@@ -1,0 +1,5 @@
+package dax
+
+const (
+	ClusterEndpointEncryptionTypeNone = "NONE"
+)

--- a/website/docs/r/dax_cluster.html.markdown
+++ b/website/docs/r/dax_cluster.html.markdown
@@ -25,6 +25,10 @@ resource "aws_dax_cluster" "bar" {
 
 The following arguments are supported:
 
+* `cluster_endpoint_encryption_type` – (Optional) The type of encryption the
+cluster's endpoint should support. Valid values are: `NONE` and `TLS`.
+Default value is `NONE`.
+
 * `cluster_name` – (Required) Group identifier. DAX converts this name to
 lowercase
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #20352

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDAXCluster PKG=dax                   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dax/... -v -count 1 -parallel 20 -run='TestAccDAXCluster' -timeout 180m
=== RUN   TestAccDAXCluster_basic
=== PAUSE TestAccDAXCluster_basic
=== RUN   TestAccDAXCluster_resize
=== PAUSE TestAccDAXCluster_resize
=== RUN   TestAccDAXCluster_Encryption_disabled
=== PAUSE TestAccDAXCluster_Encryption_disabled
=== RUN   TestAccDAXCluster_Encryption_enabled
=== PAUSE TestAccDAXCluster_Encryption_enabled
=== RUN   TestAccDAXCluster_EndpointEncryption_disabled
=== PAUSE TestAccDAXCluster_EndpointEncryption_disabled
=== RUN   TestAccDAXCluster_EndpointEncryption_enabled
=== PAUSE TestAccDAXCluster_EndpointEncryption_enabled
=== CONT  TestAccDAXCluster_basic
=== CONT  TestAccDAXCluster_Encryption_enabled
=== CONT  TestAccDAXCluster_resize
=== CONT  TestAccDAXCluster_EndpointEncryption_enabled
=== CONT  TestAccDAXCluster_EndpointEncryption_disabled
=== CONT  TestAccDAXCluster_Encryption_disabled
--- PASS: TestAccDAXCluster_Encryption_disabled (797.99s)
--- PASS: TestAccDAXCluster_Encryption_enabled (853.76s)
--- PASS: TestAccDAXCluster_EndpointEncryption_enabled (915.64s)
--- PASS: TestAccDAXCluster_EndpointEncryption_disabled (979.93s)
--- PASS: TestAccDAXCluster_basic (1164.41s)
--- PASS: TestAccDAXCluster_resize (1586.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dax        1594.203s
...
```
