### PR TITLE
r/networkfirewall_resource_policy: add error handling during delete for possible RAM related error

### DIFF
--- a/.changelog/22402.txt
+++ b/.changelog/22402.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkfirewall_resource_policy: Handle delete-after-create eventual consistency
+```

--- a/internal/service/networkfirewall/wait.go
+++ b/internal/service/networkfirewall/wait.go
@@ -13,6 +13,8 @@ const (
 	firewallTimeout = 20 * time.Minute
 	// Maximum amount of time to wait for a Firewall Policy to be deleted
 	firewallPolicyTimeout = 10 * time.Minute
+	// Maximum amount of time to wait for a Resource Policy to be deleted
+	resourcePolicyDeleteTimeout = 2 * time.Minute
 	// Maximum amount of time to wait for a Rule Group to be deleted
 	ruleGroupDeleteTimeout = 10 * time.Minute
 )


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22174

#### Notes
* error seems to occur only during immediate delete-after-create behavior seen during `disappears` acceptance testing as other tests were passing before code change

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccNetworkFirewallResourcePolicy_disappears (131.81s)
--- PASS: TestAccNetworkFirewallResourcePolicy_ruleGroup (138.82s)
--- PASS: TestAccNetworkFirewallResourcePolicy_basic (139.01s)
--- PASS: TestAccNetworkFirewallResourcePolicy_Disappears_firewallPolicy (146.00s)
--- PASS: TestAccNetworkFirewallResourcePolicy_Disappears_ruleGroup (146.00s)
--- PASS: TestAccNetworkFirewallResourcePolicy_ignoreEquivalent (148.07s)
```
