### PR TITLE
r/appsync_datasource - http authorization + rdbms source

### DIFF
--- a/.changelog/22411.txt
+++ b/.changelog/22411.txt
@@ -1,15 +1,15 @@
 ```release-note:enhancement
-resource/aws_appsync_datasource: Add Support for `delta_sync_config` and `versioned` attributes to the `dynamodb_config` block.
+resource/aws_appsync_datasource: Add `delta_sync_config` and `versioned` to the `dynamodb_config` configuration block
 ```
 
 ```release-note:enhancement
-resource/aws_appsync_datasource: Add Support for `authorization_config` attribute to the `http_config` block.
+resource/aws_appsync_datasource: Add `authorization_config` attribute to the `http_config` configuration block
 ```
 
 ```release-note:enhancement
-resource/aws_appsync_datasource: Add plan time validation for `service_role_arn`, `lambda_config.function_arn`
+resource/aws_appsync_datasource: Add plan time validation for `service_role_arn` and `lambda_config.function_arn`
 ```
 
 ```release-note:enhancement
-resource/aws_appsync_datasource: Add support for `relational_database_config` attribute.
+resource/aws_appsync_datasource: Add `relational_database_config` argument
 ```

--- a/.changelog/22411.txt
+++ b/.changelog/22411.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/aws_appsync_datasource: Add Support for `delta_sync_config` and `versioned` attributes to the `dynamodb_config` block.
+```
+
+```release-note:enhancement
+resource/aws_appsync_datasource: Add Support for `authorization_config` attribute to the `http_config` block.
+```
+
+```release-note:enhancement
+resource/aws_appsync_datasource: Add plan time validation for `service_role_arn`, `lambda_config.function_arn`
+```
+
+```release-note:enhancement
+resource/aws_appsync_datasource: Add support for `relational_database_config` attribute.
+```

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -23,6 +23,8 @@ func TestAccAppSync_serial(t *testing.T) {
 			"Type_http_auth":                testAccAppSyncDataSource_Type_http_auth,
 			"Type_lambda":                   testAccAppSyncDataSource_Type_lambda,
 			"Type_none":                     testAccAppSyncDataSource_Type_none,
+			"Type_rdbms":                    testAccAppsyncDatasource_Type_RelationalDatabase,
+			"Type_rdbms_options":            testAccAppsyncDatasource_Type_RelationalDatabaseWithOptions,
 		},
 		"GraphQLAPI": {
 			"basic":                     testAccAppSyncGraphQLAPI_basic,

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -20,6 +20,7 @@ func TestAccAppSync_serial(t *testing.T) {
 			"type":                          testAccAppSyncDataSource_type,
 			"Type_dynamoDB":                 testAccAppSyncDataSource_Type_dynamoDB,
 			"Type_http":                     testAccAppSyncDataSource_Type_http,
+			"Type_http_auth":                testAccAppSyncDataSource_Type_http_auth,
 			"Type_lambda":                   testAccAppSyncDataSource_Type_lambda,
 			"Type_none":                     testAccAppSyncDataSource_Type_none,
 		},

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -444,6 +444,38 @@ func expandAppsyncDynamodbDataSourceConfig(l []interface{}, currentRegion string
 		result.UseCallerCredentials = aws.Bool(v.(bool))
 	}
 
+	if v, ok := configured["versioned"]; ok {
+		result.Versioned = aws.Bool(v.(bool))
+	}
+
+	if v, ok := configured["delta_sync_config"].([]interface{}); ok && len(v) > 0 {
+		result.DeltaSyncConfig = expandAppsyncDynamodbDataSourceDeltaSyncConfig(v)
+	}
+
+	return result
+}
+
+func expandAppsyncDynamodbDataSourceDeltaSyncConfig(l []interface{}) *appsync.DeltaSyncConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	configured := l[0].(map[string]interface{})
+
+	result := &appsync.DeltaSyncConfig{}
+
+	if v, ok := configured["base_table_ttl"].(int); ok {
+		result.BaseTableTTL = aws.Int64(int64(v))
+	}
+
+	if v, ok := configured["delta_sync_table_ttl"].(int); ok {
+		result.DeltaSyncTableTTL = aws.Int64(int64(v))
+	}
+
+	if v, ok := configured["delta_sync_table_name"].(string); ok {
+		result.DeltaSyncTableName = aws.String(v)
+	}
+
 	return result
 }
 
@@ -459,6 +491,36 @@ func flattenAppsyncDynamodbDataSourceConfig(config *appsync.DynamodbDataSourceCo
 
 	if config.UseCallerCredentials != nil {
 		result["use_caller_credentials"] = aws.BoolValue(config.UseCallerCredentials)
+	}
+
+	if config.Versioned != nil {
+		result["versioned"] = aws.BoolValue(config.Versioned)
+	}
+
+	if config.DeltaSyncConfig != nil {
+		result["delte_sync_config"] = flattenAppsyncDynamodbDataSourceDeltaSyncConfig(config.DeltaSyncConfig)
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func flattenAppsyncDynamodbDataSourceDeltaSyncConfig(config *appsync.DeltaSyncConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{}
+
+	if config.DeltaSyncTableName != nil {
+		result["delta_sync_table_name"] = aws.StringValue(config.DeltaSyncTableName)
+	}
+
+	if config.BaseTableTTL != nil {
+		result["base_table_ttl"] = aws.Int64Value(config.BaseTableTTL)
+	}
+
+	if config.DeltaSyncTableTTL != nil {
+		result["delta_sync_table_ttl"] = aws.Int64Value(config.DeltaSyncTableTTL)
 	}
 
 	return []map[string]interface{}{result}
@@ -507,6 +569,10 @@ func expandAppsyncHTTPDataSourceConfig(l []interface{}) *appsync.HttpDataSourceC
 		Endpoint: aws.String(configured["endpoint"].(string)),
 	}
 
+	if v, ok := configured["authorization_config"].([]interface{}); ok && len(v) > 0 {
+		result.AuthorizationConfig = expandAppsyncHTTPDataSourceAuthorizationConfig(v)
+	}
+
 	return result
 }
 
@@ -517,6 +583,77 @@ func flattenAppsyncHTTPDataSourceConfig(config *appsync.HttpDataSourceConfig) []
 
 	result := map[string]interface{}{
 		"endpoint": aws.StringValue(config.Endpoint),
+	}
+
+	if config.AuthorizationConfig != nil {
+		result["authorization_config"] = flattenAppsyncHTTPDataSourceAuthorizationConfig(config.AuthorizationConfig)
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func expandAppsyncHTTPDataSourceAuthorizationConfig(l []interface{}) *appsync.AuthorizationConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	configured := l[0].(map[string]interface{})
+
+	result := &appsync.AuthorizationConfig{
+		AuthorizationType: aws.String(configured["authorization_type"].(string)),
+	}
+
+	if v, ok := configured["aws_iam_confg"].([]interface{}); ok && len(v) > 0 {
+		result.AwsIamConfig = expandAppsyncHTTPDataSourceAwsIamConfig(v)
+	}
+
+	return result
+}
+
+func flattenAppsyncHTTPDataSourceAuthorizationConfig(config *appsync.AuthorizationConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"authorization_type": aws.StringValue(config.AuthorizationType),
+	}
+
+	if config.AwsIamConfig != nil {
+		result["aws_iam_confg"] = flattenAppsyncHTTPDataSourceAwsIamConfig(config.AwsIamConfig)
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func expandAppsyncHTTPDataSourceAwsIamConfig(l []interface{}) *appsync.AwsIamConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	configured := l[0].(map[string]interface{})
+
+	result := &appsync.AwsIamConfig{}
+
+	if v, ok := configured["signing_region"].(string); ok {
+		result.SigningRegion = aws.String(v)
+	}
+
+	if v, ok := configured["signing_service_name"].(string); ok {
+		result.SigningServiceName = aws.String(v)
+	}
+
+	return result
+}
+
+func flattenAppsyncHTTPDataSourceAwsIamConfig(config *appsync.AwsIamConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"signing_region":       aws.StringValue(config.SigningRegion),
+		"signing_service_name": aws.StringValue(config.SigningServiceName),
 	}
 
 	return []map[string]interface{}{result}

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -132,7 +132,7 @@ func ResourceDataSource() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"authorization_type": {
 										Type:         schema.TypeString,
-										Required:     true,
+										Optional:     true,
 										Default:      appsync.AuthorizationTypeAwsIam,
 										ValidateFunc: validation.StringInSlice(appsync.AuthorizationType_Values(), true),
 									},

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -275,7 +275,7 @@ func resourceDataSourceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	_, err := conn.CreateDataSource(input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Appsync Datasource: %w", err)
 	}
 
 	d.SetId(d.Get("api_id").(string) + "-" + d.Get("name").(string))
@@ -603,7 +603,7 @@ func expandAppsyncHTTPDataSourceAuthorizationConfig(l []interface{}) *appsync.Au
 		AuthorizationType: aws.String(configured["authorization_type"].(string)),
 	}
 
-	if v, ok := configured["aws_iam_confg"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := configured["aws_iam_config"].([]interface{}); ok && len(v) > 0 {
 		result.AwsIamConfig = expandAppsyncHTTPDataSourceAwsIamConfig(v)
 	}
 
@@ -620,7 +620,7 @@ func flattenAppsyncHTTPDataSourceAuthorizationConfig(config *appsync.Authorizati
 	}
 
 	if config.AwsIamConfig != nil {
-		result["aws_iam_confg"] = flattenAppsyncHTTPDataSourceAwsIamConfig(config.AwsIamConfig)
+		result["aws_iam_config"] = flattenAppsyncHTTPDataSourceAwsIamConfig(config.AwsIamConfig)
 	}
 
 	return []map[string]interface{}{result}

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -635,11 +635,11 @@ func expandAppsyncHTTPDataSourceAwsIamConfig(l []interface{}) *appsync.AwsIamCon
 
 	result := &appsync.AwsIamConfig{}
 
-	if v, ok := configured["signing_region"].(string); ok {
+	if v, ok := configured["signing_region"].(string); ok && v != "" {
 		result.SigningRegion = aws.String(v)
 	}
 
-	if v, ok := configured["signing_service_name"].(string); ok {
+	if v, ok := configured["signing_service_name"].(string); ok && v != "" {
 		result.SigningServiceName = aws.String(v)
 	}
 

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -383,7 +383,7 @@ func testAccAppsyncDatasource_Type_RelationalDatabase(t *testing.T) {
 	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
 	resourceName := "aws_appsync_datasource.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appsync.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appsync.EndpointsID),
 		Providers:    acctest.Providers,
@@ -411,7 +411,7 @@ func testAccAppsyncDatasource_Type_RelationalDatabaseWithOptions(t *testing.T) {
 	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
 	resourceName := "aws_appsync_datasource.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appsync.EndpointsID, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, appsync.EndpointsID),
 		Providers:    acctest.Providers,

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -853,7 +853,7 @@ resource "aws_appsync_datasource" "test" {
     authorization_config {
       aws_iam_config {
         signing_region       = %[2]q
-        signing_service_name = "s3" 
+        signing_service_name = "s3"
       }
     }
   }

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -346,6 +346,34 @@ func testAccAppSyncDataSource_Type_http(t *testing.T) {
 	})
 }
 
+func testAccAppSyncDataSource_Type_http_auth(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appsync.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, appsync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDestroyDataSource,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_Type_HTTPAuth(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExistsDataSource(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "http_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.endpoint", "http://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAppSyncDataSource_Type_lambda(t *testing.T) {
 	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
 	iamRoleResourceName := "aws_iam_role.test"
@@ -787,19 +815,38 @@ func testAccAppsyncDatasourceConfig_Type_HTTP(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
-  name                = %q
+  name                = %[1]q
 }
 
 resource "aws_appsync_datasource" "test" {
   api_id = aws_appsync_graphql_api.test.id
-  name   = %q
+  name   = %[1]q
   type   = "HTTP"
 
   http_config {
     endpoint = "http://example.com"
   }
 }
-`, rName, rName)
+`, rName)
+}
+
+func testAccAppsyncDatasourceConfig_Type_HTTPAuth(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %[1]q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id = aws_appsync_graphql_api.test.id
+  name   = %[1]q
+  type   = "HTTP"
+
+  http_config {
+    endpoint = "http://example.com"
+  }
+}
+`, rName)
 }
 
 func testAccAppsyncDatasourceConfig_Type_Lambda(rName string) string {

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -379,6 +379,63 @@ func testAccAppSyncDataSource_Type_http_auth(t *testing.T) {
 	})
 }
 
+func testAccAppsyncDatasource_Type_RelationalDatabase(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appsync.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, appsync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDestroyDataSource,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfigTypeRelationalDatabase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExistsDataSource(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "relational_database_config.0.http_endpoint_config.0.region", acctest.Region()),
+					resource.TestCheckResourceAttrPair(resourceName, "relational_database_config.0.http_endpoint_config.0.database_name", "aws_rds_cluster.test", "database_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "relational_database_config.0.http_endpoint_config.0.aws_secret_store_arn", "aws_secretsmanager_secret.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAppsyncDatasource_Type_RelationalDatabaseWithOptions(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appsync.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, appsync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDestroyDataSource,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfigTypeRelationalDatabaseWithOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExistsDataSource(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "relational_database_config.0.http_endpoint_config.0.schema", "mydb"),
+					resource.TestCheckResourceAttr(resourceName, "relational_database_config.0.http_endpoint_config.0.region", acctest.Region()),
+					resource.TestCheckResourceAttrPair(resourceName, "relational_database_config.0.http_endpoint_config.0.database_name", "aws_rds_cluster.test", "database_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "relational_database_config.0.http_endpoint_config.0.aws_secret_store_arn", "aws_secretsmanager_secret.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAppSyncDataSource_Type_lambda(t *testing.T) {
 	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
 	iamRoleResourceName := "aws_iam_role.test"
@@ -859,6 +916,116 @@ resource "aws_appsync_datasource" "test" {
   }
 }
 `, rName, region)
+}
+
+func testAccAppsyncDatasourceConfigBaseRelationalDatabase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = %[1]q
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id = aws_secretsmanager_secret.test.id
+  secret_string = jsonencode(
+    {
+      username = "foo"
+      password = "mustbeeightcharaters"
+    }
+  )
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = %[1]q
+  engine_mode                     = "serverless"
+  database_name                   = "mydb"
+  master_username                 = "foo"
+  master_password                 = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot             = true
+
+  scaling_configuration {
+    min_capacity = 1
+    max_capacity = 2
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : "sts:AssumeRole",
+        "Principal" : {
+          "Service" : "appsync.amazonaws.com"
+        },
+        "Effect" : "Allow"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.id
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "rds:*"
+        ],
+        "Effect" : "Allow",
+        "Resource" : [
+          aws_rds_cluster.test.arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %[1]q
+}
+`, rName)
+}
+
+func testAccAppsyncDatasourceConfigTypeRelationalDatabase(rName string) string {
+	return testAccAppsyncDatasourceConfigBaseRelationalDatabase(rName) + fmt.Sprintf(`
+resource "aws_appsync_datasource" "test" {
+  api_id           = aws_appsync_graphql_api.test.id
+  name             = %[1]q
+  service_role_arn = aws_iam_role.test.arn
+  type             = "RELATIONAL_DATABASE"
+
+  relational_database_config {
+    http_endpoint_config {
+      db_cluster_identifier = aws_rds_cluster.test.id
+      aws_secret_store_arn  = aws_secretsmanager_secret.test.arn
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAppsyncDatasourceConfigTypeRelationalDatabaseWithOptions(rName string) string {
+	return testAccAppsyncDatasourceConfigBaseRelationalDatabase(rName) + fmt.Sprintf(`
+resource "aws_appsync_datasource" "test" {
+  api_id           = aws_appsync_graphql_api.test.id
+  name             = %[1]q
+  service_role_arn = aws_iam_role.test.arn
+  type             = "RELATIONAL_DATABASE"
+
+  relational_database_config {
+    http_endpoint_config {
+      db_cluster_identifier = aws_rds_cluster.test.id
+      database_name         = aws_rds_cluster.test.database_name
+      aws_secret_store_arn  = aws_secretsmanager_secret.test.arn
+      schema                = "mydb"
+    }
+  }
+}
+`, rName)
 }
 
 func testAccAppsyncDatasourceConfig_Type_Lambda(rName string) string {

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -357,11 +357,16 @@ func testAccAppSyncDataSource_Type_http_auth(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyDataSource,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncDatasourceConfig_Type_HTTPAuth(rName),
+				Config: testAccAppsyncDatasourceConfig_Type_HTTPAuth(rName, acctest.Region()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExistsDataSource(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "http_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "http_config.0.endpoint", "http://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.authorization_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.authorization_config.0.authorization_type", "AWS_IAM"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.authorization_config.0.aws_iam_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.authorization_config.0.aws_iam_config.0.signing_region", acctest.Region()),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.authorization_config.0.aws_iam_config.0.signing_service_name", "3"),
 					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
 				),
 			},
@@ -830,7 +835,7 @@ resource "aws_appsync_datasource" "test" {
 `, rName)
 }
 
-func testAccAppsyncDatasourceConfig_Type_HTTPAuth(rName string) string {
+func testAccAppsyncDatasourceConfig_Type_HTTPAuth(rName, region string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
@@ -844,9 +849,16 @@ resource "aws_appsync_datasource" "test" {
 
   http_config {
     endpoint = "http://example.com"
+
+    authorization_config {
+      aws_iam_config {
+        signing_region       = %[2]q
+        signing_service_name = "s3" 
+      }
+    }
   }
 }
-`, rName)
+`, rName, region)
 }
 
 func testAccAppsyncDatasourceConfig_Type_Lambda(rName string) string {

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -36,6 +36,7 @@ func testAccAppSyncDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "http_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "relational_database_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
 				),

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -89,13 +89,14 @@ The following arguments are supported:
 
 * `api_id` - (Required) The API ID for the GraphQL API for the DataSource.
 * `name` - (Required) A user-supplied name for the DataSource.
-* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`.
+* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`, `RELATIONAL_DATABASE`.
 * `description` - (Optional) A description of the DataSource.
 * `service_role_arn` - (Optional) The IAM service role ARN for the data source.
 * `dynamodb_config` - (Optional) DynamoDB settings. See [below](#dynamodb_config)
 * `elasticsearch_config` - (Optional) Amazon Elasticsearch settings. See [below](#elasticsearch_config)
 * `http_config` - (Optional) HTTP settings. See [below](#http_config)
 * `lambda_config` - (Optional) AWS Lambda settings. See [below](#lambda_config)
+* `relational_database_config` (Optional) AWS RDS settings. See [Relational Database Config](#relational_database_config)
 
 ### dynamodb_config
 
@@ -117,6 +118,38 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `endpoint` - (Required) HTTP URL.
+* `authorization_config` - (Optional) The authorization configuration in case the HTTP endpoint requires authorization. See [Authorization Config](#authorization_config).
+
+#### authorization_config
+
+The following arguments are supported:
+
+* `authorization_type` - (Optional) The authorization type that the HTTP endpoint requires. Default values is `AWS_IAM`.
+* `aws_iam_config` - (Optional) The Identity and Access Management (IAM) settings. See [AWS IAM Config](#aws_iam_config).
+
+##### aws_iam_config
+
+The following arguments are supported:
+
+* `signing_region` - (Optional) The signing Amazon Web Services Region for IAM authorization.
+* `signing_service_name`- (Optional) The signing service name for IAM authorization.
+
+### relational_database_config
+
+The following arguments are supported:
+
+* `http_endpoint_config` - (Required) The Amazon RDS HTTP endpoint configuration. See [HTTP Endpoint Config](#http_endpoint_config).
+* `source_type` - (Optional) Source type for the relational database. Valid values: `RDS_HTTP_ENDPOINT`.
+
+#### http_endpoint_config
+
+The following arguments are supported:
+
+* `db_cluster_identifier` - (Required) Amazon RDS cluster identifier.
+* `aws_secret_store_arn` - (Required) AWS secret store ARN for database credentials.
+* `database_name` - (Optional) Logical database name.
+* `region` - (Optional) AWS Region for RDS HTTP endpoint. Defaults to current region.
+* `schema` - (Optional) Logical schema name.
 
 ### lambda_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Supersedes #13080
Supersedes #16923
Supersedes #9337
Closes #8870
Closes #12721
Closes #9628

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppSync_serial/DataSource PKG=appsync
        --- PASS: TestAccAppSync_serial/DataSource/Type_http_auth (56.40s)
        --- PASS: TestAccAppSync_serial/DataSource/Type_rdbms_options (381.87s)
        --- PASS: TestAccAppSync_serial/DataSource/Type_rdbms (394.86s)
```
