### PR TITLE
td/remove id from resource schema

### DIFF
--- a/internal/service/route53resolver/dnssec_config.go
+++ b/internal/service/route53resolver/dnssec_config.go
@@ -27,11 +27,6 @@ func ResourceDNSSECConfig() *schema.Resource {
 				Computed: true,
 			},
 
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/route53resolver/dnssec_config.go
+++ b/internal/service/route53resolver/dnssec_config.go
@@ -85,7 +85,6 @@ func resourceDNSSECConfigRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("id", config.Id)
 	d.Set("owner_id", config.OwnerId)
 	d.Set("resource_id", config.ResourceId)
 	d.Set("validation_status", config.ValidationStatus)

--- a/internal/service/route53resolver/firewall_rule_group.go
+++ b/internal/service/route53resolver/firewall_rule_group.go
@@ -30,11 +30,6 @@ func ResourceFirewallRuleGroup() *schema.Resource {
 				Computed: true,
 			},
 
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,

--- a/internal/service/route53resolver/firewall_rule_group.go
+++ b/internal/service/route53resolver/firewall_rule_group.go
@@ -104,7 +104,6 @@ func resourceFirewallRuleGroupRead(d *schema.ResourceData, meta interface{}) err
 
 	arn := aws.StringValue(ruleGroup.Arn)
 	d.Set("arn", arn)
-	d.Set("id", ruleGroup.Id)
 	d.Set("name", ruleGroup.Name)
 	d.Set("owner_id", ruleGroup.OwnerId)
 	d.Set("share_status", ruleGroup.ShareStatus)

--- a/internal/service/route53resolver/firewall_rule_group_test.go
+++ b/internal/service/route53resolver/firewall_rule_group_test.go
@@ -29,6 +29,7 @@ func TestAccRoute53ResolverFirewallRuleGroup_basic(t *testing.T) {
 				Config: testAccRoute53ResolverFirewallRuleGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
@@ -82,6 +83,7 @@ func TestAccRoute53ResolverFirewallRuleGroup_tags(t *testing.T) {
 				Config: testAccRoute53ResolverFirewallRuleGroupConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
@@ -98,6 +100,7 @@ func TestAccRoute53ResolverFirewallRuleGroup_tags(t *testing.T) {
 				Config: testAccRoute53ResolverFirewallRuleGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
@@ -110,6 +113,7 @@ func TestAccRoute53ResolverFirewallRuleGroup_tags(t *testing.T) {
 				Config: testAccRoute53ResolverFirewallRuleGroupConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverFirewallRuleGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22404

Resources affected:

1. [aws_route53_resolver_dnssec_config](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/route53resolver/dnssec_config.go)
2. [aws_route53_resolver_firewall_rule_group](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/route53resolver/firewall_rule_group.go)

Changes

1. Remove `id` from resource schema
2. Remove extra `d.Set("id", config.Id)` since ID is already present
3. Add test for ID for `aws_route53_resolver_firewall_rule_group` which does not currently check for the ID attribute

Output from acceptance testing:

First resource test: `aws_route53_resolver_dnssec_config`

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccRoute53ResolverDNSSECConfig PKG=route53resolver
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53resolver/... -v -count 1 -parallel 20 -run='TestAccRoute53ResolverDNSSECConfig' -timeout 180m
=== RUN   TestAccRoute53ResolverDNSSECConfig_basic
=== PAUSE TestAccRoute53ResolverDNSSECConfig_basic
=== RUN   TestAccRoute53ResolverDNSSECConfig_disappear
=== PAUSE TestAccRoute53ResolverDNSSECConfig_disappear
=== CONT  TestAccRoute53ResolverDNSSECConfig_basic
=== CONT  TestAccRoute53ResolverDNSSECConfig_disappear


--- PASS: TestAccRoute53ResolverDNSSECConfig_disappear (536.93s)
--- PASS: TestAccRoute53ResolverDNSSECConfig_basic (543.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    550.461s

...
```

Second resource test: `aws_route53_resolver_firewall_rule_group`. NOTE: Default AWS VPC limit per region is 5

```
$ make testacc TESTS=TestAccRoute53ResolverFirewallRuleGroup PKG=route53resolver ACCTEST_PARALLELISM=4 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53resolver/... -v -count 1 -parallel 4 -run='TestAccRoute53ResolverFirewallRuleGroup' -timeout 180m
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_name
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_name
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_priority
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_priority
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_tags
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_tags
=== RUN   TestAccRoute53ResolverFirewallRuleGroup_basic
=== PAUSE TestAccRoute53ResolverFirewallRuleGroup_basic
=== RUN   TestAccRoute53ResolverFirewallRuleGroup_disappears
=== PAUSE TestAccRoute53ResolverFirewallRuleGroup_disappears
=== RUN   TestAccRoute53ResolverFirewallRuleGroup_tags
=== PAUSE TestAccRoute53ResolverFirewallRuleGroup_tags
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_priority
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_tags
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_basic (167.17s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroup_tags
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection (218.80s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroup_disappears
--- PASS: TestAccRoute53ResolverFirewallRuleGroup_disappears (25.22s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroup_basic
--- PASS: TestAccRoute53ResolverFirewallRuleGroup_tags (86.01s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_name
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_tags (257.68s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears
--- PASS: TestAccRoute53ResolverFirewallRuleGroup_basic (34.48s)
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_priority (279.12s)
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears (170.61s)

--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_name (331.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver    592.539s
...
```


