### PR TITLE
fix validation parameter and style

### DIFF
--- a/.changelog/22418.txt
+++ b/.changelog/22418.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_ipam_pool_cidr_allocation: update validation function range to 0 and 32
+```

--- a/.changelog/22418.txt
+++ b/.changelog/22418.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
-resource/aws_vpc_ipam_pool_cidr_allocation: update validation function range to 0 and 32
+```release-note:bug
+resource/aws_vpc_ipam_pool_cidr_allocation: update `cidr` and `netmask_length` attributes netmask to a minimum of 0 and maximum of 32
 ```

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation.go
@@ -17,9 +17,9 @@ import (
 
 func ResourceVPCIpamPoolCidrAllocation() *schema.Resource {
 	return &schema.Resource{
-		Create: ResourceVPCIpamPoolCidrAllocationCreate,
-		Read:   ResourceVPCIpamPoolCidrAllocationRead,
-		Delete: ResourceVPCIpamPoolCidrAllocationDelete,
+		Create: resourceVPCIpamPoolCidrAllocationCreate,
+		Read:   resourceVPCIpamPoolCidrAllocationRead,
+		Delete: resourceVPCIpamPoolCidrAllocationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -32,7 +32,7 @@ func ResourceVPCIpamPoolCidrAllocation() *schema.Resource {
 				ConflictsWith: []string{"netmask_length"},
 				ValidateFunc: validation.Any(
 					verify.ValidIPv4CIDRNetworkAddress,
-					validation.IsCIDRNetwork(VPCCIDRMinIPv4, VPCCIDRMaxIPv4),
+					validation.IsCIDRNetwork(0, 32),
 				),
 			},
 			"description": {
@@ -53,7 +53,7 @@ func ResourceVPCIpamPoolCidrAllocation() *schema.Resource {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ForceNew:      true,
-				ValidateFunc:  validation.IntBetween(VPCCIDRMinIPv4, VPCCIDRMaxIPv4),
+				ValidateFunc:  validation.IntBetween(0, 32),
 				ConflictsWith: []string{"cidr"},
 			},
 			"resource_id": {
@@ -76,7 +76,7 @@ const (
 	IpamPoolAllocationNotFound = "InvalidIpamPoolCidrAllocationId.NotFound"
 )
 
-func ResourceVPCIpamPoolCidrAllocationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCIpamPoolCidrAllocationCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 	pool_id := d.Get("ipam_pool_id").(string)
 
@@ -104,10 +104,10 @@ func ResourceVPCIpamPoolCidrAllocationCreate(d *schema.ResourceData, meta interf
 	}
 	d.SetId(encodeIpamPoolCidrAllocationID(aws.StringValue(output.IpamPoolAllocation.IpamPoolAllocationId), pool_id))
 
-	return ResourceVPCIpamPoolCidrAllocationRead(d, meta)
+	return resourceVPCIpamPoolCidrAllocationRead(d, meta)
 }
 
-func ResourceVPCIpamPoolCidrAllocationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCIpamPoolCidrAllocationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	cidr_allocation, pool_id, err := FindIpamPoolCidrAllocation(conn, d.Id())
@@ -140,7 +140,7 @@ func ResourceVPCIpamPoolCidrAllocationRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func ResourceVPCIpamPoolCidrAllocationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceVPCIpamPoolCidrAllocationDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
 	input := &ec2.ReleaseIpamPoolAllocationInput{

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `cidr` - (Optional) The CIDR you want to assign to the pool.
 * `description` - (Optional) The description for the allocation.
 * `ipam_pool_id` - (Required) The ID of the pool to which you want to assign a CIDR.
-* `netmask_length` - (Optional) The netmask length of the CIDR you would like to allocate to the IPAM pool.
+* `netmask_length` - (Optional) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-32`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #22401

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCIpamPoolAllocation PKG=ec2 ACCTEST_PARALLELISM=1     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 1 -run='TestAccVPCIpamPoolAllocation' -timeout 180m
=== RUN   TestAccVPCIpamPoolAllocation_ipv4Basic
=== PAUSE TestAccVPCIpamPoolAllocation_ipv4Basic
=== RUN   TestAccVPCIpamPoolAllocation_ipv4BasicNetmask
=== PAUSE TestAccVPCIpamPoolAllocation_ipv4BasicNetmask
=== CONT  TestAccVPCIpamPoolAllocation_ipv4Basic
--- PASS: TestAccVPCIpamPoolAllocation_ipv4Basic (119.37s)
=== CONT  TestAccVPCIpamPoolAllocation_ipv4BasicNetmask
--- PASS: TestAccVPCIpamPoolAllocation_ipv4BasicNetmask (115.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        237.762s

...
```
