### PR TITLE
sweeper/fsx: Avoid `Error adding (aws_fsx_ontap_volume) to sweeperFuncs: function already exists in map`

### DIFF
--- a/internal/service/fsx/sweep.go
+++ b/internal/service/fsx/sweep.go
@@ -48,7 +48,7 @@ func init() {
 		F:    sweepFSXOpenzfsFileSystems,
 	})
 
-	resource.AddTestSweepers("aws_fsx_ontap_volume", &resource.Sweeper{
+	resource.AddTestSweepers("aws_fsx_openzfs_volume", &resource.Sweeper{
 		Name: "aws_fsx_openzfs_volume",
 		F:    sweepFSXOpenzfsVolume,
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #22234.

While looking at something else:

```console
% make sweep SWEEPARGS=-sweep-run=aws_customer_gateway,aws_vpn_gateway SWEEP=us-east-1,us-east-2,us-west-1,us-west-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-1,us-east-2,us-west-1,us-west-2 -sweep-run=aws_customer_gateway,aws_vpn_gateway -timeout 60m
2022/01/05 16:31:30 [ERR] Error adding (aws_fsx_ontap_volume) to sweeperFuncs: function already exists in map
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	7.273s
FAIL
make: *** [sweep] Error 1
```