### PR TITLE
r/glue_trigger - add `start_on_creation`

### DIFF
--- a/.changelog/22439.txt
+++ b/.changelog/22439.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_trigger: Add `start_on_creation` argument
+```

--- a/internal/service/glue/trigger.go
+++ b/internal/service/glue/trigger.go
@@ -157,6 +157,10 @@ func ResourceTrigger() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"start_on_creation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"type": {
@@ -210,6 +214,10 @@ func resourceTriggerCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("workflow_name"); ok {
 		input.WorkflowName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("start_on_creation"); ok {
+		input.StartOnCreation = aws.Bool(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Creating Glue Trigger: %s", input)

--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -114,6 +114,7 @@ The following arguments are supported:
 * `predicate` – (Optional) A predicate to specify when the new trigger should fire. Required when trigger type is `CONDITIONAL`. See [Predicate](#predicate) Below.
 * `schedule` – (Optional) A cron expression used to specify the schedule. [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html)
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `start_on_creation` – (Optional) Set to true to start `SCHEDULED` and `CONDITIONAL` triggers when created. True is not supported for `ON_DEMAND` triggers.
 * `type` – (Required) The type of trigger. Valid values are `CONDITIONAL`, `ON_DEMAND`, and `SCHEDULED`.
 * `workflow_name` - (Optional) A workflow to which the trigger should be associated to. Every workflow graph (DAG) needs a starting trigger (`ON_DEMAND` or `SCHEDULED` type) and can contain multiple additional `CONDITIONAL` triggers.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22437

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS= TestAccGlueTrigger_ PKG=glue
--- PASS: TestAccGlueTrigger_disappears (150.53s)
--- PASS: TestAccGlueTrigger_Actions_security (180.67s)
--- PASS: TestAccGlueTrigger_basic (188.90s)
--- PASS: TestAccGlueTrigger_workflowName (189.36s)
--- PASS: TestAccGlueTrigger_startOnCreate (219.90s)
--- PASS: TestAccGlueTrigger_description (263.74s)
--- PASS: TestAccGlueTrigger_schedule (303.57s)
--- PASS: TestAccGlueTrigger_crawler (303.88s)
--- PASS: TestAccGlueTrigger_predicate (303.88s)
--- PASS: TestAccGlueTrigger_tags (388.45s)
--- PASS: TestAccGlueTrigger_Actions_notify (403.88s)
--- PASS: TestAccGlueTrigger_enabled (410.36s)
```
