### PR TITLE
sweeper/AppStream: Delete the correct resource types

### DIFF
--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -151,16 +151,19 @@ func resourceDirectoryConfigUpdate(ctx context.Context, d *schema.ResourceData, 
 func resourceDirectoryConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppStreamConn
 
+	log.Printf("[DEBUG] Deleting AppStream Directory Config: (%s)", d.Id())
 	_, err := conn.DeleteDirectoryConfigWithContext(ctx, &appstream.DeleteDirectoryConfigInput{
 		DirectoryName: aws.String(d.Id()),
 	})
 
+	if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
-			return nil
-		}
 		return diag.FromErr(fmt.Errorf("error deleting AppStream Directory Config (%s): %w", d.Id(), err))
 	}
+
 	return nil
 }
 

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -324,6 +324,7 @@ func resourceImageBuilderUpdate(ctx context.Context, d *schema.ResourceData, met
 func resourceImageBuilderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppStreamConn
 
+	log.Printf("[DEBUG] Deleting AppStream Image Builder: (%s)", d.Id())
 	_, err := conn.DeleteImageBuilderWithContext(ctx, &appstream.DeleteImageBuilderInput{
 		Name: aws.String(d.Id()),
 	})

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -379,13 +379,16 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppStreamConn
 
+	log.Printf("[DEBUG] Deleting AppStream Stack: (%s)", d.Id())
 	_, err := conn.DeleteStackWithContext(ctx, &appstream.DeleteStackInput{
 		Name: aws.String(d.Id()),
 	})
+
+	if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
-			return nil
-		}
 		return diag.FromErr(fmt.Errorf("error deleting Appstream Stack (%s): %w", d.Id(), err))
 	}
 

--- a/internal/service/appstream/sweep.go
+++ b/internal/service/appstream/sweep.go
@@ -161,6 +161,8 @@ func sweepImageBuilders(region string) error {
 	if err != nil {
 		return fmt.Errorf("error sweeping AppStream Image Builders (%s): %w", region, err)
 	}
+
+	return nil
 }
 
 func sweepStacks(region string) error {

--- a/internal/service/appstream/sweep.go
+++ b/internal/service/appstream/sweep.go
@@ -4,13 +4,11 @@
 package appstream
 
 import (
-	"context"
 	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appstream"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -40,32 +38,22 @@ func init() {
 
 func sweepDirectoryConfigs(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
 	conn := client.(*conns.AWSClient).AppStreamConn
-	sweepResources := make([]*sweep.SweepResource, 0)
-	var errs *multierror.Error
-
 	input := &appstream.DescribeDirectoryConfigsInput{}
+	sweepResources := make([]*sweep.SweepResource, 0)
 
-	err = describeDirectoryConfigsPagesWithContext(context.TODO(), conn, input, func(page *appstream.DescribeDirectoryConfigsOutput, lastPage bool) bool {
+	err = describeDirectoryConfigsPages(conn, input, func(page *appstream.DescribeDirectoryConfigsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, directoryConfig := range page.DirectoryConfigs {
-			if directoryConfig == nil {
-				continue
-			}
-
-			id := aws.StringValue(directoryConfig.DirectoryName)
-
+		for _, v := range page.DirectoryConfigs {
 			r := ResourceDirectoryConfig()
 			d := r.Data(nil)
-			d.SetId(id)
+			d.SetId(aws.StringValue(v.DirectoryName))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -74,54 +62,41 @@ func sweepDirectoryConfigs(region string) error {
 	})
 
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Appstream Directory Config sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping AppStream Directory Config sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Directory Configs: %w", err))
+		return fmt.Errorf("error listing AppStream Directory Configs (%s): %w", region, err)
 	}
 
-	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AppStream Directory Configs for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping AppStream Directory Configs (%s): %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AppStream Directory Config sweep for %s: %s", region, err)
-		return nil // In case we have completed some pages, but had errors
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepFleets(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
 	conn := client.(*conns.AWSClient).AppStreamConn
-	sweepResources := make([]*sweep.SweepResource, 0)
-	var errs *multierror.Error
-
 	input := &appstream.DescribeFleetsInput{}
+	sweepResources := make([]*sweep.SweepResource, 0)
 
-	err = describeFleetsPagesWithContext(context.TODO(), conn, input, func(page *appstream.DescribeFleetsOutput, lastPage bool) bool {
+	err = describeFleetsPages(conn, input, func(page *appstream.DescribeFleetsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, fleet := range page.Fleets {
-			if fleet == nil {
-				continue
-			}
-
-			id := aws.StringValue(fleet.Name)
-
-			r := ResourceImageBuilder()
+		for _, v := range page.Fleets {
+			r := ResourceFleet()
 			d := r.Data(nil)
-			d.SetId(id)
+			d.SetId(aws.StringValue(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -130,24 +105,21 @@ func sweepFleets(region string) error {
 	})
 
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Appstream Fleets sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping AppStream Fleet sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Fleets: %w", err))
+		return fmt.Errorf("error listing AppStream Fleets (%s): %w", region, err)
 	}
 
-	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AppStream Fleets for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping AppStream Fleets (%s): %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AppStream Fleets sweep for %s: %s", region, err)
-		return nil // In case we have completed some pages, but had errors
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepImageBuilders(region string) error {
@@ -155,28 +127,19 @@ func sweepImageBuilders(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
 	conn := client.(*conns.AWSClient).AppStreamConn
-	sweepResources := make([]*sweep.SweepResource, 0)
-	var errs *multierror.Error
-
 	input := &appstream.DescribeImageBuildersInput{}
+	sweepResources := make([]*sweep.SweepResource, 0)
 
-	err = describeImageBuildersPagesWithContext(context.TODO(), conn, input, func(page *appstream.DescribeImageBuildersOutput, lastPage bool) bool {
+	err = describeImageBuildersPages(conn, input, func(page *appstream.DescribeImageBuildersOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, imageBuilder := range page.ImageBuilders {
-			if imageBuilder == nil {
-				continue
-			}
-
-			id := aws.StringValue(imageBuilder.Name)
-
+		for _, v := range page.ImageBuilders {
 			r := ResourceImageBuilder()
 			d := r.Data(nil)
-			d.SetId(id)
+			d.SetId(aws.StringValue(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -185,54 +148,39 @@ func sweepImageBuilders(region string) error {
 	})
 
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Appstream Image Builders sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping AppStream Image Builder sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Image Builders: %w", err))
+		return fmt.Errorf("error listing AppStream Image Builders (%s): %w", region, err)
 	}
 
-	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AppStream Image Builders for %s: %w", region, err))
-	}
+	err = sweep.SweepOrchestrator(sweepResources)
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AppStream Image Builders sweep for %s: %s", region, err)
-		return nil // In case we have completed some pages, but had errors
+	if err != nil {
+		return fmt.Errorf("error sweeping AppStream Image Builders (%s): %w", region, err)
 	}
-
-	return errs.ErrorOrNil()
 }
 
 func sweepStacks(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
 	conn := client.(*conns.AWSClient).AppStreamConn
-	sweepResources := make([]*sweep.SweepResource, 0)
-	var errs *multierror.Error
-
 	input := &appstream.DescribeStacksInput{}
+	sweepResources := make([]*sweep.SweepResource, 0)
 
-	err = describeStacksPagesWithContext(context.TODO(), conn, input, func(page *appstream.DescribeStacksOutput, lastPage bool) bool {
+	err = describeStacksPages(conn, input, func(page *appstream.DescribeStacksOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, stack := range page.Stacks {
-			if stack == nil {
-				continue
-			}
-
-			id := aws.StringValue(stack.Name)
-
-			r := ResourceImageBuilder()
+		for _, v := range page.Stacks {
+			r := ResourceStack()
 			d := r.Data(nil)
-			d.SetId(id)
+			d.SetId(aws.StringValue(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -241,22 +189,19 @@ func sweepStacks(region string) error {
 	})
 
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Appstream Stacks sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping AppStream Stack sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error listing AppStream Stacks: %w", err))
+		return fmt.Errorf("error listing AppStream Stacks (%s): %w", region, err)
 	}
 
-	if err = sweep.SweepOrchestrator(sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping AppStream Stacks for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping AppStream Stacks (%s): %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping AppStream Stacks sweep for %s: %s", region, err)
-		return nil // In case we have completed some pages, but had errors
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

AppStream Fleets and Stacks were both using `ResourceImageBuilder` to delete. Correct that and log what is going on during resource deletion.

Relates #21125.

```console
% make sweep SWEEPARGS=-sweep-run=aws_appstream_directory_config,aws_appstream_fleet,aws_appstream_image_builder,aws_appstream_stack SWEEP=us-west-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2 -sweep-run=aws_appstream_directory_config,aws_appstream_fleet,aws_appstream_image_builder,aws_appstream_stack -timeout 60m
2022/01/06 12:10:57 [DEBUG] Running Sweepers for region (us-west-2):
2022/01/06 12:10:57 [DEBUG] Running Sweeper (aws_appstream_fleet) in region (us-west-2)
2022/01/06 12:10:57 [INFO] AWS Auth provider used: "EnvProvider"
2022/01/06 12:10:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/01/06 12:10:58 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:11:00 [DEBUG] Stopping AppStream Fleet: (tf-acc-test-4502632032782554176)
2022/01/06 12:11:00 [DEBUG] Stopping AppStream Fleet: (tf-acc-test-7697429245118952747)
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:11:00 [DEBUG] Stopping AppStream Fleet: (tf-acc-test-6465490967645726813)
2022/01/06 12:11:00 [DEBUG] Stopping AppStream Fleet: (tf-acc-test-905340137326791184)
2022/01/06 12:11:00 [DEBUG] Stopping AppStream Fleet: (tf-acc-test-1152914607797544686)
2022/01/06 12:11:00 [DEBUG] Stopping AppStream Fleet: (tf-acc-test-5728594923363144962)
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [STOPPED]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [STOPPED]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [STOPPED]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [STOPPED]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [STOPPED]
2022/01/06 12:11:00 [DEBUG] Waiting for state to become: [STOPPED]
2022/01/06 12:11:01 [TRACE] Waiting 200ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 200ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 200ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 200ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 200ms before next try
2022/01/06 12:11:01 [DEBUG] Deleting AppStream Fleet: (tf-acc-test-6465490967645726813)
2022/01/06 12:11:01 [TRACE] Waiting 400ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 400ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 400ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 400ms before next try
2022/01/06 12:11:01 [TRACE] Waiting 400ms before next try
2022/01/06 12:11:02 [TRACE] Waiting 800ms before next try
2022/01/06 12:11:02 [TRACE] Waiting 800ms before next try
2022/01/06 12:11:02 [TRACE] Waiting 800ms before next try
2022/01/06 12:11:02 [TRACE] Waiting 800ms before next try
2022/01/06 12:11:02 [TRACE] Waiting 800ms before next try
2022/01/06 12:11:03 [TRACE] Waiting 1.6s before next try
2022/01/06 12:11:03 [TRACE] Waiting 1.6s before next try
2022/01/06 12:11:03 [TRACE] Waiting 1.6s before next try
2022/01/06 12:11:03 [TRACE] Waiting 1.6s before next try
2022/01/06 12:11:05 [TRACE] Waiting 3.2s before next try
2022/01/06 12:11:05 [TRACE] Waiting 3.2s before next try
2022/01/06 12:11:05 [TRACE] Waiting 3.2s before next try
2022/01/06 12:11:06 [TRACE] Waiting 3.2s before next try
2022/01/06 12:11:09 [TRACE] Waiting 6.4s before next try
2022/01/06 12:11:09 [TRACE] Waiting 6.4s before next try
2022/01/06 12:11:09 [TRACE] Waiting 6.4s before next try
2022/01/06 12:11:09 [TRACE] Waiting 1.6s before next try
2022/01/06 12:11:10 [TRACE] Waiting 6.4s before next try
2022/01/06 12:11:11 [TRACE] Waiting 3.2s before next try
2022/01/06 12:11:14 [TRACE] Waiting 6.4s before next try
2022/01/06 12:11:15 [TRACE] Waiting 10s before next try
2022/01/06 12:11:16 [TRACE] Waiting 10s before next try
2022/01/06 12:11:16 [TRACE] Waiting 10s before next try
2022/01/06 12:11:16 [TRACE] Waiting 10s before next try
2022/01/06 12:11:21 [TRACE] Waiting 10s before next try
2022/01/06 12:11:26 [TRACE] Waiting 10s before next try
2022/01/06 12:11:26 [TRACE] Waiting 10s before next try
2022/01/06 12:11:26 [TRACE] Waiting 10s before next try
2022/01/06 12:11:27 [TRACE] Waiting 10s before next try
2022/01/06 12:11:32 [TRACE] Waiting 10s before next try
2022/01/06 12:11:36 [TRACE] Waiting 10s before next try
2022/01/06 12:11:36 [TRACE] Waiting 10s before next try
2022/01/06 12:11:36 [TRACE] Waiting 10s before next try
2022/01/06 12:11:37 [TRACE] Waiting 10s before next try
2022/01/06 12:11:42 [TRACE] Waiting 10s before next try
2022/01/06 12:11:47 [TRACE] Waiting 10s before next try
2022/01/06 12:11:47 [TRACE] Waiting 10s before next try
2022/01/06 12:11:47 [TRACE] Waiting 10s before next try
2022/01/06 12:11:48 [TRACE] Waiting 10s before next try
2022/01/06 12:11:52 [TRACE] Waiting 10s before next try
2022/01/06 12:11:57 [TRACE] Waiting 10s before next try
2022/01/06 12:11:57 [TRACE] Waiting 10s before next try
2022/01/06 12:11:57 [TRACE] Waiting 10s before next try
2022/01/06 12:11:58 [TRACE] Waiting 10s before next try
2022/01/06 12:12:03 [TRACE] Waiting 10s before next try
2022/01/06 12:12:07 [TRACE] Waiting 10s before next try
2022/01/06 12:12:07 [TRACE] Waiting 10s before next try
2022/01/06 12:12:07 [TRACE] Waiting 10s before next try
2022/01/06 12:12:08 [TRACE] Waiting 10s before next try
2022/01/06 12:12:13 [TRACE] Waiting 10s before next try
2022/01/06 12:12:21 [TRACE] Waiting 10s before next try
2022/01/06 12:12:21 [TRACE] Waiting 10s before next try
2022/01/06 12:12:21 [TRACE] Waiting 10s before next try
2022/01/06 12:12:21 [TRACE] Waiting 10s before next try
2022/01/06 12:12:24 [TRACE] Waiting 10s before next try
2022/01/06 12:12:31 [TRACE] Waiting 10s before next try
2022/01/06 12:12:31 [TRACE] Waiting 10s before next try
2022/01/06 12:12:31 [TRACE] Waiting 10s before next try
2022/01/06 12:12:31 [TRACE] Waiting 10s before next try
2022/01/06 12:12:34 [TRACE] Waiting 10s before next try
2022/01/06 12:12:41 [TRACE] Waiting 10s before next try
2022/01/06 12:12:41 [TRACE] Waiting 10s before next try
2022/01/06 12:12:41 [TRACE] Waiting 10s before next try
2022/01/06 12:12:42 [DEBUG] Deleting AppStream Fleet: (tf-acc-test-1152914607797544686)
2022/01/06 12:12:45 [TRACE] Waiting 10s before next try
2022/01/06 12:12:52 [TRACE] Waiting 10s before next try
2022/01/06 12:12:52 [TRACE] Waiting 10s before next try
2022/01/06 12:12:52 [TRACE] Waiting 10s before next try
2022/01/06 12:12:55 [TRACE] Waiting 10s before next try
2022/01/06 12:13:02 [TRACE] Waiting 10s before next try
2022/01/06 12:13:02 [TRACE] Waiting 10s before next try
2022/01/06 12:13:02 [TRACE] Waiting 10s before next try
2022/01/06 12:13:05 [TRACE] Waiting 10s before next try
2022/01/06 12:13:13 [TRACE] Waiting 10s before next try
2022/01/06 12:13:13 [TRACE] Waiting 10s before next try
2022/01/06 12:13:13 [TRACE] Waiting 10s before next try
2022/01/06 12:13:16 [TRACE] Waiting 10s before next try
2022/01/06 12:13:23 [TRACE] Waiting 10s before next try
2022/01/06 12:13:23 [TRACE] Waiting 10s before next try
2022/01/06 12:13:23 [DEBUG] Deleting AppStream Fleet: (tf-acc-test-4502632032782554176)
2022/01/06 12:13:26 [TRACE] Waiting 10s before next try
2022/01/06 12:13:34 [TRACE] Waiting 10s before next try
2022/01/06 12:13:34 [TRACE] Waiting 10s before next try
2022/01/06 12:13:37 [TRACE] Waiting 10s before next try
2022/01/06 12:13:44 [TRACE] Waiting 10s before next try
2022/01/06 12:13:44 [TRACE] Waiting 10s before next try
2022/01/06 12:13:47 [TRACE] Waiting 10s before next try
2022/01/06 12:13:54 [TRACE] Waiting 10s before next try
2022/01/06 12:13:54 [TRACE] Waiting 10s before next try
2022/01/06 12:13:57 [TRACE] Waiting 10s before next try
2022/01/06 12:14:05 [TRACE] Waiting 10s before next try
2022/01/06 12:14:05 [TRACE] Waiting 10s before next try
2022/01/06 12:14:08 [DEBUG] Deleting AppStream Fleet: (tf-acc-test-905340137326791184)
2022/01/06 12:14:15 [TRACE] Waiting 10s before next try
2022/01/06 12:14:15 [TRACE] Waiting 10s before next try
2022/01/06 12:14:25 [DEBUG] Deleting AppStream Fleet: (tf-acc-test-7697429245118952747)
2022/01/06 12:14:25 [DEBUG] Deleting AppStream Fleet: (tf-acc-test-5728594923363144962)
2022/01/06 12:14:26 [DEBUG] Completed Sweeper (aws_appstream_fleet) in region (us-west-2) in 3m28.477567439s
2022/01/06 12:14:26 [DEBUG] Running Sweeper (aws_appstream_image_builder) in region (us-west-2)
2022/01/06 12:14:26 [DEBUG] Completed Sweeper (aws_appstream_image_builder) in region (us-west-2) in 342.830258ms
2022/01/06 12:14:26 [DEBUG] Running Sweeper (aws_appstream_directory_config) in region (us-west-2)
2022/01/06 12:14:27 [DEBUG] Completed Sweeper (aws_appstream_directory_config) in region (us-west-2) in 374.147102ms
2022/01/06 12:14:27 [DEBUG] Running Sweeper (aws_appstream_stack) in region (us-west-2)
2022/01/06 12:14:27 [DEBUG] Waiting for state to become: [success]
2022/01/06 12:14:27 [DEBUG] Deleting AppStream Stack: (tf-acc-test-553435265065033323)
2022/01/06 12:14:28 [DEBUG] Waiting for state to become: [NotFound Unknown]
2022/01/06 12:14:28 [TRACE] Waiting 200ms before next try
2022/01/06 12:14:29 [TRACE] Waiting 400ms before next try
2022/01/06 12:14:29 [DEBUG] Completed Sweeper (aws_appstream_stack) in region (us-west-2) in 2.77370358s
2022/01/06 12:14:29 Completed Sweepers for region (us-west-2) in 3m31.968528927s
2022/01/06 12:14:29 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_appstream_stack
	- aws_appstream_fleet
	- aws_appstream_image_builder
	- aws_appstream_directory_config
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	217.442s
```