### PR TITLE
r/devicefarm_network_profile - new resource

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -998,9 +998,10 @@ func Provider() *schema.Provider {
 			"aws_dax_parameter_group": dax.ResourceParameterGroup(),
 			"aws_dax_subnet_group":    dax.ResourceSubnetGroup(),
 
-			"aws_devicefarm_device_pool": devicefarm.ResourceDevicePool(),
-			"aws_devicefarm_project":     devicefarm.ResourceProject(),
-			"aws_devicefarm_upload":      devicefarm.ResourceUpload(),
+			"aws_devicefarm_device_pool":     devicefarm.ResourceDevicePool(),
+			"aws_devicefarm_network_profile": devicefarm.ResourceNetworkProfile(),
+			"aws_devicefarm_project":         devicefarm.ResourceProject(),
+			"aws_devicefarm_upload":          devicefarm.ResourceUpload(),
 
 			"aws_detective_graph": detective.ResourceGraph(),
 

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -146,7 +146,7 @@ func resourceDevicePoolRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", devicePool.Description)
 	d.Set("max_devices", devicePool.MaxDevices)
 
-	projectArn, err := decodeDevicefarmProjectArn(arn, meta)
+	projectArn, err := decodeDevicefarmProjectArn(arn, "devicepool", meta)
 	if err != nil {
 		return fmt.Errorf("error decoding project_arn (%s): %w", arn, err)
 	}
@@ -294,16 +294,16 @@ func flattenAwsDevicefarmDevicePoolRules(list []*devicefarm.Rule) []map[string]i
 	return result
 }
 
-func decodeDevicefarmProjectArn(id string, meta interface{}) (string, error) {
+func decodeDevicefarmProjectArn(id, typ string, meta interface{}) (string, error) {
 	poolArn, err := arn.Parse(id)
 	if err != nil {
 		return "", fmt.Errorf("Error parsing '%s': %w", id, err)
 	}
 
 	poolArnResouce := poolArn.Resource
-	parts := strings.Split(strings.TrimPrefix(poolArnResouce, "devicepool:"), "/")
+	parts := strings.Split(strings.TrimPrefix(poolArnResouce, fmt.Sprintf("%s:", typ)), "/")
 	if len(parts) != 2 {
-		return "", fmt.Errorf("Unexpected format of ID (%q), expected project-id/pool-id", poolArnResouce)
+		return "", fmt.Errorf("Unexpected format of ID (%q), expected project-id/%q-id", poolArnResouce, typ)
 	}
 
 	projectId := parts[0]

--- a/internal/service/devicefarm/find.go
+++ b/internal/service/devicefarm/find.go
@@ -82,3 +82,28 @@ func FindUploadByArn(conn *devicefarm.DeviceFarm, arn string) (*devicefarm.Uploa
 
 	return output.Upload, nil
 }
+
+func FindNetworkProfileByArn(conn *devicefarm.DeviceFarm, arn string) (*devicefarm.NetworkProfile, error) {
+
+	input := &devicefarm.GetNetworkProfileInput{
+		Arn: aws.String(arn),
+	}
+	output, err := conn.GetNetworkProfile(input)
+
+	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.NetworkProfile == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.NetworkProfile, nil
+}

--- a/internal/service/devicefarm/network_profile.go
+++ b/internal/service/devicefarm/network_profile.go
@@ -1,0 +1,316 @@
+package devicefarm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceNetworkProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkProfileCreate,
+		Read:   resourceNetworkProfileRead,
+		Update: resourceNetworkProfileUpdate,
+		Delete: resourceNetworkProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 16384),
+			},
+			"downlink_bandwidth_bits": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      104857600,
+				ValidateFunc: validation.IntBetween(0, 104857600),
+			},
+			"downlink_delay_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 2000),
+			},
+			"downlink_jitter_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 2000),
+			},
+			"downlink_loss_percent": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"project_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"uplink_bandwidth_bits": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      104857600,
+				ValidateFunc: validation.IntBetween(0, 104857600),
+			},
+			"uplink_delay_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 2000),
+			},
+			"uplink_jitter_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 2000),
+			},
+			"uplink_loss_percent": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      devicefarm.NetworkProfileTypePrivate,
+				ValidateFunc: validation.StringInSlice(devicefarm.NetworkProfileType_Values(), false),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceNetworkProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &devicefarm.CreateNetworkProfileInput{
+		Name:       aws.String(d.Get("name").(string)),
+		ProjectArn: aws.String(d.Get("project_arn").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		input.Type = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("downlink_bandwidth_bits"); ok {
+		input.DownlinkBandwidthBits = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("downlink_delay_ms"); ok {
+		input.DownlinkDelayMs = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("downlink_jitter_ms"); ok {
+		input.DownlinkJitterMs = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("downlink_loss_percent"); ok {
+		input.DownlinkLossPercent = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("uplink_bandwidth_bits"); ok {
+		input.UplinkBandwidthBits = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("uplink_delay_ms"); ok {
+		input.UplinkDelayMs = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("uplink_jitter_ms"); ok {
+		input.UplinkJitterMs = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("uplink_loss_percent"); ok {
+		input.UplinkLossPercent = aws.Int64(int64(v.(int)))
+	}
+
+	out, err := conn.CreateNetworkProfile(input)
+	if err != nil {
+		return fmt.Errorf("Error creating DeviceFarm Network Profile: %w", err)
+	}
+
+	arn := aws.StringValue(out.NetworkProfile.Arn)
+	log.Printf("[DEBUG] Successsfully Created DeviceFarm Network Profile: %s", arn)
+	d.SetId(arn)
+
+	if len(tags) > 0 {
+		if err := UpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error updating DeviceFarm Network Profile (%s) tags: %w", arn, err)
+		}
+	}
+
+	return resourceNetworkProfileRead(d, meta)
+}
+
+func resourceNetworkProfileRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	project, err := FindNetworkProfileByArn(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DeviceFarm Network Profile (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading DeviceFarm Network Profile (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(project.Arn)
+	d.Set("arn", arn)
+	d.Set("name", project.Name)
+	d.Set("description", project.Description)
+	d.Set("downlink_bandwidth_bits", project.DownlinkBandwidthBits)
+	d.Set("downlink_delay_ms", project.DownlinkDelayMs)
+	d.Set("downlink_jitter_ms", project.DownlinkJitterMs)
+	d.Set("downlink_loss_percent", project.DownlinkLossPercent)
+	d.Set("uplink_bandwidth_bits", project.UplinkBandwidthBits)
+	d.Set("uplink_delay_ms", project.UplinkDelayMs)
+	d.Set("uplink_jitter_ms", project.UplinkJitterMs)
+	d.Set("uplink_loss_percent", project.UplinkLossPercent)
+	d.Set("type", project.Type)
+
+	projectArn, err := decodeDevicefarmProjectArn(arn, "networkprofile", meta)
+	if err != nil {
+		return fmt.Errorf("error decoding project_arn (%s): %w", arn, err)
+	}
+
+	d.Set("project_arn", projectArn)
+
+	tags, err := ListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for DeviceFarm Network Profile (%s): %w", arn, err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceNetworkProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &devicefarm.UpdateNetworkProfileInput{
+			Arn: aws.String(d.Id()),
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("description") {
+			input.Description = aws.String(d.Get("description").(string))
+		}
+
+		if d.HasChange("type") {
+			input.Type = aws.String(d.Get("type").(string))
+		}
+
+		if d.HasChange("downlink_bandwidth_bits") {
+			input.DownlinkBandwidthBits = aws.Int64(int64(d.Get("downlink_bandwidth_bits").(int)))
+		}
+
+		if d.HasChange("downlink_delay_ms") {
+			input.DownlinkDelayMs = aws.Int64(int64(d.Get("downlink_delay_ms").(int)))
+		}
+
+		if d.HasChange("downlink_jitter_ms") {
+			input.DownlinkJitterMs = aws.Int64(int64(d.Get("downlink_jitter_ms").(int)))
+		}
+
+		if d.HasChange("downlink_loss_percent") {
+			input.DownlinkLossPercent = aws.Int64(int64(d.Get("downlink_loss_percent").(int)))
+		}
+
+		if d.HasChange("uplink_bandwidth_bits") {
+			input.UplinkBandwidthBits = aws.Int64(int64(d.Get("uplink_bandwidth_bits").(int)))
+		}
+
+		if d.HasChange("uplink_delay_ms") {
+			input.UplinkDelayMs = aws.Int64(int64(d.Get("uplink_delay_ms").(int)))
+		}
+
+		if d.HasChange("uplink_jitter_ms") {
+			input.UplinkJitterMs = aws.Int64(int64(d.Get("uplink_jitter_ms").(int)))
+		}
+
+		if d.HasChange("uplink_loss_percent") {
+			input.UplinkLossPercent = aws.Int64(int64(d.Get("uplink_loss_percent").(int)))
+		}
+
+		log.Printf("[DEBUG] Updating DeviceFarm Network Profile: %s", d.Id())
+		_, err := conn.UpdateNetworkProfile(input)
+		if err != nil {
+			return fmt.Errorf("Error Updating DeviceFarm Network Profile: %w", err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating DeviceFarm Network Profile (%s) tags: %w", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceNetworkProfileRead(d, meta)
+}
+
+func resourceNetworkProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+
+	input := &devicefarm.DeleteNetworkProfileInput{
+		Arn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DeviceFarm Network Profile: %s", d.Id())
+	_, err := conn.DeleteNetworkProfile(input)
+	if err != nil {
+		if tfawserr.ErrMessageContains(err, devicefarm.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting DeviceFarm Network Profile: %w", err)
+	}
+
+	return nil
+}

--- a/internal/service/devicefarm/network_profile_test.go
+++ b/internal/service/devicefarm/network_profile_test.go
@@ -1,0 +1,259 @@
+package devicefarm_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdevicefarm "github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccDeviceFarmNetworkProfile_basic(t *testing.T) {
+	var pool devicefarm.NetworkProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix("tf-acc-test-updated")
+	resourceName := "aws_devicefarm_network_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmNetworkProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmNetworkProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "project_arn", "aws_devicefarm_project.test", "arn"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`networkprofile:.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmNetworkProfileConfig(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`networkprofile:.+`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceFarmNetworkProfile_tags(t *testing.T) {
+	var pool devicefarm.NetworkProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_network_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmNetworkProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmNetworkProfileConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmNetworkProfileConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDeviceFarmNetworkProfileConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceFarmNetworkProfile_disappears(t *testing.T) {
+	var pool devicefarm.NetworkProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_network_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmNetworkProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmNetworkProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceNetworkProfile(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceNetworkProfile(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDeviceFarmNetworkProfile_disappears_project(t *testing.T) {
+	var pool devicefarm.NetworkProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_network_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmNetworkProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmNetworkProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceProject(), "aws_devicefarm_project.test"),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceNetworkProfile(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDeviceFarmNetworkProfileExists(n string, v *devicefarm.NetworkProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
+		resp, err := tfdevicefarm.FindNetworkProfileByArn(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if resp == nil {
+			return fmt.Errorf("DeviceFarm Network Profile not found")
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckDeviceFarmNetworkProfileDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_devicefarm_network_profile" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := tfdevicefarm.FindNetworkProfileByArn(conn, rs.Primary.ID)
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("DeviceFarm Network Profile %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccDeviceFarmNetworkProfileConfig(rName string) string {
+	return testAccDeviceFarmProjectConfig(rName) + fmt.Sprintf(`
+resource "aws_devicefarm_network_profile" "test" {
+  name        = %[1]q
+  project_arn = aws_devicefarm_project.test.arn
+}
+`, rName)
+}
+
+func testAccDeviceFarmNetworkProfileConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccDeviceFarmProjectConfig(rName) + fmt.Sprintf(`
+resource "aws_devicefarm_network_profile" "test" {
+  name        = %[1]q
+  project_arn = aws_devicefarm_project.test.arn
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccDeviceFarmNetworkProfileConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccDeviceFarmProjectConfig(rName) + fmt.Sprintf(`
+resource "aws_devicefarm_network_profile" "test" {
+  name        = %[1]q
+  project_arn = aws_devicefarm_project.test.arn
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/devicefarm/network_profile_test.go
+++ b/internal/service/devicefarm/network_profile_test.go
@@ -39,6 +39,9 @@ func TestAccDeviceFarmNetworkProfile_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "PRIVATE"),
+					resource.TestCheckResourceAttr(resourceName, "downlink_bandwidth_bits", "104857600"),
+					resource.TestCheckResourceAttr(resourceName, "uplink_bandwidth_bits", "104857600"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "project_arn", "aws_devicefarm_project.test", "arn"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`networkprofile:.+`)),
@@ -54,6 +57,11 @@ func TestAccDeviceFarmNetworkProfile_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFarmNetworkProfileExists(resourceName, &pool),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "type", "PRIVATE"),
+					resource.TestCheckResourceAttr(resourceName, "downlink_bandwidth_bits", "104857600"),
+					resource.TestCheckResourceAttr(resourceName, "uplink_bandwidth_bits", "104857600"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "project_arn", "aws_devicefarm_project.test", "arn"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`networkprofile:.+`)),
 				),
 			},

--- a/internal/service/devicefarm/upload.go
+++ b/internal/service/devicefarm/upload.go
@@ -3,10 +3,8 @@ package devicefarm
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -118,7 +116,7 @@ func resourceUploadRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("metadata", upload.Metadata)
 	d.Set("arn", arn)
 
-	projectArn, err := decodeDevicefarmUploadProjectArn(arn, meta)
+	projectArn, err := decodeDevicefarmProjectArn(arn, "upload", meta)
 	if err != nil {
 		return fmt.Errorf("error decoding project_arn (%s): %w", arn, err)
 	}
@@ -169,28 +167,4 @@ func resourceUploadDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func decodeDevicefarmUploadProjectArn(id string, meta interface{}) (string, error) {
-	uploadArn, err := arn.Parse(id)
-	if err != nil {
-		return "", fmt.Errorf("Error parsing '%s': %w", id, err)
-	}
-
-	uploadArnResouce := uploadArn.Resource
-	parts := strings.Split(strings.TrimPrefix(uploadArnResouce, "upload:"), "/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("Unexpected format of ID (%q), expected project-id/upload-id", uploadArnResouce)
-	}
-
-	projectId := parts[0]
-	projectArn := arn.ARN{
-		AccountID: meta.(*conns.AWSClient).AccountID,
-		Partition: meta.(*conns.AWSClient).Partition,
-		Region:    meta.(*conns.AWSClient).Region,
-		Resource:  fmt.Sprintf("project:%s", projectId),
-		Service:   devicefarm.ServiceName,
-	}.String()
-
-	return projectArn, nil
 }

--- a/website/docs/r/devicefarm_network_profile.html.markdown
+++ b/website/docs/r/devicefarm_network_profile.html.markdown
@@ -23,7 +23,6 @@ resource "aws_devicefarm_project" "example" {
 resource "aws_devicefarm_network_profile" "example" {
   name        = "example"
   project_arn = aws_devicefarm_project.example.arn
-  type        = "APPIUM_JAVA_TESTNG_TEST_SPEC"
 }
 ```
 

--- a/website/docs/r/devicefarm_network_profile.html.markdown
+++ b/website/docs/r/devicefarm_network_profile.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Device Farm"
+layout: "aws"
+page_title: "AWS: aws_devicefarm_network_profile"
+description: |-
+  Provides a Devicefarm network profile
+---
+
+# Resource: aws_devicefarm_network_profile
+
+Provides a resource to manage AWS Device Farm Network Profiles.
+∂
+~> **NOTE:** AWS currently has limited regional support for Device Farm (e.g., `us-west-2`). See [AWS Device Farm endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/devicefarm.html) for information on supported regions.
+
+## Example Usage
+
+
+```terraform
+resource "aws_devicefarm_project" "example" {
+  name = "example"
+}
+
+resource "aws_devicefarm_network_profile" "example" {
+  name        = "example"
+  project_arn = aws_devicefarm_project.example.arn
+  type        = "APPIUM_JAVA_TESTNG_TEST_SPEC"
+}
+```
+
+## Argument Reference
+
+* `description` - (Optional) The description of the network profile.
+* `downlink_bandwidth_bits` - (Optional) The data throughput rate in bits per second, as an integer from `0` to `104857600`. Default value is `104857600`.
+* `downlink_delay_ms` - (Optional) Delay time for all packets to destination in milliseconds as an integer from `0` to `2000`.
+* `downlink_jitter_ms` - (Optional) Time variation in the delay of received packets in milliseconds as an integer from `0` to `2000`.
+* `downlink_loss_percent` - (Optional) Proportion of received packets that fail to arrive from `0` to `100` percent.
+* `name` - (Required) The name for the network profile.
+* `uplink_bandwidth_bits` - (Optional) The data throughput rate in bits per second, as an integer from `0` to `104857600`. Default value is `104857600`.
+* `uplink_delay_ms` - (Optional) Delay time for all packets to destination in milliseconds as an integer from `0` to `2000`.
+* `uplink_jitter_ms` - (Optional) Time variation in the delay of received packets in milliseconds as an integer from `0` to `2000`.
+* `uplink_loss_percent` - (Optional) Proportion of received packets that fail to arrive from `0` to `100` percent.
+* `project_arn` - (Required) The ARN of the project for the network profile.
+* `type` - (Optional) The type of network profile to create. Valid values are listed are `PRIVATE` and `CURATED`.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name of this network profile.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+DeviceFarm Network Profiles can be imported by their arn:
+
+```
+$ terraform import aws_devicefarm_network_profile.example arn:aws:devicefarm:us-west-2:123456789012:network profile:4fa784c7-ccb4-4dbf-ba4f-02198320daa1
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDeviceFarmNetworkProfile_ PKG=devicefarm
--- PASS: TestAccDeviceFarmNetworkProfile_disappears_project (86.85s)
--- PASS: TestAccDeviceFarmNetworkProfile_disappears (96.35s)
--- PASS: TestAccDeviceFarmNetworkProfile_basic (182.20s)
--- PASS: TestAccDeviceFarmNetworkProfile_tags (242.36s)
```

$ make testacc TESTS=TestAccDeviceFarmUpload_ PKG=devicefarm
--- PASS: TestAccDeviceFarmUpload_disappears_project (52.51s)
--- PASS: TestAccDeviceFarmUpload_disappears (59.99s)
--- PASS: TestAccDeviceFarmUpload_basic (104.69s)
```

$ make testacc TESTS= TestAccDeviceFarmDevicePool_ PKG=devicefarm
--- PASS: TestAccDeviceFarmDevicePool_disappears_project (84.65s)
--- PASS: TestAccDeviceFarmDevicePool_disappears (91.34s)
--- PASS: TestAccDeviceFarmDevicePool_basic (164.37s)
--- PASS: TestAccDeviceFarmDevicePool_tags (206.97s)
```
