### PR TITLE
data_source: new region Sagemaker account IDs (af-south-1, ap-northeast-3, eu-south-1)

### DIFF
--- a/.changelog/22455.txt
+++ b/.changelog/22455.txt
@@ -1,0 +1,19 @@
+```release-note:enhancement
+data-source/aws_sagemaker_prebuilt_ecr_image: Add account IDs for the BlazingText image in `af-south-1` and `eu-south-1` AWS Regions
+```
+
+```release-note:enhancement
+data-source/aws_sagemaker_prebuilt_ecr_image: Add account IDs for the DeepAR Forecasting image in `af-south-1` and `eu-south-1` AWS Regions
+```
+
+```release-note:enhancement
+data-source/aws_sagemaker_prebuilt_ecr_image: Add account IDs for the Factorization Machines image in `af-south-1`, `ap-northeast-3` and `eu-south-1` AWS Regions
+```
+
+```release-note:enhancement
+data-source/aws_sagemaker_prebuilt_ecr_image: Add account IDs for the XGBoost image in `af-south-1`, `ap-northeast-3` and `eu-south-1` AWS Regions
+```
+
+```release-note:enhancement
+data-source/aws_sagemaker_prebuilt_ecr_image: Add account IDs for the Spark ML Serving image in `af-south-1`, `ap-east-1`, `cn-north-1`, `cn-northwest-1`, `eu-north-1`, `eu-south-1`, `eu-west-3`, `me-south-1` and `sa-east-1` AWS Regions
+```

--- a/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
+++ b/internal/service/sagemaker/prebuilt_ecr_image_data_source.go
@@ -82,9 +82,11 @@ const (
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
 var sageMakerPrebuiltECRImageIDByRegion_Blazing = map[string]string{
+	endpoints.AfSouth1RegionID:     "455444449433",
 	endpoints.ApEast1RegionID:      "286214385809",
 	endpoints.ApNortheast1RegionID: "501404015308",
 	endpoints.ApNortheast2RegionID: "306986355934",
+	endpoints.ApNortheast3RegionID: "867004704886",
 	endpoints.ApSouth1RegionID:     "991648021394",
 	endpoints.ApSoutheast1RegionID: "475088953585",
 	endpoints.ApSoutheast2RegionID: "544295431143",
@@ -93,6 +95,7 @@ var sageMakerPrebuiltECRImageIDByRegion_Blazing = map[string]string{
 	endpoints.CnNorthwest1RegionID: "387376663083",
 	endpoints.EuCentral1RegionID:   "813361260812",
 	endpoints.EuNorth1RegionID:     "669576153137",
+	endpoints.EuSouth1RegionID:     "257386234256",
 	endpoints.EuWest1RegionID:      "685385470294",
 	endpoints.EuWest2RegionID:      "644912444149",
 	endpoints.EuWest3RegionID:      "749696950732",
@@ -107,6 +110,7 @@ var sageMakerPrebuiltECRImageIDByRegion_Blazing = map[string]string{
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
 var sageMakerPrebuiltECRImageIDByRegion_DeepAR = map[string]string{
+	endpoints.AfSouth1RegionID:     "455444449433",
 	endpoints.ApEast1RegionID:      "286214385809",
 	endpoints.ApNortheast1RegionID: "633353088612",
 	endpoints.ApNortheast2RegionID: "204372634319",
@@ -118,6 +122,7 @@ var sageMakerPrebuiltECRImageIDByRegion_DeepAR = map[string]string{
 	endpoints.CnNorthwest1RegionID: "387376663083",
 	endpoints.EuCentral1RegionID:   "495149712605",
 	endpoints.EuNorth1RegionID:     "669576153137",
+	endpoints.EuSouth1RegionID:     "257386234256",
 	endpoints.EuWest1RegionID:      "224300973850",
 	endpoints.EuWest2RegionID:      "644912444149",
 	endpoints.EuWest3RegionID:      "749696950732",
@@ -132,9 +137,11 @@ var sageMakerPrebuiltECRImageIDByRegion_DeepAR = map[string]string{
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
 var PrebuiltECRImageIDByRegion_FactorMachines = map[string]string{
+	endpoints.AfSouth1RegionID:     "455444449433",
 	endpoints.ApEast1RegionID:      "286214385809",
 	endpoints.ApNortheast1RegionID: "351501993468",
 	endpoints.ApNortheast2RegionID: "835164637446",
+	endpoints.ApNortheast3RegionID: "867004704886",
 	endpoints.ApSouth1RegionID:     "991648021394",
 	endpoints.ApSoutheast1RegionID: "475088953585",
 	endpoints.ApSoutheast2RegionID: "712309505854",
@@ -143,6 +150,7 @@ var PrebuiltECRImageIDByRegion_FactorMachines = map[string]string{
 	endpoints.CnNorthwest1RegionID: "387376663083",
 	endpoints.EuCentral1RegionID:   "664544806723",
 	endpoints.EuNorth1RegionID:     "669576153137",
+	endpoints.EuSouth1RegionID:     "257386234256",
 	endpoints.EuWest1RegionID:      "438346466558",
 	endpoints.EuWest2RegionID:      "644912444149",
 	endpoints.EuWest3RegionID:      "749696950732",
@@ -175,9 +183,11 @@ var sageMakerPrebuiltECRImageIDByRegion_LDA = map[string]string{
 
 // https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
 var sageMakerPrebuiltECRImageIDByRegion_XGBoost = map[string]string{
+	endpoints.AfSouth1RegionID:     "510948584623",
 	endpoints.ApEast1RegionID:      "651117190479",
 	endpoints.ApNortheast1RegionID: "354813040037",
 	endpoints.ApNortheast2RegionID: "366743142698",
+	endpoints.ApNortheast3RegionID: "867004704886",
 	endpoints.ApSouth1RegionID:     "720646828776",
 	endpoints.ApSoutheast1RegionID: "121021644041",
 	endpoints.ApSoutheast2RegionID: "783357654285",
@@ -186,6 +196,7 @@ var sageMakerPrebuiltECRImageIDByRegion_XGBoost = map[string]string{
 	endpoints.CnNorthwest1RegionID: "451049120500",
 	endpoints.EuCentral1RegionID:   "492215442770",
 	endpoints.EuNorth1RegionID:     "662702820516",
+	endpoints.EuSouth1RegionID:     "978288397137",
 	endpoints.EuWest1RegionID:      "141502667606",
 	endpoints.EuWest2RegionID:      "764974769150",
 	endpoints.EuWest3RegionID:      "659782779980",
@@ -198,17 +209,27 @@ var sageMakerPrebuiltECRImageIDByRegion_XGBoost = map[string]string{
 	endpoints.UsWest2RegionID:      "246618743249",
 }
 
+// https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
 // https://docs.aws.amazon.com/sagemaker/latest/dg/pre-built-docker-containers-scikit-learn-spark.html
 var PrebuiltECRImageIDByRegion_SparkML = map[string]string{
+	endpoints.AfSouth1RegionID:     "510948584623",
+	endpoints.ApEast1RegionID:      "651117190479",
 	endpoints.ApNortheast1RegionID: "354813040037",
 	endpoints.ApNortheast2RegionID: "366743142698",
 	endpoints.ApSouth1RegionID:     "720646828776",
 	endpoints.ApSoutheast1RegionID: "121021644041",
 	endpoints.ApSoutheast2RegionID: "783357654285",
 	endpoints.CaCentral1RegionID:   "341280168497",
+	endpoints.CnNorth1RegionID:     "450853457545",
+	endpoints.CnNorthwest1RegionID: "451049120500",
 	endpoints.EuCentral1RegionID:   "492215442770",
+	endpoints.EuNorth1RegionID:     "662702820516",
+	endpoints.EuSouth1RegionID:     "978288397137",
 	endpoints.EuWest1RegionID:      "141502667606",
 	endpoints.EuWest2RegionID:      "764974769150",
+	endpoints.EuWest3RegionID:      "659782779980",
+	endpoints.MeSouth1RegionID:     "801668240914",
+	endpoints.SaEast1RegionID:      "737474898029",
 	endpoints.UsEast1RegionID:      "683313688378",
 	endpoints.UsEast2RegionID:      "257758044811",
 	endpoints.UsGovWest1RegionID:   "414596584902",


### PR DESCRIPTION
missed in https://github.com/hashicorp/terraform-provider-aws/pull/12967, https://github.com/hashicorp/terraform-provider-aws/pull/13061
documented process in https://github.com/hashicorp/terraform-provider-aws/pull/22454

https://docs.aws.amazon.com/sagemaker/latest/dg/ecr-af-south-1.html
https://docs.aws.amazon.com/sagemaker/latest/dg/ecr-ap-northeast-3.html
https://docs.aws.amazon.com/sagemaker/latest/dg/ecr-eu-south-1.html

also found the rest of the SparkML account IDs there too:
https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html

---

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->