### PR TITLE
r/devicefarm_instance_profile - new resource

### DIFF
--- a/.changelog/22458.txt
+++ b/.changelog/22458.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_devicefarm_instance_profile
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -998,10 +998,11 @@ func Provider() *schema.Provider {
 			"aws_dax_parameter_group": dax.ResourceParameterGroup(),
 			"aws_dax_subnet_group":    dax.ResourceSubnetGroup(),
 
-			"aws_devicefarm_device_pool":     devicefarm.ResourceDevicePool(),
-			"aws_devicefarm_network_profile": devicefarm.ResourceNetworkProfile(),
-			"aws_devicefarm_project":         devicefarm.ResourceProject(),
-			"aws_devicefarm_upload":          devicefarm.ResourceUpload(),
+			"aws_devicefarm_device_pool":      devicefarm.ResourceDevicePool(),
+			"aws_devicefarm_instance_profile": devicefarm.ResourceInstanceProfile(),
+			"aws_devicefarm_network_profile":  devicefarm.ResourceNetworkProfile(),
+			"aws_devicefarm_project":          devicefarm.ResourceProject(),
+			"aws_devicefarm_upload":           devicefarm.ResourceUpload(),
 
 			"aws_detective_graph": detective.ResourceGraph(),
 

--- a/internal/service/devicefarm/find.go
+++ b/internal/service/devicefarm/find.go
@@ -107,3 +107,28 @@ func FindNetworkProfileByArn(conn *devicefarm.DeviceFarm, arn string) (*devicefa
 
 	return output.NetworkProfile, nil
 }
+
+func FindInstanceProfileByArn(conn *devicefarm.DeviceFarm, arn string) (*devicefarm.InstanceProfile, error) {
+
+	input := &devicefarm.GetInstanceProfileInput{
+		Arn: aws.String(arn),
+	}
+	output, err := conn.GetInstanceProfile(input)
+
+	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.InstanceProfile == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.InstanceProfile, nil
+}

--- a/internal/service/devicefarm/instance_profile.go
+++ b/internal/service/devicefarm/instance_profile.go
@@ -50,7 +50,7 @@ func ResourceInstanceProfile() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"reboot_after_user": {
+			"reboot_after_use": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -83,7 +83,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) err
 		input.PackageCleanup = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("reboot_after_user"); ok {
+	if v, ok := d.GetOk("reboot_after_use"); ok {
 		input.RebootAfterUse = aws.Bool(v.(bool))
 	}
 
@@ -128,7 +128,7 @@ func resourceInstanceProfileRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("description", instaceProf.Description)
 	d.Set("exclude_app_packages_from_cleanup", flex.FlattenStringSet(instaceProf.ExcludeAppPackagesFromCleanup))
 	d.Set("package_cleanup", instaceProf.PackageCleanup)
-	d.Set("reboot_after_user", instaceProf.RebootAfterUse)
+	d.Set("reboot_after_use", instaceProf.RebootAfterUse)
 
 	tags, err := ListTags(conn, arn)
 
@@ -174,8 +174,8 @@ func resourceInstanceProfileUpdate(d *schema.ResourceData, meta interface{}) err
 			input.PackageCleanup = aws.Bool(d.Get("package_cleanup").(bool))
 		}
 
-		if d.HasChange("reboot_after_user") {
-			input.RebootAfterUse = aws.Bool(d.Get("reboot_after_user").(bool))
+		if d.HasChange("reboot_after_use") {
+			input.RebootAfterUse = aws.Bool(d.Get("reboot_after_use").(bool))
 		}
 
 		log.Printf("[DEBUG] Updating DeviceFarm Instance Profile: %s", d.Id())

--- a/internal/service/devicefarm/instance_profile.go
+++ b/internal/service/devicefarm/instance_profile.go
@@ -1,0 +1,216 @@
+package devicefarm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceInstanceProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInstanceProfileCreate,
+		Read:   resourceInstanceProfileRead,
+		Update: resourceInstanceProfileUpdate,
+		Delete: resourceInstanceProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 16384),
+			},
+			"exclude_app_packages_from_cleanup": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"package_cleanup": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"reboot_after_user": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceInstanceProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &devicefarm.CreateInstanceProfileInput{
+		Name: aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("exclude_app_packages_from_cleanup"); ok && v.(*schema.Set).Len() > 0 {
+		input.ExcludeAppPackagesFromCleanup = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("package_cleanup"); ok {
+		input.PackageCleanup = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("reboot_after_user"); ok {
+		input.RebootAfterUse = aws.Bool(v.(bool))
+	}
+
+	out, err := conn.CreateInstanceProfile(input)
+	if err != nil {
+		return fmt.Errorf("Error creating DeviceFarm Instance Profile: %w", err)
+	}
+
+	arn := aws.StringValue(out.InstanceProfile.Arn)
+	log.Printf("[DEBUG] Successsfully Created DeviceFarm Instance Profile: %s", arn)
+	d.SetId(arn)
+
+	if len(tags) > 0 {
+		if err := UpdateTags(conn, arn, nil, tags); err != nil {
+			return fmt.Errorf("error updating DeviceFarm Instance Profile (%s) tags: %w", arn, err)
+		}
+	}
+
+	return resourceInstanceProfileRead(d, meta)
+}
+
+func resourceInstanceProfileRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	instaceProf, err := FindInstanceProfileByArn(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DeviceFarm Instance Profile (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading DeviceFarm Instance Profile (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(instaceProf.Arn)
+	d.Set("arn", arn)
+	d.Set("name", instaceProf.Name)
+	d.Set("description", instaceProf.Description)
+	d.Set("exclude_app_packages_from_cleanup", flex.FlattenStringSet(instaceProf.ExcludeAppPackagesFromCleanup))
+	d.Set("package_cleanup", instaceProf.PackageCleanup)
+	d.Set("reboot_after_user", instaceProf.RebootAfterUse)
+
+	tags, err := ListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for DeviceFarm Instance Profile (%s): %w", arn, err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceInstanceProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &devicefarm.UpdateInstanceProfileInput{
+			Arn: aws.String(d.Id()),
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("description") {
+			input.Description = aws.String(d.Get("description").(string))
+		}
+
+		if d.HasChange("exclude_app_packages_from_cleanup") {
+			input.ExcludeAppPackagesFromCleanup = flex.ExpandStringSet(d.Get("exclude_app_packages_from_cleanup").(*schema.Set))
+		}
+
+		if d.HasChange("package_cleanup") {
+			input.PackageCleanup = aws.Bool(d.Get("package_cleanup").(bool))
+		}
+
+		if d.HasChange("reboot_after_user") {
+			input.RebootAfterUse = aws.Bool(d.Get("reboot_after_user").(bool))
+		}
+
+		log.Printf("[DEBUG] Updating DeviceFarm Instance Profile: %s", d.Id())
+		_, err := conn.UpdateInstanceProfile(input)
+		if err != nil {
+			return fmt.Errorf("Error Updating DeviceFarm Instance Profile: %w", err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating DeviceFarm Instance Profile (%s) tags: %w", d.Get("arn").(string), err)
+		}
+	}
+
+	return resourceInstanceProfileRead(d, meta)
+}
+
+func resourceInstanceProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DeviceFarmConn
+
+	input := &devicefarm.DeleteInstanceProfileInput{
+		Arn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DeviceFarm Instance Profile: %s", d.Id())
+	_, err := conn.DeleteInstanceProfile(input)
+	if err != nil {
+		if tfawserr.ErrMessageContains(err, devicefarm.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting DeviceFarm Instance Profile: %w", err)
+	}
+
+	return nil
+}

--- a/internal/service/devicefarm/instance_profile_test.go
+++ b/internal/service/devicefarm/instance_profile_test.go
@@ -1,0 +1,228 @@
+package devicefarm_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfdevicefarm "github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccDeviceFarmInstanceProfile_basic(t *testing.T) {
+	var profile devicefarm.InstanceProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix("tf-acc-test-updated")
+	resourceName := "aws_devicefarm_instance_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmInstanceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmInstanceProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "reboot_after_user", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`instanceprofile:.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmInstanceProfileConfig(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "reboot_after_user", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`instanceprofile:.+`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceFarmInstanceProfile_tags(t *testing.T) {
+	var profile devicefarm.InstanceProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_instance_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmInstanceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmInstanceProfileConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeviceFarmInstanceProfileConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDeviceFarmInstanceProfileConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceFarmInstanceProfile_disappears(t *testing.T) {
+	var profile devicefarm.InstanceProfile
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_devicefarm_instance_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(devicefarm.EndpointsID, t)
+			// Currently, DeviceFarm is only supported in us-west-2
+			// https://docs.aws.amazon.com/general/latest/gr/devicefarm.html
+			acctest.PreCheckRegion(t, endpoints.UsWest2RegionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, devicefarm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDeviceFarmInstanceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceFarmInstanceProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceInstanceProfile(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfdevicefarm.ResourceInstanceProfile(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDeviceFarmInstanceProfileExists(n string, v *devicefarm.InstanceProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
+		resp, err := tfdevicefarm.FindInstanceProfileByArn(conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if resp == nil {
+			return fmt.Errorf("DeviceFarm Instance Profile not found")
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckDeviceFarmInstanceProfileDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DeviceFarmConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_devicefarm_instance_profile" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := tfdevicefarm.FindInstanceProfileByArn(conn, rs.Primary.ID)
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("DeviceFarm Instance Profile %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccDeviceFarmInstanceProfileConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_devicefarm_instance_profile" "test" {
+  name        = %[1]q
+}
+`, rName)
+}
+
+func testAccDeviceFarmInstanceProfileConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_devicefarm_instance_profile" "test" {
+  name        = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccDeviceFarmInstanceProfileConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_devicefarm_instance_profile" "test" {
+  name        = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/devicefarm/instance_profile_test.go
+++ b/internal/service/devicefarm/instance_profile_test.go
@@ -197,7 +197,7 @@ func testAccCheckDeviceFarmInstanceProfileDestroy(s *terraform.State) error {
 func testAccDeviceFarmInstanceProfileConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_devicefarm_instance_profile" "test" {
-  name        = %[1]q
+  name = %[1]q
 }
 `, rName)
 }
@@ -205,7 +205,7 @@ resource "aws_devicefarm_instance_profile" "test" {
 func testAccDeviceFarmInstanceProfileConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_devicefarm_instance_profile" "test" {
-  name        = %[1]q
+  name = %[1]q
 
   tags = {
     %[2]q = %[3]q
@@ -217,7 +217,7 @@ resource "aws_devicefarm_instance_profile" "test" {
 func testAccDeviceFarmInstanceProfileConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_devicefarm_instance_profile" "test" {
-  name        = %[1]q
+  name = %[1]q
 
   tags = {
     %[2]q = %[3]q

--- a/internal/service/devicefarm/instance_profile_test.go
+++ b/internal/service/devicefarm/instance_profile_test.go
@@ -39,7 +39,7 @@ func TestAccDeviceFarmInstanceProfile_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "reboot_after_user", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reboot_after_use", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`instanceprofile:.+`)),
 				),
@@ -54,7 +54,7 @@ func TestAccDeviceFarmInstanceProfile_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeviceFarmInstanceProfileExists(resourceName, &profile),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
-					resource.TestCheckResourceAttr(resourceName, "reboot_after_user", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reboot_after_use", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "devicefarm", regexp.MustCompile(`instanceprofile:.+`)),
 				),

--- a/website/docs/r/devicefarm_instance_profile.html.markdown
+++ b/website/docs/r/devicefarm_instance_profile.html.markdown
@@ -17,7 +17,7 @@ Provides a resource to manage AWS Device Farm Instance Profiles.
 
 ```terraform
 resource "aws_devicefarm_instance_profile" "example" {
-  name        = "example"
+  name = "example"
 }
 ```
 

--- a/website/docs/r/devicefarm_instance_profile.html.markdown
+++ b/website/docs/r/devicefarm_instance_profile.html.markdown
@@ -27,7 +27,7 @@ resource "aws_devicefarm_instance_profile" "example" {
 * `exclude_app_packages_from_cleanup` - (Optional) An array of strings that specifies the list of app packages that should not be cleaned up from the device after a test run.
 * `name` - (Required) The name for the instance profile.
 * `package_cleanup` - (Optional) When set to `true`, Device Farm removes app packages after a test run. The default value is `false` for private devices.
-* `reboot_after_user` - (Optional) When set to `true`, Device Farm reboots the instance after a test run. The default value is `true`.
+* `reboot_after_use` - (Optional) When set to `true`, Device Farm reboots the instance after a test run. The default value is `true`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/devicefarm_instance_profile.html.markdown
+++ b/website/docs/r/devicefarm_instance_profile.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Device Farm"
+layout: "aws"
+page_title: "AWS: aws_devicefarm_instance_profile"
+description: |-
+  Provides a Devicefarm instance profile
+---
+
+# Resource: aws_devicefarm_instance_profile
+
+Provides a resource to manage AWS Device Farm Instance Profiles.
+∂
+~> **NOTE:** AWS currently has limited regional support for Device Farm (e.g., `us-west-2`). See [AWS Device Farm endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/devicefarm.html) for information on supported regions.
+
+## Example Usage
+
+
+```terraform
+resource "aws_devicefarm_instance_profile" "example" {
+  name        = "example"
+}
+```
+
+## Argument Reference
+
+* `description` - (Optional) The description of the instance profile.
+* `exclude_app_packages_from_cleanup` - (Optional) An array of strings that specifies the list of app packages that should not be cleaned up from the device after a test run.
+* `name` - (Required) The name for the instance profile.
+* `package_cleanup` - (Optional) When set to `true`, Device Farm removes app packages after a test run. The default value is `false` for private devices.
+* `reboot_after_user` - (Optional) When set to `true`, Device Farm reboots the instance after a test run. The default value is `true`.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name of this instance profile.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+DeviceFarm Instance Profiles can be imported by their arn:
+
+```
+$ terraform import aws_devicefarm_instance_profile.example arn:aws:devicefarm:us-west-2:123456789012:instanceprofile:4fa784c7-ccb4-4dbf-ba4f-02198320daa1
+```

--- a/website/docs/r/devicefarm_network_profile.html.markdown
+++ b/website/docs/r/devicefarm_network_profile.html.markdown
@@ -54,5 +54,5 @@ In addition to all arguments above, the following attributes are exported:
 DeviceFarm Network Profiles can be imported by their arn:
 
 ```
-$ terraform import aws_devicefarm_network_profile.example arn:aws:devicefarm:us-west-2:123456789012:network profile:4fa784c7-ccb4-4dbf-ba4f-02198320daa1
+$ terraform import aws_devicefarm_network_profile.example arn:aws:devicefarm:us-west-2:123456789012:networkprofile:4fa784c7-ccb4-4dbf-ba4f-02198320daa1
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDeviceFarmInstanceProfile_ PKG=devicefarm
--- PASS: TestAccDeviceFarmInstanceProfile_disappears (56.17s)
--- PASS: TestAccDeviceFarmInstanceProfile_basic (114.85s)
--- PASS: TestAccDeviceFarmInstanceProfile_tags (149.49s)
```
