### PR TITLE
r/cloudwatch_log_destination_policy - add `force_update` argument

### DIFF
--- a/.changelog/22460.txt
+++ b/.changelog/22460.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudwatch_log_destination_policy: Add `force_update` argument.
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_log_destination_policy: Add plan time validation for `access_policy`.
+```

--- a/internal/service/cloudwatchlogs/destination_policy.go
+++ b/internal/service/cloudwatchlogs/destination_policy.go
@@ -3,6 +3,7 @@ package cloudwatchlogs
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -54,18 +55,23 @@ func resourceDestinationPolicyPut(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*conns.AWSClient).CloudWatchLogsConn
 
 	destination_name := d.Get("destination_name").(string)
-	access_policy := d.Get("access_policy").(string)
+
+	policy, err := structure.NormalizeJsonString(d.Get("access_policy").(string))
+
+	if err != nil {
+		return fmt.Errorf("access_policy (%s) is invalid JSON: %w", policy, err)
+	}
 
 	params := &cloudwatchlogs.PutDestinationPolicyInput{
 		DestinationName: aws.String(destination_name),
-		AccessPolicy:    aws.String(access_policy),
+		AccessPolicy:    aws.String(policy),
 	}
 
 	if v, ok := d.GetOk("force_update"); ok {
 		params.ForceUpdate = aws.Bool(v.(bool))
 	}
 
-	_, err := conn.PutDestinationPolicy(params)
+	_, err = conn.PutDestinationPolicy(params)
 
 	if err != nil {
 		return fmt.Errorf("Error creating CloudWatch Log Destination Policy with destination_name %s: %#v", destination_name, err)
@@ -88,7 +94,23 @@ func resourceDestinationPolicyRead(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 
-	d.Set("access_policy", destination.AccessPolicy)
+	normalizedPolicy, err := structure.NormalizeJsonString(`"` + aws.StringValue(destination.AccessPolicy) + `"`)
+	if err != nil {
+		return fmt.Errorf("error normalizing Log Destination Policy policy JSON: %w", err)
+	}
+
+	policy, err := strconv.Unquote(normalizedPolicy)
+	if err != nil {
+		return fmt.Errorf("error unescaping Log Destination Policy policy: %w", err)
+	}
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), policy)
+
+	if err != nil {
+		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
+	}
+
+	d.Set("access_policy", policyToSet)
 	d.Set("destination_name", destination.DestinationName)
 
 	return nil

--- a/internal/service/cloudwatchlogs/destination_policy.go
+++ b/internal/service/cloudwatchlogs/destination_policy.go
@@ -7,7 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceDestinationPolicy() *schema.Resource {
@@ -18,10 +21,7 @@ func ResourceDestinationPolicy() *schema.Resource {
 		Delete: resourceDestinationPolicyDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				d.Set("destination_name", d.Id())
-				return []*schema.ResourceData{d}, nil
-			},
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -32,8 +32,19 @@ func ResourceDestinationPolicy() *schema.Resource {
 			},
 
 			"access_policy": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
+
+			"force_update": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 		},
 	}
@@ -50,10 +61,14 @@ func resourceDestinationPolicyPut(d *schema.ResourceData, meta interface{}) erro
 		AccessPolicy:    aws.String(access_policy),
 	}
 
+	if v, ok := d.GetOk("force_update"); ok {
+		params.ForceUpdate = aws.Bool(v.(bool))
+	}
+
 	_, err := conn.PutDestinationPolicy(params)
 
 	if err != nil {
-		return fmt.Errorf("Error creating DestinationPolicy with destination_name %s: %#v", destination_name, err)
+		return fmt.Errorf("Error creating CloudWatch Log Destination Policy with destination_name %s: %#v", destination_name, err)
 	}
 
 	d.SetId(destination_name)
@@ -62,8 +77,7 @@ func resourceDestinationPolicyPut(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDestinationPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).CloudWatchLogsConn
-	destination_name := d.Get("destination_name").(string)
-	destination, exists, err := LookupDestination(conn, destination_name, nil)
+	destination, exists, err := LookupDestination(conn, d.Id(), nil)
 	if err != nil {
 		return err
 	}
@@ -75,6 +89,7 @@ func resourceDestinationPolicyRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.Set("access_policy", destination.AccessPolicy)
+	d.Set("destination_name", destination.DestinationName)
 
 	return nil
 }

--- a/website/docs/r/cloudwatch_log_destination_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_destination_policy.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 
 * `destination_name` - (Required) A name for the subscription filter
 * `access_policy` - (Required) The policy document. This is a JSON formatted string.
+* `force_update` - (Optional) Specify true if you are updating an existing destination policy to grant permission to an organization ID instead of granting permission to individual AWS accounts.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22445

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccCloudWatchLogsDestinationPolicy_ PKG=cloudwatchlogs

--- PASS: TestAccCloudWatchLogsDestinationPolicy_basic (142.72s)
```
