### PR TITLE
r/cloudfront_distribution - bump `origin_read_timeout` validation to `180`

### DIFF
--- a/.changelog/22461.txt
+++ b/.changelog/22461.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_distribution: `origin_read_timeout` validation fix #21034
+```

--- a/.changelog/22461.txt
+++ b/.changelog/22461.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cloudfront_distribution: `origin_read_timeout` validation fix #21034
+resource/aws_cloudfront_distribution: Increase the maximum valid `origin_read_timeout` value to `180`
 ```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -546,7 +546,7 @@ func ResourceDistribution() *schema.Resource {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Default:      30,
-										ValidateFunc: validation.IntBetween(1, 60),
+										ValidateFunc: validation.IntBetween(1, 180),
 									},
 									"origin_protocol_policy": {
 										Type:         schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21034

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
