### PR TITLE
Add support for EC2 Instance Metadata Tags

### DIFF
--- a/.changelog/22463.txt
+++ b/.changelog/22463.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/aws_instance: Add the `instance_metadata_tags` argument to the `metadata_options` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_instance: Add the `instance_metadata_tags` attribute to the `metadata_options` configuration block
+```
+
+```release-note:enhancement
+resource/aws_launch_template: Add the `instance_metadata_tags` argument to the `metadata_options` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_launch_tenplate: Add the `instance_metadata_tags` attribute to the `metadata_options` configuration block
+```

--- a/internal/service/ec2/instance.go
+++ b/internal/service/ec2/instance.go
@@ -371,6 +371,12 @@ func ResourceInstance() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{ec2.HttpTokensStateOptional, ec2.HttpTokensStateRequired}, false),
 						},
+						"instance_metadata_tags": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      ec2.InstanceMetadataTagsStateDisabled,
+							ValidateFunc: validation.StringInSlice(ec2.InstanceMetadataTagsState_Values(), false),
+						},
 					},
 				},
 			},
@@ -1561,6 +1567,7 @@ func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					// These parameters are not allowed unless HttpEndpoint is enabled
 					input.HttpTokens = aws.String(mo["http_tokens"].(string))
 					input.HttpPutResponseHopLimit = aws.Int64(int64(mo["http_put_response_hop_limit"].(int)))
+					input.InstanceMetadataTags = aws.String(mo["instance_metadata_tags"].(string))
 				}
 				_, err := conn.ModifyInstanceMetadataOptions(input)
 				if err != nil {
@@ -2940,6 +2947,10 @@ func expandEc2InstanceMetadataOptions(l []interface{}) *ec2.InstanceMetadataOpti
 		if v, ok := m["http_put_response_hop_limit"].(int); ok && v != 0 {
 			opts.HttpPutResponseHopLimit = aws.Int64(int64(v))
 		}
+
+		if v, ok := m["instance_metadata_tags"].(string); ok && v != "" {
+			opts.InstanceMetadataTags = aws.String(v)
+		}
 	}
 
 	return opts
@@ -3017,6 +3028,7 @@ func flattenEc2InstanceMetadataOptions(opts *ec2.InstanceMetadataOptionsResponse
 		"http_endpoint":               aws.StringValue(opts.HttpEndpoint),
 		"http_put_response_hop_limit": aws.Int64Value(opts.HttpPutResponseHopLimit),
 		"http_tokens":                 aws.StringValue(opts.HttpTokens),
+		"instance_metadata_tags":      aws.StringValue(opts.InstanceMetadataTags),
 	}
 
 	return []interface{}{m}

--- a/internal/service/ec2/instance_data_source.go
+++ b/internal/service/ec2/instance_data_source.go
@@ -335,6 +335,10 @@ func DataSourceInstance() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"instance_metadata_tags": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/ec2/instance_data_source_test.go
+++ b/internal/service/ec2/instance_data_source_test.go
@@ -568,6 +568,7 @@ func TestAccEC2InstanceDataSource_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_put_response_hop_limit", resourceName, "metadata_options.0.http_put_response_hop_limit"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.instance_metadata_tags", resourceName, "metadata_options.0.instance_metadata_tags"),
 				),
 			},
 		},
@@ -1085,6 +1086,7 @@ resource "aws_instance" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
+    instance_metadata_tags      = "enabled"
   }
 }
 

--- a/internal/service/ec2/instance_test.go
+++ b/internal/service/ec2/instance_test.go
@@ -3499,6 +3499,7 @@ func TestAccEC2Instance_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "disabled"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "disabled"),
 				),
 			},
 			{
@@ -3509,6 +3510,7 @@ func TestAccEC2Instance_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "enabled"),
 				),
 			},
 			{
@@ -6263,6 +6265,7 @@ resource "aws_instance" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
+    instance_metadata_tags      = "enabled"
   }
 }
 `, rName))

--- a/internal/service/ec2/launch_template.go
+++ b/internal/service/ec2/launch_template.go
@@ -407,6 +407,12 @@ func ResourceLaunchTemplate() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 64),
 						},
+						"instance_metadata_tags": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      ec2.LaunchTemplateInstanceMetadataTagsStateDisabled,
+							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateInstanceMetadataTagsState_Values(), false),
+						},
 					},
 				},
 			},
@@ -1141,6 +1147,10 @@ func expandLaunchTemplateInstanceMetadataOptions(l []interface{}) *ec2.LaunchTem
 		if v, ok := m["http_put_response_hop_limit"].(int); ok && v != 0 {
 			opts.HttpPutResponseHopLimit = aws.Int64(int64(v))
 		}
+
+		if v, ok := m["instance_metadata_tags"].(string); ok && v != "" {
+			opts.InstanceMetadataTags = aws.String(v)
+		}
 	}
 
 	return opts
@@ -1156,6 +1166,7 @@ func flattenLaunchTemplateInstanceMetadataOptions(opts *ec2.LaunchTemplateInstan
 		"http_protocol_ipv6":          aws.StringValue(opts.HttpProtocolIpv6),
 		"http_put_response_hop_limit": aws.Int64Value(opts.HttpPutResponseHopLimit),
 		"http_tokens":                 aws.StringValue(opts.HttpTokens),
+		"instance_metadata_tags":      aws.StringValue(opts.InstanceMetadataTags),
 	}
 
 	return []interface{}{m}

--- a/internal/service/ec2/launch_template_data_source.go
+++ b/internal/service/ec2/launch_template_data_source.go
@@ -234,6 +234,10 @@ func DataSourceLaunchTemplate() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"instance_metadata_tags": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/ec2/launch_template_data_source_test.go
+++ b/internal/service/ec2/launch_template_data_source_test.go
@@ -151,6 +151,7 @@ func TestAccEC2LaunchTemplateDataSource_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_protocol_ipv6", resourceName, "metadata_options.0.http_protocol_ipv6"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_put_response_hop_limit", resourceName, "metadata_options.0.http_put_response_hop_limit"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.instance_metadata_tags", resourceName, "metadata_options.0.instance_metadata_tags"),
 				),
 			},
 		},
@@ -370,6 +371,7 @@ resource "aws_launch_template" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
+    instance_metadata_tags      = "enabled"
   }
 }
 

--- a/internal/service/ec2/launch_template_test.go
+++ b/internal/service/ec2/launch_template_test.go
@@ -1152,6 +1152,7 @@ func TestAccEC2LaunchTemplate_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "disabled"),
 				),
 			},
 			{
@@ -1168,6 +1169,24 @@ func TestAccEC2LaunchTemplate_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLaunchTemplateConfig_metadataOptionsInstanceTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "enabled"),
 				),
 			},
 		},
@@ -2262,6 +2281,22 @@ resource "aws_launch_template" "test" {
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
     http_protocol_ipv6          = "enabled"
+  }
+}
+`, rName)
+}
+
+func testAccLaunchTemplateConfig_metadataOptionsInstanceTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+    http_protocol_ipv6          = "enabled"
+    instance_metadata_tags      = "enabled"
   }
 }
 `, rName)

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -122,6 +122,7 @@ interpolation.
     * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
     * `http_tokens` - If session tokens are required: `optional`, `required`.
     * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
+    * `instance_metadata_tags` - If access to instance tags is allowed from the metadata service: `enabled`, `disabled`.
 * `enclave_options` - The enclave options of the Instance.
     * `enabled` - Whether Nitro Enclaves are enabled.
 

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -77,6 +77,7 @@ In addition to all arguments above, the following attributes are exported:
     * `http_tokens` - If session tokens are required: `optional`, `required`.
     * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
     * `http_protocol_ipv6` - The state of IPv6 endpoint for the instance metadata service: `enabled`, `disabled`.
+    * `instance_metadata_tags` - If access to instance tags is allowed from the metadata service: `enabled`, `disabled`.
 * `monitoring` - The monitoring option for the instance.
 * `network_interfaces` - Customize network interfaces to be attached at instance boot time. See [Network
   Interfaces](#network-interfaces) below for more details.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -238,6 +238,7 @@ The `metadata_options` block supports the following:
 * `http_endpoint` - (Optional) Whether the metadata service is available. Valid values include `enabled` or `disabled`. Defaults to `enabled`.
 * `http_put_response_hop_limit` - (Optional) Desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Valid values are integer from `1` to `64`. Defaults to `1`.
 * `http_tokens` - (Optional) Whether or not the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Valid values include `optional` or `required`. Defaults to `optional`.
+* `instance_metadata_tags` - (optional) Enables or disables access to instance tags from the instance metadata service. Valid values include `enabled` or `disabled`. Defaults to `disabled`.
 
 For more information, see the documentation on the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -75,6 +75,7 @@ resource "aws_launch_template" "foo" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
   }
 
   monitoring {
@@ -275,6 +276,7 @@ The `metadata_options` block supports the following:
 * `http_tokens` - (Optional) Whether or not the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Can be `"optional"` or `"required"`. (Default: `"optional"`).
 * `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`. (Default: `1`).
 * `http_protocol_ipv6` - (Optional) Enables or disables the IPv6 endpoint for the instance metadata service. (Default: `disabled`).
+* `instance_metadata_tags` - (optional) Enables or disables access to instance tags from the instance metadata service. (Default: `disabled`).
 
 For more information, see the documentation on the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 


### PR DESCRIPTION
EC2 Instance tags can now be exposed via the metadata service, if enabled via a metadata option 🎉 
https://aws.amazon.com/about-aws/whats-new/2022/01/instance-tags-amazon-ec2-instance-metadata-service/
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS

Depends on #22456 - support for instance tags on Instance and Launch Template resources (but not Launch Configurations) was added to github.com/aws/aws-sdk-go in in v1.42.29.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22456.
Closes #22465.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEC2Instance_metadataOptions PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_metadataOptions' -timeout 180m
=== RUN   TestAccEC2Instance_metadataOptions
=== PAUSE TestAccEC2Instance_metadataOptions
=== CONT  TestAccEC2Instance_metadataOptions
--- PASS: TestAccEC2Instance_metadataOptions (331.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	331.481s

$ make testacc TESTS=TestAccEC2InstanceDataSource_metadataOptions PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2InstanceDataSource_metadataOptions' -timeout 180m
=== RUN   TestAccEC2InstanceDataSource_metadataOptions
=== PAUSE TestAccEC2InstanceDataSource_metadataOptions
=== CONT  TestAccEC2InstanceDataSource_metadataOptions
--- PASS: TestAccEC2InstanceDataSource_metadataOptions (158.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	158.517s

$ make testacc TESTS=TestAccEC2LaunchTemplate_metadataOptions PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_metadataOptions' -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (256.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	256.509s

$ make testacc TESTS=TestAccEC2LaunchTemplateDataSource_metadataOptions PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplateDataSource_metadataOptions' -timeout 180m
=== RUN   TestAccEC2LaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccEC2LaunchTemplateDataSource_metadataOptions
=== CONT  TestAccEC2LaunchTemplateDataSource_metadataOptions
--- PASS: TestAccEC2LaunchTemplateDataSource_metadataOptions (87.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	87.379s
...
```
