### PR TITLE
r/aws_vpc_ipam_pool_cidr_allocation - new attribute

### DIFF
--- a/.changelog/22470.txt
+++ b/.changelog/22470.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_ipam_pool_cidr_allocation: Add `disallowed_cidrs` argument
+```

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
@@ -74,6 +74,33 @@ func TestAccVPCIpamPoolAllocation_ipv4BasicNetmask(t *testing.T) {
 	})
 }
 
+func TestAccVPCIpamPoolAllocation_ipv4DisallowedCidr(t *testing.T) {
+	resourceName := "aws_vpc_ipam_pool_cidr_allocation.test"
+	disallowedCidr := "172.2.0.0/28"
+	netmaskLength := "28"
+	expectedCidr := "172.2.0.16/28"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCIpamPoolAllocationIpv4DisallowedCidr(netmaskLength, disallowedCidr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cidr", expectedCidr),
+					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.0", disallowedCidr),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "ipam_pool_id", "aws_vpc_ipam_pool.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "netmask_length", netmaskLength),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVPCIpamAllocationExists(n string, allocation *ec2.IpamPoolAllocation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -175,4 +202,23 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
   ]
 }
 `, netmask))
+}
+
+func testAccVPCIpamPoolAllocationIpv4DisallowedCidr(netmaskLength, disallowedCidr string) string {
+	return acctest.ConfigCompose(
+		testAccVPCIpamPoolCidrPrivateBase,
+		fmt.Sprintf(`
+resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
+  ipam_pool_id   = aws_vpc_ipam_pool.test.id
+  netmask_length = %[1]q
+
+  disallowed_cidrs = [
+    %[2]q
+  ]
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test
+  ]
+}
+`, netmaskLength, disallowedCidr))
 }

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
@@ -150,7 +150,9 @@ resource "aws_vpc_ipam_pool_cidr" "test" {
 `
 
 func testAccVPCIpamPoolAllocationIpv4(cidr string) string {
-	return testAccVPCIpamPoolCidrPrivateBase + fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccVPCIpamPoolCidrPrivateBase,
+		fmt.Sprintf(`
 resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id
   cidr         = %[1]q
@@ -158,11 +160,13 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
     aws_vpc_ipam_pool_cidr.test
   ]
 }
-`, cidr)
+`, cidr))
 }
 
 func testAccVPCIpamPoolAllocationIpv4Netmask(netmask string) string {
-	return testAccVPCIpamPoolCidrPrivateBase + fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccVPCIpamPoolCidrPrivateBase,
+		fmt.Sprintf(`
 resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
   ipam_pool_id   = aws_vpc_ipam_pool.test.id
   netmask_length = %[1]q
@@ -170,5 +174,5 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
     aws_vpc_ipam_pool_cidr.test
   ]
 }
-`, netmask)
+`, netmask))
 }

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -43,12 +43,49 @@ resource "aws_vpc_ipam" "example" {
 }
 ```
 
+With the `disallowed_cidrs` attribute:
+
+```terraform
+data "aws_region" "current" {}
+
+resource "aws_vpc_ipam_pool_cidr_allocation" "example" {
+  ipam_pool_id  = aws_vpc_ipam_pool.example.id
+  netmaskLength = 28
+
+  disallowed_cidrs = [
+    "172.2.0.0/28"
+  ]
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.example
+  ]
+}
+
+resource "aws_vpc_ipam_pool_cidr" "example" {
+  ipam_pool_id = aws_vpc_ipam_pool.example.id
+  cidr         = "172.2.0.0/16"
+}
+
+resource "aws_vpc_ipam_pool" "example" {
+  address_family = "ipv4"
+  ipam_scope_id  = aws_vpc_ipam.example.private_default_scope_id
+  locale         = data.aws_region.current.name
+}
+
+resource "aws_vpc_ipam" "example" {
+  operating_regions {
+    region_name = data.aws_region.current.name
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `cidr` - (Optional) The CIDR you want to assign to the pool.
 * `description` - (Optional) The description for the allocation.
+* `disallowed_cidrs` - (Optional) Exclude a particular CIDR range from being returned by the pool.
 * `ipam_pool_id` - (Required) The ID of the pool to which you want to assign a CIDR.
 * `netmask_length` - (Optional) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-32`.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22471

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCIpamPoolAllocation PKG=ec2 ACCTEST_PARALLELISM=1 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 1 -run='TestAccVPCIpamPoolAllocation' -timeout 180m
=== RUN   TestAccVPCIpamPoolAllocation_ipv4Basic
=== PAUSE TestAccVPCIpamPoolAllocation_ipv4Basic
=== RUN   TestAccVPCIpamPoolAllocation_ipv4BasicNetmask
=== PAUSE TestAccVPCIpamPoolAllocation_ipv4BasicNetmask
=== RUN   TestAccVPCIpamPoolAllocation_ipv4DisallowedCidr
=== PAUSE TestAccVPCIpamPoolAllocation_ipv4DisallowedCidr
=== CONT  TestAccVPCIpamPoolAllocation_ipv4Basic
--- PASS: TestAccVPCIpamPoolAllocation_ipv4Basic (138.24s)
=== CONT  TestAccVPCIpamPoolAllocation_ipv4BasicNetmask
--- PASS: TestAccVPCIpamPoolAllocation_ipv4BasicNetmask (109.75s)
=== CONT  TestAccVPCIpamPoolAllocation_ipv4DisallowedCidr
--- PASS: TestAccVPCIpamPoolAllocation_ipv4DisallowedCidr (126.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        383.549s

...
```
