### PR TITLE
added nil check for nfs exports

### DIFF
--- a/.changelog/22480.txt
+++ b/.changelog/22480.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_fsx_openzfs_file_system: Fix issue with Null NFS Export when root volume configuraiton specified.
+resource/aws_fsx_openzfs_file_system: Fix issue with Null NFS Export when root volume configuration specified.
 ```

--- a/.changelog/22480.txt
+++ b/.changelog/22480.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
-resource/aws_fsx_openzfs_file_system: Fix issue with Null NFS Export when root volume configuration specified.
+resource/aws_fsx_openzfs_file_system: Fix crash with nil `root_volume_configuration.nfs_exports` value
+```
+
+```release-note:bug
+resource/aws_fsx_openzfs_file_system: Change `root_volume_configuration.copy_tags_to_snapshots` to ForceNew
 ```

--- a/.changelog/22480.txt
+++ b/.changelog/22480.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_openzfs_file_system: Fix issue with Null NFS Export when root volume configuraiton specified.
+```

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -774,9 +774,11 @@ func flattenFsxOpenzfsFileNfsExports(rs []*fsx.OpenZFSNfsExport) []map[string]in
 	exports := make([]map[string]interface{}, 0)
 
 	for _, export := range rs {
-		cfg := make(map[string]interface{})
-		cfg["client_configurations"] = flattenFsxOpenzfsClientConfigurations(export.ClientConfigurations)
-		exports = append(exports, cfg)
+		if export != nil {
+			cfg := make(map[string]interface{})
+			cfg["client_configurations"] = flattenFsxOpenzfsClientConfigurations(export.ClientConfigurations)
+			exports = append(exports, cfg)
+		}
 	}
 
 	if len(exports) > 0 {
@@ -790,10 +792,12 @@ func flattenFsxOpenzfsClientConfigurations(rs []*fsx.OpenZFSClientConfiguration)
 	configurations := make([]map[string]interface{}, 0)
 
 	for _, configuration := range rs {
-		cfg := make(map[string]interface{})
-		cfg["clients"] = aws.StringValue(configuration.Clients)
-		cfg["options"] = flex.FlattenStringList(configuration.Options)
-		configurations = append(configurations, cfg)
+		if configuration != nil {
+			cfg := make(map[string]interface{})
+			cfg["clients"] = aws.StringValue(configuration.Clients)
+			cfg["options"] = flex.FlattenStringList(configuration.Options)
+			configurations = append(configurations, cfg)
+		}
 	}
 
 	if len(configurations) > 0 {
@@ -807,11 +811,13 @@ func flattenFsxOpenzfsFileUserAndGroupQuotas(rs []*fsx.OpenZFSUserOrGroupQuota) 
 	quotas := make([]map[string]interface{}, 0)
 
 	for _, quota := range rs {
-		cfg := make(map[string]interface{})
-		cfg["id"] = aws.Int64Value(quota.Id)
-		cfg["storage_capacity_quota_gib"] = aws.Int64Value(quota.StorageCapacityQuotaGiB)
-		cfg["type"] = aws.StringValue(quota.Type)
-		quotas = append(quotas, cfg)
+		if quota != nil {
+			cfg := make(map[string]interface{})
+			cfg["id"] = aws.Int64Value(quota.Id)
+			cfg["storage_capacity_quota_gib"] = aws.Int64Value(quota.StorageCapacityQuotaGiB)
+			cfg["type"] = aws.StringValue(quota.Type)
+			quotas = append(quotas, cfg)
+		}
 	}
 
 	if len(quotas) > 0 {

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -108,6 +108,7 @@ func ResourceOpenzfsFileSystem() *schema.Resource {
 						"copy_tags_to_snapshots": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 						"data_compression_type": {
 							Type:         schema.TypeString,

--- a/internal/service/fsx/openzfs_file_system_test.go
+++ b/internal/service/fsx/openzfs_file_system_test.go
@@ -237,6 +237,37 @@ func TestAccFSxOpenzfsFileSystem_rootVolume(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccOpenzfsFileSystemRootVolume4Config(rName, "NONE", "false", 128, 1024),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxOpenzfsFileSystemExists(resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "root_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume_configuration.0.data_compression_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume_configuration.0.nfs_exports.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume_configuration.0.read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "root_volume_configuration.0.user_and_group_quotas.#", "4"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "root_volume_configuration.0.user_and_group_quotas.*", map[string]string{
+						"id":                         "10",
+						"storage_capacity_quota_gib": "128",
+						"type":                       "USER",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "root_volume_configuration.0.user_and_group_quotas.*", map[string]string{
+						"id":                         "20",
+						"storage_capacity_quota_gib": "1024",
+						"type":                       "GROUP",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "root_volume_configuration.0.user_and_group_quotas.*", map[string]string{
+						"id":                         "5",
+						"storage_capacity_quota_gib": "1024",
+						"type":                       "GROUP",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "root_volume_configuration.0.user_and_group_quotas.*", map[string]string{
+						"id":                         "100",
+						"storage_capacity_quota_gib": "128",
+						"type":                       "USER",
+					}),
+				),
+			},
 		},
 	})
 }
@@ -1051,6 +1082,46 @@ resource "aws_fsx_openzfs_file_system" "test" {
       storage_capacity_quota_gib = %[4]d
       type                       = "USER"
     }
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, dataCompression, readOnly, userQuota, groupQuota))
+}
+
+func testAccOpenzfsFileSystemRootVolume4Config(rName, dataCompression, readOnly string, userQuota, groupQuota int) string {
+	return acctest.ConfigCompose(testAccOpenzfsFileSystemBaseConfig(rName), fmt.Sprintf(`
+resource "aws_fsx_openzfs_file_system" "test" {
+  storage_capacity    = 64
+  subnet_ids          = [aws_subnet.test1.id]
+  deployment_type     = "SINGLE_AZ_1"
+  throughput_capacity = 64
+  root_volume_configuration {
+    copy_tags_to_snapshots = true
+    data_compression_type  = %[2]q
+
+	user_and_group_quotas {
+		id                         = 10
+		storage_capacity_quota_gib = %[4]d
+		type                       = "USER"
+	  }
+	  user_and_group_quotas {
+		id                         = 20
+		storage_capacity_quota_gib = %[5]d
+		type                       = "GROUP"
+	  }
+	  user_and_group_quotas {
+		id                         = 5
+		storage_capacity_quota_gib = %[5]d
+		type                       = "GROUP"
+	  }
+	  user_and_group_quotas {
+		id                         = 100
+		storage_capacity_quota_gib = %[4]d
+		type                       = "USER"
+	  }
   }
 
   tags = {

--- a/internal/service/fsx/openzfs_file_system_test.go
+++ b/internal/service/fsx/openzfs_file_system_test.go
@@ -1102,26 +1102,26 @@ resource "aws_fsx_openzfs_file_system" "test" {
     copy_tags_to_snapshots = true
     data_compression_type  = %[2]q
 
-	user_and_group_quotas {
-		id                         = 10
-		storage_capacity_quota_gib = %[4]d
-		type                       = "USER"
-	  }
-	  user_and_group_quotas {
-		id                         = 20
-		storage_capacity_quota_gib = %[5]d
-		type                       = "GROUP"
-	  }
-	  user_and_group_quotas {
-		id                         = 5
-		storage_capacity_quota_gib = %[5]d
-		type                       = "GROUP"
-	  }
-	  user_and_group_quotas {
-		id                         = 100
-		storage_capacity_quota_gib = %[4]d
-		type                       = "USER"
-	  }
+    user_and_group_quotas {
+      id                         = 10
+      storage_capacity_quota_gib = %[4]d
+      type                       = "USER"
+    }
+    user_and_group_quotas {
+      id                         = 20
+      storage_capacity_quota_gib = %[5]d
+      type                       = "GROUP"
+    }
+    user_and_group_quotas {
+      id                         = 5
+      storage_capacity_quota_gib = %[5]d
+      type                       = "GROUP"
+    }
+    user_and_group_quotas {
+      id                         = 100
+      storage_capacity_quota_gib = %[4]d
+      type                       = "USER"
+    }
   }
 
   tags = {

--- a/internal/service/fsx/openzfs_volume.go
+++ b/internal/service/fsx/openzfs_volume.go
@@ -520,9 +520,11 @@ func flattenFsxOpenzfsVolumeNfsExports(rs []*fsx.OpenZFSNfsExport) []map[string]
 	exports := make([]map[string]interface{}, 0)
 
 	for _, export := range rs {
-		cfg := make(map[string]interface{})
-		cfg["client_configurations"] = flattenFsxOpenzfsVolumeClientConfigurations(export.ClientConfigurations)
-		exports = append(exports, cfg)
+		if export != nil {
+			cfg := make(map[string]interface{})
+			cfg["client_configurations"] = flattenFsxOpenzfsVolumeClientConfigurations(export.ClientConfigurations)
+			exports = append(exports, cfg)
+		}
 	}
 
 	if len(exports) > 0 {
@@ -536,10 +538,12 @@ func flattenFsxOpenzfsVolumeClientConfigurations(rs []*fsx.OpenZFSClientConfigur
 	configurations := make([]map[string]interface{}, 0)
 
 	for _, configuration := range rs {
-		cfg := make(map[string]interface{})
-		cfg["clients"] = aws.StringValue(configuration.Clients)
-		cfg["options"] = flex.FlattenStringList(configuration.Options)
-		configurations = append(configurations, cfg)
+		if configuration != nil {
+			cfg := make(map[string]interface{})
+			cfg["clients"] = aws.StringValue(configuration.Clients)
+			cfg["options"] = flex.FlattenStringList(configuration.Options)
+			configurations = append(configurations, cfg)
+		}
 	}
 
 	if len(configurations) > 0 {
@@ -553,11 +557,13 @@ func flattenFsxOpenzfsVolumeUserAndGroupQuotas(rs []*fsx.OpenZFSUserOrGroupQuota
 	quotas := make([]map[string]interface{}, 0)
 
 	for _, quota := range rs {
-		cfg := make(map[string]interface{})
-		cfg["id"] = aws.Int64Value(quota.Id)
-		cfg["storage_capacity_quota_gib"] = aws.Int64Value(quota.StorageCapacityQuotaGiB)
-		cfg["type"] = aws.StringValue(quota.Type)
-		quotas = append(quotas, cfg)
+		if quota != nil {
+			cfg := make(map[string]interface{})
+			cfg["id"] = aws.Int64Value(quota.Id)
+			cfg["storage_capacity_quota_gib"] = aws.Int64Value(quota.StorageCapacityQuotaGiB)
+			cfg["type"] = aws.StringValue(quota.Type)
+			quotas = append(quotas, cfg)
+		}
 	}
 
 	if len(quotas) > 0 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22475

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccFSxOpenzfsFileSystem_rootVolume PKG=fsx
=== RUN   TestAccFSxOpenzfsFileSystem_rootVolume
=== PAUSE TestAccFSxOpenzfsFileSystem_rootVolume
=== CONT  TestAccFSxOpenzfsFileSystem_rootVolume
--- PASS: TestAccFSxOpenzfsFileSystem_rootVolume (1409.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1414.120s
...
```
