### PR TITLE
r/appsync_function - Support `sync_config` and `max_batch_size`

### DIFF
--- a/.changelog/22484.txt
+++ b/.changelog/22484.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appsync_function: Add `max_batch_size` and `sync_config` arguments.
+```

--- a/.changelog/22484.txt
+++ b/.changelog/22484.txt
@@ -1,7 +1,3 @@
 ```release-note:enhancement
 resource/aws_appsync_function: Add `max_batch_size` and `sync_config` arguments.
 ```
-
-```release-note:bug
-resource/aws_appsync_datasource: Fix `delta_sync_config` argument on read.
-```

--- a/.changelog/22484.txt
+++ b/.changelog/22484.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_appsync_function: Add `max_batch_size` and `sync_config` arguments.
 ```
+
+```release-note:bug
+resource/aws_appsync_datasource: Fix `delta_sync_config` argument on read.
+```

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -63,6 +63,7 @@ func TestAccAppSync_serial(t *testing.T) {
 			"disappears":              testAccAppSyncFunction_disappears,
 			"description":             testAccAppSyncFunction_description,
 			"responseMappingTemplate": testAccAppSyncFunction_responseMappingTemplate,
+			"sync":                    testAccAppSyncFunction_syncConfig,
 		},
 		"Resolver": {
 			"basic":             testAccAppSyncResolver_basic,

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -498,7 +498,7 @@ func flattenAppsyncDynamodbDataSourceConfig(config *appsync.DynamodbDataSourceCo
 	}
 
 	if config.DeltaSyncConfig != nil {
-		result["delte_sync_config"] = flattenAppsyncDynamodbDataSourceDeltaSyncConfig(config.DeltaSyncConfig)
+		result["delta_sync_config"] = flattenAppsyncDynamodbDataSourceDeltaSyncConfig(config.DeltaSyncConfig)
 	}
 
 	return []map[string]interface{}{result}

--- a/internal/service/appsync/function.go
+++ b/internal/service/appsync/function.go
@@ -132,7 +132,7 @@ func resourceFunctionCreate(d *schema.ResourceData, meta interface{}) error {
 		input.ResponseMappingTemplate = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("max_batch_size"); ok {
+	if v, ok := d.GetOkExists("max_batch_size"); ok {
 		input.MaxBatchSize = aws.Int64(int64(v.(int)))
 	}
 
@@ -219,6 +219,10 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("max_batch_size"); ok {
 		input.MaxBatchSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("sync_config"); ok && len(v.([]interface{})) > 0 {
+		input.SyncConfig = expandAppsyncSyncConfig(v.([]interface{}))
 	}
 
 	_, err = conn.UpdateFunction(input)

--- a/internal/service/appsync/function.go
+++ b/internal/service/appsync/function.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceFunction() *schema.Resource {
@@ -35,16 +36,15 @@ func ResourceFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"max_batch_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 2000),
+			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`[_A-Za-z][_0-9A-Za-z]*`).MatchString(value) {
-						errors = append(errors, fmt.Errorf("%q must match [_A-Za-z][_0-9A-Za-z]*", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[_A-Za-z][_0-9A-Za-z]*`), "must match [_A-Za-z][_0-9A-Za-z]*"),
 			},
 			"request_mapping_template": {
 				Type:     schema.TypeString,
@@ -69,6 +69,39 @@ func ResourceFunction() *schema.Resource {
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"sync_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"conflict_detection": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(appsync.ConflictDetectionType_Values(), false),
+						},
+						"conflict_handler": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(appsync.ConflictHandlerType_Values(), false),
+						},
+						"lambda_conflict_handler_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lambda_conflict_handler_arn": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidARN,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			"function_id": {
 				Type:     schema.TypeString,
@@ -99,9 +132,17 @@ func resourceFunctionCreate(d *schema.ResourceData, meta interface{}) error {
 		input.ResponseMappingTemplate = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("max_batch_size"); ok {
+		input.MaxBatchSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("sync_config"); ok && len(v.([]interface{})) > 0 {
+		input.SyncConfig = expandAppsyncSyncConfig(v.([]interface{}))
+	}
+
 	resp, err := conn.CreateFunction(input)
 	if err != nil {
-		return fmt.Errorf("Error creating AppSync Function: %s", err)
+		return fmt.Errorf("Error creating AppSync Function: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s-%s", apiID, aws.StringValue(resp.FunctionConfiguration.FunctionId)))
@@ -129,18 +170,24 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("Error getting AppSync Function %s: %s", d.Id(), err)
+		return fmt.Errorf("Error getting AppSync Function %s: %w", d.Id(), err)
 	}
 
+	function := resp.FunctionConfiguration
 	d.Set("api_id", apiID)
 	d.Set("function_id", functionID)
-	d.Set("data_source", resp.FunctionConfiguration.DataSourceName)
-	d.Set("description", resp.FunctionConfiguration.Description)
-	d.Set("arn", resp.FunctionConfiguration.FunctionArn)
-	d.Set("function_version", resp.FunctionConfiguration.FunctionVersion)
-	d.Set("name", resp.FunctionConfiguration.Name)
-	d.Set("request_mapping_template", resp.FunctionConfiguration.RequestMappingTemplate)
-	d.Set("response_mapping_template", resp.FunctionConfiguration.ResponseMappingTemplate)
+	d.Set("data_source", function.DataSourceName)
+	d.Set("description", function.Description)
+	d.Set("arn", function.FunctionArn)
+	d.Set("function_version", function.FunctionVersion)
+	d.Set("name", function.Name)
+	d.Set("request_mapping_template", function.RequestMappingTemplate)
+	d.Set("response_mapping_template", function.ResponseMappingTemplate)
+	d.Set("max_batch_size", function.MaxBatchSize)
+
+	if err := d.Set("sync_config", flattenAppsyncSyncConfig(function.SyncConfig)); err != nil {
+		return fmt.Errorf("error setting sync_config: %w", err)
+	}
 
 	return nil
 }
@@ -170,9 +217,13 @@ func resourceFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.ResponseMappingTemplate = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("max_batch_size"); ok {
+		input.MaxBatchSize = aws.Int64(int64(v.(int)))
+	}
+
 	_, err = conn.UpdateFunction(input)
 	if err != nil {
-		return fmt.Errorf("Error updating AppSync Function %s: %s", d.Id(), err)
+		return fmt.Errorf("Error updating AppSync Function %s: %w", d.Id(), err)
 	}
 
 	return resourceFunctionRead(d, meta)
@@ -196,7 +247,7 @@ func resourceFunctionDelete(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("Error deleting AppSync Function %s: %s", d.Id(), err)
+		return fmt.Errorf("Error deleting AppSync Function %s: %w", d.Id(), err)
 	}
 
 	return nil
@@ -208,4 +259,70 @@ func DecodeFunctionID(id string) (string, string, error) {
 		return "", "", fmt.Errorf("expected ID in format ApiID-FunctionID, received: %s", id)
 	}
 	return idParts[0], idParts[1], nil
+}
+
+func expandAppsyncSyncConfig(l []interface{}) *appsync.SyncConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	configured := l[0].(map[string]interface{})
+
+	result := &appsync.SyncConfig{}
+
+	if v, ok := configured["conflict_detection"].(string); ok {
+		result.ConflictDetection = aws.String(v)
+	}
+
+	if v, ok := configured["conflict_handler"].(string); ok {
+		result.ConflictHandler = aws.String(v)
+	}
+
+	if v, ok := configured["lambda_conflict_handler_config"].([]interface{}); ok && len(v) > 0 {
+		result.LambdaConflictHandlerConfig = expandAppsyncLambdaConflictHandlerConfig(v)
+	}
+
+	return result
+}
+
+func flattenAppsyncSyncConfig(config *appsync.SyncConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"conflict_detection":             aws.StringValue(config.ConflictDetection),
+		"conflict_handler":               aws.StringValue(config.ConflictHandler),
+		"lambda_conflict_handler_config": flattenAppsyncLambdaConflictHandlerConfig(config.LambdaConflictHandlerConfig),
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func expandAppsyncLambdaConflictHandlerConfig(l []interface{}) *appsync.LambdaConflictHandlerConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	configured := l[0].(map[string]interface{})
+
+	result := &appsync.LambdaConflictHandlerConfig{}
+
+	if v, ok := configured["lambda_conflict_handler_arn"].(string); ok {
+		result.LambdaConflictHandlerArn = aws.String(v)
+	}
+
+	return result
+}
+
+func flattenAppsyncLambdaConflictHandlerConfig(config *appsync.LambdaConflictHandlerConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"lambda_conflict_handler_arn": aws.StringValue(config.LambdaConflictHandlerArn),
+	}
+
+	return []map[string]interface{}{result}
 }

--- a/internal/service/appsync/function_test.go
+++ b/internal/service/appsync/function_test.go
@@ -280,11 +280,11 @@ resource "aws_appsync_datasource" "test" {
     table_name = aws_dynamodb_table.test.name
 	versioned  = true
 
-	delta_sync_config {
+    delta_sync_config {
       base_table_ttl        = 60
       delta_sync_table_name = aws_dynamodb_table.test.name
       delta_sync_table_ttl  = 60
-	}
+    }
   }
 }
 

--- a/internal/service/appsync/function_test.go
+++ b/internal/service/appsync/function_test.go
@@ -278,7 +278,7 @@ resource "aws_appsync_datasource" "test" {
   dynamodb_config {
     region     = %[2]q
     table_name = aws_dynamodb_table.test.name
-	versioned  = true
+    versioned  = true
 
     delta_sync_config {
       base_table_ttl        = 60

--- a/website/docs/r/appsync_function.html.markdown
+++ b/website/docs/r/appsync_function.html.markdown
@@ -78,11 +78,27 @@ The following arguments are supported:
 
 * `api_id` - (Required) The ID of the associated AppSync API.
 * `data_source` - (Required) The Function DataSource name.
+* `max_batch_size` - (Optional) The maximum batching size for a resolver. Valid values are between `0` and `2000`.
 * `name` - (Required) The Function name. The function name does not have to be unique.
 * `request_mapping_template` - (Required) The Function request mapping template. Functions support only the 2018-05-29 version of the request mapping template.
 * `response_mapping_template` - (Required) The Function response mapping template.
 * `description` - (Optional) The Function description.
+* `sync_config` - (Optional) Describes a Sync configuration for a resolver. See [Sync Config](#sync-config).
 * `function_version` - (Optional) The version of the request mapping template. Currently the supported value is `2018-05-29`.
+
+### Sync Config
+
+The following arguments are supported:
+
+* `conflict_detection` - (Optional) The Conflict Detection strategy to use. Valid values are `NONE` and `VERSION`.
+* `conflict_handler` - (Optional) The Conflict Resolution strategy to perform in the event of a conflict. Valid values are `NONE`, `OPTIMISTIC_CONCURRENCY`, `AUTOMERGE`, and `LAMBDA`.
+* `lambda_conflict_handler_config` - (Optional) The Lambda Conflict Handler Config when configuring `LAMBDA` as the Conflict Handler. See [Lambda Conflict Handler Config](#lambda-conflict-handler-config).
+
+#### Lambda Conflict Handler Config
+
+The following arguments are supported:
+
+* `lambda_conflict_handler_arn` - (Optional) The Amazon Resource Name (ARN) for the Lambda function to use as the Conflict Handler.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Requires #22411 (sync config only works for versioned data sources)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppSync_serial/Function/sync PKG=appsync > a.txt
--- PASS: TestAccAppSync_serial (76.11s)
    --- PASS: TestAccAppSync_serial/Function (76.11s)
        --- PASS: TestAccAppSync_serial/Function/sync (76.11s)
```
