### PR TITLE
r/aws_eks_cluster: Add ip_family argument

### DIFF
--- a/.changelog/22485.txt
+++ b/.changelog/22485.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_eks_cluster: Add `ip_family` argument
+resource/aws_eks_cluster: Add `ip_family` to the `kubernetes_network_config` configuration block
 ```

--- a/.changelog/22485.txt
+++ b/.changelog/22485.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add `ip_family` argument
+```

--- a/.changelog/22485.txt
+++ b/.changelog/22485.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_eks_cluster: Add `ip_family` to the `kubernetes_network_config` configuration block
 ```
+
+```release-note:enhancement
+data-source/aws_eks_cluster: Add `ip_family` to the `kubernetes_network_config` configuration block
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -137,6 +137,13 @@ func ResourceCluster() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"ip_family": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(eks.IpFamily_Values(), false),
+						},
 						"service_ipv4_cidr": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -146,13 +153,6 @@ func ResourceCluster() *schema.Resource {
 								validation.IsCIDRNetwork(12, 24),
 								validation.StringMatch(regexp.MustCompile(`^(10|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168)\..*`), "must be within 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16"),
 							),
-						},
-						"ip_family": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(eks.IpFamily_Values(), false),
 						},
 					},
 				},

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -147,6 +147,13 @@ func ResourceCluster() *schema.Resource {
 								validation.StringMatch(regexp.MustCompile(`^(10|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168)\..*`), "must be within 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16"),
 							),
 						},
+						"ip_family": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(eks.IpFamily_Values(), false),
+						},
 					},
 				},
 			},
@@ -615,6 +622,10 @@ func expandEksNetworkConfigRequest(tfList []interface{}) *eks.KubernetesNetworkC
 		apiObject.ServiceIpv4Cidr = aws.String(v)
 	}
 
+	if v, ok := tfMap["ip_family"].(string); ok && v != "" {
+		apiObject.IpFamily = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -748,6 +759,7 @@ func flattenEksNetworkConfig(apiObject *eks.KubernetesNetworkConfigResponse) []i
 
 	tfMap := map[string]interface{}{
 		"service_ipv4_cidr": aws.StringValue(apiObject.ServiceIpv4Cidr),
+		"ip_family":         aws.StringValue(apiObject.IpFamily),
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -69,6 +69,10 @@ func DataSourceCluster() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"ip_family": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"service_ipv4_cidr": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/internal/service/eks/cluster_data_source_test.go
+++ b/internal/service/eks/cluster_data_source_test.go
@@ -38,6 +38,7 @@ func TestAccEKSClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.#", dataSourceResourceName, "identity.0.oidc.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.0.issuer", dataSourceResourceName, "identity.0.oidc.0.issuer"),
 					resource.TestCheckResourceAttrPair(resourceName, "kubernetes_network_config.#", dataSourceResourceName, "kubernetes_network_config.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "kubernetes_network_config.0.ip_family", dataSourceResourceName, "kubernetes_network_config.0.ip_family"),
 					resource.TestCheckResourceAttrPair(resourceName, "kubernetes_network_config.0.service_ipv4_cidr", dataSourceResourceName, "kubernetes_network_config.0.service_ipv4_cidr"),
 					resource.TestMatchResourceAttr(dataSourceResourceName, "platform_version", regexp.MustCompile(`^eks\.\d+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", dataSourceResourceName, "role_arn"),

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -43,6 +43,7 @@ func TestAccEKSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "kubernetes_network_config.0.service_ipv4_cidr"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.0.ip_family", "ipv4"),
 					resource.TestMatchResourceAttr(resourceName, "platform_version", regexp.MustCompile(`^eks\.\d+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "status", eks.ClusterStatusActive),
@@ -548,6 +549,56 @@ func TestAccEKSCluster_Network_serviceIPv4CIDR(t *testing.T) {
 	})
 }
 
+func TestAccEKSCluster_Network_ipFamily(t *testing.T) {
+	var cluster1, cluster2 eks.Cluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_eks_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, eks.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterConfig_NetworkConfig_IPFamily(rName, `"v6"`),
+				ExpectError: regexp.MustCompile(`expected .* to be one of \[ipv4 ipv6]`),
+			},
+			{
+				Config:      testAccClusterConfig_NetworkConfig_IPFamily(rName, `"IPv4"`),
+				ExpectError: regexp.MustCompile(`expected .* to be one of \[ipv4 ipv6]`),
+			},
+			{
+				Config: testAccClusterConfig_NetworkConfig_IPFamily(rName, `"ipv6"`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.0.ip_family", "ipv6"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:             testAccClusterConfig_NetworkConfig_IPFamily(rName, `"ipv6"`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccClusterConfig_NetworkConfig_IPFamily(rName, `"ipv4"`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &cluster2),
+					testAccCheckClusterRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kubernetes_network_config.0.ip_family", "ipv4"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckClusterExists(resourceName string, cluster *eks.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -673,6 +724,8 @@ resource "aws_iam_role_policy_attachment" "test-AmazonEKSClusterPolicy" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
+  assign_generated_ipv6_cidr_block = true
+
   tags = {
     Name                          = %[1]q
     "kubernetes.io/cluster/%[1]s" = "shared"
@@ -685,6 +738,9 @@ resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.test.id
+
+  ipv6_cidr_block				  = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, count.index)
+  assign_ipv6_address_on_creation = true
 
   tags = {
     Name                          = %[1]q
@@ -930,4 +986,23 @@ resource "aws_eks_cluster" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
 `, rName, serviceIpv4Cidr))
+}
+
+func testAccClusterConfig_NetworkConfig_IPFamily(rName string, ipFamily string) string {
+	return acctest.ConfigCompose(testAccClusterConfig_Base(rName), fmt.Sprintf(`
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  kubernetes_network_config {
+    ip_family = %[2]s
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
+}
+`, rName, ipFamily))
 }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -739,7 +739,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.test.id
 
-  ipv6_cidr_block				  = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, count.index)
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, count.index)
   assign_ipv6_address_on_creation = true
 
   tags = {

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -201,6 +201,7 @@ The following arguments are supported in the `kubernetes_network_config` configu
     * Doesn't overlap with any CIDR block assigned to the VPC that you selected for VPC.
 
     * Between /24 and /12.
+* `ip_family` - (Optional) The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`. You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22407

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEKSCluster_Network_ipFamily PKG=eks

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSCluster_Network_ipFamily'  -timeout 180m
=== RUN   TestAccEKSCluster_Network_ipFamily
=== PAUSE TestAccEKSCluster_Network_ipFamily
=== CONT  TestAccEKSCluster_Network_ipFamily
--- PASS: TestAccEKSCluster_Network_ipFamily (1469.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	1473.522s
```
