### PR TITLE
New Resource: aws_memorydb_snapshot

### DIFF
--- a/.changelog/22486.txt
+++ b/.changelog/22486.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_memorydb_snapshot
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1403,6 +1403,7 @@ func Provider() *schema.Provider {
 			"aws_memorydb_acl":             memorydb.ResourceACL(),
 			"aws_memorydb_cluster":         memorydb.ResourceCluster(),
 			"aws_memorydb_parameter_group": memorydb.ResourceParameterGroup(),
+			"aws_memorydb_snapshot":        memorydb.ResourceSnapshot(),
 			"aws_memorydb_subnet_group":    memorydb.ResourceSubnetGroup(),
 			"aws_memorydb_user":            memorydb.ResourceUser(),
 

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -309,7 +309,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 			{
 				Config: testAccClusterConfigBaseNetwork(), // empty Config not supported
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSnapshotExists(rName),
+					testAccCheckSnapshotExistsByName(rName),
 				),
 			},
 		},
@@ -1028,7 +1028,7 @@ func testAccCheckClusterExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckSnapshotExists(snapshotName string) resource.TestCheckFunc {
+func testAccCheckSnapshotExistsByName(snapshotName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).MemoryDBConn
 

--- a/internal/service/memorydb/snapshot.go
+++ b/internal/service/memorydb/snapshot.go
@@ -1,0 +1,302 @@
+package memorydb
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceSnapshot() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSnapshotCreate,
+		ReadContext:   resourceSnapshotRead,
+		UpdateContext: resourceSnapshotUpdate,
+		DeleteContext: resourceSnapshotDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(snapshotAvailableTimeout),
+			Delete: schema.DefaultTimeout(snapshotDeletedTimeout),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"maintenance_window": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num_shards": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"parameter_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"snapshot_retention_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"snapshot_window": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"kms_key_arn": {
+				// The API will accept an ID, but return the ARN on every read.
+				// For the sake of consistency, force everyone to use ARN-s.
+				// To prevent confusion, the attribute is suffixed _arn rather
+				// than the _id implied by the API.
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringDoesNotMatch(
+						regexp.MustCompile(`[-][-]`),
+						"The name may not contain two consecutive hyphens."),
+					validation.StringMatch(
+						// Similar to ElastiCache, MemoryDB normalises names to lowercase.
+						regexp.MustCompile(`^[a-z0-9-]*[a-z0-9]$`),
+						"Only lowercase alphanumeric characters and hyphens allowed. The name may not end with a hyphen."),
+				),
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255-resource.UniqueIDSuffixLength),
+					validation.StringDoesNotMatch(
+						regexp.MustCompile(`[-][-]`),
+						"The name may not contain two consecutive hyphens."),
+					validation.StringMatch(
+						// Similar to ElastiCache, MemoryDB normalises names to lowercase.
+						regexp.MustCompile(`^[a-z0-9-]+$`),
+						"Only lowercase alphanumeric characters and hyphens allowed."),
+				),
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
+	input := &memorydb.CreateSnapshotInput{
+		ClusterName:  aws.String(d.Get("cluster_name").(string)),
+		SnapshotName: aws.String(name),
+		Tags:         Tags(tags.IgnoreAWS()),
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok {
+		input.KmsKeyId = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating MemoryDB Snapshot: %s", input)
+	_, err := conn.CreateSnapshotWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("error creating MemoryDB Snapshot (%s): %s", name, err)
+	}
+
+	if err := waitSnapshotAvailable(ctx, conn, name, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for MemoryDB Snapshot (%s) to be created: %s", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceSnapshotRead(ctx, d, meta)
+}
+
+func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return diag.Errorf("error updating MemoryDB Snapshot (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceSnapshotRead(ctx, d, meta)
+}
+
+func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	snapshot, err := FindSnapshotByName(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] MemoryDB Snapshot (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error reading MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", snapshot.ARN)
+	if err := d.Set("cluster_configuration", flattenClusterConfiguration(snapshot.ClusterConfiguration)); err != nil {
+		return diag.Errorf("failed to set cluster_configuration for MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+	d.Set("cluster_name", snapshot.ClusterConfiguration.Name)
+	d.Set("kms_key_arn", snapshot.KmsKeyId)
+	d.Set("name", snapshot.Name)
+	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(snapshot.Name)))
+	d.Set("source", snapshot.Source)
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return diag.Errorf("error listing tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.Errorf("error setting tags_all for MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).MemoryDBConn
+
+	log.Printf("[DEBUG] Deleting MemoryDB Snapshot: (%s)", d.Id())
+	_, err := conn.DeleteSnapshotWithContext(ctx, &memorydb.DeleteSnapshotInput{
+		SnapshotName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, memorydb.ErrCodeSnapshotNotFoundFault) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error deleting MemoryDB Snapshot (%s): %s", d.Id(), err)
+	}
+
+	if err := waitSnapshotDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for MemoryDB Snapshot (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func flattenClusterConfiguration(v *memorydb.ClusterConfiguration) []interface{} {
+	if v == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"description":              aws.StringValue(v.Description),
+		"engine_version":           aws.StringValue(v.EngineVersion),
+		"maintenance_window":       aws.StringValue(v.MaintenanceWindow),
+		"name":                     aws.StringValue(v.Name),
+		"node_type":                aws.StringValue(v.NodeType),
+		"num_shards":               aws.Int64Value(v.NumShards),
+		"parameter_group_name":     aws.StringValue(v.ParameterGroupName),
+		"port":                     aws.Int64Value(v.Port),
+		"snapshot_retention_limit": aws.Int64Value(v.SnapshotRetentionLimit),
+		"snapshot_window":          aws.StringValue(v.SnapshotWindow),
+		"subnet_group_name":        aws.StringValue(v.SubnetGroupName),
+		"topic_arn":                aws.StringValue(v.TopicArn),
+		"vpc_id":                   aws.StringValue(v.VpcId),
+	}
+
+	return []interface{}{m}
+}

--- a/internal/service/memorydb/snapshot_test.go
+++ b/internal/service/memorydb/snapshot_test.go
@@ -1,0 +1,403 @@
+package memorydb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/memorydb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfmemorydb "github.com/hashicorp/terraform-provider-aws/internal/service/memorydb"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccMemoryDBSnapshot_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "memorydb", "snapshot/"+rName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.description", "aws_memorydb_cluster.test", "description"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.engine_version", "aws_memorydb_cluster.test", "engine_version"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.maintenance_window", "aws_memorydb_cluster.test", "maintenance_window"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.name", "aws_memorydb_cluster.test", "name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.node_type", "aws_memorydb_cluster.test", "node_type"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.num_shards", "aws_memorydb_cluster.test", "num_shards"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.parameter_group_name", "aws_memorydb_cluster.test", "parameter_group_name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.port", "aws_memorydb_cluster.test", "port"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.snapshot_retention_limit", "aws_memorydb_cluster.test", "snapshot_retention_limit"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.snapshot_window", "aws_memorydb_cluster.test", "snapshot_window"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.subnet_group_name", "aws_memorydb_cluster.test", "subnet_group_name"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.vpc_id", "aws_memorydb_subnet_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "source", "manual"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Test", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMemoryDBSnapshot_disappears(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfmemorydb.ResourceSnapshot(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccMemoryDBSnapshot_nameGenerated(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotConfig_withNoName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					create.TestCheckResourceAttrNameGenerated(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "terraform-"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMemoryDBSnapshot_namePrefix(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotConfig_withNamePrefix(rName, "tftest-"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					create.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tftest-"),
+					resource.TestCheckResourceAttr(resourceName, "name_prefix", "tftest-"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMemoryDBSnapshot_create_withKMS(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotConfig_withKMS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "kms_key_arn", "aws_kms_key.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMemoryDBSnapshot_update_tags(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, memorydb.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSnapshotConfig_withTags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSnapshotConfig_withTags2(rName, "Key1", "value1", "Key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSnapshotConfig_withTags1(rName, "Key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.Key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSnapshotConfig_withTags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckSnapshotDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).MemoryDBConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_memorydb_snapshot" {
+			continue
+		}
+
+		_, err := tfmemorydb.FindSnapshotByName(context.Background(), conn, rs.Primary.Attributes["name"])
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("MemoryDB Snapshot %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckSnapshotExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No MemoryDB Snapshot ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MemoryDBConn
+
+		_, err := tfmemorydb.FindSnapshotByName(context.Background(), conn, rs.Primary.Attributes["name"])
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccSnapshotConfigBase(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVpcWithSubnets(2),
+		fmt.Sprintf(`
+resource "aws_memorydb_subnet_group" "test" {
+  subnet_ids = aws_subnet.test.*.id
+}
+
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = %[1]q
+  vpc_id      = aws_vpc.test.id
+}
+
+resource "aws_memorydb_cluster" "test" {
+  acl_name                 = "open-access"
+  name                     = %[1]q
+  node_type                = "db.t4g.small"
+  num_replicas_per_shard   = 0
+  num_shards               = 1
+  security_group_ids       = [aws_security_group.test.id]
+  snapshot_retention_limit = 0
+  subnet_group_name        = aws_memorydb_subnet_group.test.id
+}
+`, rName),
+	)
+}
+
+func testAccSnapshotConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  name         = %[1]q
+
+  tags = {
+    Test = "test"
+  }
+}
+`, rName),
+	)
+}
+
+func testAccSnapshotConfig_withKMS(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  kms_key_arn  = aws_kms_key.test.arn
+  name         = %[1]q
+}
+`, rName),
+	)
+}
+
+func testAccSnapshotConfig_withNoName(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		`
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+}
+`,
+	)
+}
+
+func testAccSnapshotConfig_withNamePrefix(rName, prefix string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  name_prefix  = %[1]q
+
+  tags = {
+    Test = "test"
+  }
+}
+`, prefix),
+	)
+}
+
+func testAccSnapshotConfig_withTags0(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  name         = %[1]q
+}
+`, rName),
+	)
+}
+
+func testAccSnapshotConfig_withTags1(rName, tag1Key, tag1Value string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  name         = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tag1Key, tag1Value),
+	)
+}
+
+func testAccSnapshotConfig_withTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return acctest.ConfigCompose(
+		testAccSnapshotConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_memorydb_snapshot" "test" {
+  cluster_name = aws_memorydb_cluster.test.name
+  name         = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value),
+	)
+}

--- a/internal/service/memorydb/status.go
+++ b/internal/service/memorydb/status.go
@@ -31,6 +31,10 @@ const (
 	clusterSnsTopicStatusActive   = "ACTIVE"
 	clusterSnsTopicStatusInactive = "INACTIVE"
 
+	snapshotStatusCreating  = "creating"
+	snapshotStatusAvailable = "available"
+	snapshotStatusDeleting  = "deleting"
+
 	userStatusActive    = "active"
 	userStatusDeleting  = "deleting"
 	userStatusModifying = "modifying"
@@ -110,6 +114,23 @@ func statusClusterSecurityGroups(ctx context.Context, conn *memorydb.MemoryDB, c
 		}
 
 		return cluster, clusterSecurityGroupStatusActive, nil
+	}
+}
+
+// statusSnapshot fetches the MemoryDB Snapshot and its status.
+func statusSnapshot(ctx context.Context, conn *memorydb.MemoryDB, snapshotName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		snapshot, err := FindSnapshotByName(ctx, conn, snapshotName)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return snapshot, aws.StringValue(snapshot.Status), nil
 	}
 }
 

--- a/website/docs/r/memorydb_snapshot.html.markdown
+++ b/website/docs/r/memorydb_snapshot.html.markdown
@@ -1,0 +1,70 @@
+---
+subcategory: "MemoryDB"
+layout: "aws"
+page_title: "AWS: aws_memorydb_snapshot"
+description: |-
+  Provides a MemoryDB Snapshot.
+---
+
+# Resource: aws_memorydb_snapshot
+
+Provides a MemoryDB Snapshot.
+
+More information about snapshot and restore can be found in the [MemoryDB User Guide](https://docs.aws.amazon.com/memorydb/latest/devguide/snapshots.html).
+
+## Example Usage
+
+```terraform
+resource "aws_memorydb_snapshot" "example" {
+  cluster_name = aws_memorydb_cluster.example.name
+  name         = "my-snapshot"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_name` - (Required, Forces new resource) Name of the MemoryDB cluster to take a snapshot of.
+* `name` - (Optional, Forces new resource) Name of the snapshot. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `kms_key_arn` - (Optional, Forces new resource) ARN of the KMS key used to encrypt the snapshot at rest.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the snapshot.
+* `arn` - The ARN of the snapshot.
+* `cluster_configuration` - The configuration of the cluster from which the snapshot was taken.
+    * `description` - Description for the cluster.
+    * `engine_version` - Version number of the Redis engine used by the cluster.
+    * `maintenance_window` - The weekly time range during which maintenance on the cluster is performed.
+    * `name` - Name of the cluster.
+    * `node_type` - Compute and memory capacity of the nodes in the cluster.
+    * `num_shards` - Number of shards in the cluster.
+    * `parameter_group_name` - Name of the parameter group associated with the cluster.
+    * `port` - Port number on which the cluster accepts connections.
+    * `snapshot_retention_limit` - Number of days for which MemoryDB retains automatic snapshots before deleting them.
+    * `snapshot_window` - The daily time range (in UTC) during which MemoryDB begins taking a daily snapshot of the shard.
+    * `subnet_group_name` - Name of the subnet group used by the cluster.
+    * `topic_arn` - ARN of the SNS topic to which cluster notifications are sent.
+    * `vpc_id` - The VPC in which the cluster exists.
+* `source` - Indicates whether the snapshot is from an automatic backup (`automated`) or was created manually (`manual`).
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Timeouts
+
+`aws_memorydb_snapshot` provides the following [timeout configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+- `create` - (Default `120 minutes`) Used when taking the snapshot of a cluster.
+- `delete` - (Default `120 minutes`) Used when deleting a snapshot.
+
+## Import
+
+Use the `name` to import a snapshot. For example:
+
+```
+$ terraform import aws_memorydb_snapshot.example my-snapshot
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20631

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=memorydb TESTS=TestAccMemoryDBSnapshot_ ACCTEST_PARALLELISM=3 ACCTEST_TIMEOUT=600m
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 3 -run='TestAccMemoryDBSnapshot_' -timeout 600m
=== RUN   TestAccMemoryDBSnapshot_basic
=== PAUSE TestAccMemoryDBSnapshot_basic
=== RUN   TestAccMemoryDBSnapshot_disappears
=== PAUSE TestAccMemoryDBSnapshot_disappears
=== RUN   TestAccMemoryDBSnapshot_nameGenerated
=== PAUSE TestAccMemoryDBSnapshot_nameGenerated
=== RUN   TestAccMemoryDBSnapshot_namePrefix
=== PAUSE TestAccMemoryDBSnapshot_namePrefix
=== RUN   TestAccMemoryDBSnapshot_create_withKMS
=== PAUSE TestAccMemoryDBSnapshot_create_withKMS
=== RUN   TestAccMemoryDBSnapshot_update_tags
=== PAUSE TestAccMemoryDBSnapshot_update_tags
=== CONT  TestAccMemoryDBSnapshot_basic
=== CONT  TestAccMemoryDBSnapshot_namePrefix
=== CONT  TestAccMemoryDBSnapshot_update_tags
--- PASS: TestAccMemoryDBSnapshot_namePrefix (2116.01s)
=== CONT  TestAccMemoryDBSnapshot_nameGenerated
--- PASS: TestAccMemoryDBSnapshot_basic (2117.61s)
=== CONT  TestAccMemoryDBSnapshot_create_withKMS
--- PASS: TestAccMemoryDBSnapshot_update_tags (2219.01s)
=== CONT  TestAccMemoryDBSnapshot_disappears
--- PASS: TestAccMemoryDBSnapshot_nameGenerated (2167.53s)
--- PASS: TestAccMemoryDBSnapshot_create_withKMS (2208.95s)
--- PASS: TestAccMemoryDBSnapshot_disappears (2230.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   4450.952s
```
