### PR TITLE
[docs] r/aws_subnet - add missing Attribute References

### DIFF
--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -76,9 +76,17 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the subnet
 * `arn` - The ARN of the subnet.
+* `assign_ipv6_address_on_creation` - Whether or not the network interfaces created in the specific subnet has been assigned an IPv6 address.
+* `availability_zone` - The AZ for the subnet.
+* `availability_zone_id` - The AZ ID of the subnet.
+* `cidr_block` - The IPv4 CIDR block for the subnet.
+* `ipv6_cidr_block` - The IPv6 network range for the subnet
 * `ipv6_cidr_block_association_id` - The association ID for the IPv6 CIDR block.
+* `map_public_ip_on_launch` - Whether or not subnet has a public IP Assigned.
+* `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.
 * `owner_id` - The ID of the AWS account that owns the subnet.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `vpc_id` - The VPC ID.
 
 ## Timeouts
 


### PR DESCRIPTION
### Version 

Version: `Terraform v0.14.4`

### Summary



Update the [Attribute Reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#attributes-reference) for `aws_subnet` to better reflect the outputs.

There are many of the attribute references are missing from the documentation but are actually available.

#### Example output:

```sh
  {
    "arn" = "arn:aws:ec2:us-east-1:222132484852:subnet/subnet-091afc4e4438ff6d5"
    "assign_ipv6_address_on_creation" = false
    "availability_zone" = "us-east-1a"
    "availability_zone_id" = "use1-az2"
    "cidr_block" = "10.0.1.0/24"
    "id" = "subnet-091afc4e4438ff6d5"
    "ipv6_cidr_block" = ""
    "ipv6_cidr_block_association_id" = ""
    "map_public_ip_on_launch" = false
    "outpost_arn" = ""
    "owner_id" = "222132484852"
    "tags" = {
      "Name" = "subnet-public-us-east-1a"
    }
    "vpc_id" = "vpc-0fbe9811ef6584db0"
  },
```


code reference: [ec2/subnet.go](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/subnet.go#L299-L368)


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
