### PR TITLE
r/aws_vpc_ipam_preview_next_cidr - new attribute

### DIFF
--- a/.changelog/22501.txt
+++ b/.changelog/22501.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_ipam_preview_next_cidr: Add `disallowed_cidrs` argument
+```

--- a/internal/service/ec2/vpc_ipam_preview_next_cidr.go
+++ b/internal/service/ec2/vpc_ipam_preview_next_cidr.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	// "github.com/hashicorp/terraform-provider-aws/internal/flex"
-	// "github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceVPCIpamPreviewNextCidr() *schema.Resource {
@@ -24,20 +24,19 @@ func ResourceVPCIpamPreviewNextCidr() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			// // temp comment out till bug is resolved
-			// "disallowed_cidrs": {
-			// 	Type:     schema.TypeSet,
-			// 	Optional: true,
-			// 	ForceNew: true,
-			// 	Elem: &schema.Schema{
-			// 		Type: schema.TypeString,
-			// 		ValidateFunc: validation.Any(
-			// 			verify.ValidIPv4CIDRNetworkAddress,
-			// 			// Follow the numbers used for netmask_length
-			// 			validation.IsCIDRNetwork(0, 32),
-			// 		),
-			// 	},
-			// },
+			"disallowed_cidrs": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.Any(
+						verify.ValidIPv4CIDRNetworkAddress,
+						// Follow the numbers used for netmask_length
+						validation.IsCIDRNetwork(0, 32),
+					),
+				},
+			},
 			"ipam_pool_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -70,9 +69,9 @@ func resourceVPCIpamPreviewNextCidrCreate(d *schema.ResourceData, meta interface
 		PreviewNextCidr: aws.Bool(true),
 	}
 
-	// if v, ok := d.GetOk("disallowed_cidrs"); ok && v.(*schema.Set).Len() > 0 {
-	// 	input.DisallowedCidrs = flex.ExpandStringSet(v.(*schema.Set))
-	// }
+	if v, ok := d.GetOk("disallowed_cidrs"); ok && v.(*schema.Set).Len() > 0 {
+		input.DisallowedCidrs = flex.ExpandStringSet(v.(*schema.Set))
+	}
 
 	if v, ok := d.GetOk("netmask_length"); ok {
 		input.NetmaskLength = aws.Int64(int64(v.(int)))

--- a/internal/service/ec2/vpc_ipam_preview_next_cidr_test.go
+++ b/internal/service/ec2/vpc_ipam_preview_next_cidr_test.go
@@ -66,32 +66,32 @@ func TestAccVPCIpamPreviewNextCidr_ipv4Allocated(t *testing.T) {
 	})
 }
 
-// // temp comment out till bug is resolved
-// func TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr(t *testing.T) {
-// 	resourceName := "aws_vpc_ipam_preview_next_cidr.test"
-// 	disallowedCidr := "172.2.0.0/32"
-// 	netmaskLength := "28"
+func TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr(t *testing.T) {
+	resourceName := "aws_vpc_ipam_preview_next_cidr.test"
+	disallowedCidr := "172.2.0.0/28"
+	netmaskLength := "28"
+	expectedCidr := "172.2.0.16/28"
 
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
-// 		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
-// 		Providers:    acctest.Providers,
-// 		CheckDestroy: nil,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccVPCIpamPreviewNextCidrIpv4DisallowedCidr(netmaskLength, disallowedCidr),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrSet(resourceName, "cidr"),
-// 					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.#", "1"),
-// 					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.0", disallowedCidr),
-// 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-// 					resource.TestCheckResourceAttrPair(resourceName, "ipam_pool_id", "aws_vpc_ipam_pool.test", "id"),
-// 					resource.TestCheckResourceAttr(resourceName, "netmask_length", netmaskLength),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccIPAMPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCIpamPreviewNextCidrIpv4DisallowedCidr(netmaskLength, disallowedCidr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cidr", expectedCidr),
+					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disallowed_cidrs.0", disallowedCidr),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "ipam_pool_id", "aws_vpc_ipam_pool.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "netmask_length", netmaskLength),
+				),
+			},
+		},
+	})
+}
 
 const testAccVPCIpamPreviewNextCidrIpv4Base = `
 data "aws_region" "current" {}
@@ -150,20 +150,19 @@ resource "aws_vpc_ipam_pool_cidr_allocation" "test" {
 `, netmaskLength))
 }
 
-// // temp comment out till bug is resolved
-// func testAccVPCIpamPreviewNextCidrIpv4DisallowedCidr(netmaskLength, disallowedCidr string) string {
-// 	return testAccVPCIpamPreviewNextCidrIpv4Base + fmt.Sprintf(`
-// resource "aws_vpc_ipam_preview_next_cidr" "test" {
-//   ipam_pool_id   = aws_vpc_ipam_pool.test.id
-//   netmask_length = %[1]q
+func testAccVPCIpamPreviewNextCidrIpv4DisallowedCidr(netmaskLength, disallowedCidr string) string {
+	return testAccVPCIpamPreviewNextCidrIpv4Base + fmt.Sprintf(`
+resource "aws_vpc_ipam_preview_next_cidr" "test" {
+  ipam_pool_id   = aws_vpc_ipam_pool.test.id
+  netmask_length = %[1]q
 
-//   disallowed_cidrs = [
-//     %[2]q
-//   ]
+  disallowed_cidrs = [
+    %[2]q
+  ]
 
-//   depends_on = [
-//     aws_vpc_ipam_pool_cidr.test
-//   ]
-// }
-// `, netmaskLength, disallowedCidr)
-// }
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.test
+  ]
+}
+`, netmaskLength, disallowedCidr)
+}

--- a/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
@@ -21,6 +21,10 @@ resource "aws_vpc_ipam_preview_next_cidr" "example" {
   ipam_pool_id   = aws_vpc_ipam_pool.example.id
   netmask_length = 28
 
+  disallowed_cidrs = [
+	  "172.2.0.0/32"
+  ]
+
   depends_on = [
     aws_vpc_ipam_pool_cidr.example
   ]
@@ -48,6 +52,7 @@ resource "aws_vpc_ipam" "example" {
 
 The following arguments are supported:
 
+* `disallowed_cidrs` - (Optional) Exclude a particular CIDR range from being returned by the pool.
 * `ipam_pool_id` - (Required) The ID of the pool to which you want to assign a CIDR.
 * `netmask_length` - (Optional) The netmask length of the CIDR you would like to preview from the IPAM pool.
 

--- a/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
@@ -22,7 +22,7 @@ resource "aws_vpc_ipam_preview_next_cidr" "example" {
   netmask_length = 28
 
   disallowed_cidrs = [
-	  "172.2.0.0/32"
+    "172.2.0.0/32"
   ]
 
   depends_on = [


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22305

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccVPCIpamPreviewNextCidr PKG=ec2 ACCTEST_PARALLELISM=1  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 1 -run='TestAccVPCIpamPreviewNextCidr'  -timeout 180m
=== RUN   TestAccVPCIpamPreviewNextCidr_ipv4Basic
=== PAUSE TestAccVPCIpamPreviewNextCidr_ipv4Basic
=== RUN   TestAccVPCIpamPreviewNextCidr_ipv4Allocated
=== PAUSE TestAccVPCIpamPreviewNextCidr_ipv4Allocated
=== RUN   TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr
=== PAUSE TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr
=== CONT  TestAccVPCIpamPreviewNextCidr_ipv4Basic
--- PASS: TestAccVPCIpamPreviewNextCidr_ipv4Basic (101.96s)
=== CONT  TestAccVPCIpamPreviewNextCidr_ipv4Allocated
--- PASS: TestAccVPCIpamPreviewNextCidr_ipv4Allocated (149.21s)
=== CONT  TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr
--- PASS: TestAccVPCIpamPreviewNextCidr_ipv4DisallowedCidr (121.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        380.761s
...
```
