### PR TITLE
Modifications to resolve github CI errors

### DIFF
--- a/.changelog/22438.txt
+++ b/.changelog/22438.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
-resource/aws_vpc_ipam_pool: Modified ipam pool data source and test to fix github CI errors
+data-source/aws_vpc_ipam_pool: Return an error if more than 1 IPAM Pool matches
+```
+
+```release-note:bug
+data-source/aws_vpc_ipam_pool: Set `address_family`, `allocation_default_netmask_length`, `allocation_max_netmask_length`, `allocation_min_netmask_length` and `tags` attributes
 ```

--- a/.changelog/22438.txt
+++ b/.changelog/22438.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_ipam_pool: Modified ipam pool data source and test to fix github CI errors
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ BUG FIXES:
 
 * resource/aws_cloudfront_distribution: Increase the maximum valid `origin_read_timeout` value to `180` ([#22461](https://github.com/hashicorp/terraform-provider-aws/issues/22461))
 * resource/aws_fsx_lustre_file_system: Add missing values to `per_unit_storage_throughput` validation ([#22462](https://github.com/hashicorp/terraform-provider-aws/issues/22462))
-* resource/aws_vpc_ipam_pool: Modified ipam pool data source and test to fix github CI errors. [#22438](https://github.com/hashicorp/terraform-provider-aws/issues/22438)
 
 ## 3.71.0 (January 06, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ BUG FIXES:
 
 * resource/aws_cloudfront_distribution: Increase the maximum valid `origin_read_timeout` value to `180` ([#22461](https://github.com/hashicorp/terraform-provider-aws/issues/22461))
 * resource/aws_fsx_lustre_file_system: Add missing values to `per_unit_storage_throughput` validation ([#22462](https://github.com/hashicorp/terraform-provider-aws/issues/22462))
+* resource/aws_vpc_ipam_pool: Modified ipam pool data source and test to fix github CI errors. [#22438](https://github.com/hashicorp/terraform-provider-aws/issues/22438)
 
 ## 3.71.0 (January 06, 2022)
 

--- a/internal/service/ec2/vpc_ipam_pool.go
+++ b/internal/service/ec2/vpc_ipam_pool.go
@@ -206,24 +206,18 @@ func ResourceVPCIpamPoolRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("arn", pool.IpamPoolArn)
-
-	scopeId := strings.Split(*pool.IpamScopeArn, "/")[1]
-
 	d.Set("address_family", pool.AddressFamily)
-
-	if pool.PubliclyAdvertisable != nil {
-		d.Set("publicly_advertisable", pool.PubliclyAdvertisable)
-	}
-
 	d.Set("allocation_resource_tags", KeyValueTags(ec2TagsFromIpamAllocationTags(pool.AllocationResourceTags)).Map())
+	d.Set("arn", pool.IpamPoolArn)
 	d.Set("auto_import", pool.AutoImport)
+	d.Set("aws_service", pool.AwsService)
 	d.Set("description", pool.Description)
-	d.Set("ipam_scope_id", scopeId)
+	scopeID := strings.Split(aws.StringValue(pool.IpamScopeArn), "/")[1]
+	d.Set("ipam_scope_id", scopeID)
 	d.Set("ipam_scope_type", pool.IpamScopeType)
 	d.Set("locale", pool.Locale)
 	d.Set("pool_depth", pool.PoolDepth)
-	d.Set("aws_service", pool.AwsService)
+	d.Set("publicly_advertisable", pool.PubliclyAdvertisable)
 	d.Set("source_ipam_pool_id", pool.SourceIpamPoolId)
 	d.Set("state", pool.State)
 

--- a/internal/service/ec2/vpc_ipam_pool_data_source.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -115,6 +116,11 @@ func dataSourceVPCIpamPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if output == nil || len(output.IpamPools) == 0 || output.IpamPools[0] == nil {
 		return nil
 	}
+
+	if len(output.IpamPools) > 1 {
+		return fmt.Errorf("multiple IPAM Pools matched; use additional constraints to reduce matches to a single IPAM pool")
+	}
+
 	pool = output.IpamPools[0]
 
 	d.SetId(aws.StringValue(pool.IpamPoolId))

--- a/internal/service/ec2/vpc_ipam_pool_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source_test.go
@@ -1,12 +1,10 @@
 package ec2_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
@@ -21,34 +19,28 @@ func TestAccDataSourceVPCIpamPool_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVPCIpamPoolOptions,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceVPCIpamPoolID(dataSourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "address_family", resourceName, "address_family"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "allocation_default_netmask_length", resourceName, "allocation_default_netmask_length"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "allocation_max_netmask_length", resourceName, "allocation_max_netmask_length"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "allocation_min_netmask_length", resourceName, "allocation_min_netmask_length"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "allocation_resource_tags.%", resourceName, "allocation_resource_tags.%"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "auto_import", resourceName, "auto_import"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "aws_service", resourceName, "aws_service"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ipam_scope_id", resourceName, "ipam_scope_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ipam_scope_type", resourceName, "ipam_scope_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "locale", resourceName, "locale"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "pool_depth", resourceName, "pool_depth"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "publicly_advertisable", resourceName, "publicly_advertisable"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "source_ipam_pool_id", resourceName, "source_ipam_pool_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "state", resourceName, "state"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckDataSourceVPCIpamPoolID(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find ipam pool: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("ipam pool ID not set")
-		}
-		return nil
-	}
 }
 
 const testAccVPCIpamPoolOptions = testAccVPCIpamPoolBase + `

--- a/internal/service/ec2/vpc_ipam_pool_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source_test.go
@@ -43,7 +43,7 @@ func TestAccDataSourceVPCIpamPool_basic(t *testing.T) {
 	})
 }
 
-const testAccVPCIpamPoolOptions = testAccVPCIpamPoolBase + `
+var testAccVPCIpamPoolOptions = acctest.ConfigCompose(testAccVPCIpamPoolBase, `
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv4"
   ipam_scope_id                     = aws_vpc_ipam.test.private_default_scope_id
@@ -58,6 +58,6 @@ resource "aws_vpc_ipam_pool" "test" {
 }
 
 data "aws_vpc_ipam_pool" "test" {
-	ipam_pool_id = aws_vpc_ipam_pool.test.id	
+  ipam_pool_id = aws_vpc_ipam_pool.test.id
 }
-`
+`)

--- a/internal/service/ec2/vpc_ipam_pool_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source_test.go
@@ -66,6 +66,6 @@ resource "aws_vpc_ipam_pool" "test" {
 }
 
 data "aws_vpc_ipam_pool" "test" {
-  depends_on = [aws_vpc_ipam_pool.test]
+	ipam_pool_id = aws_vpc_ipam_pool.test.id	
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #22438

2022-01-10T09:32:26-08:00 info layer=debugger launching process with args: [/var/folders/km/mt9r_90d1fv2_rpcb1nxkjb8_kl971/T/__debug_bin1626238921 -test.v -test.run ^TestAccDataSourceVPCIpamPool_basic$]
Type 'dlv help' for list of commands.
2022-01-10T09:32:33-08:00 debug layer=debugger continuing
=== RUN   TestAccDataSourceVPCIpamPool_basic
=== PAUSE TestAccDataSourceVPCIpamPool_basic
=== CONT  TestAccDataSourceVPCIpamPool_basic
--- PASS: TestAccDataSourceVPCIpamPool_basic (59.77s)
PASS
Process 54636 has exited with status 0
Detaching
2022-01-10T09:33:32-08:00 debug layer=debugger detaching
dlv dap (54591) exited with code: 0


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=func TestAccDataSourceVPCIpamPool_basic' PKG_NAME='./internal/service/ec2'

...
```
