### PR TITLE
r/appsync_resolver - add `sync_config` and `max_batch_size`

### DIFF
--- a/.changelog/22510.txt
+++ b/.changelog/22510.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appsync_resolver: Add `max_batch_size` and `sync_config` arguments.
+```

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -75,6 +75,7 @@ func TestAccAppSync_serial(t *testing.T) {
 			"multipleResolvers": testAccAppSyncResolver_multipleResolvers,
 			"pipeline":          testAccAppSyncResolver_pipeline,
 			"caching":           testAccAppSyncResolver_caching,
+			"sync":              testAccAppSyncResolver_syncConfig,
 		},
 	}
 

--- a/internal/service/appsync/resolver.go
+++ b/internal/service/appsync/resolver.go
@@ -47,6 +47,11 @@ func ResourceResolver() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"pipeline_config"},
 			},
+			"max_batch_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 2000),
+			},
 			"request_template": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -56,13 +61,10 @@ func ResourceResolver() *schema.Resource {
 				Optional: true,
 			},
 			"kind": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  appsync.ResolverKindUnit,
-				ValidateFunc: validation.StringInSlice([]string{
-					appsync.ResolverKindUnit,
-					appsync.ResolverKindPipeline,
-				}, true),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      appsync.ResolverKindUnit,
+				ValidateFunc: validation.StringInSlice(appsync.ResolverKind_Values(), true),
 			},
 			"pipeline_config": {
 				Type:          schema.TypeList,
@@ -93,11 +95,43 @@ func ResourceResolver() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-							Set: schema.HashString,
 						},
 						"ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
+						},
+					},
+				},
+			},
+			"sync_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"conflict_detection": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(appsync.ConflictDetectionType_Values(), false),
+						},
+						"conflict_handler": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(appsync.ConflictHandlerType_Values(), false),
+						},
+						"lambda_conflict_handler_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lambda_conflict_handler_arn": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidARN,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -118,6 +152,14 @@ func resourceResolverCreate(d *schema.ResourceData, meta interface{}) error {
 		TypeName:  aws.String(d.Get("type").(string)),
 		FieldName: aws.String(d.Get("field").(string)),
 		Kind:      aws.String(d.Get("kind").(string)),
+	}
+
+	if v, ok := d.GetOkExists("max_batch_size"); ok {
+		input.MaxBatchSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("sync_config"); ok && len(v.([]interface{})) > 0 {
+		input.SyncConfig = expandAppsyncSyncConfig(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("data_source"); ok {
@@ -152,7 +194,7 @@ func resourceResolverCreate(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error creating AppSync Resolver: %s", err)
+		return fmt.Errorf("error creating AppSync Resolver: %w", err)
 	}
 
 	d.SetId(d.Get("api_id").(string) + "-" + d.Get("type").(string) + "-" + d.Get("field").(string))
@@ -184,24 +226,30 @@ func resourceResolverRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error getting AppSync Resolver (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting AppSync Resolver (%s): %w", d.Id(), err)
 	}
 
+	resolver := resp.Resolver
 	d.Set("api_id", apiID)
-	d.Set("arn", resp.Resolver.ResolverArn)
-	d.Set("type", resp.Resolver.TypeName)
-	d.Set("field", resp.Resolver.FieldName)
-	d.Set("data_source", resp.Resolver.DataSourceName)
-	d.Set("request_template", resp.Resolver.RequestMappingTemplate)
-	d.Set("response_template", resp.Resolver.ResponseMappingTemplate)
-	d.Set("kind", resp.Resolver.Kind)
+	d.Set("arn", resolver.ResolverArn)
+	d.Set("type", resolver.TypeName)
+	d.Set("field", resolver.FieldName)
+	d.Set("data_source", resolver.DataSourceName)
+	d.Set("request_template", resolver.RequestMappingTemplate)
+	d.Set("response_template", resolver.ResponseMappingTemplate)
+	d.Set("kind", resolver.Kind)
+	d.Set("max_batch_size", resolver.MaxBatchSize)
 
-	if err := d.Set("pipeline_config", flattenAppsyncPipelineConfig(resp.Resolver.PipelineConfig)); err != nil {
-		return fmt.Errorf("Error setting pipeline_config: %s", err)
+	if err := d.Set("sync_config", flattenAppsyncSyncConfig(resolver.SyncConfig)); err != nil {
+		return fmt.Errorf("error setting sync_config: %w", err)
 	}
 
-	if err := d.Set("caching_config", flattenAppsyncCachingConfig(resp.Resolver.CachingConfig)); err != nil {
-		return fmt.Errorf("Error setting caching_config: %s", err)
+	if err := d.Set("pipeline_config", flattenAppsyncPipelineConfig(resolver.PipelineConfig)); err != nil {
+		return fmt.Errorf("Error setting pipeline_config: %w", err)
+	}
+
+	if err := d.Set("caching_config", flattenAppsyncCachingConfig(resolver.CachingConfig)); err != nil {
+		return fmt.Errorf("Error setting caching_config: %w", err)
 	}
 
 	return nil
@@ -238,6 +286,14 @@ func resourceResolverUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("caching_config"); ok {
 		input.CachingConfig = expandAppsyncResolverCachingConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOkExists("max_batch_size"); ok {
+		input.MaxBatchSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("sync_config"); ok && len(v.([]interface{})) > 0 {
+		input.SyncConfig = expandAppsyncSyncConfig(v.([]interface{}))
 	}
 
 	mutexKey := fmt.Sprintf("appsync-schema-%s", d.Get("api_id").(string))

--- a/internal/service/appsync/resolver_test.go
+++ b/internal/service/appsync/resolver_test.go
@@ -34,6 +34,37 @@ func testAccAppSyncResolver_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "appsync", regexp.MustCompile("apis/.+/types/.+/resolvers/.+")),
 					resource.TestCheckResourceAttr(resourceName, "data_source", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "request_template"),
+					resource.TestCheckResourceAttr(resourceName, "max_batch_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sync_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAppSyncResolver_syncConfig(t *testing.T) {
+	var resolver1 appsync.Resolver
+	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
+	resourceName := "aws_appsync_resolver.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(appsync.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, appsync.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckResolverDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncResolverSyncConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResolverExists(resourceName, &resolver1),
+					resource.TestCheckResourceAttr(resourceName, "sync_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sync_config.0.conflict_detection", "VERSION"),
+					resource.TestCheckResourceAttr(resourceName, "sync_config.0.conflict_handler", "OPTIMISTIC_CONCURRENCY"),
 				),
 			},
 			{
@@ -83,14 +114,14 @@ func testAccAppSyncResolver_dataSource(t *testing.T) {
 		CheckDestroy: testAccCheckResolverDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncResolver_DataSource(rName, "test_ds_1"),
+				Config: testAccAppsyncResolver_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResolverExists(resourceName, &resolver1),
-					resource.TestCheckResourceAttr(resourceName, "data_source", "test_ds_1"),
+					resource.TestCheckResourceAttr(resourceName, "data_source", rName),
 				),
 			},
 			{
-				Config: testAccAppsyncResolver_DataSource(rName, "test_ds_2"),
+				Config: testAccAppsyncResolver_DataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResolverExists(resourceName, &resolver2),
 					resource.TestCheckResourceAttr(resourceName, "data_source", "test_ds_2"),
@@ -354,11 +385,11 @@ func testAccCheckResolverExists(name string, resolver *appsync.Resolver) resourc
 	}
 }
 
-func testAccAppsyncResolver_basic(rName string) string {
+func testAccAppsyncResolverBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
-  name                = %q
+  name                = %[1]q
 
   schema = <<EOF
 type Mutation {
@@ -383,14 +414,18 @@ EOF
 
 resource "aws_appsync_datasource" "test" {
   api_id = aws_appsync_graphql_api.test.id
-  name   = %q
+  name   = %[1]q
   type   = "HTTP"
 
   http_config {
     endpoint = "http://example.com"
   }
 }
+`, rName)
+}
 
+func testAccAppsyncResolver_basic(rName string) string {
+	return testAccAppsyncResolverBaseConfig(rName) + `
 resource "aws_appsync_resolver" "test" {
   api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
@@ -416,47 +451,12 @@ EOF
 #end
 EOF
 }
-`, rName, rName)
+`
 }
 
-func testAccAppsyncResolver_DataSource(rName, dataSource string) string {
-	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name                = %q
-
-  schema = <<EOF
-type Mutation {
-	putPost(id: ID!, title: String!): Post
-}
-
-type Post {
-	id: ID!
-	title: String!
-}
-
-type Query {
-	singlePost(id: ID!): Post
-}
-
-schema {
-	query: Query
-	mutation: Mutation
-}
-EOF
-}
-
-resource "aws_appsync_datasource" "test_ds_1" {
-  api_id = aws_appsync_graphql_api.test.id
-  name   = "test_ds_1"
-  type   = "HTTP"
-
-  http_config {
-    endpoint = "http://example.com"
-  }
-}
-
-resource "aws_appsync_datasource" "test_ds_2" {
+func testAccAppsyncResolver_DataSource(rName string) string {
+	return testAccAppsyncResolverBaseConfig(rName) + `
+resource "aws_appsync_datasource" "test2" {
   api_id = aws_appsync_graphql_api.test.id
   name   = "test_ds_2"
   type   = "HTTP"
@@ -470,7 +470,7 @@ resource "aws_appsync_resolver" "test" {
   api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
   type        = "Query"
-  data_source = aws_appsync_datasource.%s.name
+  data_source = aws_appsync_datasource.test2.name
 
   request_template = <<EOF
 {
@@ -491,7 +491,7 @@ EOF
 #end
 EOF
 }
-`, rName, dataSource)
+`
 }
 
 func testAccAppsyncResolver_DataSource_lambda(rName string) string {
@@ -542,42 +542,7 @@ resource "aws_appsync_resolver" "test" {
 }
 
 func testAccAppsyncResolver_RequestTemplate(rName, resourcePath string) string {
-	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name                = %q
-
-  schema = <<EOF
-type Mutation {
-	putPost(id: ID!, title: String!): Post
-}
-
-type Post {
-	id: ID!
-	title: String!
-}
-
-type Query {
-	singlePost(id: ID!): Post
-}
-
-schema {
-	query: Query
-	mutation: Mutation
-}
-EOF
-}
-
-resource "aws_appsync_datasource" "test" {
-  api_id = aws_appsync_graphql_api.test.id
-  name   = %q
-  type   = "HTTP"
-
-  http_config {
-    endpoint = "http://example.com"
-  }
-}
-
+	return testAccAppsyncResolverBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_appsync_resolver" "test" {
   api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
@@ -588,7 +553,7 @@ resource "aws_appsync_resolver" "test" {
 {
     "version": "2018-05-29",
     "method": "GET",
-    "resourcePath": %q,
+    "resourcePath": %[1]q,
     "params":{
         "headers": $utils.http.copyheaders($ctx.request.headers)
     }
@@ -603,46 +568,11 @@ EOF
 #end
 EOF
 }
-`, rName, rName, resourcePath)
+`, resourcePath)
 }
 
 func testAccAppsyncResolver_ResponseTemplate(rName string, statusCode int) string {
-	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name                = %q
-
-  schema = <<EOF
-type Mutation {
-	putPost(id: ID!, title: String!): Post
-}
-
-type Post {
-	id: ID!
-	title: String!
-}
-
-type Query {
-	singlePost(id: ID!): Post
-}
-
-schema {
-	query: Query
-	mutation: Mutation
-}
-EOF
-}
-
-resource "aws_appsync_datasource" "test" {
-  api_id = aws_appsync_graphql_api.test.id
-  name   = %q
-  type   = "HTTP"
-
-  http_config {
-    endpoint = "http://example.com"
-  }
-}
-
+	return testAccAppsyncResolverBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_appsync_resolver" "test" {
   api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
@@ -662,14 +592,14 @@ resource "aws_appsync_resolver" "test" {
 EOF
 
   response_template = <<EOF
-#if($ctx.result.statusCode == %d)
+#if($ctx.result.statusCode == %[1]d)
     $ctx.result.body
 #else
     $utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
 }
-`, rName, rName, statusCode)
+`, statusCode)
 }
 
 func testAccAppsyncResolver_multipleResolvers(rName string) string {
@@ -748,45 +678,11 @@ resource "aws_appsync_datasource" "test" {
 }
 
 func testAccAppsyncResolver_pipelineConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name                = "%[1]s"
-  schema              = <<EOF
-type Mutation {
-		putPost(id: ID!, title: String!): Post
-}
-
-type Post {
-		id: ID!
-		title: String!
-}
-
-type Query {
-		singlePost(id: ID!): Post
-}
-
-schema {
-		query: Query
-		mutation: Mutation
-}
-EOF
-}
-
-resource "aws_appsync_datasource" "test" {
-  api_id = aws_appsync_graphql_api.test.id
-  name   = "%[1]s"
-  type   = "HTTP"
-
-  http_config {
-    endpoint = "http://example.com"
-  }
-}
-
+	return testAccAppsyncResolverBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_appsync_function" "test" {
   api_id                   = aws_appsync_graphql_api.test.id
   data_source              = aws_appsync_datasource.test.name
-  name                     = "%[1]s"
+  name                     = %[1]q
   request_mapping_template = <<EOF
 {
 		"version": "2018-05-29",
@@ -840,41 +736,7 @@ EOF
 }
 
 func testAccAppsyncResolver_cachingConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name                = "%[1]s"
-  schema              = <<EOF
-type Mutation {
-	putPost(id: ID!, title: String!): Post
-}
-
-type Post {
-	id: ID!
-	title: String!
-}
-
-type Query {
-	singlePost(id: ID!): Post
-}
-
-schema {
-	query: Query
-	mutation: Mutation
-}
-EOF
-}
-
-resource "aws_appsync_datasource" "test" {
-  api_id = aws_appsync_graphql_api.test.id
-  name   = "%[1]s"
-  type   = "HTTP"
-
-  http_config {
-    endpoint = "http://example.com"
-  }
-}
-
+	return testAccAppsyncResolverBaseConfig(rName) + `
 resource "aws_appsync_resolver" "test" {
   api_id           = aws_appsync_graphql_api.test.id
   field            = "singlePost"
@@ -907,6 +769,85 @@ EOF
     ]
     ttl = 60
   }
+}
+`
+}
+
+func testAccAppsyncResolverSyncConfig(rName string) string {
+	return testAccAppsyncDatasourceConfig_base_DynamoDB(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %[1]q
+
+  schema = <<EOF
+type Mutation {
+	putPost(id: ID!, title: String!): Post
+}
+
+type Post {
+	id: ID!
+	title: String!
+}
+
+type Query {
+	singlePost(id: ID!): Post
+}
+
+schema {
+	query: Query
+	mutation: Mutation
+}
+EOF
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = aws_appsync_graphql_api.test.id
+  name             = %[1]q
+  service_role_arn = aws_iam_role.test.arn
+  type             = "AMAZON_DYNAMODB"
+
+  dynamodb_config {
+    table_name = aws_dynamodb_table.test.name
+    versioned  = true
+
+    delta_sync_config {
+      base_table_ttl        = 60
+      delta_sync_table_name = aws_dynamodb_table.test.name
+      delta_sync_table_ttl  = 60
+    }
+  }
+}
+
+
+resource "aws_appsync_resolver" "test" {
+  api_id      = aws_appsync_graphql_api.test.id
+  field       = "singlePost"
+  type        = "Query"
+  data_source = aws_appsync_datasource.test.name
+
+  sync_config {
+    conflict_detection = "VERSION"
+    conflict_handler   = "OPTIMISTIC_CONCURRENCY"
+  }
+
+  request_template = <<EOF
+{
+    "version": "2018-05-29",
+    "method": "GET",
+    "resourcePath": "/",
+    "params":{
+        "headers": $utils.http.copyheaders($ctx.request.headers)
+    }
+}
+EOF
+
+  response_template = <<EOF
+#if($ctx.result.statusCode == 200)
+    $ctx.result.body
+#else
+    $utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
 }
 `, rName)
 }

--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -111,12 +111,28 @@ The following arguments are supported:
 * `request_template` - (Optional) The request mapping template for UNIT resolver or 'before mapping template' for PIPELINE resolver. Required for non-Lambda resolvers.
 * `response_template` - (Optional) The response mapping template for UNIT resolver or 'after mapping template' for PIPELINE resolver. Required for non-Lambda resolvers.
 * `data_source` - (Optional) The DataSource name.
+* `max_batch_size` - (Optional) The maximum batching size for a resolver. Valid values are between `0` and `2000`.
 * `kind`  - (Optional) The resolver type. Valid values are `UNIT` and `PIPELINE`.
+* `sync_config` - (Optional) Describes a Sync configuration for a resolver. See [Sync Config](#sync-config).
 * `pipeline_config` - (Optional) The PipelineConfig.
     * `functions` - (Required) The list of Function ID.
 * `caching_config` - (Optional) The CachingConfig.
     * `caching_keys` - (Optional) The list of caching key.
     * `ttl` - (Optional) The TTL in seconds.
+
+### Sync Config
+
+The following arguments are supported:
+
+* `conflict_detection` - (Optional) The Conflict Detection strategy to use. Valid values are `NONE` and `VERSION`.
+* `conflict_handler` - (Optional) The Conflict Resolution strategy to perform in the event of a conflict. Valid values are `NONE`, `OPTIMISTIC_CONCURRENCY`, `AUTOMERGE`, and `LAMBDA`.
+* `lambda_conflict_handler_config` - (Optional) The Lambda Conflict Handler Config when configuring `LAMBDA` as the Conflict Handler. See [Lambda Conflict Handler Config](#lambda-conflict-handler-config).
+
+#### Lambda Conflict Handler Config
+
+The following arguments are supported:
+
+* `lambda_conflict_handler_arn` - (Optional) The Amazon Resource Name (ARN) for the Lambda function to use as the Conflict Handler.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppSync_serial/Resolver PKG=appsync
--- PASS: TestAccAppSync_serial (934.97s)
    --- PASS: TestAccAppSync_serial/Resolver (934.97s)
        --- PASS: TestAccAppSync_serial/Resolver/disappears (74.04s)
        --- PASS: TestAccAppSync_serial/Resolver/multipleResolvers (145.61s)
        --- PASS: TestAccAppSync_serial/Resolver/pipeline (68.55s)
        --- PASS: TestAccAppSync_serial/Resolver/sync (89.22s)
        --- PASS: TestAccAppSync_serial/Resolver/basic (65.54s)
        --- PASS: TestAccAppSync_serial/Resolver/dataSource (121.74s)
        --- PASS: TestAccAppSync_serial/Resolver/DataSource_lambda (92.17s)
        --- PASS: TestAccAppSync_serial/Resolver/requestTemplate (114.98s)
        --- PASS: TestAccAppSync_serial/Resolver/responseTemplate (109.70s)
        --- PASS: TestAccAppSync_serial/Resolver/caching (53.41s)
```
