### PR TITLE
sns/topic: ISO-friendly tagging

### DIFF
--- a/.changelog/22511.txt
+++ b/.changelog/22511.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sns_topic: Allow `tags` errors to be non-fatal to support ISO environments
+```

--- a/.changelog/22511.txt
+++ b/.changelog/22511.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sns_topic: Allow certain `tags` errors to be non-fatal to support ISO environments
+resource/aws_sns_topic: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```

--- a/.changelog/22511.txt
+++ b/.changelog/22511.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sns_topic: Allow `tags` errors to be non-fatal to support ISO environments
+resource/aws_sns_topic: Allow certain `tags` errors to be non-fatal to support ISO environments
 ```

--- a/internal/service/sns/consts.go
+++ b/internal/service/sns/consts.go
@@ -72,6 +72,6 @@ const (
 )
 
 const (
-	ErrCodeInvalidAction = "InvalidAction"
 	ErrCodeAccessDenied  = "AccessDenied"
+	ErrCodeInvalidAction = "InvalidAction"
 )

--- a/internal/service/sns/consts.go
+++ b/internal/service/sns/consts.go
@@ -72,7 +72,6 @@ const (
 )
 
 const (
-	ErrCodeInvalidAction      = "InvalidAction"
-	ErrCodeAccessDenied       = "AccessDenied"
-	ErrCodeAuthorizationError = "AuthorizationError"
+	ErrCodeInvalidAction = "InvalidAction"
+	ErrCodeAccessDenied  = "AccessDenied"
 )

--- a/internal/service/sns/consts.go
+++ b/internal/service/sns/consts.go
@@ -70,3 +70,9 @@ const (
 	TopicAttributeNameSQSSuccessFeedbackSampleRate         = "SQSSuccessFeedbackSampleRate"
 	TopicAttributeNameTopicArn                             = "TopicArn"
 )
+
+const (
+	ErrCodeInvalidAction      = "InvalidAction"
+	ErrCodeAccessDenied       = "AccessDenied"
+	ErrCodeAuthorizationError = "AuthorizationError"
+)

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -273,7 +273,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -319,7 +319,7 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 
 	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") {
 		// ISO partitions may not support tagging, giving error
-		log.Printf("[DEBUG] Unable to read tags for SNS topic %s: %s", d.Id(), err)
+		log.Printf("[WARN] Unable to read tags for SNS topic %s: %s", d.Id(), err)
 		return nil
 	}
 
@@ -363,7 +363,7 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
 			if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "InvalidAction") {
 				// ISO partitions may not support tagging, giving error
-				log.Printf("[DEBUG] Unable to update tags for SNS topic %s: %s", d.Id(), err)
+				log.Printf("[WARN] Unable to update tags for SNS topic %s: %s", d.Id(), err)
 				return resourceTopicRead(d, meta)
 			}
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -251,7 +251,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateTopic(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError)) {
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException)) {
 		log.Printf("[WARN] SNS Topic (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 		output, err = conn.CreateTopic(input)
@@ -273,7 +273,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError)) {
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)
@@ -326,7 +326,7 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
 		// ISO partitions may not support tagging, giving error
 		log.Printf("[WARN] Unable to list tags for SNS topic %s: %s", d.Id(), err)
 		return nil
@@ -372,7 +372,7 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
 			// ISO partitions may not support tagging, giving error
 			log.Printf("[WARN] Unable to update tags for SNS topic %s: %s", d.Id(), err)
 			return resourceTopicRead(d, meta)

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -243,7 +244,8 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 		delete(attributes, TopicAttributeNameFifoTopic)
 	}
 
-	if len(tags) > 0 {
+	// Tag-on-create is currently only supported in AWS Commercial
+	if len(tags) > 0 && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -251,7 +251,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateTopic(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "InvalidAction") || tfawserr.ErrCodeContains(err, "AuthorizationError")) {
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError)) {
 		log.Printf("[WARN] SNS Topic (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 		output, err = conn.CreateTopic(input)
@@ -273,7 +273,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "InvalidAction") || tfawserr.ErrCodeContains(err, "AuthorizationError")) {
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)
@@ -326,7 +326,7 @@ func resourceTopicRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") || tfawserr.ErrCodeContains(err, "InvalidAction") {
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
 		// ISO partitions may not support tagging, giving error
 		log.Printf("[WARN] Unable to list tags for SNS topic %s: %s", d.Id(), err)
 		return nil
@@ -372,7 +372,7 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") || tfawserr.ErrCodeContains(err, "InvalidAction") {
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
 			// ISO partitions may not support tagging, giving error
 			log.Printf("[WARN] Unable to update tags for SNS topic %s: %s", d.Id(), err)
 			return resourceTopicRead(d, meta)

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -244,8 +243,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 		delete(attributes, TopicAttributeNameFifoTopic)
 	}
 
-	// Tag-on-create is currently only supported in AWS Commercial
-	if len(tags) > 0 && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
+	if len(tags) > 0 {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -251,7 +251,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateTopic(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException)) {
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction)) {
 		log.Printf("[WARN] SNS Topic (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 		output, err = conn.CreateTopic(input)
@@ -273,7 +273,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException)) {
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sns.ErrCodeAuthorizationErrorException) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for SNS Topic (%s): %s", d.Id(), err)
 			return resourceTopicRead(d, meta)

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -368,13 +368,16 @@ func resourceTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") || tfawserr.ErrCodeContains(err, "InvalidAction") {
-				// ISO partitions may not support tagging, giving error
-				log.Printf("[WARN] Unable to update tags for SNS topic %s: %s", d.Id(), err)
-				return resourceTopicRead(d, meta)
-			}
 
+		err := UpdateTags(conn, d.Id(), o, n)
+
+		if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") || tfawserr.ErrCodeContains(err, "InvalidAction") {
+			// ISO partitions may not support tagging, giving error
+			log.Printf("[WARN] Unable to update tags for SNS topic %s: %s", d.Id(), err)
+			return resourceTopicRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating SNS topic tags: %w", err)
 		}
 	}

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -250,7 +250,7 @@ func resourceTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating SNS Topic: %s", input)
 	output, err := conn.CreateTopic(input)
 
-	// ISO partitions may not support tagging, giving error
+	// Some partitions may not support tag-on-create
 	if input.Tags != nil && (tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "InvalidAction") || tfawserr.ErrCodeContains(err, "AuthorizationError")) {
 		log.Printf("[WARN] SNS Topic (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21209
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccSNSTopic_ PKG=sns
--- PASS: TestAccSNSTopic_fifoExpectContentBasedDeduplicationError (4.25s)
--- PASS: TestAccSNSTopic_disappears (17.49s)
--- PASS: TestAccSNSTopic_name (24.78s)
--- PASS: TestAccSNSTopic_NamePrefix_fifoTopic (24.97s)
--- PASS: TestAccSNSTopic_namePrefix (25.12s)
--- PASS: TestAccSNSTopic_Name_fifoTopic (25.13s)
--- PASS: TestAccSNSTopic_policy (25.14s)
--- PASS: TestAccSNSTopic_NameGenerated_fifoTopic (25.14s)
--- PASS: TestAccSNSTopic_withDeliveryPolicy (25.14s)
--- PASS: TestAccSNSTopic_basic (25.18s)
--- PASS: TestAccSNSTopic_withIAMRole (32.51s)
--- PASS: TestAccSNSTopic_fifoWithContentBasedDeduplication (34.85s)
--- PASS: TestAccSNSTopic_encryption (35.21s)
--- PASS: TestAccSNSTopic_deliveryStatus (36.25s)
--- PASS: TestAccSNSTopic_tags (44.99s)
--- PASS: TestAccSNSTopic_withFakeIAMRole (130.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	132.191s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccSNSTopic_ PKG=sns
--- PASS: TestAccSNSTopic_fifoExpectContentBasedDeduplicationError (5.28s)
--- SKIP: TestAccSNSTopic_Name_fifoTopic (10.68s)
--- SKIP: TestAccSNSTopic_fifoWithContentBasedDeduplication (10.69s)
--- SKIP: TestAccSNSTopic_NameGenerated_fifoTopic (10.69s)
--- SKIP: TestAccSNSTopic_NamePrefix_fifoTopic (10.70s)
--- PASS: TestAccSNSTopic_disappears (20.55s)
--- PASS: TestAccSNSTopic_withDeliveryPolicy (27.36s)
--- PASS: TestAccSNSTopic_basic (27.42s)
--- PASS: TestAccSNSTopic_name (27.49s)
--- PASS: TestAccSNSTopic_namePrefix (27.54s)
--- PASS: TestAccSNSTopic_policy (27.57s)
--- PASS: TestAccSNSTopic_withIAMRole (33.66s)
--- PASS: TestAccSNSTopic_deliveryStatus (40.43s)
--- PASS: TestAccSNSTopic_encryption (40.64s)
--- PASS: TestAccSNSTopic_tags (53.25s)
--- PASS: TestAccSNSTopic_withFakeIAMRole (133.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	134.787s
```
