### PR TITLE
r/aws_dynamodb_table_gsi

### DIFF
--- a/.changelog/22513.txt
+++ b/.changelog/22513.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `manage_index_as_own_resource` arguments.
+```
+
+```release-note:new-resource
+aws_dynamodb_table_gsi
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1080,6 +1080,7 @@ func Provider() *schema.Provider {
 			"aws_dynamodb_table":                         dynamodb.ResourceTable(),
 			"aws_dynamodb_table_item":                    dynamodb.ResourceTableItem(),
 			"aws_dynamodb_tag":                           dynamodb.ResourceTag(),
+			"aws_dynamodb_table_gsi":                     dynamodb.ResourceAwsDynamoDbTableGsi(),
 
 			"aws_ami":                                             ec2.ResourceAMI(),
 			"aws_ami_copy":                                        ec2.ResourceAMICopy(),

--- a/internal/service/dynamodb/gsi.go
+++ b/internal/service/dynamodb/gsi.go
@@ -1,0 +1,335 @@
+package dynamodb
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func ResourceAwsDynamoDbTableGsi() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDynamoDbTableGsiCreate,
+		Read:   resourceAwsDynamoDbTableGsiRead,
+		Update: resourceAwsDynamoDbTableGsiUpdate,
+		Delete: resourceAwsDynamoDbTableGsiDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute), // provisioned throughput changes only
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"hash_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"range_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"write_capacity": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"read_capacity": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"projection_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(dynamodb.ProjectionType_Values(), false),
+			},
+			"non_key_attributes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"billing_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      dynamodb.BillingModeProvisioned,
+				ValidateFunc: validation.StringInSlice(dynamodb.BillingMode_Values(), false),
+			},
+			"attribute": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								dynamodb.ScalarAttributeTypeB,
+								dynamodb.ScalarAttributeTypeN,
+								dynamodb.ScalarAttributeTypeS,
+							}, false),
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+					return create.StringHashcode(buf.String())
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsDynamoDbTableGsiCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+
+	tableName := d.Get("table_name").(string)
+	indexName := d.Get("name").(string)
+	keySchemaMap := map[string]interface{}{
+		"hash_key": d.Get("hash_key").(string),
+	}
+	if v, ok := d.GetOk("range_key"); ok {
+		keySchemaMap["range_key"] = v.(string)
+	}
+
+	log.Printf("[DEBUG] Creating DynamoDB table index with key schema: %#v", keySchemaMap)
+	req := &dynamodb.UpdateTableInput{
+		TableName: aws.String(tableName),
+	}
+
+	projection := &dynamodb.Projection{
+		ProjectionType: aws.String(d.Get("projection_type").(string)),
+	}
+
+	if v, ok := d.Get("non_key_attributes").(*schema.Set); ok {
+		projection.NonKeyAttributes = flex.ExpandStringList(v.List())
+	}
+
+	capacityMap := map[string]interface{}{
+		"write_capacity": d.Get("write_capacity"),
+		"read_capacity":  d.Get("read_capacity"),
+	}
+	billingMode := d.Get("billing_mode").(string)
+
+	createOp := &dynamodb.GlobalSecondaryIndexUpdate{
+		Create: &dynamodb.CreateGlobalSecondaryIndexAction{
+			IndexName:             aws.String(indexName),
+			KeySchema:             expandDynamoDbKeySchema(keySchemaMap),
+			Projection:            projection,
+			ProvisionedThroughput: expandDynamoDbProvisionedThroughput(capacityMap, billingMode),
+		},
+	}
+
+	req.GlobalSecondaryIndexUpdates = []*dynamodb.GlobalSecondaryIndexUpdate{createOp}
+	if v, ok := d.GetOk("attribute"); ok {
+		aSet := v.(*schema.Set)
+		req.AttributeDefinitions = expandDynamoDbAttributes(aSet.List())
+	}
+
+	var output *dynamodb.UpdateTableOutput
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		var err error
+		output, err = conn.UpdateTable(req)
+		if err != nil {
+			if tfawserr.ErrMessageContains(err, "ThrottlingException", "") {
+				return resource.RetryableError(err)
+			}
+			if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeResourceInUseException, "") {
+				return resource.RetryableError(err)
+			}
+			// Subscriber limit exceeded: Only 1 online index can be created or deleted simultaneously per table
+			if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeLimitExceededException, "simultaneously") {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if tfresource.TimedOut(err) {
+		return fmt.Errorf(`Updating table timed out: %s`, err)
+	}
+	if err != nil {
+		return err
+	}
+
+	gsiDescription := findDynamoDbGsi(&output.TableDescription.GlobalSecondaryIndexes, indexName)
+	d.SetId(
+		aws.StringValue(gsiDescription.IndexName),
+	)
+
+	_, err = waitDynamoDBGSIActive(conn, d.Get("table_name").(string), d.Id())
+	return err
+}
+
+func resourceAwsDynamoDbTableGsiUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+
+	capacityMap := map[string]interface{}{
+		"write_capacity": d.Get("write_capacity"),
+		"read_capacity":  d.Get("read_capacity"),
+	}
+	billingMode := d.Get("billing_mode").(string)
+	req := &dynamodb.UpdateTableInput{
+		TableName: aws.String(d.Get("table_name").(string)),
+		GlobalSecondaryIndexUpdates: []*dynamodb.GlobalSecondaryIndexUpdate{
+			{
+				Update: &dynamodb.UpdateGlobalSecondaryIndexAction{
+					IndexName:             aws.String(d.Id()),
+					ProvisionedThroughput: expandDynamoDbProvisionedThroughput(capacityMap, billingMode),
+				},
+			},
+		},
+	}
+
+	err := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		var err error
+		_, err = conn.UpdateTable(req)
+		if err != nil {
+			if tfawserr.ErrMessageContains(err, "ThrottlingException", "") {
+				return resource.RetryableError(err)
+			}
+			if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeResourceInUseException, "") {
+				return resource.RetryableError(err)
+			}
+			// Subscriber limit exceeded: Only 1 online index can be created or deleted simultaneously per table
+			if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeLimitExceededException, "simultaneously") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if tfresource.TimedOut(err) {
+		return fmt.Errorf(`Updating table timed out: %s`, err)
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = waitDynamoDBGSIActive(conn, d.Get("table_name").(string), d.Id())
+	return err
+}
+
+func resourceAwsDynamoDbTableGsiRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+	tableName := d.Get("table_name").(string)
+	d.Set("table_name", tableName)
+
+	result, err := conn.DescribeTable(&dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		return err
+	}
+
+	gsi := findDynamoDbGsi(&result.Table.GlobalSecondaryIndexes, d.Id())
+	d.Set("write_capacity", gsi.ProvisionedThroughput.WriteCapacityUnits)
+	d.Set("read_capacity", gsi.ProvisionedThroughput.ReadCapacityUnits)
+	d.Set("projection_type", gsi.Projection.ProjectionType)
+	d.Set("non_key_attributes", gsi.Projection.NonKeyAttributes)
+
+	gsiAttributeNames := make(map[string]struct{}, len(gsi.KeySchema))
+	for _, attribute := range gsi.KeySchema {
+		if aws.StringValue(attribute.KeyType) == dynamodb.KeyTypeHash {
+			d.Set("hash_key", attribute.AttributeName)
+			gsiAttributeNames[*attribute.AttributeName] = struct{}{}
+		}
+
+		if aws.StringValue(attribute.KeyType) == dynamodb.KeyTypeRange {
+			d.Set("range_key", attribute.AttributeName)
+			gsiAttributeNames[*attribute.AttributeName] = struct{}{}
+		}
+	}
+	attributes := []interface{}{}
+	for _, attrdef := range result.Table.AttributeDefinitions {
+		if _, ok := gsiAttributeNames[*attrdef.AttributeName]; ok {
+			attribute := map[string]string{
+				"name": *attrdef.AttributeName,
+				"type": *attrdef.AttributeType,
+			}
+			attributes = append(attributes, attribute)
+		}
+	}
+	d.Set("attribute", attributes)
+
+	return err
+}
+
+func resourceAwsDynamoDbTableGsiDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DynamoDBConn
+
+	req := &dynamodb.UpdateTableInput{
+		TableName: aws.String(d.Get("table_name").(string)),
+		GlobalSecondaryIndexUpdates: []*dynamodb.GlobalSecondaryIndexUpdate{
+			{
+				Delete: &dynamodb.DeleteGlobalSecondaryIndexAction{
+					IndexName: aws.String(d.Id()),
+				},
+			},
+		},
+	}
+
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := conn.UpdateTable(req)
+		if err != nil {
+			// Subscriber limit exceeded: Only 1 online index can be created or deleted simultaneously per table
+			if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeLimitExceededException, "simultaneously") {
+				return resource.RetryableError(err)
+			}
+			if tfawserr.ErrMessageContains(err, dynamodb.ErrCodeResourceInUseException, "") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if tfresource.TimedOut(err) {
+		return fmt.Errorf(`Updating table timed out: %s`, err)
+	}
+	if err != nil {
+		return err
+	}
+
+	err = waitDynamoDBGSIDeleted(conn, d.Get("table_name").(string), d.Id())
+	return err
+}
+
+func findDynamoDbGsi(gsiList *[]*dynamodb.GlobalSecondaryIndexDescription, target string) *dynamodb.GlobalSecondaryIndexDescription {
+	for _, gsiObject := range *gsiList {
+		if aws.StringValue(gsiObject.IndexName) == target {
+			return gsiObject
+		}
+	}
+	return nil
+}

--- a/internal/service/dynamodb/gsi_test.go
+++ b/internal/service/dynamodb/gsi_test.go
@@ -1,0 +1,238 @@
+package dynamodb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+//TODO: Fix Cyclic dependency of attribute and global_secondary_index update
+// After applying this test step and performing a `terraform refresh`, the plan was not empty.
+func TestAccAWSDynamoDbTableGsi_basic(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	resourceName := "aws_dynamodb_table_gsi.gsi"
+	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+	gsiName := fmt.Sprintf("test-gsi-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.table", "name", tableName),
+					resource.TestCheckResourceAttr(resourceName, "name", gsiName),
+					resource.TestCheckResourceAttr(resourceName, "read_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "write_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "hash_key", "TestGsiHashKey"),
+					resource.TestCheckResourceAttr(resourceName, "projection_type", "KEYS_ONLY"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableGsi_updateCapacity(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+	gsiName := fmt.Sprintf("test-gsi-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasicMoreCapacity(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "5"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableGsi_updateNonAttributes(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+	resourceName := "aws_dynamodb_table_gsi.gsi"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiInitialOtherAttributes(tableName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr(resourceName, "non_key_attributes.0", "SomeId"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDynamoDbGsiConfigUpdatedOtherAttributes(tableName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr(resourceName, "non_key_attributes.0", "RandomAttribute"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableGsi_delete(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	tableName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+	gsiName := fmt.Sprintf("test-gsi-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.table", "name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "name", gsiName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "read_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_gsi.gsi", "write_capacity", "1"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbGsiConfigBasicDelete(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialTableExists("aws_dynamodb_table.table", &conf),
+					func(*terraform.State) error {
+						if len(conf.Table.GlobalSecondaryIndexes) > 0 {
+							return fmt.Errorf("expected to find no global secondary indexes, instead found: %v", conf.Table.GlobalSecondaryIndexes)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccBasicDynamoTable(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "table" {
+  name                         = "%s"
+  read_capacity                = 1
+  write_capacity               = 1
+  hash_key                     = "id"
+  manage_index_as_own_resource = true
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+`, tableName)
+}
+
+func testAccAWSDynamoDbGsiConfigBasic(tableName, gsiName string) string {
+	return testAccBasicDynamoTable(tableName) + fmt.Sprintf(`
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name      = aws_dynamodb_table.table.id
+  name            = "%s"
+  hash_key        = "TestGsiHashKey"
+  write_capacity  = 1
+  read_capacity   = 1
+  projection_type = "KEYS_ONLY"
+  attribute {
+    name = "TestGsiHashKey"
+    type = "S"
+  }
+}
+`, gsiName)
+}
+
+func testAccAWSDynamoDbGsiConfigBasicMoreCapacity(tableName, gsiName string) string {
+	return testAccBasicDynamoTable(tableName) + fmt.Sprintf(`
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name      = aws_dynamodb_table.table.id
+  name            = "%s"
+  hash_key        = "TestGsiHashKey"
+  write_capacity  = 5
+  read_capacity   = 5
+  projection_type = "KEYS_ONLY"
+
+  attribute {
+    name = "TestGsiHashKey"
+    type = "S"
+  }
+}
+`, gsiName)
+}
+
+func testAccAWSDynamoDbGsiConfigBasicDelete(tableName string) string {
+	return testAccBasicDynamoTable(tableName)
+}
+
+func testAccAWSDynamoDbGsiInitialOtherAttributes(tableName string) string {
+	return testAccBasicDynamoTable(tableName) + (`
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name         = aws_dynamodb_table.table.id
+  name               = "gsi1-index"
+  hash_key           = "att1"
+  write_capacity     = "1"
+  read_capacity      = "1"
+  projection_type    = "INCLUDE"
+  non_key_attributes = ["SomeId"]
+  attribute {
+    name = "att1"
+    type = "S"
+  }
+}
+`)
+}
+
+func testAccAWSDynamoDbGsiConfigUpdatedOtherAttributes(tableName string) string {
+	return testAccBasicDynamoTable(tableName) + `
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name         = aws_dynamodb_table.table.id
+  name               = "gsi1-index"
+  hash_key           = "att1"
+  write_capacity     = "1"
+  read_capacity      = "1"
+  projection_type    = "INCLUDE"
+  non_key_attributes = ["RandomAttribute"]
+  attribute {
+    name = "att1"
+    type = "S"
+  }
+}
+`
+}

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -156,7 +156,7 @@ func waitDynamoDBGSIActive(conn *dynamodb.DynamoDB, tableName, indexName string)
 	return nil, err
 }
 
-func waitDynamoDBGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string) (*dynamodb.GlobalSecondaryIndexDescription, error) {
+func waitDynamoDBGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			dynamodb.IndexStatusActive,
@@ -170,11 +170,11 @@ func waitDynamoDBGSIDeleted(conn *dynamodb.DynamoDB, tableName, indexName string
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*dynamodb.GlobalSecondaryIndexDescription); ok {
-		return output, err
+	if _, ok := outputRaw.(*dynamodb.GlobalSecondaryIndexDescription); ok {
+		return nil
 	}
 
-	return nil, err
+	return err
 }
 
 func waitDynamoDBPITRUpdated(conn *dynamodb.DynamoDB, tableName string, toEnable bool) (*dynamodb.PointInTimeRecoveryDescription, error) {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -113,6 +113,7 @@ definition after you have created the resource.
 * `global_secondary_index` - (Optional) Describe a GSI for the table;
   subject to the normal limits on the number of GSIs, projected
 attributes, etc.
+* `manage_index_as_own_resource` (Optional) - designed to be able to migrate and use aws_dynamodb_table_gsi
 * `point_in_time_recovery` - (Optional) Enable point-in-time recovery options.
 * `replica` - (Optional) Configuration block(s) with [DynamoDB Global Tables V2 (version 2019.11.21)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html) replication configurations. Detailed below.
 * `restore_source_name` - (Optional) The name of the table to restore. Must match the name of an existing table.

--- a/website/docs/r/dynamodb_table_gsi.markdown
+++ b/website/docs/r/dynamodb_table_gsi.markdown
@@ -1,0 +1,140 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: dynamodb_table_gsi"
+description: |-
+  Provides a DynamoDB Secondary Index resource
+---
+
+# Resource: aws_dynamodb_table_gsi
+
+ Provides a DynamoDB Global Secondary Index resource
+
+ ~> **Note:** It is recommended to use `lifecycle` [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) for `read_capacity` and/or `write_capacity` if there's [autoscaling policy](/docs/providers/aws/r/appautoscaling_policy.html) attached to the index.
+
+## Example Usage
+
+ The following dynamodb table description models the table and GSI shown
+ in the [AWS SDK example documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html)
+
+ ```terraform
+ resource "aws_dynamodb_table" "basic-dynamodb-table" {
+   name           = "GameScores"
+   read_capacity  = 20
+   write_capacity = 20
+   hash_key       = "UserId"
+   range_key      = "GameTitle"
+
+   attribute {
+     name = "UserId"
+     type = "S"
+   }
+
+   attribute {
+     name = "GameTitle"
+     type = "S"
+   }
+
+   ttl {
+     attribute_name = "TimeToExist"
+     enabled        = false
+   }
+
+   tags {
+     Name        = "dynamodb-table-1"
+     Environment = "production"
+   }
+ }
+
+ resource "aws_dynamodb_table_gsi" "basic-dynamodb-table-gsi" {
+   name               = "GameTitleIndex"
+   hash_key           = "GameTitle"
+   range_key          = "TopScore"
+   write_capacity     = 10
+   read_capacity      = 10
+   projection_type    = "INCLUDE"
+   non_key_attributes = ["UserId"]
+
+   attribute {
+     name = "GameTitle"
+     type = "S"
+   }
+
+   attribute {
+     name = "TopScore"
+     type = "N"
+   }
+ }
+ ```
+
+ Notes: `attribute` can be lists
+
+ ``terraform
+   attribute = [{
+     name = "UserId"
+     type = "S"
+   }, {
+     name = "GameTitle"
+     type = "S"
+   }, {
+     name = "TopScore"
+     type = "N"
+   }]
+ ```
+
+## Argument Reference
+
+ The following arguments are supported:
+
+* `name` - (Required) The name of the GSI, this needs to be unique
+   within the table definition.
+* `hash_key` - (Required, Forces new resource) The attribute to use as the hash (partition) key for the GSI. Must also be defined as an `attribute`, see below.
+* `range_key` - (Optional, Forces new resource) The attribute to use as the range (sort) key for the GSI. Must also be defined as an `attribute`, see below.
+* `write_capacity` - (Required) The number of write units for this GSI
+* `read_capacity` - (Required) The number of read units for this GSI
+* `attribute` - (Required) List of nested attribute definitions. Only required for `hash_key` and `range_key` attributes. Each attribute has two properties:
+    * `name` - (Required) The name of the attribute
+    * `type` - (Required) Attribute type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data
+* `projection_type` - (Required) One of `ALL`, `INCLUDE` or `KEYS_ONLY`
+    where `ALL` projects every attribute into the index, `KEYS_ONLY`
+     projects just the hash and range key into the index, and `INCLUDE`
+     projects only the keys specified in the _non_key_attributes_
+     parameter.
+* `non_key_attributes` - (Optional) Only required with `INCLUDE` as a
+   projection type; a list of attributes to project into the index. These
+   do not need to be defined as attributes on the table.
+
+### Timeouts
+
+ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when creating the GSI
+* `update` - (Defaults to 5 mins) Used when updating the GSI. Note that a GSI update only consists of provisioned capacity updates
+* `delete` - (Defaults to 10 mins) Used when deleting the GSI
+
+### A note about attributes
+
+ Only define attributes on the table object that are going to be used as:
+
+* GSI hash key or range key
+
+ The DynamoDB API expects attribute structure (name and type) to be
+ passed along when creating or updating GSI/LSIs or creating the initial
+ table. You should not add any attributes that belong to the table or
+ other indexes. If you add attributes here that are not used in these
+ scenarios it can cause an infinite loop in planning.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the index
+
+## Import
+
+DynamoDB tables can be imported using the `index name`, e.g.,
+
+```
+$ terraform import aws_dynamodb_table_gsi.basic-dynamodb-index GameScores
+```

--- a/website/docs/r/dynamodb_table_gsi.markdown
+++ b/website/docs/r/dynamodb_table_gsi.markdown
@@ -19,45 +19,34 @@ description: |-
 
  ```terraform
  resource "aws_dynamodb_table" "basic-dynamodb-table" {
-   name           = "GameScores"
-   read_capacity  = 20
-   write_capacity = 20
-   hash_key       = "UserId"
-   range_key      = "GameTitle"
+  name                         = "GameScores"
+  read_capacity                = 1
+  write_capacity               = 1
+  hash_key                     = "UserId"
+  range_key                    = "TopScoreDateTime"
+  manage_index_as_own_resource = true
 
-   attribute {
-     name = "UserId"
-     type = "S"
-   }
-
-   attribute {
-     name = "GameTitle"
-     type = "S"
-   }
-
-   ttl {
-     attribute_name = "TimeToExist"
-     enabled        = false
-   }
-
-   tags {
-     Name        = "dynamodb-table-1"
-     Environment = "production"
-   }
- }
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
+  attribute {
+    name = "TopScoreDateTime"
+    type = "S"
+  }
+}
 
 resource "aws_dynamodb_table_gsi" "gsi" {
   table_name         = aws_dynamodb_table.basic-dynamodb-table.id
-  name               = "PlayerNameIndex"
-  hash_key           = "PlayerName"
+  name               = "GameTitleIndex"
+  hash_key           = "GameTitle"
   range_key          = "TopScore"
   write_capacity     = 10
   read_capacity      = 10
   projection_type    = "INCLUDE"
-  non_key_attributes = ["OpponentId"]
-
+  non_key_attributes = ["Wins"]
   attribute {
-    name = "PlayerName"
+    name = "GameTitle"
     type = "S"
   }
 
@@ -72,6 +61,7 @@ resource "aws_dynamodb_table_gsi" "gsi" {
 
  The following arguments are supported:
 
+* `table_name` - (Required) The name of the table to attach to.
 * `name` - (Required) The name of the GSI, this needs to be unique
    within the table definition.
 * `hash_key` - (Required, Forces new resource) The attribute to use as the hash (partition) key for the GSI. Must also be defined as an `attribute`, see below.

--- a/website/docs/r/dynamodb_table_gsi.markdown
+++ b/website/docs/r/dynamodb_table_gsi.markdown
@@ -46,41 +46,27 @@ description: |-
    }
  }
 
- resource "aws_dynamodb_table_gsi" "basic-dynamodb-table-gsi" {
-   name               = "GameTitleIndex"
-   hash_key           = "GameTitle"
-   range_key          = "TopScore"
-   write_capacity     = 10
-   read_capacity      = 10
-   projection_type    = "INCLUDE"
-   non_key_attributes = ["UserId"]
+resource "aws_dynamodb_table_gsi" "gsi" {
+  table_name         = aws_dynamodb_table.basic-dynamodb-table.id
+  name               = "PlayerNameIndex"
+  hash_key           = "PlayerName"
+  range_key          = "TopScore"
+  write_capacity     = 10
+  read_capacity      = 10
+  projection_type    = "INCLUDE"
+  non_key_attributes = ["OpponentId"]
 
-   attribute {
-     name = "GameTitle"
-     type = "S"
-   }
+  attribute {
+    name = "PlayerName"
+    type = "S"
+  }
 
-   attribute {
-     name = "TopScore"
-     type = "N"
-   }
- }
- ```
-
- Notes: `attribute` can be lists
-
- ``terraform
-   attribute = [{
-     name = "UserId"
-     type = "S"
-   }, {
-     name = "GameTitle"
-     type = "S"
-   }, {
-     name = "TopScore"
-     type = "N"
-   }]
- ```
+  attribute {
+    name = "TopScore"
+    type = "N"
+  }
+}
+```
 
 ## Argument Reference
 
@@ -133,8 +119,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-DynamoDB tables can be imported using the `index name`, e.g.,
+DynamoDB tables can be imported using the `table-name:index-name`, e.g.,
 
 ```
-$ terraform import aws_dynamodb_table_gsi.basic-dynamodb-index GameScores
+$ terraform import aws_dynamodb_table_gsi.basic-dynamodb-index GameScores:PlayerNameIndex
 ```


### PR DESCRIPTION
Co-Authored-By: @ben-bourdin451. updated to v2 sdks from #6688

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates or Closes #17096
Relates or Closes #671

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ TF_ACC=1 go test ././internal/service/dynamodb/... -v -count 1 -parallel 3  -run=TestAccAWSDynamoDbTableGsi_ -timeout 180m
=== RUN   TestAccAWSDynamoDbTableGsi_basic
=== PAUSE TestAccAWSDynamoDbTableGsi_basic
=== RUN   TestAccAWSDynamoDbTableGsi_updateCapacity
=== PAUSE TestAccAWSDynamoDbTableGsi_updateCapacity
=== RUN   TestAccAWSDynamoDbTableGsi_updateNonAttributes
=== PAUSE TestAccAWSDynamoDbTableGsi_updateNonAttributes
=== RUN   TestAccAWSDynamoDbTableGsi_delete
=== PAUSE TestAccAWSDynamoDbTableGsi_delete
=== CONT  TestAccAWSDynamoDbTableGsi_basic
=== CONT  TestAccAWSDynamoDbTableGsi_updateNonAttributes
=== CONT  TestAccAWSDynamoDbTableGsi_updateCapacity
--- PASS: TestAccAWSDynamoDbTableGsi_basic (280.10s)
=== CONT  TestAccAWSDynamoDbTableGsi_delete
--- PASS: TestAccAWSDynamoDbTableGsi_updateCapacity (309.75s)
--- PASS: TestAccAWSDynamoDbTableGsi_updateNonAttributes (691.06s)
--- PASS: TestAccAWSDynamoDbTableGsi_delete (431.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   714.664s
```

Contributor Notes:
Open for feedback...
- similar to aws security groups ingress/egress + security group rules, separating GSIs has an issue where attributes can be defined in different places. To avoid computed value differences when reading, I used a CustomizeDiff, but it clears the whole attribute. Not sure if you can clear just the attribute in the set in question.
- Along the same lines, i added a feature switch to manage it externally. Is this an acceptable approach?