### PR TITLE
sqs/queue: Make ISO-friendly tags

### DIFF
--- a/.changelog/22516.txt
+++ b/.changelog/22516.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sqs_queue: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22516.txt
+++ b/.changelog/22516.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_sqs_queue: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+data-source/aws_sqs_queue: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/internal/service/sqs/consts.go
+++ b/internal/service/sqs/consts.go
@@ -1,7 +1,9 @@
 package sqs
 
 const (
-	ErrCodeInvalidAction = "InvalidAction"
+	ErrCodeInvalidAction      = "InvalidAction"
+	ErrCodeAccessDenied       = "AccessDenied"
+	ErrCodeAuthorizationError = "AuthorizationError"
 )
 
 const (

--- a/internal/service/sqs/consts.go
+++ b/internal/service/sqs/consts.go
@@ -1,9 +1,9 @@
 package sqs
 
 const (
-	ErrCodeInvalidAction      = "InvalidAction"
 	ErrCodeAccessDenied       = "AccessDenied"
 	ErrCodeAuthorizationError = "AuthorizationError"
+	ErrCodeInvalidAction      = "InvalidAction"
 )
 
 const (

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -219,7 +219,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}, sqs.ErrCodeQueueDeletedRecently)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError)) {
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation)) {
 		log.Printf("[WARN] SQS Queue (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 		outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(queueCreatedTimeout, func() (interface{}, error) {
@@ -243,7 +243,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction)) {
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)
@@ -307,7 +307,7 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return ListTags(conn, d.Id())
 	}, sqs.ErrCodeQueueDoesNotExist)
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] Unable to list tags for SQS Queue %s: %s", d.Id(), err)
 		return nil
@@ -364,7 +364,7 @@ func resourceQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) {
 			// Some partitions may not support tagging, giving error
 			log.Printf("[WARN] Unable to update tags for SQS Queue %s: %s", d.Id(), err)
 			return resourceQueueRead(d, meta)

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -243,7 +243,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -210,8 +209,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 
 	input.Attributes = aws.StringMap(attributes)
 
-	// Tag-on-create is currently only supported in AWS Commercial
-	if len(tags) > 0 && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
+	if len(tags) > 0 {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
@@ -219,6 +217,15 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(queueCreatedTimeout, func() (interface{}, error) {
 		return conn.CreateQueue(input)
 	}, sqs.ErrCodeQueueDeletedRecently)
+
+	// Some partitions may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, "AuthorizationError")) {
+		log.Printf("[WARN] SQS Queue (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+		outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(queueCreatedTimeout, func() (interface{}, error) {
+			return conn.CreateQueue(input)
+		}, sqs.ErrCodeQueueDeletedRecently)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error creating SQS Queue (%s): %w", name, err)
@@ -232,9 +239,17 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error waiting for SQS Queue (%s) attributes to create: %w", d.Id(), err)
 	}
 
-	// Tag-on-create is currently only supported in AWS Commercial
-	if len(tags) > 0 && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
-		if err := UpdateTags(conn, d.Id(), nil, tags); err != nil {
+	// Only post-create tagging supported in some partitions
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction)) {
+			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
+			log.Printf("[WARN] error adding tags after create for SQS Queue (%s): %s", d.Id(), err)
+			return resourceQueueRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating SQS Queue (%s) tags: %w", d.Id(), err)
 		}
 	}
@@ -292,14 +307,13 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return ListTags(conn, d.Id())
 	}, sqs.ErrCodeQueueDoesNotExist)
 
-	if err != nil {
-		// Non-standard partitions (e.g. US Gov) and some local development
-		// solutions do not yet support this API call. Depending on the
-		// implementation it may return InvalidAction or AWS.SimpleQueueService.UnsupportedOperation
-		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidAction) || tfawserr.ErrCodeEquals(err, sqs.ErrCodeUnsupportedOperation) {
-			return nil
-		}
+	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+		// Some partitions may not support tagging, giving error
+		log.Printf("[WARN] Unable to list tags for SQS Queue %s: %s", d.Id(), err)
+		return nil
+	}
 
+	if err != nil {
 		return fmt.Errorf("error listing tags for SQS Queue (%s): %w", d.Id(), err)
 	}
 
@@ -348,7 +362,15 @@ func resourceQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+		err := UpdateTags(conn, d.Id(), o, n)
+
+		if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") || tfawserr.ErrCodeContains(err, "InvalidAction") {
+			// Some partitions may not support tagging, giving error
+			log.Printf("[WARN] Unable to update tags for SQS Queue %s: %s", d.Id(), err)
+			return resourceQueueRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating SQS Queue (%s) tags: %w", d.Id(), err)
 		}
 	}

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -2,9 +2,11 @@ package sqs
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -59,6 +61,12 @@ func dataSourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(queueURL)
 
 	tags, err := ListTags(conn, queueURL)
+
+	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") {
+		// ISO partitions may not support tagging, giving error
+		log.Printf("[WARN] Unable to read tags for SQS queue data source %s: %s", d.Id(), err)
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for SQS Queue (%s): %w", queueURL, err)

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -62,9 +62,9 @@ func dataSourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, queueURL)
 
-	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, "AuthorizationError") {
-		// ISO partitions may not support tagging, giving error
-		log.Printf("[WARN] Unable to read tags for SQS queue data source %s: %s", d.Id(), err)
+	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+		// Some partitions may not support tagging, giving error
+		log.Printf("[WARN] Unable to list tags for SQS Queue %s: %s", d.Id(), err)
 		return nil
 	}
 

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -62,7 +62,7 @@ func dataSourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, queueURL)
 
-	if tfawserr.ErrCodeContains(err, "AccessDenied") || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] Unable to list tags for SQS Queue %s: %s", d.Id(), err)
 		return nil

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -62,7 +62,7 @@ func dataSourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, queueURL)
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] Unable to list tags for SQS Queue %s: %s", d.Id(), err)
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18135
Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS='TestAccSQSQueue_|TestAccSQSQueueDataSource_' PKG=sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue_|TestAccSQSQueueDataSource_'  -timeout 180m
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (4.43s)
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (4.58s)
--- PASS: TestAccSQSQueueDataSource_basic (60.23s)
--- PASS: TestAccSQSQueue_namePrefix (62.87s)
--- PASS: TestAccSQSQueue_Name_generated (58.80s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (63.35s)
--- PASS: TestAccSQSQueue_fifoQueue (63.47s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (63.57s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (63.59s)
--- PASS: TestAccSQSQueue_basic (59.01s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (63.59s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (63.61s)
--- PASS: TestAccSQSQueue_disappears (73.49s)
--- PASS: TestAccSQSQueue_tags (84.71s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (101.13s)
--- PASS: TestAccSQSQueue_update (101.49s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (109.12s)
--- PASS: TestAccSQSQueueDataSource_tags (49.80s)
--- PASS: TestAccSQSQueue_Policy_basic (112.63s)
--- PASS: TestAccSQSQueue_redriveAllowPolicy (136.23s)
--- PASS: TestAccSQSQueue_encryption (136.97s)
--- PASS: TestAccSQSQueue_redrivePolicy (140.99s)
--- PASS: TestAccSQSQueue_recentlyDeleted (211.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	212.978s
```

GovCloud:
```console
  % make testacc TESTS='TestAccSQSQueue_|TestAccSQSQueueDataSource_' PKG=sqs    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue_|TestAccSQSQueueDataSource_'  -timeout 180m
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (6.48s)
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (6.59s)
--- PASS: TestAccSQSQueue_tags (94.58s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (106.12s)
--- PASS: TestAccSQSQueue_Name_generated (103.52s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (111.81s)
--- PASS: TestAccSQSQueue_namePrefix (112.42s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (113.71s)
--- PASS: TestAccSQSQueue_Policy_basic (115.58s)
--- PASS: TestAccSQSQueue_update (153.36s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (156.87s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (158.29s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (162.00s)
--- PASS: TestAccSQSQueue_fifoQueue (162.47s)
--- PASS: TestAccSQSQueue_basic (155.99s)
--- SKIP: TestAccSQSQueue_redriveAllowPolicy (163.41s)
--- PASS: TestAccSQSQueue_redrivePolicy (189.21s)
--- PASS: TestAccSQSQueueDataSource_tags (99.62s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (203.82s)
--- PASS: TestAccSQSQueueDataSource_basic (224.29s)
--- PASS: TestAccSQSQueue_disappears (234.13s)
--- PASS: TestAccSQSQueue_encryption (248.37s)
--- PASS: TestAccSQSQueue_recentlyDeleted (275.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	277.168s
```