### PR TITLE
r/aws_ssm_parameter: Mark `version` as computed when value changes

### DIFF
--- a/.changelog/22522.txt
+++ b/.changelog/22522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_parameter: Mark `version` as Computed when `value` changes
+```

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -101,13 +101,16 @@ func ResourceParameter() *schema.Resource {
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
 
-		CustomizeDiff: customdiff.All(
+		CustomizeDiff: customdiff.Sequence(
 			// Prevent the following error during tier update from Advanced to Standard:
 			// ValidationException: This parameter uses the advanced-parameter tier. You can't downgrade a parameter from the advanced-parameter tier to the standard-parameter tier. If necessary, you can delete the advanced parameter and recreate it as a standard parameter.
 			// In the case of Advanced to Intelligent-Tiering, a ValidationException is not thrown
 			// but rather no change occurs without resource re-creation
 			customdiff.ForceNewIfChange("tier", func(_ context.Context, old, new, meta interface{}) bool {
 				return old.(string) == ssm.ParameterTierAdvanced && (new.(string) == ssm.ParameterTierStandard || new.(string) == ssm.ParameterTierIntelligentTiering)
+			}),
+			customdiff.ComputedIf("version", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("value")
 			}),
 			verify.SetTagsDiff,
 		),

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -222,7 +222,10 @@ func TestAccSSMParameter_overwrite(t *testing.T) {
 		CheckDestroy: testAccCheckParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterBasicConfig(name, "String", "test2"),
+				Config: testAccParameterBasicOverwriteConfig(name, "String", "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
 			},
 			{
 				ResourceName:            resourceName,
@@ -236,7 +239,33 @@ func TestAccSSMParameter_overwrite(t *testing.T) {
 					testAccCheckParameterExists(resourceName, &param),
 					resource.TestCheckResourceAttr(resourceName, "value", "test3"),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
 				),
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12213
+func TestAccSSMParameter_overwriteCascade(t *testing.T) {
+	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ssm.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterCascadeOverwriteConfig(name, "test1"),
+			},
+			{
+				Config: testAccParameterCascadeOverwriteConfig(name, "test2"),
+			},
+			{
+				Config:             testAccParameterCascadeOverwriteConfig(name, "test2"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -818,6 +847,24 @@ resource "aws_ssm_parameter" "test" {
   }
 }
 `, rName, overwrite, tagKey1, tagValue1)
+}
+
+func testAccParameterCascadeOverwriteConfig(rName, value string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test_upstream" {
+  name      = "test_parameter_upstream-%[1]s"
+  type      = "String"
+  value     = "%[2]s"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "test_downstream" {
+  name      = "test_parameter_downstream-%[1]s"
+  type      = "String"
+  value     = aws_ssm_parameter.test_upstream.version
+  overwrite = true
+}
+`, rName, value)
 }
 
 func testAccParameterSecureConfig(rName string, value string) string {


### PR DESCRIPTION
Ensure we refresh the `version` field when updating the contents of an SSM parameter. (Drive-by: Correct use of inconsistent
resources in `TestAccSSMParameter_overwrite` test phases.)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12213.

Output from acceptance testing:

```
Acceptance test output:

$ make testacc TESTS=TestAccSSMParameter_overwrite PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameter_overwrite' -timeout 180m
=== RUN   TestAccSSMParameter_overwrite
=== PAUSE TestAccSSMParameter_overwrite
=== RUN   TestAccSSMParameter_overwriteCascade
=== PAUSE TestAccSSMParameter_overwriteCascade
=== RUN   TestAccSSMParameter_overwriteWithTags
=== PAUSE TestAccSSMParameter_overwriteWithTags
=== CONT  TestAccSSMParameter_overwrite
=== CONT  TestAccSSMParameter_overwriteCascade
=== CONT  TestAccSSMParameter_overwriteWithTags
--- PASS: TestAccSSMParameter_overwriteWithTags (34.18s)
--- PASS: TestAccSSMParameter_overwrite (56.54s)
--- PASS: TestAccSSMParameter_overwriteCascade (87.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        87.972s
```
