### PR TITLE
d/aws_connect_quick_connect

### DIFF
--- a/.changelog/22527.txt
+++ b/.changelog/22527.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_connect_quick_connect
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -412,6 +412,7 @@ func Provider() *schema.Provider {
 			"aws_connect_hours_of_operation":          connect.DataSourceHoursOfOperation(),
 			"aws_connect_instance":                    connect.DataSourceInstance(),
 			"aws_connect_lambda_function_association": connect.DataSourceLambdaFunctionAssociation(),
+			"aws_connect_quick_connect":               connect.DataSourceQuickConnect(),
 
 			"aws_cur_report_definition": cur.DataSourceReportDefinition(),
 

--- a/internal/service/connect/enum.go
+++ b/internal/service/connect/enum.go
@@ -17,6 +17,9 @@ const (
 	// ListLambdaFunctionsMaxResults Valid Range: Minimum value of 1. Maximum value of 25.
 	//https://docs.aws.amazon.com/connect/latest/APIReference/API_ListLambdaFunctions.html
 	ListLambdaFunctionsMaxResults = 25
+	// ListLambdaFunctionsMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
+	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListQuickConnects.html
+	ListQuickConnectsMaxResults = 60
 )
 
 func InstanceAttributeMapping() map[string]string {

--- a/internal/service/connect/quick_connect_data_source.go
+++ b/internal/service/connect/quick_connect_data_source.go
@@ -1,0 +1,104 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/connect"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceQuickConnect() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQuickConnectRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"name", "quick_connect_id"},
+			},
+			"quick_connect_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"phone_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"phone_number": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"queue_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"contact_flow_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"queue_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"quick_connect_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"contact_flow_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"user_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"quick_connect_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"quick_connect_id", "name"},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}

--- a/internal/service/connect/quick_connect_data_source_test.go
+++ b/internal/service/connect/quick_connect_data_source_test.go
@@ -1,0 +1,82 @@
+package connect_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/connect"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccConnectQuickConnectDataSource_QuickConnectID(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_quick_connect.test"
+	datasourceName := "data.aws_connect_quick_connect.test"
+	phoneNumber := "+12345678912"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQuickConnectDataSourceConfig_QuickConnectID(rName, resourceName, phoneNumber),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.#", resourceName, "quick_connect_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.0.quick_connect_type", resourceName, "quick_connect_config.0.quick_connect_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.0.phone_config.#", resourceName, "quick_connect_config.0.phone_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.0.phone_config.0.phone_number", resourceName, "quick_connect_config.0.phone_config.0.phone_number"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_id", resourceName, "quick_connect_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+
+func testAccQuickConnectBaseDataSourceConfig(rName, rName2, phoneNumber string) string {
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+}
+
+resource "aws_connect_quick_connect" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = %[2]q
+  description = "Test Quick Connect Description"
+
+  quick_connect_config {
+    quick_connect_type = "PHONE_NUMBER"
+
+    phone_config {
+      phone_number = %[3]q
+    }
+  }
+
+  tags = {
+    "Name" = "Test Quick Connect"
+  }
+}
+	`, rName, rName2, phoneNumber)
+}
+
+func testAccQuickConnectDataSourceConfig_QuickConnectID(rName, rName2, phoneNumber string) string {
+	return acctest.ConfigCompose(
+		testAccQuickConnectBaseDataSourceConfig(rName, rName2, phoneNumber),
+		`
+data "aws_connect_quick_connect" "test" {
+  instance_id      = aws_connect_instance.test.id
+  quick_connect_id = aws_connect_quick_connect.test.quick_connect_id
+}
+`)
+}

--- a/internal/service/connect/quick_connect_data_source_test.go
+++ b/internal/service/connect/quick_connect_data_source_test.go
@@ -40,6 +40,36 @@ func TestAccConnectQuickConnectDataSource_QuickConnectID(t *testing.T) {
 	})
 }
 
+func TestAccConnectQuickConnectDataSource_name(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_quick_connect.test"
+	datasourceName := "data.aws_connect_quick_connect.test"
+	phoneNumber := "+12345678912"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQuickConnectDataSourceConfig_Name(rName, rName2, phoneNumber),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.#", resourceName, "quick_connect_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.0.quick_connect_type", resourceName, "quick_connect_config.0.quick_connect_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.0.phone_config.#", resourceName, "quick_connect_config.0.phone_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_config.0.phone_config.0.phone_number", resourceName, "quick_connect_config.0.phone_config.0.phone_number"),
+					resource.TestCheckResourceAttrPair(datasourceName, "quick_connect_id", resourceName, "quick_connect_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
 
 func testAccQuickConnectBaseDataSourceConfig(rName, rName2, phoneNumber string) string {
 	return fmt.Sprintf(`
@@ -77,6 +107,17 @@ func testAccQuickConnectDataSourceConfig_QuickConnectID(rName, rName2, phoneNumb
 data "aws_connect_quick_connect" "test" {
   instance_id      = aws_connect_instance.test.id
   quick_connect_id = aws_connect_quick_connect.test.quick_connect_id
+}
+`)
+}
+
+func testAccQuickConnectDataSourceConfig_Name(rName, rName2, phoneNumber string) string {
+	return acctest.ConfigCompose(
+		testAccQuickConnectBaseDataSourceConfig(rName, rName2, phoneNumber),
+		`
+data "aws_connect_quick_connect" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = aws_connect_quick_connect.test.name
 }
 `)
 }

--- a/website/docs/d/connect_quick_connect.markdown
+++ b/website/docs/d/connect_quick_connect.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "Connect"
+layout: "aws"
+page_title: "AWS: aws_connect_quick_connect"
+description: |-
+  Provides details about a specific Amazon Connect Quick Connect.
+---
+
+# Data Source: aws_connect_quick_connect
+
+Provides details about a specific Amazon Connect Quick Connect.
+
+## Example Usage
+
+By `name`
+
+```hcl
+data "aws_connect_quick_connect" "example" {
+  instance_id = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name        = "Example"
+}
+```
+
+By `quick_connect_id`
+
+```hcl
+data "aws_connect_quick_connect" "example" {
+  instance_id      = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  quick_connect_id = "cccccccc-bbbb-cccc-dddd-111111111111"
+}
+```
+
+## Argument Reference
+
+~> **NOTE:** `instance_id` and one of either `name` or `quick_connect_id` is required.
+
+The following arguments are supported:
+
+* `quick_connect_id` - (Optional) Returns information on a specific Quick Connect by Quick Connect id
+* `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
+* `name` - (Optional) Returns information on a specific Quick Connect by name
+
+## Attributes Reference
+
+In addition to all of the arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the Quick Connect.
+* `description` - Specifies the description of the Quick Connect.
+* `id` - The identifier of the hosting Amazon Connect Instance and identifier of the Quick Connect separated by a colon (`:`).
+* `quick_connect_config` - A block that defines the configuration information for the Quick Connect: `quick_connect_type` and one of `phone_config`, `queue_config`, `user_config` . The Quick Connect Config block is documented below.
+* `quick_connect_id` - The identifier for the Quick Connect.
+* `tags` - A map of tags to assign to the Quick Connect.
+
+A `quick_connect_config` block contains the following arguments:
+
+* `quick_connect_type` - Specifies the configuration type of the Quick Connect. Valid values are `PHONE_NUMBER`, `QUEUE`, `USER`.
+* `phone_config` - Specifies the phone configuration of the Quick Connect. This is returned only if `quick_connect_type` is `PHONE_NUMBER`. The `phone_config` block is documented below.
+* `queue_config` - Specifies the queue configuration of the Quick Connect. This is returned only if `quick_connect_type` is `QUEUE`. The `queue_config` block is documented below.
+* `user_config` - Specifies the user configuration of the Quick Connect. This is returned only if `quick_connect_type` is `USER`. The `user_config` block is documented below.
+
+A `phone_config` block contains the following arguments:
+
+* `phone_number` - Specifies the phone number in in E.164 format.
+
+A `queue_config` block contains the following arguments:
+
+* `contact_flow_id` - Specifies the identifier of the contact flow.
+* `queue_id` - Specifies the identifier for the queue.
+
+A `user_config` block contains the following arguments:
+
+* `contact_flow_id` - Specifies the identifier of the contact flow.
+* `user_id` - Specifies the identifier for the user.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21022

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccConnectQuickConnectDataSource PKG=connect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnectQuickConnectDataSource'  -timeout 180m
=== RUN   TestAccConnectQuickConnectDataSource_QuickConnectID
--- PASS: TestAccConnectQuickConnectDataSource_QuickConnectID (154.49s)
=== RUN   TestAccConnectQuickConnectDataSource_name
--- PASS: TestAccConnectQuickConnectDataSource_name (116.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    305.939s

...
```
