### PR TITLE
ecs: ISO-friendly tagging

### DIFF
--- a/.changelog/22529.txt
+++ b/.changelog/22529.txt
@@ -5,3 +5,7 @@ resource/aws_ecs_capacity_provider: Attempt `tags`-on-create, fallback to tag af
 ```release-note:enhancement
 resource/aws_ecs_cluster: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_ecs_service: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22529.txt
+++ b/.changelog/22529.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_ecs_capacity_provider: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_ecs_cluster: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22529.txt
+++ b/.changelog/22529.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_capacity_provider: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22529.txt
+++ b/.changelog/22529.txt
@@ -9,3 +9,7 @@ resource/aws_ecs_cluster: Attempt `tags`-on-create, fallback to tag after create
 ```release-note:enhancement
 resource/aws_ecs_service: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_ecs_task_definition: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22529.txt
+++ b/.changelog/22529.txt
@@ -13,3 +13,7 @@ resource/aws_ecs_service: Attempt `tags`-on-create, fallback to tag after create
 ```release-note:enhancement
 resource/aws_ecs_task_definition: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_ecs_task_set: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -125,8 +125,30 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Creating ECS Capacity Provider: %s", input)
 	output, err := conn.CreateCapacityProvider(&input)
 
+	// Some partitions may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+		log.Printf("[WARN] ECS Capacity Provider (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+		output, err = conn.CreateCapacityProvider(&input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating ECS Capacity Provider (%s): %w", name, err)
+	}
+
+	// Post-create tagging supported in some partitions
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
+			log.Printf("[WARN] error adding tags after create for ECS Capacity Provider (%s): %s", d.Id(), err)
+			return resourceCapacityProviderRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ECS Capacity Provider (%s) tags: %w", name, err)
+		}
 	}
 
 	d.SetId(aws.StringValue(output.CapacityProvider.CapacityProviderArn))
@@ -160,6 +182,12 @@ func resourceCapacityProviderRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", output.Name)
 
 	tags := KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+		// ISO partitions may not support tagging, giving error
+		log.Printf("[WARN] Unable to list tags for ECS Capacity Provider %s: %s", d.Id(), err)
+		return nil
+	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
@@ -212,7 +240,16 @@ func resourceCapacityProviderUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+
+		err := UpdateTags(conn, d.Id(), o, n)
+
+		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+			// ISO partitions may not support tagging, giving error
+			log.Printf("[WARN] Unable to update tags for ECS Capacity Provider %s: %s", d.Id(), err)
+			return resourceCapacityProviderRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating ECS Capacity Provider (%s) tags: %w", d.Id(), err)
 		}
 	}

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -140,7 +140,7 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] error adding tags after create for ECS Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -228,7 +228,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] error adding tags after create for ECS Cluster (%s): %s", d.Id(), err)
 			return resourceClusterRead(d, meta)

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -218,11 +218,11 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] ECS cluster %s created", aws.StringValue(out.Cluster.ClusterArn))
 
+	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
+
 	if _, err := waitClusterAvailable(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available: %w", d.Id(), err)
 	}
-
-	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
 
 	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
 	if input.Tags == nil && len(tags) > 0 {

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -181,8 +181,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	input := &ecs.CreateClusterInput{
 		ClusterName:                     aws.String(clusterName),
-		DefaultCapacityProviderStrategy: expandEcsCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set)),
-		Tags:                            Tags(tags.IgnoreAWS()),
+		DefaultCapacityProviderStrategy: expandCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set)),
 	}
 
 	if v, ok := d.GetOk("capacity_providers"); ok {
@@ -190,33 +189,27 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("setting"); ok {
-		input.Settings = expandEcsSettings(v.(*schema.Set))
+		input.Settings = expandClusterSettings(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("configuration"); ok && len(v.([]interface{})) > 0 {
-		input.Configuration = expandECSClusterConfiguration(v.([]interface{}))
+		input.Configuration = expandClusterConfiguration(v.([]interface{}))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	// CreateCluster will create the ECS IAM Service Linked Role on first ECS provision
 	// This process does not complete before the initial API call finishes.
-	var out *ecs.CreateClusterOutput
-	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
-		var err error
-		out, err = conn.CreateCluster(input)
+	out, err := retryClusterCreate(conn, input)
 
-		if tfawserr.ErrMessageContains(err, ecs.ErrCodeInvalidParameterException, "Unable to assume the service linked role") {
-			return resource.RetryableError(err)
-		}
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+		log.Printf("[WARN] ECS Cluster (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
 
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		out, err = conn.CreateCluster(input)
+		out, err = retryClusterCreate(conn, input)
 	}
 
 	if err != nil {
@@ -225,10 +218,25 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] ECS cluster %s created", aws.StringValue(out.Cluster.ClusterArn))
 
-	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
-
 	if _, err := waitClusterAvailable(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available: %w", d.Id(), err)
+	}
+
+	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); !ok || len(v.(map[string]interface{})) == 0 && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+			// If default tags only, log and continue. Otherwise, error.
+			log.Printf("[WARN] error adding tags after create for ECS Cluster (%s): %s", d.Id(), err)
+			return resourceClusterRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ECS Cluster (%s) tags: %w", clusterName, err)
+		}
 	}
 
 	return resourceClusterRead(d, meta)
@@ -298,21 +306,27 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("capacity_providers", aws.StringValueSlice(cluster.CapacityProviders)); err != nil {
 		return fmt.Errorf("error setting capacity_providers: %w", err)
 	}
-	if err := d.Set("default_capacity_provider_strategy", flattenEcsCapacityProviderStrategy(cluster.DefaultCapacityProviderStrategy)); err != nil {
+	if err := d.Set("default_capacity_provider_strategy", flattenCapacityProviderStrategy(cluster.DefaultCapacityProviderStrategy)); err != nil {
 		return fmt.Errorf("error setting default_capacity_provider_strategy: %w", err)
 	}
 
-	if err := d.Set("setting", flattenEcsSettings(cluster.Settings)); err != nil {
+	if err := d.Set("setting", flattenClusterSettings(cluster.Settings)); err != nil {
 		return fmt.Errorf("error setting setting: %w", err)
 	}
 
 	if cluster.Configuration != nil {
-		if err := d.Set("configuration", flattenECSClusterConfiguration(cluster.Configuration)); err != nil {
+		if err := d.Set("configuration", flattenClusterConfiguration(cluster.Configuration)); err != nil {
 			return fmt.Errorf("error setting configuration: %w", err)
 		}
 	}
 
 	tags := KeyValueTags(cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+		log.Printf("[WARN] Unable to list tags for ECS Cluster %s: %s", d.Id(), err)
+		return nil
+	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
@@ -335,11 +349,11 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if v, ok := d.GetOk("setting"); ok {
-			input.Settings = expandEcsSettings(v.(*schema.Set))
+			input.Settings = expandClusterSettings(v.(*schema.Set))
 		}
 
 		if v, ok := d.GetOk("configuration"); ok && len(v.([]interface{})) > 0 {
-			input.Configuration = expandECSClusterConfiguration(v.([]interface{}))
+			input.Configuration = expandClusterConfiguration(v.([]interface{}))
 		}
 
 		_, err := conn.UpdateCluster(&input)
@@ -355,7 +369,15 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+		err := UpdateTags(conn, d.Id(), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+			log.Printf("[WARN] Unable to update tags for ECS Cluster %s: %s", d.Id(), err)
+			return nil
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating ECS Cluster (%s) tags: %w", d.Id(), err)
 		}
 	}
@@ -364,7 +386,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		input := ecs.PutClusterCapacityProvidersInput{
 			Cluster:                         aws.String(d.Id()),
 			CapacityProviders:               flex.ExpandStringSet(d.Get("capacity_providers").(*schema.Set)),
-			DefaultCapacityProviderStrategy: expandEcsCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set)),
+			DefaultCapacityProviderStrategy: expandCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set)),
 		}
 
 		err := resource.Retry(ecsClusterTimeoutUpdate, func() *resource.RetryError {
@@ -446,7 +468,31 @@ func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandEcsSettings(configured *schema.Set) []*ecs.ClusterSetting {
+func retryClusterCreate(conn *ecs.ECS, input *ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error) {
+	var output *ecs.CreateClusterOutput
+	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
+		var err error
+		output, err = conn.CreateCluster(input)
+
+		if tfawserr.ErrMessageContains(err, ecs.ErrCodeInvalidParameterException, "Unable to assume the service linked role") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateCluster(input)
+	}
+
+	return output, err
+}
+
+func expandClusterSettings(configured *schema.Set) []*ecs.ClusterSetting {
 	list := configured.List()
 	if len(list) == 0 {
 		return nil
@@ -468,7 +514,7 @@ func expandEcsSettings(configured *schema.Set) []*ecs.ClusterSetting {
 	return settings
 }
 
-func flattenEcsSettings(list []*ecs.ClusterSetting) []map[string]interface{} {
+func flattenClusterSettings(list []*ecs.ClusterSetting) []map[string]interface{} {
 	if len(list) == 0 {
 		return nil
 	}
@@ -485,7 +531,7 @@ func flattenEcsSettings(list []*ecs.ClusterSetting) []map[string]interface{} {
 	return result
 }
 
-func flattenECSClusterConfiguration(apiObject *ecs.ClusterConfiguration) []interface{} {
+func flattenClusterConfiguration(apiObject *ecs.ClusterConfiguration) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -493,12 +539,12 @@ func flattenECSClusterConfiguration(apiObject *ecs.ClusterConfiguration) []inter
 	tfMap := map[string]interface{}{}
 
 	if apiObject.ExecuteCommandConfiguration != nil {
-		tfMap["execute_command_configuration"] = flattenECSClusterConfigurationExecuteCommandConfiguration(apiObject.ExecuteCommandConfiguration)
+		tfMap["execute_command_configuration"] = flattenClusterConfigurationExecuteCommandConfiguration(apiObject.ExecuteCommandConfiguration)
 	}
 	return []interface{}{tfMap}
 }
 
-func flattenECSClusterConfigurationExecuteCommandConfiguration(apiObject *ecs.ExecuteCommandConfiguration) []interface{} {
+func flattenClusterConfigurationExecuteCommandConfiguration(apiObject *ecs.ExecuteCommandConfiguration) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -510,7 +556,7 @@ func flattenECSClusterConfigurationExecuteCommandConfiguration(apiObject *ecs.Ex
 	}
 
 	if apiObject.LogConfiguration != nil {
-		tfMap["log_configuration"] = flattenECSClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiObject.LogConfiguration)
+		tfMap["log_configuration"] = flattenClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiObject.LogConfiguration)
 	}
 
 	if apiObject.Logging != nil {
@@ -520,7 +566,7 @@ func flattenECSClusterConfigurationExecuteCommandConfiguration(apiObject *ecs.Ex
 	return []interface{}{tfMap}
 }
 
-func flattenECSClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiObject *ecs.ExecuteCommandLogConfiguration) []interface{} {
+func flattenClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiObject *ecs.ExecuteCommandLogConfiguration) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -545,7 +591,7 @@ func flattenECSClusterConfigurationExecuteCommandConfigurationLogConfiguration(a
 	return []interface{}{tfMap}
 }
 
-func expandECSClusterConfiguration(nc []interface{}) *ecs.ClusterConfiguration {
+func expandClusterConfiguration(nc []interface{}) *ecs.ClusterConfiguration {
 	if len(nc) == 0 {
 		return &ecs.ClusterConfiguration{}
 	}
@@ -553,13 +599,13 @@ func expandECSClusterConfiguration(nc []interface{}) *ecs.ClusterConfiguration {
 
 	config := &ecs.ClusterConfiguration{}
 	if v, ok := raw["execute_command_configuration"].([]interface{}); ok && len(v) > 0 {
-		config.ExecuteCommandConfiguration = expandECSClusterConfigurationExecuteCommandConfiguration(v)
+		config.ExecuteCommandConfiguration = expandClusterConfigurationExecuteCommandConfiguration(v)
 	}
 
 	return config
 }
 
-func expandECSClusterConfigurationExecuteCommandConfiguration(nc []interface{}) *ecs.ExecuteCommandConfiguration {
+func expandClusterConfigurationExecuteCommandConfiguration(nc []interface{}) *ecs.ExecuteCommandConfiguration {
 	if len(nc) == 0 {
 		return &ecs.ExecuteCommandConfiguration{}
 	}
@@ -567,7 +613,7 @@ func expandECSClusterConfigurationExecuteCommandConfiguration(nc []interface{}) 
 
 	config := &ecs.ExecuteCommandConfiguration{}
 	if v, ok := raw["log_configuration"].([]interface{}); ok && len(v) > 0 {
-		config.LogConfiguration = expandECSClusterConfigurationExecuteCommandLogConfiguration(v)
+		config.LogConfiguration = expandClusterConfigurationExecuteCommandLogConfiguration(v)
 	}
 
 	if v, ok := raw["kms_key_id"].(string); ok && v != "" {
@@ -581,7 +627,7 @@ func expandECSClusterConfigurationExecuteCommandConfiguration(nc []interface{}) 
 	return config
 }
 
-func expandECSClusterConfigurationExecuteCommandLogConfiguration(nc []interface{}) *ecs.ExecuteCommandLogConfiguration {
+func expandClusterConfigurationExecuteCommandLogConfiguration(nc []interface{}) *ecs.ExecuteCommandLogConfiguration {
 	if len(nc) == 0 {
 		return &ecs.ExecuteCommandLogConfiguration{}
 	}

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -366,22 +366,6 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		err := UpdateTags(conn, d.Id(), o, n)
-
-		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
-			log.Printf("[WARN] Unable to update tags for ECS Cluster %s: %s", d.Id(), err)
-			return nil
-		}
-
-		if err != nil {
-			return fmt.Errorf("error updating ECS Cluster (%s) tags: %w", d.Id(), err)
-		}
-	}
-
 	if d.HasChanges("capacity_providers", "default_capacity_provider_strategy") {
 		input := ecs.PutClusterCapacityProvidersInput{
 			Cluster:                         aws.String(d.Id()),
@@ -414,6 +398,22 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if _, err := waitClusterAvailable(conn, d.Id()); err != nil {
 			return fmt.Errorf("error waiting for ECS Cluster (%s) to become Available: %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		err := UpdateTags(conn, d.Id(), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+			log.Printf("[WARN] Unable to update tags for ECS Cluster %s: %s", d.Id(), err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating ECS Cluster (%s) tags: %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/cluster_data_source.go
+++ b/internal/service/ecs/cluster_data_source.go
@@ -89,7 +89,7 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("running_tasks_count", cluster.RunningTasksCount)
 	d.Set("registered_container_instances_count", cluster.RegisteredContainerInstancesCount)
 
-	if err := d.Set("setting", flattenEcsSettings(cluster.Settings)); err != nil {
+	if err := d.Set("setting", flattenClusterSettings(cluster.Settings)); err != nil {
 		return fmt.Errorf("error setting setting: %w", err)
 	}
 

--- a/internal/service/ecs/flex.go
+++ b/internal/service/ecs/flex.go
@@ -34,7 +34,7 @@ func expandLoadBalancers(configured []interface{}) []*ecs.LoadBalancer {
 }
 
 // Flattens an array of ECS LoadBalancers into a []map[string]interface{}
-func flattenECSLoadBalancers(list []*ecs.LoadBalancer) []map[string]interface{} {
+func flattenLoadBalancers(list []*ecs.LoadBalancer) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, loadBalancer := range list {
 		l := map[string]interface{}{

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -598,8 +598,8 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
+		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
-			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] error adding tags after create for ECS Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}
@@ -1197,7 +1197,7 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
 			log.Printf("[WARN] Unable to update tags for ECS Service %s: %s", d.Id(), err)
-			return nil
+			return resourceServiceRead(d, meta)
 		}
 
 		if err != nil {

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -315,6 +315,10 @@ func TestAccECSService_healthCheckGracePeriodSeconds(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, ecs.EndpointsID),
@@ -411,6 +415,10 @@ func TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndH
 	var service ecs.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -1097,6 +1105,10 @@ func TestAccECSService_ServiceRegistries_changes(t *testing.T) {
 	serviceDiscoveryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	updatedServiceDiscoveryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(servicediscovery.EndpointsID, t) },

--- a/internal/service/ecs/tag_test.go
+++ b/internal/service/ecs/tag_test.go
@@ -24,7 +24,7 @@ func TestAccECSTag_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsTagConfig(rName, "key1", "value1"),
+				Config: testAccTagConfig(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", "key1"),
@@ -51,7 +51,7 @@ func TestAccECSTag_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsTagConfig(rName, "key1", "value1"),
+				Config: testAccTagConfig(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTagExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfecs.ResourceTag(), resourceName),
@@ -74,7 +74,7 @@ func TestAccECSTag_ResourceARN_batchComputeEnvironment(t *testing.T) {
 		CheckDestroy: testAccCheckTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsTagConfigResourceArnBatchComputeEnvironment(rName),
+				Config: testAccTagConfigResourceArnBatchComputeEnvironment(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTagExists(resourceName),
 				),
@@ -99,7 +99,7 @@ func TestAccECSTag_value(t *testing.T) {
 		CheckDestroy: testAccCheckTagDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsTagConfig(rName, "key1", "value1"),
+				Config: testAccTagConfig(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", "key1"),
@@ -112,7 +112,7 @@ func TestAccECSTag_value(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEcsTagConfig(rName, "key1", "value1updated"),
+				Config: testAccTagConfig(rName, "key1", "value1updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", "key1"),
@@ -123,7 +123,7 @@ func TestAccECSTag_value(t *testing.T) {
 	})
 }
 
-func testAccEcsTagConfig(rName string, key string, value string) string {
+func testAccTagConfig(rName string, key string, value string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %[1]q
@@ -141,7 +141,7 @@ resource "aws_ecs_tag" "test" {
 `, rName, key, value)
 }
 
-func testAccEcsTagConfigResourceArnBatchComputeEnvironment(rName string) string {
+func testAccTagConfigResourceArnBatchComputeEnvironment(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -545,7 +545,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
 			log.Printf("[WARN] error adding tags after create for ECS Task Definition (%s): %s", d.Id(), err)
-			return resourceServiceRead(d, meta)
+			return resourceTaskDefinitionRead(d, meta)
 		}
 
 		if err != nil {

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -67,9 +67,9 @@ func ResourceTaskDefinition() *schema.Resource {
 					// Sort the lists of environment variables as they are serialized to state, so we won't get
 					// spurious reorderings in plans (diff is suppressed if the environment variables haven't changed,
 					// but they still show in the plan if some other property changes).
-					orderedCDs, _ := expandEcsContainerDefinitions(v.(string))
+					orderedCDs, _ := expandContainerDefinitions(v.(string))
 					containerDefinitions(orderedCDs).OrderEnvironmentVariables()
-					unnormalizedJson, _ := flattenEcsContainerDefinitions(orderedCDs)
+					unnormalizedJson, _ := flattenContainerDefinitions(orderedCDs)
 					json, _ := structure.NormalizeJsonString(unnormalizedJson)
 					return json
 				},
@@ -422,7 +422,7 @@ func ResourceTaskDefinition() *schema.Resource {
 
 func ValidTaskDefinitionContainerDefinitions(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	_, err := expandEcsContainerDefinitions(value)
+	_, err := expandContainerDefinitions(value)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("ECS Task Definition container_definitions is invalid: %s", err))
 	}
@@ -435,7 +435,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	rawDefinitions := d.Get("container_definitions").(string)
-	definitions, err := expandEcsContainerDefinitions(rawDefinitions)
+	definitions, err := expandContainerDefinitions(rawDefinitions)
 	if err != nil {
 		return err
 	}
@@ -479,17 +479,17 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("volume"); ok {
-		volumes := expandEcsVolumes(v.(*schema.Set).List())
+		volumes := expandVolumes(v.(*schema.Set).List())
 		input.Volumes = volumes
 	}
 
 	if v, ok := d.GetOk("inference_accelerator"); ok {
-		input.InferenceAccelerators = expandEcsInferenceAccelerators(v.(*schema.Set).List())
+		input.InferenceAccelerators = expandInferenceAccelerators(v.(*schema.Set).List())
 	}
 
 	constraints := d.Get("placement_constraints").(*schema.Set).List()
 	if len(constraints) > 0 {
-		cons, err := expandEcsTaskDefinitionPlacementConstraints(constraints)
+		cons, err := expandTaskDefinitionPlacementConstraints(constraints)
 		if err != nil {
 			return err
 		}
@@ -502,16 +502,16 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 
 	runtimePlatformConfigs := d.Get("runtime_platform").([]interface{})
 	if len(runtimePlatformConfigs) > 0 && runtimePlatformConfigs[0] != nil {
-		input.RuntimePlatform = expandEcsTaskDefinitionRuntimePlatformConfiguration(runtimePlatformConfigs)
+		input.RuntimePlatform = expandTaskDefinitionRuntimePlatformConfiguration(runtimePlatformConfigs)
 	}
 
 	proxyConfigs := d.Get("proxy_configuration").([]interface{})
 	if len(proxyConfigs) > 0 {
-		input.ProxyConfiguration = expandEcsTaskDefinitionProxyConfiguration(proxyConfigs)
+		input.ProxyConfiguration = expandTaskDefinitionProxyConfiguration(proxyConfigs)
 	}
 
 	if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]interface{})) > 0 {
-		input.EphemeralStorage = expandEcsTaskDefinitionEphemeralStorage(v.([]interface{}))
+		input.EphemeralStorage = expandTaskDefinitionEphemeralStorage(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Registering ECS task definition: %s", input)
@@ -565,7 +565,7 @@ func resourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error 
 	// some other property changes).
 	containerDefinitions(taskDefinition.ContainerDefinitions).OrderEnvironmentVariables()
 
-	defs, err := flattenEcsContainerDefinitions(taskDefinition.ContainerDefinitions)
+	defs, err := flattenContainerDefinitions(taskDefinition.ContainerDefinitions)
 	if err != nil {
 		return err
 	}
@@ -593,11 +593,11 @@ func resourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
-	if err := d.Set("volume", flattenEcsVolumes(taskDefinition.Volumes)); err != nil {
+	if err := d.Set("volume", flattenVolumes(taskDefinition.Volumes)); err != nil {
 		return fmt.Errorf("error setting volume: %w", err)
 	}
 
-	if err := d.Set("inference_accelerator", flattenEcsInferenceAccelerators(taskDefinition.InferenceAccelerators)); err != nil {
+	if err := d.Set("inference_accelerator", flattenInferenceAccelerators(taskDefinition.InferenceAccelerators)); err != nil {
 		return fmt.Errorf("error setting inference accelerators: %w", err)
 	}
 
@@ -617,7 +617,7 @@ func resourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error setting proxy_configuration: %w", err)
 	}
 
-	if err := d.Set("ephemeral_storage", flattenEcsTaskDefinitionEphemeralStorage(taskDefinition.EphemeralStorage)); err != nil {
+	if err := d.Set("ephemeral_storage", flattenTaskDefinitionEphemeralStorage(taskDefinition.EphemeralStorage)); err != nil {
 		return fmt.Errorf("error setting ephemeral_storage: %w", err)
 	}
 	return nil
@@ -778,7 +778,7 @@ func resourceTaskDefinitionVolumeHash(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func flattenEcsInferenceAccelerators(list []*ecs.InferenceAccelerator) []map[string]interface{} {
+func flattenInferenceAccelerators(list []*ecs.InferenceAccelerator) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, iAcc := range list {
 		l := map[string]interface{}{
@@ -791,7 +791,7 @@ func flattenEcsInferenceAccelerators(list []*ecs.InferenceAccelerator) []map[str
 	return result
 }
 
-func expandEcsInferenceAccelerators(configured []interface{}) []*ecs.InferenceAccelerator {
+func expandInferenceAccelerators(configured []interface{}) []*ecs.InferenceAccelerator {
 	iAccs := make([]*ecs.InferenceAccelerator, 0, len(configured))
 	for _, lRaw := range configured {
 		data := lRaw.(map[string]interface{})
@@ -805,7 +805,7 @@ func expandEcsInferenceAccelerators(configured []interface{}) []*ecs.InferenceAc
 	return iAccs
 }
 
-func expandEcsTaskDefinitionPlacementConstraints(constraints []interface{}) ([]*ecs.TaskDefinitionPlacementConstraint, error) {
+func expandTaskDefinitionPlacementConstraints(constraints []interface{}) ([]*ecs.TaskDefinitionPlacementConstraint, error) {
 	var pc []*ecs.TaskDefinitionPlacementConstraint
 	for _, raw := range constraints {
 		p := raw.(map[string]interface{})
@@ -823,7 +823,7 @@ func expandEcsTaskDefinitionPlacementConstraints(constraints []interface{}) ([]*
 	return pc, nil
 }
 
-func expandEcsTaskDefinitionRuntimePlatformConfiguration(runtimePlatformConfig []interface{}) *ecs.RuntimePlatform {
+func expandTaskDefinitionRuntimePlatformConfiguration(runtimePlatformConfig []interface{}) *ecs.RuntimePlatform {
 	config := runtimePlatformConfig[0]
 
 	configMap := config.(map[string]interface{})
@@ -842,7 +842,7 @@ func expandEcsTaskDefinitionRuntimePlatformConfiguration(runtimePlatformConfig [
 	return ecsProxyConfig
 }
 
-func expandEcsTaskDefinitionProxyConfiguration(proxyConfigs []interface{}) *ecs.ProxyConfiguration {
+func expandTaskDefinitionProxyConfiguration(proxyConfigs []interface{}) *ecs.ProxyConfiguration {
 	proxyConfig := proxyConfigs[0]
 	configMap := proxyConfig.(map[string]interface{})
 
@@ -867,7 +867,7 @@ func expandEcsTaskDefinitionProxyConfiguration(proxyConfigs []interface{}) *ecs.
 	return ecsProxyConfig
 }
 
-func expandEcsVolumes(configured []interface{}) []*ecs.Volume {
+func expandVolumes(configured []interface{}) []*ecs.Volume {
 	volumes := make([]*ecs.Volume, 0, len(configured))
 
 	// Loop over our configured volumes and create
@@ -887,15 +887,15 @@ func expandEcsVolumes(configured []interface{}) []*ecs.Volume {
 		}
 
 		if v, ok := data["docker_volume_configuration"].([]interface{}); ok && len(v) > 0 {
-			l.DockerVolumeConfiguration = expandEcsVolumesDockerVolume(v)
+			l.DockerVolumeConfiguration = expandVolumesDockerVolume(v)
 		}
 
 		if v, ok := data["efs_volume_configuration"].([]interface{}); ok && len(v) > 0 {
-			l.EfsVolumeConfiguration = expandEcsVolumesEFSVolume(v)
+			l.EfsVolumeConfiguration = expandVolumesEFSVolume(v)
 		}
 
 		if v, ok := data["fsx_windows_file_server_volume_configuration"].([]interface{}); ok && len(v) > 0 {
-			l.FsxWindowsFileServerVolumeConfiguration = expandEcsVolumesFsxWinVolume(v)
+			l.FsxWindowsFileServerVolumeConfiguration = expandVolumesFsxWinVolume(v)
 		}
 
 		volumes = append(volumes, l)
@@ -904,7 +904,7 @@ func expandEcsVolumes(configured []interface{}) []*ecs.Volume {
 	return volumes
 }
 
-func expandEcsVolumesDockerVolume(configList []interface{}) *ecs.DockerVolumeConfiguration {
+func expandVolumesDockerVolume(configList []interface{}) *ecs.DockerVolumeConfiguration {
 	config := configList[0].(map[string]interface{})
 	dockerVol := &ecs.DockerVolumeConfiguration{}
 
@@ -934,7 +934,7 @@ func expandEcsVolumesDockerVolume(configList []interface{}) *ecs.DockerVolumeCon
 	return dockerVol
 }
 
-func expandEcsVolumesEFSVolume(efsConfig []interface{}) *ecs.EFSVolumeConfiguration {
+func expandVolumesEFSVolume(efsConfig []interface{}) *ecs.EFSVolumeConfiguration {
 	config := efsConfig[0].(map[string]interface{})
 	efsVol := &ecs.EFSVolumeConfiguration{}
 
@@ -954,13 +954,13 @@ func expandEcsVolumesEFSVolume(efsConfig []interface{}) *ecs.EFSVolumeConfigurat
 	}
 	if v, ok := config["authorization_config"].([]interface{}); ok && len(v) > 0 {
 		efsVol.RootDirectory = nil
-		efsVol.AuthorizationConfig = expandEcsVolumesEFSVolumeAuthorizationConfig(v)
+		efsVol.AuthorizationConfig = expandVolumesEFSVolumeAuthorizationConfig(v)
 	}
 
 	return efsVol
 }
 
-func expandEcsVolumesEFSVolumeAuthorizationConfig(efsConfig []interface{}) *ecs.EFSAuthorizationConfig {
+func expandVolumesEFSVolumeAuthorizationConfig(efsConfig []interface{}) *ecs.EFSAuthorizationConfig {
 	authconfig := efsConfig[0].(map[string]interface{})
 	auth := &ecs.EFSAuthorizationConfig{}
 
@@ -975,7 +975,7 @@ func expandEcsVolumesEFSVolumeAuthorizationConfig(efsConfig []interface{}) *ecs.
 	return auth
 }
 
-func expandEcsVolumesFsxWinVolume(fsxWinConfig []interface{}) *ecs.FSxWindowsFileServerVolumeConfiguration {
+func expandVolumesFsxWinVolume(fsxWinConfig []interface{}) *ecs.FSxWindowsFileServerVolumeConfiguration {
 	config := fsxWinConfig[0].(map[string]interface{})
 	fsxVol := &ecs.FSxWindowsFileServerVolumeConfiguration{}
 
@@ -988,13 +988,13 @@ func expandEcsVolumesFsxWinVolume(fsxWinConfig []interface{}) *ecs.FSxWindowsFil
 	}
 
 	if v, ok := config["authorization_config"].([]interface{}); ok && len(v) > 0 {
-		fsxVol.AuthorizationConfig = expandEcsVolumesFsxWinVolumeAuthorizationConfig(v)
+		fsxVol.AuthorizationConfig = expandVolumesFsxWinVolumeAuthorizationConfig(v)
 	}
 
 	return fsxVol
 }
 
-func expandEcsVolumesFsxWinVolumeAuthorizationConfig(config []interface{}) *ecs.FSxWindowsFileServerAuthorizationConfig {
+func expandVolumesFsxWinVolumeAuthorizationConfig(config []interface{}) *ecs.FSxWindowsFileServerAuthorizationConfig {
 	authconfig := config[0].(map[string]interface{})
 	auth := &ecs.FSxWindowsFileServerAuthorizationConfig{}
 
@@ -1009,7 +1009,7 @@ func expandEcsVolumesFsxWinVolumeAuthorizationConfig(config []interface{}) *ecs.
 	return auth
 }
 
-func flattenEcsVolumes(list []*ecs.Volume) []map[string]interface{} {
+func flattenVolumes(list []*ecs.Volume) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, volume := range list {
 		l := map[string]interface{}{
@@ -1146,7 +1146,7 @@ func flattenFsxWinVolumeAuthorizationConfig(config *ecs.FSxWindowsFileServerAuth
 	return items
 }
 
-func flattenEcsContainerDefinitions(definitions []*ecs.ContainerDefinition) (string, error) {
+func flattenContainerDefinitions(definitions []*ecs.ContainerDefinition) (string, error) {
 	b, err := jsonutil.BuildJSON(definitions)
 	if err != nil {
 		return "", err
@@ -1155,7 +1155,7 @@ func flattenEcsContainerDefinitions(definitions []*ecs.ContainerDefinition) (str
 	return string(b), nil
 }
 
-func expandEcsContainerDefinitions(rawDefinitions string) ([]*ecs.ContainerDefinition, error) {
+func expandContainerDefinitions(rawDefinitions string) ([]*ecs.ContainerDefinition, error) {
 	var definitions []*ecs.ContainerDefinition
 
 	err := json.Unmarshal([]byte(rawDefinitions), &definitions)
@@ -1166,7 +1166,7 @@ func expandEcsContainerDefinitions(rawDefinitions string) ([]*ecs.ContainerDefin
 	return definitions, nil
 }
 
-func expandEcsTaskDefinitionEphemeralStorage(config []interface{}) *ecs.EphemeralStorage {
+func expandTaskDefinitionEphemeralStorage(config []interface{}) *ecs.EphemeralStorage {
 	configMap := config[0].(map[string]interface{})
 
 	es := &ecs.EphemeralStorage{
@@ -1176,7 +1176,7 @@ func expandEcsTaskDefinitionEphemeralStorage(config []interface{}) *ecs.Ephemera
 	return es
 }
 
-func flattenEcsTaskDefinitionEphemeralStorage(pc *ecs.EphemeralStorage) []map[string]interface{} {
+func flattenTaskDefinitionEphemeralStorage(pc *ecs.EphemeralStorage) []map[string]interface{} {
 	if pc == nil {
 		return nil
 	}

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 func init() {
-	acctest.RegisterServiceErrorCheckFunc(ecs.EndpointsID, testAccErrorCheckSkipECS)
+	acctest.RegisterServiceErrorCheckFunc(ecs.EndpointsID, testAccErrorCheckSkip)
 }
 
-func testAccErrorCheckSkipECS(t *testing.T) resource.ErrorCheckFunc {
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"Unsupported field 'inferenceAccelerators'",
 	)
@@ -713,7 +713,7 @@ func TestAccECSTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 				Config: testAccTaskDefinitionUpdatedVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(resourceName, &after),
-					testAccCheckEcsTaskDefinitionRecreated(t, &before, &after),
+					testAccCheckTaskDefinitionRecreated(t, &before, &after),
 				),
 			},
 			{
@@ -1099,7 +1099,7 @@ func testAccCheckTaskDefinitionProxyConfiguration(after *ecs.TaskDefinition, con
 	}
 }
 
-func testAccCheckEcsTaskDefinitionRecreated(t *testing.T,
+func testAccCheckTaskDefinitionRecreated(t *testing.T,
 	before, after *ecs.TaskDefinition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *before.Revision == *after.Revision {

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -430,7 +430,7 @@ func TestAccECSTaskDefinition_fsxWinFileSystem(t *testing.T) {
 	domainName := acctest.RandomDomainName()
 
 	if testing.Short() {
-		t.Skip("skipping ~3400s test in short mode")
+		t.Skip("skipping long-running test in short mode")
 	}
 
 	if acctest.Partition() == "aws-us-gov" {

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -301,7 +301,7 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("capacity_provider_strategy"); ok && v.(*schema.Set).Len() > 0 {
-		input.CapacityProviderStrategy = expandEcsCapacityProviderStrategy(v.(*schema.Set))
+		input.CapacityProviderStrategy = expandCapacityProviderStrategy(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("external_id"); ok {
@@ -317,7 +317,7 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("network_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.NetworkConfiguration = expandEcsNetworkConfiguration(v.([]interface{}))
+		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("platform_version"); ok {
@@ -422,7 +422,7 @@ func resourceTaskSetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("task_definition", taskSet.TaskDefinition)
 	d.Set("task_set_id", taskSet.Id)
 
-	if err := d.Set("capacity_provider_strategy", flattenEcsCapacityProviderStrategy(taskSet.CapacityProviderStrategy)); err != nil {
+	if err := d.Set("capacity_provider_strategy", flattenCapacityProviderStrategy(taskSet.CapacityProviderStrategy)); err != nil {
 		return fmt.Errorf("error setting capacity_provider_strategy: %w", err)
 	}
 
@@ -430,7 +430,7 @@ func resourceTaskSetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting load_balancer: %w", err)
 	}
 
-	if err := d.Set("network_configuration", flattenEcsNetworkConfiguration(taskSet.NetworkConfiguration)); err != nil {
+	if err := d.Set("network_configuration", flattenNetworkConfiguration(taskSet.NetworkConfiguration)); err != nil {
 		return fmt.Errorf("error setting network_configuration: %w", err)
 	}
 

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -332,31 +332,21 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 		input.ServiceRegistries = expandServiceRegistries(v.([]interface{}))
 	}
 
-	// Retry due to AWS IAM & ECS eventual consistency
-	output, err := tfresource.RetryWhen(
-		tfiam.PropagationTimeout+taskSetCreateTimeout,
-		func() (interface{}, error) {
-			return conn.CreateTaskSet(input)
-		},
-		func(err error) (bool, error) {
-			if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException, ecs.ErrCodeServiceNotFoundException, ecs.ErrCodeTaskSetNotFoundException) ||
-				tfawserr.ErrMessageContains(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
-				return true, err
-			}
-			return false, err
-		},
-	)
+	output, err := retryTaskSetCreate(conn, input)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+		log.Printf("[WARN] ECS Task Set (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+
+		output, err = retryTaskSetCreate(conn, input)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error creating ECS TaskSet: %w", err)
 	}
 
-	result, ok := output.(*ecs.CreateTaskSetOutput)
-	if !ok || result == nil || result.TaskSet == nil {
-		return fmt.Errorf("error creating ECS TaskSet: empty output")
-	}
-
-	taskSetId := aws.StringValue(result.TaskSet.Id)
+	taskSetId := aws.StringValue(output.TaskSet.Id)
 
 	d.SetId(fmt.Sprintf("%s,%s,%s", taskSetId, service, cluster))
 
@@ -364,6 +354,21 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 		timeout, _ := time.ParseDuration(d.Get("wait_until_stable_timeout").(string))
 		if err := waitTaskSetStable(conn, timeout, taskSetId, service, cluster); err != nil {
 			return fmt.Errorf("error waiting for ECS TaskSet (%s) to be stable: %w", d.Id(), err)
+		}
+	}
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+			// If default tags only, log and continue. Otherwise, error.
+			log.Printf("[WARN] error adding tags after create for ECS Task Set (%s): %s", d.Id(), err)
+			return resourceTaskSetRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ECS Task Set (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -444,6 +449,12 @@ func resourceTaskSetRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags := KeyValueTags(taskSet.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+		log.Printf("[WARN] Unable to list tags for ECS Task Set %s: %s", d.Id(), err)
+		return nil
+	}
+
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
@@ -490,8 +501,16 @@ func resourceTaskSetUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating ECS TaskSet (%s) tags: %w", d.Id(), err)
+		err := UpdateTags(conn, d.Get("arn").(string), o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+			log.Printf("[WARN] Unable to update tags for ECS Task Set %s: %s", d.Id(), err)
+			return resourceTaskSetRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating ECS Task Set (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -542,4 +561,27 @@ func TaskSetParseID(id string) (string, string, string, error) {
 	}
 
 	return parts[0], parts[1], parts[2], nil
+}
+
+func retryTaskSetCreate(conn *ecs.ECS, input *ecs.CreateTaskSetInput) (*ecs.CreateTaskSetOutput, error) {
+	outputRaw, err := tfresource.RetryWhen(
+		tfiam.PropagationTimeout+taskSetCreateTimeout,
+		func() (interface{}, error) {
+			return conn.CreateTaskSet(input)
+		},
+		func(err error) (bool, error) {
+			if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException, ecs.ErrCodeServiceNotFoundException, ecs.ErrCodeTaskSetNotFoundException) ||
+				tfawserr.ErrMessageContains(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
+				return true, err
+			}
+			return false, err
+		},
+	)
+
+	output, ok := outputRaw.(*ecs.CreateTaskSetOutput)
+	if !ok || output == nil || output.TaskSet == nil {
+		return nil, fmt.Errorf("error creating ECS TaskSet: empty output")
+	}
+
+	return output, err
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18134
Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccECSCapacityProvider_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCapacityProvider_'  -timeout 180m
--- PASS: TestAccECSCapacityProvider_managedScalingPartial (60.22s)
--- PASS: TestAccECSCapacityProvider_basic (62.32s)
--- PASS: TestAccECSCapacityProvider_disappears (70.58s)
--- PASS: TestAccECSCapacityProvider_managedScaling (84.65s)
--- PASS: TestAccECSCapacityProvider_tags (105.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	107.208s
% make testacc TESTS='TestAccECSCluster_|TestAccECSClusterDataSource_' PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCluster_|TestAccECSClusterDataSource_'  -timeout 180m
--- PASS: TestAccECSCluster_disappears (24.22s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (26.66s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (26.67s)
--- PASS: TestAccECSCluster_basic (28.62s)
--- PASS: TestAccECSCluster_tags (45.77s)
--- PASS: TestAccECSCluster_capacityProviders (49.19s)
--- PASS: TestAccECSCluster_configuration (53.38s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (56.16s)
--- PASS: TestAccECSCluster_containerInsights (64.45s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (82.06s)
--- PASS: TestAccECSCluster_singleCapacityProvider (91.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	93.274s
% make testacc TESTS=TestAccECSService_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_'  -timeout 180m
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (39.38s)
--- PASS: TestAccECSService_DeploymentControllerType_external (72.17s)
--- PASS: TestAccECSService_iamRole (83.27s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (85.96s)
--- PASS: TestAccECSService_Tags_managed (85.98s)
--- PASS: TestAccECSService_DeploymentValues_basic (85.98s)
--- PASS: TestAccECSService_basic (97.08s)
--- PASS: TestAccECSService_executeCommand (99.57s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (101.12s)
--- PASS: TestAccECSService_clusterName (101.42s)
--- PASS: TestAccECSService_Tags_basic (124.13s)
--- PASS: TestAccECSService_loadBalancerChanges (125.69s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (26.35s)
--- PASS: TestAccECSService_PlacementStrategy_missing (0.76s)
--- PASS: TestAccECSService_renamedCluster (96.48s)
--- PASS: TestAccECSService_familyAndRevision (98.09s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (57.22s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (87.65s)
--- PASS: TestAccECSService_Tags_propagate (204.03s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (122.63s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (115.68s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (87.73s)
--- PASS: TestAccECSService_multipleTargetGroups (237.27s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (152.36s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (150.99s)
--- PASS: TestAccECSService_ServiceRegistries_container (168.87s)
--- PASS: TestAccECSService_ServiceRegistries_basic (169.31s)
--- PASS: TestAccECSService_alb (255.31s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (256.95s)
--- PASS: TestAccECSService_PlacementConstraints_basic (83.23s)
--- PASS: TestAccECSService_basicImport (74.96s)
--- PASS: TestAccECSService_forceNewDeployment (82.01s)
--- PASS: TestAccECSService_PlacementStrategy_basic (71.56s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (292.41s)
--- PASS: TestAccECSService_disappears (70.90s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (173.24s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (183.78s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (154.16s)
--- PASS: TestAccECSService_ServiceRegistries_changes (358.48s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (195.90s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (366.25s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (406.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	407.952s
% make testacc TESTS=TestAccECSTaskDefinition_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_'  -timeout 180m
=== CONT  TestAccECSTaskDefinition_fsxWinFileSystem
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (37.18s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (37.18s)
--- PASS: TestAccECSTaskDefinition_arrays (37.25s)
--- PASS: TestAccECSTaskDefinition_constraint (38.17s)
--- PASS: TestAccECSTaskDefinition_ipcMode (40.44s)
--- PASS: TestAccECSTaskDefinition_networkMode (40.98s)
--- PASS: TestAccECSTaskDefinition_executionRole (41.14s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (41.15s)
--- PASS: TestAccECSTaskDefinition_pidMode (41.57s)
--- PASS: TestAccECSTaskDefinition_proxy (50.32s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (51.29s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (51.50s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (51.67s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (52.62s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (56.34s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (59.41s)
--- PASS: TestAccECSTaskDefinition_basic (59.52s)
--- PASS: TestAccECSTaskDefinition_runtimePlatform (28.67s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (28.67s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (27.79s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (26.35s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (27.13s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (27.14s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (27.38s)
--- PASS: TestAccECSTaskDefinition_disappears (38.34s)
--- PASS: TestAccECSTaskDefinition_tags (77.43s)
--- PASS: TestAccECSTaskDefinition_service (134.49s)
% make testacc TESTS=TestAccECSTaskSet_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskSet_'  -timeout 180m
--- PASS: TestAccECSTaskSet_basic (67.75s)
--- PASS: TestAccECSTaskSet_withExternalId (67.88s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargate (72.10s)
--- PASS: TestAccECSTaskSet_disappears (72.32s)
--- PASS: TestAccECSTaskSet_withMultipleCapacityProviderStrategies (78.61s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargateAndPlatformVersion (98.70s)
--- PASS: TestAccECSTaskSet_withScale (109.89s)
--- PASS: TestAccECSTaskSet_Tags (119.91s)
--- PASS: TestAccECSTaskSet_withServiceRegistries (142.46s)
--- PASS: TestAccECSTaskSet_withCapacityProviderStrategy (143.92s)
--- PASS: TestAccECSTaskSet_withAlb (226.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	227.898s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS='TestAccECSCluster_|TestAccECSClusterDataSource_' PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCluster_|TestAccECSClusterDataSource_'  -timeout 180m
--- PASS: TestAccECSCluster_disappears (28.35s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (31.05s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (31.06s)
--- PASS: TestAccECSCluster_basic (33.04s)
--- PASS: TestAccECSCluster_capacityProviders (56.13s)
--- PASS: TestAccECSCluster_tags (56.86s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (60.39s)
--- PASS: TestAccECSCluster_configuration (61.18s)
--- PASS: TestAccECSCluster_containerInsights (74.93s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (82.22s)
--- PASS: TestAccECSCluster_singleCapacityProvider (83.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	84.985s
% make testacc TESTS=TestAccECSCapacityProvider_ PKG=ecs      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCapacityProvider_'  -timeout 180m
--- PASS: TestAccECSCapacityProvider_basic (64.15s)
--- PASS: TestAccECSCapacityProvider_managedScalingPartial (77.52s)
--- PASS: TestAccECSCapacityProvider_disappears (77.98s)
--- PASS: TestAccECSCapacityProvider_tags (109.95s)
--- PASS: TestAccECSCapacityProvider_managedScaling (130.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	132.035s
% make testacc TESTS=TestAccECSService_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_'  -timeout 180m
--- PASS: TestAccECSService_PlacementStrategy_missing (3.93s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (52.38s)
--- PASS: TestAccECSService_iamRole (60.28s)
--- PASS: TestAccECSService_basic (83.24s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (83.52s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (83.53s)
--- PASS: TestAccECSService_ServiceRegistries_basic (94.49s)
--- PASS: TestAccECSService_ServiceRegistries_container (94.70s)
--- PASS: TestAccECSService_renamedCluster (95.62s)
--- PASS: TestAccECSService_forceNewDeployment (98.85s)
--- PASS: TestAccECSService_executeCommand (104.07s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (122.97s)
--- PASS: TestAccECSService_Tags_managed (74.97s)
--- PASS: TestAccECSService_PlacementStrategy_basic (139.89s)
--- PASS: TestAccECSService_PlacementConstraints_basic (60.31s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (149.25s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (74.79s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (164.54s)
--- PASS: TestAccECSService_DeploymentValues_basic (75.22s)
--- PASS: TestAccECSService_clusterName (74.88s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (181.34s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (182.28s)
--- PASS: TestAccECSService_ServiceRegistries_changes (186.19s)
--- PASS: TestAccECSService_Tags_basic (121.25s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (74.91s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (95.58s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (44.54s)
--- PASS: TestAccECSService_DeploymentControllerType_external (62.59s)
--- PASS: TestAccECSService_disappears (78.03s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (134.02s)
--- PASS: TestAccECSService_familyAndRevision (93.59s)
--- PASS: TestAccECSService_multipleTargetGroups (245.15s)
--- PASS: TestAccECSService_basicImport (65.17s)
--- PASS: TestAccECSService_Tags_propagate (219.97s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (187.25s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (110.20s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (309.64s)
--- PASS: TestAccECSService_loadBalancerChanges (214.15s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (356.37s)
--- PASS: TestAccECSService_alb (273.01s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (235.58s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (342.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	514.930s
% make testacc TESTS=TestAccECSTaskDefinition_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinition_'  -timeout 180m
--- SKIP: TestAccECSTaskDefinition_fsxWinFileSystem (0.00s)
--- SKIP: TestAccECSTaskDefinition_runtimePlatform (1.42s)
--- SKIP: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (1.42s)
--- SKIP: TestAccECSTaskDefinition_Fargate_runtimePlatform (0.00s)
--- SKIP: TestAccECSTaskDefinition_inferenceAccelerator (15.21s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (36.91s)
--- PASS: TestAccECSTaskDefinition_arrays (36.95s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (36.98s)
--- PASS: TestAccECSTaskDefinition_constraint (37.07s)
--- PASS: TestAccECSTaskDefinition_networkMode (43.17s)
--- PASS: TestAccECSTaskDefinition_ipcMode (43.69s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (43.70s)
--- PASS: TestAccECSTaskDefinition_pidMode (43.75s)
--- PASS: TestAccECSTaskDefinition_executionRole (43.80s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (47.69s)
--- PASS: TestAccECSTaskDefinition_proxy (49.57s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (50.66s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (52.44s)
--- PASS: TestAccECSTaskDefinition_disappears (55.07s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (40.73s)
--- PASS: TestAccECSTaskDefinition_basic (58.75s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (58.87s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (28.32s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (28.39s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (28.45s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (68.33s)
--- PASS: TestAccECSTaskDefinition_tags (83.55s)
--- PASS: TestAccECSTaskDefinition_service (132.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	134.283s
% make testacc TESTS=TestAccECSTaskSet_ PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskSet_'  -timeout 180m
--- PASS: TestAccECSTaskSet_withExternalId (72.01s)
--- PASS: TestAccECSTaskSet_basic (72.07s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargate (75.85s)
--- PASS: TestAccECSTaskSet_withServiceRegistries (76.37s)
--- PASS: TestAccECSTaskSet_disappears (76.47s)
--- PASS: TestAccECSTaskSet_withScale (101.01s)
--- PASS: TestAccECSTaskSet_Tags (103.49s)
--- PASS: TestAccECSTaskSet_withMultipleCapacityProviderStrategies (105.68s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargateAndPlatformVersion (120.39s)
--- PASS: TestAccECSTaskSet_withCapacityProviderStrategy (135.02s)
--- PASS: TestAccECSTaskSet_withAlb (263.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	265.305s
```