### PR TITLE
r/aws_subnet: Resource-based naming is not available in the `ap-southeast-3` region

### DIFF
--- a/.changelog/22531.txt
+++ b/.changelog/22531.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_subnet: Resource-based naming is not available in the `ap-southeast-3` region
+```

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -435,6 +435,22 @@ func StatusSubnetMapPublicIPOnLaunch(conn *ec2.EC2, id string) resource.StateRef
 	}
 }
 
+func StatusSubnetPrivateDNSHostnameTypeOnLaunch(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindSubnetByID(conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.PrivateDnsNameOptionsOnLaunch.HostnameType), nil
+	}
+}
+
 func StatusTransitGatewayPrefixListReferenceState(conn *ec2.EC2, transitGatewayRouteTableID string, prefixListID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		transitGatewayPrefixListReference, err := FindTransitGatewayPrefixListReference(conn, transitGatewayRouteTableID, prefixListID)

--- a/internal/service/ec2/subnet.go
+++ b/internal/service/ec2/subnet.go
@@ -147,7 +147,6 @@ func resourceSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	input := &ec2.CreateSubnetInput{
 		AvailabilityZone:   aws.String(d.Get("availability_zone").(string)),
 		AvailabilityZoneId: aws.String(d.Get("availability_zone_id").(string)),
-		Ipv6Native:         aws.Bool(d.Get("ipv6_native").(bool)),
 		TagSpecifications:  ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSubnet),
 		VpcId:              aws.String(d.Get("vpc_id").(string)),
 	}
@@ -158,6 +157,10 @@ func resourceSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("ipv6_cidr_block"); ok {
 		input.Ipv6CidrBlock = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ipv6_native"); ok {
+		input.Ipv6Native = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("outpost_arn"); ok {
@@ -290,6 +293,10 @@ func resourceSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 
 		if _, err := conn.ModifySubnetAttribute(input); err != nil {
 			return fmt.Errorf("error setting EC2 Subnet (%s) PrivateDnsHostnameTypeOnLaunch: %w", d.Id(), err)
+		}
+
+		if _, err := WaitSubnetPrivateDNSHostnameTypeOnLaunchUpdated(conn, d.Id(), d.Get("private_dns_hostname_type_on_launch").(string)); err != nil {
+			return fmt.Errorf("error waiting for EC2 Subnet (%s) PrivateDnsHostnameTypeOnLaunch update: %w", d.Id(), err)
 		}
 	}
 
@@ -479,6 +486,10 @@ func resourceSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if _, err := conn.ModifySubnetAttribute(input); err != nil {
 			return fmt.Errorf("error setting EC2 Subnet (%s) PrivateDnsHostnameTypeOnLaunch: %w", d.Id(), err)
+		}
+
+		if _, err := WaitSubnetPrivateDNSHostnameTypeOnLaunchUpdated(conn, d.Id(), d.Get("private_dns_hostname_type_on_launch").(string)); err != nil {
+			return fmt.Errorf("error waiting for EC2 Subnet (%s) PrivateDnsHostnameTypeOnLaunch update: %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/subnet_test.go
+++ b/internal/service/ec2/subnet_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -21,6 +22,12 @@ func TestAccEC2Subnet_basic(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	// Resource-based naming is not available in the AWS Asia Pacific (Jakarta) Region.
+	defaultPrivateDNSHostnameTypeOnLaunch := "ip-name"
+	if acctest.Region() == endpoints.ApSoutheast3RegionID {
+		defaultPrivateDNSHostnameTypeOnLaunch = ""
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -46,7 +53,7 @@ func TestAccEC2Subnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "map_public_ip_on_launch", "false"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_hostname_type_on_launch", "ip-name"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_hostname_type_on_launch", defaultPrivateDNSHostnameTypeOnLaunch),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -808,6 +815,11 @@ func TestAccEC2Subnet_enableDNS64(t *testing.T) {
 }
 
 func TestAccEC2Subnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
+	// Resource-based naming is not available in the AWS Asia Pacific (Jakarta) Region.
+	if region := acctest.Region(); region == endpoints.ApSoutheast3RegionID {
+		t.Skipf("Resource-based naming is not available in the %s region", region)
+	}
+
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -855,6 +867,11 @@ func TestAccEC2Subnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
 }
 
 func TestAccEC2Subnet_ipv6Native(t *testing.T) {
+	// IPv6-only subnets are not available in the AWS Asia Pacific (Jakarta) Region.
+	if region := acctest.Region(); region == endpoints.ApSoutheast3RegionID {
+		t.Skipf("Resource-based naming is not available in the %s region", region)
+	}
+
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/subnet_test.go
+++ b/internal/service/ec2/subnet_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -22,12 +21,6 @@ func TestAccEC2Subnet_basic(t *testing.T) {
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	// Resource-based naming is not available in the AWS Asia Pacific (Jakarta) Region.
-	defaultPrivateDNSHostnameTypeOnLaunch := "ip-name"
-	if acctest.Region() == endpoints.ApSoutheast3RegionID {
-		defaultPrivateDNSHostnameTypeOnLaunch = ""
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -53,7 +46,7 @@ func TestAccEC2Subnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "map_public_ip_on_launch", "false"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "private_dns_hostname_type_on_launch", defaultPrivateDNSHostnameTypeOnLaunch),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_hostname_type_on_launch", "ip-name"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -815,11 +808,6 @@ func TestAccEC2Subnet_enableDNS64(t *testing.T) {
 }
 
 func TestAccEC2Subnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
-	// Resource-based naming is not available in the AWS Asia Pacific (Jakarta) Region.
-	if region := acctest.Region(); region == endpoints.ApSoutheast3RegionID {
-		t.Skipf("Resource-based naming is not available in the %s region", region)
-	}
-
 	var subnet ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -867,11 +855,6 @@ func TestAccEC2Subnet_privateDnsNameOptionsOnLaunch(t *testing.T) {
 }
 
 func TestAccEC2Subnet_ipv6Native(t *testing.T) {
-	// IPv6-only subnets are not available in the AWS Asia Pacific (Jakarta) Region.
-	if region := acctest.Region(); region == endpoints.ApSoutheast3RegionID {
-		t.Skipf("Resource-based naming is not available in the %s region", region)
-	}
-
 	var v ec2.Subnet
 	resourceName := "aws_subnet.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -585,6 +585,24 @@ func WaitSubnetMapPublicIPOnLaunchUpdated(conn *ec2.EC2, subnetID string, expect
 	return nil, err
 }
 
+func WaitSubnetPrivateDNSHostnameTypeOnLaunchUpdated(conn *ec2.EC2, subnetID string, expectedValue string) (*ec2.Subnet, error) {
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{expectedValue},
+		Refresh:    StatusSubnetPrivateDNSHostnameTypeOnLaunch(conn, subnetID),
+		Timeout:    SubnetAttributePropagationTimeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.Subnet); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 const (
 	TransitGatewayPrefixListReferenceTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #22498.

Previously:

```console
% AWS_DEFAULT_REGION=ap-southeast-3 make testacc TESTS=TestAccEC2Subnet_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Subnet_basic'  -timeout 180m
=== RUN   TestAccEC2Subnet_basic
=== PAUSE TestAccEC2Subnet_basic
=== CONT  TestAccEC2Subnet_basic
    subnet_test.go:25: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating EC2 Subnet: InvalidParameter: The parameter ipv6Native is not recognized
        	status code: 400, request id: 984022b4-35f4-4581-adec-34a058e59131
        
          with aws_subnet.test,
          on terraform_plugin_test.tf line 10, in resource "aws_subnet" "test":
          10: resource "aws_subnet" "test" {
        
--- FAIL: TestAccEC2Subnet_basic (37.39s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	41.076s
FAIL
make: *** [testacc] Error 1
```

Now

```console
% AWS_DEFAULT_REGION=ap-southeast-3 make testacc TESTS=TestAccEC2Subnet_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Subnet_basic'  -timeout 180m
=== RUN   TestAccEC2Subnet_basic
=== PAUSE TestAccEC2Subnet_basic
=== CONT  TestAccEC2Subnet_basic
--- PASS: TestAccEC2Subnet_basic (79.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	83.756s
```

Also addresses failing CI test:

```
=== RUN   TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
=== PAUSE TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
=== CONT  TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
subnet_test.go:815: Step 1/4 error: Check failed: Check 4/4 error: aws_subnet.test: Attribute 'private_dns_hostname_type_on_launch' expected "resource-name", got "ip-name"
--- FAIL: TestAccEC2Subnet_privateDnsNameOptionsOnLaunch (70.15s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### `ap-southeast-3`

```console
% AWS_DEFAULT_REGION=ap-southeast-3 make testacc TESTARGS='-run=TestAccEC2Subnet_\|TestAccEC2SubnetDataSource_' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2Subnet_\|TestAccEC2SubnetDataSource_ -timeout 180m
=== RUN   TestAccEC2SubnetDataSource_basic
=== PAUSE TestAccEC2SubnetDataSource_basic
=== RUN   TestAccEC2SubnetDataSource_ipv6ByIPv6Filter
=== PAUSE TestAccEC2SubnetDataSource_ipv6ByIPv6Filter
=== RUN   TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock
=== PAUSE TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock
=== RUN   TestAccEC2Subnet_basic
=== PAUSE TestAccEC2Subnet_basic
=== RUN   TestAccEC2Subnet_tags
=== PAUSE TestAccEC2Subnet_tags
=== RUN   TestAccEC2Subnet_DefaultTags_providerOnly
=== PAUSE TestAccEC2Subnet_DefaultTags_providerOnly
=== RUN   TestAccEC2Subnet_DefaultTags_updateToProviderOnly
=== PAUSE TestAccEC2Subnet_DefaultTags_updateToProviderOnly
=== RUN   TestAccEC2Subnet_DefaultTags_updateToResourceOnly
=== PAUSE TestAccEC2Subnet_DefaultTags_updateToResourceOnly
=== RUN   TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag
=== PAUSE TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag
=== RUN   TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag
=== PAUSE TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag
=== RUN   TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag
=== PAUSE TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag
=== RUN   TestAccEC2Subnet_defaultAndIgnoreTags
=== PAUSE TestAccEC2Subnet_defaultAndIgnoreTags
=== RUN   TestAccEC2Subnet_updateTagsKnownAtApply
=== PAUSE TestAccEC2Subnet_updateTagsKnownAtApply
=== RUN   TestAccEC2Subnet_ignoreTags
=== PAUSE TestAccEC2Subnet_ignoreTags
=== RUN   TestAccEC2Subnet_ipv6
=== PAUSE TestAccEC2Subnet_ipv6
=== RUN   TestAccEC2Subnet_enableIPv6
=== PAUSE TestAccEC2Subnet_enableIPv6
=== RUN   TestAccEC2Subnet_availabilityZoneID
=== PAUSE TestAccEC2Subnet_availabilityZoneID
=== RUN   TestAccEC2Subnet_disappears
=== PAUSE TestAccEC2Subnet_disappears
=== RUN   TestAccEC2Subnet_customerOwnedIPv4Pool
=== PAUSE TestAccEC2Subnet_customerOwnedIPv4Pool
=== RUN   TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch
=== PAUSE TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch
=== RUN   TestAccEC2Subnet_mapPublicIPOnLaunch
=== PAUSE TestAccEC2Subnet_mapPublicIPOnLaunch
=== RUN   TestAccEC2Subnet_outpost
=== PAUSE TestAccEC2Subnet_outpost
=== RUN   TestAccEC2Subnet_enableDNS64
=== PAUSE TestAccEC2Subnet_enableDNS64
=== RUN   TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
    subnet_test.go:820: Resource-based naming is not available in the ap-southeast-3 region
--- SKIP: TestAccEC2Subnet_privateDnsNameOptionsOnLaunch (0.00s)
=== RUN   TestAccEC2Subnet_ipv6Native
    subnet_test.go:872: Resource-based naming is not available in the ap-southeast-3 region
--- SKIP: TestAccEC2Subnet_ipv6Native (0.00s)
=== CONT  TestAccEC2SubnetDataSource_basic
=== CONT  TestAccEC2Subnet_updateTagsKnownAtApply
=== CONT  TestAccEC2Subnet_customerOwnedIPv4Pool
    acctest.go:1245: skipping acceptance testing: RequestError: send request failed
        caused by: Get "https://outposts.ap-southeast-3.amazonaws.com/outposts": dial tcp: lookup outposts.ap-southeast-3.amazonaws.com: no such host
--- SKIP: TestAccEC2Subnet_customerOwnedIPv4Pool (29.07s)
=== CONT  TestAccEC2Subnet_outpost
    acctest.go:1245: skipping acceptance testing: RequestError: send request failed
        caused by: Get "https://outposts.ap-southeast-3.amazonaws.com/outposts": dial tcp: lookup outposts.ap-southeast-3.amazonaws.com: no such host
--- SKIP: TestAccEC2Subnet_outpost (19.68s)
=== CONT  TestAccEC2Subnet_disappears
--- PASS: TestAccEC2SubnetDataSource_basic (73.92s)
=== CONT  TestAccEC2Subnet_availabilityZoneID
--- PASS: TestAccEC2Subnet_disappears (59.87s)
=== CONT  TestAccEC2Subnet_enableIPv6
--- PASS: TestAccEC2Subnet_availabilityZoneID (70.66s)
=== CONT  TestAccEC2Subnet_ipv6
--- PASS: TestAccEC2Subnet_updateTagsKnownAtApply (169.43s)
=== CONT  TestAccEC2Subnet_ignoreTags
--- PASS: TestAccEC2Subnet_enableIPv6 (172.85s)
=== CONT  TestAccEC2Subnet_mapPublicIPOnLaunch
--- PASS: TestAccEC2Subnet_ignoreTags (138.82s)
=== CONT  TestAccEC2Subnet_enableDNS64
--- PASS: TestAccEC2Subnet_ipv6 (173.50s)
=== CONT  TestAccEC2Subnet_DefaultTags_updateToProviderOnly
--- PASS: TestAccEC2Subnet_DefaultTags_updateToProviderOnly (101.74s)
=== CONT  TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag
--- PASS: TestAccEC2Subnet_mapPublicIPOnLaunch (202.83s)
=== CONT  TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag
--- PASS: TestAccEC2Subnet_enableDNS64 (203.98s)
=== CONT  TestAccEC2Subnet_defaultAndIgnoreTags
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag (115.67s)
=== CONT  TestAccEC2Subnet_DefaultTags_providerOnly
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag (123.49s)
=== CONT  TestAccEC2Subnet_DefaultTags_updateToResourceOnly
--- PASS: TestAccEC2Subnet_defaultAndIgnoreTags (139.31s)
=== CONT  TestAccEC2Subnet_basic
--- PASS: TestAccEC2Subnet_DefaultTags_providerOnly (126.42s)
=== CONT  TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock
--- PASS: TestAccEC2Subnet_DefaultTags_updateToResourceOnly (108.07s)
=== CONT  TestAccEC2Subnet_tags
--- PASS: TestAccEC2Subnet_basic (67.40s)
=== CONT  TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch
    acctest.go:1245: skipping acceptance testing: RequestError: send request failed
        caused by: Get "https://outposts.ap-southeast-3.amazonaws.com/outposts": dial tcp: lookup outposts.ap-southeast-3.amazonaws.com: no such host
--- SKIP: TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch (22.25s)
=== CONT  TestAccEC2SubnetDataSource_ipv6ByIPv6Filter
--- PASS: TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock (118.49s)
=== CONT  TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag (1.00s)
--- PASS: TestAccEC2SubnetDataSource_ipv6ByIPv6Filter (120.10s)
--- PASS: TestAccEC2Subnet_tags (172.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	892.443s
```

#### `us-west-2`

```console
% make testacc TESTARGS='-run=TestAccEC2Subnet_\|TestAccEC2SubnetDataSource_' PKG=ec2 ACCTEST_PARALLELISM=4 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 4  -run=TestAccEC2Subnet_\|TestAccEC2SubnetDataSource_ -timeout 180m
=== RUN   TestAccEC2SubnetDataSource_basic
=== PAUSE TestAccEC2SubnetDataSource_basic
=== RUN   TestAccEC2SubnetDataSource_ipv6ByIPv6Filter
=== PAUSE TestAccEC2SubnetDataSource_ipv6ByIPv6Filter
=== RUN   TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock
=== PAUSE TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock
=== RUN   TestAccEC2Subnet_basic
=== PAUSE TestAccEC2Subnet_basic
=== RUN   TestAccEC2Subnet_tags
=== PAUSE TestAccEC2Subnet_tags
=== RUN   TestAccEC2Subnet_DefaultTags_providerOnly
=== PAUSE TestAccEC2Subnet_DefaultTags_providerOnly
=== RUN   TestAccEC2Subnet_DefaultTags_updateToProviderOnly
=== PAUSE TestAccEC2Subnet_DefaultTags_updateToProviderOnly
=== RUN   TestAccEC2Subnet_DefaultTags_updateToResourceOnly
=== PAUSE TestAccEC2Subnet_DefaultTags_updateToResourceOnly
=== RUN   TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag
=== PAUSE TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag
=== RUN   TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag
=== PAUSE TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag
=== RUN   TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag
=== PAUSE TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag
=== RUN   TestAccEC2Subnet_defaultAndIgnoreTags
=== PAUSE TestAccEC2Subnet_defaultAndIgnoreTags
=== RUN   TestAccEC2Subnet_updateTagsKnownAtApply
=== PAUSE TestAccEC2Subnet_updateTagsKnownAtApply
=== RUN   TestAccEC2Subnet_ignoreTags
=== PAUSE TestAccEC2Subnet_ignoreTags
=== RUN   TestAccEC2Subnet_ipv6
=== PAUSE TestAccEC2Subnet_ipv6
=== RUN   TestAccEC2Subnet_enableIPv6
=== PAUSE TestAccEC2Subnet_enableIPv6
=== RUN   TestAccEC2Subnet_availabilityZoneID
=== PAUSE TestAccEC2Subnet_availabilityZoneID
=== RUN   TestAccEC2Subnet_disappears
=== PAUSE TestAccEC2Subnet_disappears
=== RUN   TestAccEC2Subnet_customerOwnedIPv4Pool
=== PAUSE TestAccEC2Subnet_customerOwnedIPv4Pool
=== RUN   TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch
=== PAUSE TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch
=== RUN   TestAccEC2Subnet_mapPublicIPOnLaunch
=== PAUSE TestAccEC2Subnet_mapPublicIPOnLaunch
=== RUN   TestAccEC2Subnet_outpost
=== PAUSE TestAccEC2Subnet_outpost
=== RUN   TestAccEC2Subnet_enableDNS64
=== PAUSE TestAccEC2Subnet_enableDNS64
=== RUN   TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
=== PAUSE TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
=== RUN   TestAccEC2Subnet_ipv6Native
=== PAUSE TestAccEC2Subnet_ipv6Native
=== CONT  TestAccEC2SubnetDataSource_basic
=== CONT  TestAccEC2Subnet_ignoreTags
=== CONT  TestAccEC2Subnet_DefaultTags_updateToResourceOnly
=== CONT  TestAccEC2Subnet_tags
--- PASS: TestAccEC2SubnetDataSource_basic (28.96s)
=== CONT  TestAccEC2Subnet_updateTagsKnownAtApply
--- PASS: TestAccEC2Subnet_DefaultTags_updateToResourceOnly (45.28s)
=== CONT  TestAccEC2Subnet_defaultAndIgnoreTags
--- PASS: TestAccEC2Subnet_ignoreTags (55.39s)
=== CONT  TestAccEC2Subnet_customerOwnedIPv4Pool
    acctest.go:1254: skipping since no Outposts found
--- SKIP: TestAccEC2Subnet_customerOwnedIPv4Pool (0.82s)
=== CONT  TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag (1.18s)
=== CONT  TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch
    acctest.go:1254: skipping since no Outposts found
--- SKIP: TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch (0.60s)
=== CONT  TestAccEC2Subnet_disappears
--- PASS: TestAccEC2Subnet_tags (63.44s)
=== CONT  TestAccEC2Subnet_ipv6Native
--- PASS: TestAccEC2Subnet_disappears (23.06s)
=== CONT  TestAccEC2Subnet_availabilityZoneID
--- PASS: TestAccEC2Subnet_updateTagsKnownAtApply (61.87s)
=== CONT  TestAccEC2Subnet_privateDnsNameOptionsOnLaunch
--- PASS: TestAccEC2Subnet_defaultAndIgnoreTags (53.95s)
=== CONT  TestAccEC2Subnet_enableIPv6
--- PASS: TestAccEC2Subnet_ipv6Native (38.37s)
=== CONT  TestAccEC2Subnet_ipv6
--- PASS: TestAccEC2Subnet_availabilityZoneID (26.68s)
=== CONT  TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag
--- PASS: TestAccEC2Subnet_enableIPv6 (63.82s)
=== CONT  TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag (59.10s)
=== CONT  TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock
--- PASS: TestAccEC2Subnet_ipv6 (65.01s)
=== CONT  TestAccEC2Subnet_basic
--- PASS: TestAccEC2Subnet_basic (25.29s)
=== CONT  TestAccEC2SubnetDataSource_ipv6ByIPv6Filter
--- PASS: TestAccEC2SubnetDataSource_ipv6ByIPv6CIDRBlock (43.90s)
=== CONT  TestAccEC2Subnet_DefaultTags_providerOnly
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag (55.42s)
=== CONT  TestAccEC2Subnet_DefaultTags_updateToProviderOnly
--- PASS: TestAccEC2SubnetDataSource_ipv6ByIPv6Filter (41.86s)
=== CONT  TestAccEC2Subnet_outpost
    acctest.go:1254: skipping since no Outposts found
--- SKIP: TestAccEC2Subnet_outpost (0.60s)
=== CONT  TestAccEC2Subnet_mapPublicIPOnLaunch
--- PASS: TestAccEC2Subnet_privateDnsNameOptionsOnLaunch (149.34s)
=== CONT  TestAccEC2Subnet_enableDNS64
--- PASS: TestAccEC2Subnet_DefaultTags_updateToProviderOnly (42.62s)
--- PASS: TestAccEC2Subnet_DefaultTags_providerOnly (58.94s)
--- PASS: TestAccEC2Subnet_mapPublicIPOnLaunch (91.01s)
--- PASS: TestAccEC2Subnet_enableDNS64 (91.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	335.805s
```