### PR TITLE
ecr: ISO-friendly tagging

### DIFF
--- a/.changelog/22535.txt
+++ b/.changelog/22535.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecr_repository: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22535.txt
+++ b/.changelog/22535.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_ecr_repository: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+data-source/aws_ecr_repository: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/internal/service/ecr/consts.go
+++ b/internal/service/ecr/consts.go
@@ -1,0 +1,5 @@
+package ecr
+
+const (
+	ErrCodeAccessDenied = "AccessDenied"
+)

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -114,8 +115,11 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	input := ecr.CreateRepositoryInput{
 		ImageTagMutability:      aws.String(d.Get("image_tag_mutability").(string)),
 		RepositoryName:          aws.String(d.Get("name").(string)),
-		Tags:                    Tags(tags.IgnoreAWS()),
 		EncryptionConfiguration: expandEcrRepositoryEncryptionConfiguration(d.Get("encryption_configuration").([]interface{})),
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	imageScanningConfigs := d.Get("image_scanning_configuration").([]interface{})
@@ -131,6 +135,15 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Creating ECR repository: %#v", input)
 	out, err := conn.CreateRepository(&input)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ecr.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecr.ErrCodeValidationException)) {
+		log.Printf("[WARN] ECR Repository (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+
+		out, err = conn.CreateRepository(&input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating ECR repository: %s", err)
 	}
@@ -140,6 +153,21 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] ECR repository created: %q", *repository.RepositoryArn)
 
 	d.SetId(aws.StringValue(repository.RepositoryName))
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if input.Tags == nil && len(tags) > 0 && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ecr.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecr.ErrCodeValidationException)) {
+			log.Printf("[WARN] error adding tags after create for ECR Repository (%s): %s", d.Id(), err)
+			return resourceRepositoryRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ECR Repository (%s) tags: %w", d.Id(), err)
+		}
+	}
 
 	return resourceRepositoryRead(d, meta)
 }
@@ -198,10 +226,26 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("repository_url", repository.RepositoryUri)
 	d.Set("image_tag_mutability", repository.ImageTagMutability)
 
+	if err := d.Set("image_scanning_configuration", flattenImageScanningConfiguration(repository.ImageScanningConfiguration)); err != nil {
+		return fmt.Errorf("error setting image_scanning_configuration for ECR Repository (%s): %w", arn, err)
+	}
+
+	if err := d.Set("encryption_configuration", flattenEcrRepositoryEncryptionConfiguration(repository.EncryptionConfiguration)); err != nil {
+		return fmt.Errorf("error setting encryption_configuration for ECR Repository (%s): %w", arn, err)
+	}
+
 	tags, err := ListTags(conn, arn)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ecr.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecr.ErrCodeValidationException)) {
+		log.Printf("[WARN] Unable to list tags for ECR Repository %s: %s", d.Id(), err)
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error listing tags for ECR Repository (%s): %w", arn, err)
 	}
+
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
@@ -211,14 +255,6 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
 		return fmt.Errorf("error setting tags_all: %w", err)
-	}
-
-	if err := d.Set("image_scanning_configuration", flattenImageScanningConfiguration(repository.ImageScanningConfiguration)); err != nil {
-		return fmt.Errorf("error setting image_scanning_configuration for ECR Repository (%s): %w", arn, err)
-	}
-
-	if err := d.Set("encryption_configuration", flattenEcrRepositoryEncryptionConfiguration(repository.EncryptionConfiguration)); err != nil {
-		return fmt.Errorf("error setting encryption_configuration for ECR Repository (%s): %w", arn, err)
 	}
 
 	return nil
@@ -288,8 +324,16 @@ func resourceRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating ECR Repository (%s) tags: %s", arn, err)
+		err := UpdateTags(conn, arn, o, n)
+
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ecr.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecr.ErrCodeValidationException)) {
+			// Some partitions may not support tagging, giving error
+			log.Printf("[WARN] Unable to update tags for ECR Repository %s: %s", d.Id(), err)
+			return resourceRepositoryRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating ECR Repository (%s) tags: %w", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18133
Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS='TestAccECRRepository_|TestAccECRRepositoryDataSource_' PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_|TestAccECRRepositoryDataSource_'  -timeout 180m
--- PASS: TestAccECRRepositoryDataSource_nonExistent (3.85s)
--- PASS: TestAccECRRepositoryDataSource_basic (18.78s)
--- PASS: TestAccECRRepository_immutability (19.56s)
--- PASS: TestAccECRRepository_basic (19.65s)
--- PASS: TestAccECRRepositoryDataSource_encryption (22.34s)
--- PASS: TestAccECRRepository_tags (30.92s)
--- PASS: TestAccECRRepository_Encryption_aes256 (35.73s)
--- PASS: TestAccECRRepository_Encryption_kms (38.52s)
--- PASS: TestAccECRRepository_Image_scanning (45.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	46.752s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS='TestAccECRRepository_|TestAccECRRepositoryDataSource_' PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_|TestAccECRRepositoryDataSource_'  -timeout 180m
--- PASS: TestAccECRRepositoryDataSource_nonExistent (4.89s)
--- PASS: TestAccECRRepositoryDataSource_basic (21.46s)
--- PASS: TestAccECRRepository_immutability (23.20s)
--- PASS: TestAccECRRepository_basic (23.36s)
--- PASS: TestAccECRRepositoryDataSource_encryption (26.15s)
--- PASS: TestAccECRRepository_tags (34.07s)
--- PASS: TestAccECRRepository_Encryption_aes256 (42.01s)
--- PASS: TestAccECRRepository_Encryption_kms (43.75s)
--- PASS: TestAccECRRepository_Image_scanning (52.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	54.141s
```
