### PR TITLE
r/s3_bucket: read-only `acl` and `grant` arguments

### DIFF
--- a/.changelog/22537.txt
+++ b/.changelog/22537.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_s3_bucket: The `acl` and `grant` arguments have been deprecated and are now read-only. Use the `aws_s3_bucket_acl` resource instead.
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -806,6 +806,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// The call to HeadBucket above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketPolicy, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchBucketPolicy) {
 		return fmt.Errorf("error getting S3 bucket (%s) policy: %w", d.Id(), err)
 	}
@@ -834,6 +843,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			})
 		})
 
+		// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+		// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+		// such as GetBucketAcl, the error should be caught for non-new buckets as follows.
+		if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+			log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		if err != nil {
 			return fmt.Errorf("error getting S3 Bucket (%s) ACL: %w", d.Id(), err)
 		}
@@ -853,6 +871,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketCors, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchCORSConfiguration) {
 		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
 	}
@@ -871,6 +899,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketWebsite, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented, ErrCodeNoSuchWebsiteConfiguration) {
 		return fmt.Errorf("error getting S3 Bucket website configuration: %w", err)
 	}
@@ -895,6 +933,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketVersioning, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket versioning (%s): %w", d.Id(), err)
 	}
@@ -913,6 +960,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketAccelerateConfiguration, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	// Amazon S3 Transfer Acceleration might not be supported in the region
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument) {
 		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %w", err)
@@ -930,6 +986,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketRequestPayment, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
 	}
@@ -944,6 +1009,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketLogging, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket logging: %s", err)
@@ -964,6 +1038,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketLifecycleConfiguration, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration) {
 		return fmt.Errorf("error getting S3 Bucket (%s) Lifecycle Configuration: %w", d.Id(), err)
 	}
@@ -983,6 +1067,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketReplication, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeReplicationConfigurationNotFound) {
 		return fmt.Errorf("error getting S3 Bucket replication: %w", err)
@@ -1004,6 +1097,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketEncryption, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil && !tfawserr.ErrMessageContains(err, ErrCodeServerSideEncryptionConfigurationNotFound, "encryption configuration was not found") {
 		return fmt.Errorf("error getting S3 Bucket encryption: %w", err)
 	}
@@ -1022,6 +1125,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetObjectLockConfiguration, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	// Object lock not supported in all partitions (extra guard, also guards in read func)
 	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeObjectLockConfigurationNotFound) {
@@ -1058,6 +1170,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 			r.Config.Credentials = conn.Config.Credentials
 		})
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as s3manager.GetBucketRegionWithClient, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket location: %s", err)
 	}
@@ -1084,6 +1206,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Add website_endpoint as an attribute
 	websiteEndpoint, err := websiteEndpoint(meta.(*conns.AWSClient), d)
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketLocation, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}
@@ -1100,6 +1232,15 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	tagsRaw, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
 		return BucketListTags(conn, d.Id())
 	})
+
+	// The S3 API method calls above can occasionally return no error (i.e. NoSuchBucket)
+	// after a bucket has been deleted (eventual consistency woes :/), thus, when making extra S3 API calls
+	// such as GetBucketTagging, the error should be caught for non-new buckets as follows.
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -435,12 +435,6 @@ func testAccBucketAclBasicConfig(rName, acl string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -456,12 +450,6 @@ data "aws_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -499,12 +487,6 @@ data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -443,7 +443,7 @@ func TestAccS3Bucket_Manage_objectLockWithVersioning(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -105,9 +105,6 @@ func TestAccS3Bucket_Basic_emptyString(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_withNoSystemTags(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -167,9 +164,6 @@ func TestAccS3Bucket_Tags_withNoSystemTags(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_withSystemTags(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -255,9 +249,6 @@ func TestAccS3Bucket_Tags_withSystemTags(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_ignoreTags(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -303,9 +294,6 @@ func TestAccS3Bucket_Tags_ignoreTags(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_basic(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	rInt := sdkacctest.RandInt()
 	resourceName := "aws_s3_bucket.bucket1"
 
@@ -348,7 +336,7 @@ func TestAccS3Bucket_Basic_namePrefix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "bucket_prefix"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
 			},
 		},
 	})
@@ -383,9 +371,6 @@ func TestAccS3Bucket_Basic_generatedName(t *testing.T) {
 // not empty" error in Terraform, to check against regressions.
 // See https://github.com/hashicorp/terraform/pull/2925
 func TestAccS3Bucket_Basic_shouldFailNotFound(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -465,9 +450,6 @@ func TestAccS3Bucket_Manage_objectLockWithVersioning(t *testing.T) {
 }
 
 func TestAccS3Bucket_Basic_forceDestroy(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -494,9 +476,6 @@ func TestAccS3Bucket_Basic_forceDestroy(t *testing.T) {
 // to not contain these extra slashes, out-of-band handling and other AWS
 // services may create keys with extra slashes (empty "directory" prefixes).
 func TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -518,9 +497,6 @@ func TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes(t *testing.T) {
 }
 
 func TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled(t *testing.T) {
-	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
-	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
-
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -1232,13 +1232,17 @@ resource "aws_s3_bucket" "test" {
 func testAccBucketConfig_objectLockEnabledWithVersioning(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket        = "%s"
-  acl           = "private"
+  bucket        = %[1]q
   force_destroy = true
 
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -131,7 +131,7 @@ func TestAccS3Bucket_Tags_withNoSystemTags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccBucketConfig_withUpdatedTags(bucketName),
@@ -217,7 +217,7 @@ func TestAccS3Bucket_Tags_withSystemTags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccBucketConfig_withTags(bucketName),
@@ -322,7 +322,7 @@ func TestAccS3Bucket_Tags_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -70,7 +70,7 @@ func TestAccS3Bucket_Basic_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -98,13 +98,16 @@ func TestAccS3Bucket_Basic_emptyString(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
 }
 
 func TestAccS3Bucket_Tags_withNoSystemTags(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -164,6 +167,9 @@ func TestAccS3Bucket_Tags_withNoSystemTags(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_withSystemTags(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -249,6 +255,9 @@ func TestAccS3Bucket_Tags_withSystemTags(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_ignoreTags(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -294,6 +303,9 @@ func TestAccS3Bucket_Tags_ignoreTags(t *testing.T) {
 }
 
 func TestAccS3Bucket_Tags_basic(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	rInt := sdkacctest.RandInt()
 	resourceName := "aws_s3_bucket.bucket1"
 
@@ -336,7 +348,7 @@ func TestAccS3Bucket_Basic_namePrefix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "bucket_prefix"},
 			},
 		},
 	})
@@ -361,7 +373,7 @@ func TestAccS3Bucket_Basic_generatedName(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "bucket_prefix"},
 			},
 		},
 	})
@@ -371,6 +383,9 @@ func TestAccS3Bucket_Basic_generatedName(t *testing.T) {
 // not empty" error in Terraform, to check against regressions.
 // See https://github.com/hashicorp/terraform/pull/2925
 func TestAccS3Bucket_Basic_shouldFailNotFound(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -415,7 +430,7 @@ func TestAccS3Bucket_Manage_objectLock(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -450,6 +465,9 @@ func TestAccS3Bucket_Manage_objectLockWithVersioning(t *testing.T) {
 }
 
 func TestAccS3Bucket_Basic_forceDestroy(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -476,6 +494,9 @@ func TestAccS3Bucket_Basic_forceDestroy(t *testing.T) {
 // to not contain these extra slashes, out-of-band handling and other AWS
 // services may create keys with extra slashes (empty "directory" prefixes).
 func TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 
@@ -497,6 +518,9 @@ func TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes(t *testing.T) {
 }
 
 func TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled(t *testing.T) {
+	// TODO: remove skip once aws_s3_bucket_acl resource is available in the provider
+	t.Skipf("skipping acceptance testing: aws_s3_bucket 'acl' and 'grant' are read-only, migrate configuration to aws_s3_bucket_acl")
+
 	resourceName := "aws_s3_bucket.bucket"
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -336,7 +336,7 @@ func TestAccS3Bucket_Basic_namePrefix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "bucket_prefix"},
 			},
 		},
 	})
@@ -1060,12 +1060,6 @@ func testAccBucketConfig_withNoTags(bucketName string) string {
 resource "aws_s3_bucket" "bucket" {
   bucket        = %[1]q
   force_destroy = false
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -1085,12 +1079,6 @@ resource "aws_s3_bucket" "bucket" {
     Key1 = "AAA"
     Key2 = "BBB"
     Key3 = "CCC"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
   }
 }
 
@@ -1113,12 +1101,6 @@ resource "aws_s3_bucket" "bucket" {
     Key4 = "DDD"
     Key5 = "EEE"
   }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -1138,12 +1120,6 @@ resource "aws_s3_bucket" "bucket1" {
     Name        = "tf-test-bucket-1-%[1]d"
     Environment = "%[1]d"
   }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test1" {
@@ -1158,12 +1134,6 @@ resource "aws_s3_bucket" "bucket2" {
   tags = {
     Name        = "tf-test-bucket-2-%[1]d"
     Environment = "%[1]d"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
   }
 }
 
@@ -1180,12 +1150,6 @@ resource "aws_s3_bucket" "bucket3" {
     Name        = "tf-test-bucket-3-%[1]d"
     Environment = "%[1]d"
   }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test3" {
@@ -1200,12 +1164,6 @@ resource "aws_s3_bucket" "bucket4" {
   tags = {
     Name        = "tf-test-bucket-4-%[1]d"
     Environment = "%[1]d"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
   }
 }
 
@@ -1222,12 +1180,6 @@ resource "aws_s3_bucket" "bucket5" {
     Name        = "tf-test-bucket-5-%[1]d"
     Environment = "%[1]d"
   }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test5" {
@@ -1243,12 +1195,6 @@ resource "aws_s3_bucket" "bucket6" {
     Name        = "tf-test-bucket-6-%[1]d"
     Environment = "%[1]d"
   }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test6" {
@@ -1262,12 +1208,6 @@ func testAccBucketDestroyedConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -1315,12 +1255,6 @@ func testAccBucketConfig_forceDestroy(bucketName string) string {
 resource "aws_s3_bucket" "bucket" {
   bucket        = "%s"
   force_destroy = true
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -1338,12 +1272,6 @@ resource "aws_s3_bucket" "bucket" {
 
   object_lock_configuration {
     object_lock_enabled = "Enabled"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
   }
 }
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -69,7 +69,7 @@ See the [`aws_s3_bucket_server_side_encryption_configuration` resource](s3_bucke
 
 ### Using ACL policy grants
 
-The `acl` and `grant` arguments are read-only as of version 4.0.
+The `acl` and `grant` arguments are read-only as of version 4.0 of the Terraform AWS Provider.
 See the [`aws_s3_bucket_acl` resource](s3_bucket_acl.html.markdown) for configuration details.
 
 ## Argument Reference

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -69,25 +69,8 @@ See the [`aws_s3_bucket_server_side_encryption_configuration` resource](s3_bucke
 
 ### Using ACL policy grants
 
-```terraform
-data "aws_canonical_user_id" "current_user" {}
-
-resource "aws_s3_bucket" "bucket" {
-  bucket = "mybucket"
-
-  grant {
-    id          = data.aws_canonical_user_id.current_user.id
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL"]
-  }
-
-  grant {
-    type        = "Group"
-    permissions = ["READ_ACP", "WRITE"]
-    uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
-  }
-}
-```
+The `acl` and `grant` arguments are read-only as of version 4.0.
+See the [`aws_s3_bucket_acl` resource](s3_bucket_acl.html.markdown) for configuration details.
 
 ## Argument Reference
 
@@ -95,18 +78,9 @@ The following arguments are supported:
 
 * `bucket` - (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-* `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
-* `grant` - (Optional) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 * `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
-
-The `grant` object supports the following:
-
-* `id` - (optional) Canonical user id to grant for. Used only when `type` is `CanonicalUser`.
-* `type` - (required) - Type of grantee to apply for. Valid values are `CanonicalUser` and `Group`. `AmazonCustomerByEmail` is not supported.
-* `permissions` - (required) List of permissions to apply for grantee. Valid values are `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_CONTROL`.
-* `uri` - (optional) Uri address to grant for. Used only when `type` is `Group`.
 
 The `object_lock_configuration` object supports the following:
 
@@ -122,6 +96,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the bucket.
 * `acceleration_status` - (Optional) The accelerate configuration status of the bucket. Not available in `cn-north-1` or `us-gov-west-1`.
+* `acl` - The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) applied to the bucket.
 * `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 * `bucket_regional_domain_name` - The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
@@ -131,6 +106,11 @@ In addition to all arguments above, the following attributes are exported:
     * `allowed_origins` - Set of origins customers are able to access the bucket from.
     * `expose_headers` - Set of headers in the response that customers are able to access from their applications.
     * `max_age_seconds` The time in seconds that browser can cache the response for a preflight request.
+* `grant` - The set of [ACL policy grants](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl).
+    * `id` - Canonical user id of the grantee.
+    * `type` - Type of grantee.
+    * `permissions` - List of permissions given to the grantee.
+    * `uri` - URI of the grantee group.
 * `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 * `lifecycle_rule` - A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html).
     * `id` - Unique identifier for the rule.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/4418
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAcl_disappears (23.03s)
--- PASS: TestAccS3BucketAcl_basic (33.22s)
--- PASS: TestAccS3BucketAcl_updateACL (55.95s)
--- PASS: TestAccS3BucketAcl_grantToACL (57.26s)
--- PASS: TestAccS3BucketAcl_ACLToGrant (57.88s)
--- PASS: TestAccS3BucketAcl_updateGrant (61.74s)

--- PASS: TestAccS3Bucket_Basic_acceleration (116.58s)
--- PASS: TestAccS3Bucket_Basic_basic (94.35s)
--- PASS: TestAccS3Bucket_Basic_emptyString (96.89s)
--- PASS: TestAccS3Bucket_Basic_generatedName (95.67s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (96.46s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (97.50s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (116.76s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (95.20s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (95.87s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (83.28s)
--- PASS: TestAccS3Bucket_Manage_objectLock (105.45s)
--- PASS: TestAccS3Bucket_Manage_versioning (117.72s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (97.09s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (95.80s)
--- PASS: TestAccS3Bucket_Security_corsDelete (83.35s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (94.79s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (115.49s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (115.99s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (97.14s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (96.63s)
--- SKIP: TestAccS3Bucket_Basic_forceDestroy (0.00s)
--- SKIP: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (0.00s)
--- SKIP: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (0.00s)
--- SKIP: TestAccS3Bucket_Basic_shouldFailNotFound (0.00s)
--- SKIP: TestAccS3Bucket_Manage_lifecycleBasic (0.00s)
--- SKIP: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (0.00s)
--- SKIP: TestAccS3Bucket_Replication_RTC_valid (0.00s)
--- SKIP: TestAccS3Bucket_Replication_basic (0.00s)
--- SKIP: TestAccS3Bucket_Replication_expectVersioningValidationError (0.00s)
--- SKIP: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (0.00s)
--- SKIP: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (0.00s)
--- SKIP: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (0.00s)
--- SKIP: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (0.00s)
--- SKIP: TestAccS3Bucket_Replication_schemaV2 (0.00s)
--- SKIP: TestAccS3Bucket_Replication_schemaV2SameRegion (0.00s)
--- SKIP: TestAccS3Bucket_Replication_twoDestination (0.00s)
--- SKIP: TestAccS3Bucket_Replication_withoutPrefix (0.00s)
--- SKIP: TestAccS3Bucket_Replication_withoutStorageClass (0.00s)
--- SKIP: TestAccS3Bucket_Security_logging (0.00s)
--- SKIP: TestAccS3Bucket_Security_policy (0.00s)
--- SKIP: TestAccS3Bucket_Tags_basic (0.00s)
--- SKIP: TestAccS3Bucket_Tags_ignoreTags (0.00s)
--- SKIP: TestAccS3Bucket_Tags_withNoSystemTags (0.00s)
--- SKIP: TestAccS3Bucket_Tags_withSystemTags (0.00s)
```
