### PR TITLE
r/s3_bucket: read-only `policy` argument

### DIFF
--- a/.changelog/22538.txt
+++ b/.changelog/22538.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket: The `policy` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_policy` resource instead.
+```

--- a/.changelog/22538.txt
+++ b/.changelog/22538.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_s3_bucket: The `policy` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_policy` resource instead.
 ```

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -1240,17 +1240,18 @@ data "aws_availability_zones" "available" {
 
 func testAccLoadBalancerAccessLogsCommon(r string) string {
 	return fmt.Sprintf(`
-data "aws_elb_service_account" "current" {
-}
+data "aws_elb_service_account" "current" {}
 
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "accesslogs_bucket" {
   bucket        = "%[1]s"
   acl           = "private"
   force_destroy = true
+}
 
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.accesslogs_bucket.id
   policy = <<EOF
 {
   "Id": "Policy1446577137248",

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -1182,6 +1182,9 @@ resource "aws_elb" "test" {
 func testAccLoadBalancerAccessLogsOn(r string) string {
 	return `
 resource "aws_elb" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
 
   listener {
@@ -1211,6 +1214,9 @@ data "aws_availability_zones" "available" {
 func testAccLoadBalancerAccessLogsDisabled(r string) string {
 	return `
 resource "aws_elb" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
 
   listener {

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -859,6 +858,8 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 
 	if output, ok := pol.(*s3.GetBucketPolicyOutput); ok {
 		d.Set("policy", output.Policy)
+	} else {
+		d.Set("policy", nil)
 	}
 
 	//Read the Grant ACL. Reset if `acl` (canned ACL) is set.

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -5,6 +5,7 @@ package s3
 
 const (
 	ErrCodeMethodNotAllowed                          = "MethodNotAllowed"
+	ErrCodeNoSuchBucketPolicy                        = "NoSuchBucketPolicy"
 	ErrCodeNoSuchConfiguration                       = "NoSuchConfiguration"
 	ErrCodeNoSuchCORSConfiguration                   = "NoSuchCORSConfiguration"
 	ErrCodeNoSuchLifecycleConfiguration              = "NoSuchLifecycleConfiguration"

--- a/website/docs/d/billing_service_account.html.markdown
+++ b/website/docs/d/billing_service_account.html.markdown
@@ -20,46 +20,40 @@ resource "aws_s3_bucket" "billing_logs" {
   acl    = "private"
 }
 
-data "aws_iam_policy_document" "billing_logging" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_billing_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:GetBucketPolicy",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::my-billing-tf-test-bucket",
-    ]
-  }
-
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_billing_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:PutObject",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::my-billing-tf-test-bucket/*",
-    ]
-  }
-}
-
 resource "aws_s3_bucket_policy" "allow_billing_logging" {
   bucket = aws_s3_bucket.billing_logs.id
-  policy = data.aws_iam_policy_document.billing_logging.json
+  policy = <<POLICY
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetBucketAcl", "s3:GetBucketPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket",
+      "Principal": {
+        "AWS": [
+          "${data.aws_billing_service_account.main.arn}"
+        ]
+      }
+    },
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/*",
+      "Principal": {
+        "AWS": [
+          "${data.aws_billing_service_account.main.arn}"
+        ]
+      }
+    }
+  ]
+}
+POLICY
 }
 ```
 

--- a/website/docs/d/billing_service_account.html.markdown
+++ b/website/docs/d/billing_service_account.html.markdown
@@ -18,42 +18,50 @@ data "aws_billing_service_account" "main" {}
 resource "aws_s3_bucket" "billing_logs" {
   bucket = "my-billing-tf-test-bucket"
   acl    = "private"
-
-  policy = <<POLICY
-{
-  "Id": "Policy",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetBucketAcl", "s3:GetBucketPolicy"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket",
-      "Principal": {
-        "AWS": [
-          "${data.aws_billing_service_account.main.arn}"
-        ]
-      }
-    },
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/*",
-      "Principal": {
-        "AWS": [
-          "${data.aws_billing_service_account.main.arn}"
-        ]
-      }
-    }
-  ]
 }
-POLICY
+
+data "aws_iam_policy_document" "billing_logging" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_billing_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketPolicy",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::my-billing-tf-test-bucket",
+    ]
+  }
+
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_billing_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::my-billing-tf-test-bucket/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_billing_logging" {
+  bucket = aws_s3_bucket.billing_logs.id
+  policy = data.aws_iam_policy_document.billing_logging.json
 }
 ```
-
 
 ## Attributes Reference
 

--- a/website/docs/d/cloudtrail_service_account.html.markdown
+++ b/website/docs/d/cloudtrail_service_account.html.markdown
@@ -19,32 +19,51 @@ data "aws_cloudtrail_service_account" "main" {}
 resource "aws_s3_bucket" "bucket" {
   bucket        = "tf-cloudtrail-logging-test-bucket"
   force_destroy = true
-
-  policy = <<EOF
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "Put bucket policy needed for trails",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
-      },
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*"
-    },
-    {
-      "Sid": "Get bucket policy needed for trails",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
-      },
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket"
-    }
-  ]
 }
-EOF
+
+data "aws_iam_policy_document" "cloudtrail_logging" {
+  statement {
+    sid = "Put bucket policy needed for trails"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_cloudtrail_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*",
+    ]
+  }
+
+  statement {
+    sid = "Get bucket policy needed for trails"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_cloudtrail_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::tf-cloudtrail-logging-test-bucket",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_cloudtrail_logging" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.cloudtrail_logging.json
 }
 ```
 

--- a/website/docs/d/cloudtrail_service_account.html.markdown
+++ b/website/docs/d/cloudtrail_service_account.html.markdown
@@ -21,49 +21,33 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
-data "aws_iam_policy_document" "cloudtrail_logging" {
-  statement {
-    sid = "Put bucket policy needed for trails"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_cloudtrail_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:PutObject",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*",
-    ]
-  }
-
-  statement {
-    sid = "Get bucket policy needed for trails"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_cloudtrail_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:GetBucketAcl",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::tf-cloudtrail-logging-test-bucket",
-    ]
-  }
-}
-
 resource "aws_s3_bucket_policy" "allow_cloudtrail_logging" {
   bucket = aws_s3_bucket.bucket.id
-  policy = data.aws_iam_policy_document.cloudtrail_logging.json
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "Put bucket policy needed for trails",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*"
+    },
+    {
+      "Sid": "Get bucket policy needed for trails",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
+      },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket"
+    }
+  ]
+}
+EOF
 }
 ```
 

--- a/website/docs/d/elb_service_account.html.markdown
+++ b/website/docs/d/elb_service_account.html.markdown
@@ -21,28 +21,28 @@ resource "aws_s3_bucket" "elb_logs" {
   acl    = "private"
 }
 
-data "aws_iam_policy_document" "elb_logging" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_elb_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:PutObject",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::my-elb-tf-test-bucket/AWSLogs/*",
-    ]
-  }
-}
-
 resource "aws_s3_bucket_policy" "allow_elb_logging" {
   bucket = aws_s3_bucket.elb_logs.id
-  policy = data.aws_iam_policy_document.elb_logging.json
+  policy = <<POLICY
+{
+  "Id": "Policy",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::my-elb-tf-test-bucket/AWSLogs/*",
+      "Principal": {
+        "AWS": [
+          "${data.aws_elb_service_account.main.arn}"
+        ]
+      }
+    }
+  ]
+}
+POLICY
 }
 
 resource "aws_elb" "bar" {

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -54,8 +54,6 @@ exactly match a pair on desired instances.
 several valid keys, for a full reference, check out
 [describe-instances in the AWS CLI reference][1].
 
-* `allow_no_results` - (Optional) Defaults to false. If true, empty lists could be returned for `ids`, `private_ips` and  `public_ips`. This is useful when querying the count of ephemeral instances (e.g. managed via autoscaling group) which may not be created yet.
-
 ## Attributes Reference
 
 * `id` - AWS Region.

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -54,6 +54,8 @@ exactly match a pair on desired instances.
 several valid keys, for a full reference, check out
 [describe-instances in the AWS CLI reference][1].
 
+* `allow_no_results` - (Optional) Defaults to false. If true, empty lists could be returned for `ids`, `private_ips` and  `public_ips`. This is useful when querying the count of ephemeral instances (e.g. managed via autoscaling group) which may not be created yet.
+
 ## Attributes Reference
 
 * `id` - AWS Region.

--- a/website/docs/d/redshift_service_account.html.markdown
+++ b/website/docs/d/redshift_service_account.html.markdown
@@ -19,32 +19,51 @@ data "aws_redshift_service_account" "main" {}
 resource "aws_s3_bucket" "bucket" {
   bucket        = "tf-redshift-logging-test-bucket"
   force_destroy = true
-
-  policy = <<EOF
-{
-	"Version": "2008-10-17",
-	"Statement": [
-		{
-            "Sid": "Put bucket policy needed for audit logging",
-            "Effect": "Allow",
-            "Principal": {
-		        "AWS": "${data.aws_redshift_service_account.main.arn}"
-            },
-            "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
-        },
-        {
-            "Sid": "Get bucket policy needed for audit logging ",
-            "Effect": "Allow",
-            "Principal": {
-		        "AWS": "${data.aws_redshift_service_account.main.arn}"
-            },
-            "Action": "s3:GetBucketAcl",
-            "Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"
-        }
-	]
 }
-EOF
+
+data "aws_iam_policy_document" "audit_logging" {
+  statement {
+    sid = "Put bucket policy needed for audit logging"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_redshift_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::tf-redshift-logging-test-bucket/*",
+    ]
+  }
+
+  statement {
+    sid = "Get bucket policy needed for audit logging"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_redshift_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::tf-redshift-logging-test-bucket",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_audit_logging" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.audit_logging.json
 }
 ```
 

--- a/website/docs/d/redshift_service_account.html.markdown
+++ b/website/docs/d/redshift_service_account.html.markdown
@@ -21,49 +21,33 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
-data "aws_iam_policy_document" "audit_logging" {
-  statement {
-    sid = "Put bucket policy needed for audit logging"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_redshift_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:PutObject",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::tf-redshift-logging-test-bucket/*",
-    ]
-  }
-
-  statement {
-    sid = "Get bucket policy needed for audit logging"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_redshift_service_account.main.arn}"]
-    }
-
-    actions = [
-      "s3:GetBucketAcl",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:s3:::tf-redshift-logging-test-bucket",
-    ]
-  }
-}
-
 resource "aws_s3_bucket_policy" "allow_audit_logging" {
   bucket = aws_s3_bucket.bucket.id
-  policy = data.aws_iam_policy_document.audit_logging.json
+  policy = <<EOF
+{
+	"Version": "2008-10-17",
+	"Statement": [
+		{
+            "Sid": "Put bucket policy needed for audit logging",
+            "Effect": "Allow",
+            "Principal": {
+		        "AWS": "${data.aws_redshift_service_account.main.arn}"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
+        },
+        {
+            "Sid": "Get bucket policy needed for audit logging ",
+            "Effect": "Allow",
+            "Principal": {
+		        "AWS": "${data.aws_redshift_service_account.main.arn}"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"
+        }
+	]
+}
+EOF
 }
 ```
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -185,8 +185,6 @@ The following arguments are supported:
 * `bucket_prefix` - (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
 * `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
 * `grant` - (Optional) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
-* `policy` - (Optional) A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a `terraform plan`. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
-
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
@@ -280,6 +278,7 @@ In addition to all arguments above, the following attributes are exported:
 * `logging` - The [logging parameters](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) for the bucket.
     * `target_bucket` - The name of the bucket that receives the log objects.
     * `target_prefix` - The prefix for all log object keys/
+* `policy` - The [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document.
 * `region` - The AWS region this bucket resides in.
 * `replication_configuration` - The [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html).
     * `role` - The ARN of the IAM role for Amazon S3 assumed when replicating the objects.
@@ -331,5 +330,3 @@ S3 bucket can be imported using the `bucket`, e.g.,
 ```
 $ terraform import aws_s3_bucket.bucket bucket-name
 ```
-
-The `policy` argument is not imported and will be deprecated in a future version 3.x of the Terraform AWS Provider for removal in version 4.0. Use the [`aws_s3_bucket_policy` resource](/docs/providers/aws/r/s3_bucket_policy.html) to manage the S3 Bucket Policy instead.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccELBLoadBalancerDataSource_basic (162.45s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_disabled (229.81s)
--- PASS: TestAccELBLoadBalancer_AccessLogs_enabled (71.85s)
--- PASS: TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate (246.75s)
--- PASS: TestAccELBLoadBalancer_Swap_subnets (185.75s)
--- PASS: TestAccELBLoadBalancer_availabilityZones (186.23s)
--- PASS: TestAccELBLoadBalancer_basic (155.22s)
--- PASS: TestAccELBLoadBalancer_connectionDraining (179.82s)
--- PASS: TestAccELBLoadBalancer_desyncMitigationMode (92.31s)
--- PASS: TestAccELBLoadBalancer_desyncMitigationMode_update (170.63s)
--- PASS: TestAccELBLoadBalancer_disappears (266.08s)
--- PASS: TestAccELBLoadBalancer_fullCharacterRange (103.78s)
--- PASS: TestAccELBLoadBalancer_generatedName (111.45s)
--- PASS: TestAccELBLoadBalancer_generatesNameForZeroValue (244.88s)
--- PASS: TestAccELBLoadBalancer_healthCheck (120.99s)
--- PASS: TestAccELBLoadBalancer_instanceAttaching (200.23s)
--- PASS: TestAccELBLoadBalancer_listener (130.65s)
--- PASS: TestAccELBLoadBalancer_namePrefix (49.09s)
--- PASS: TestAccELBLoadBalancer_securityGroups (198.96s)
--- PASS: TestAccELBLoadBalancer_tags (176.68s)
--- PASS: TestAccELBLoadBalancer_timeout (156.86s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (15.14s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (168.28s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (166.07s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (170.10s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (166.91s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (167.67s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (102.36s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (14.79s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (100.66s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (98.93s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (153.95s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (241.90s)
--- PASS: TestAccS3BucketDataSource_basic (87.18s)
--- PASS: TestAccS3BucketDataSource_website (88.95s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (379.52s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (101.77s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (85.80s)
--- PASS: TestAccS3BucketInventory_basic (101.76s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (101.14s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (98.38s)
--- PASS: TestAccS3BucketMetric_basic (100.06s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (15.64s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (167.85s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (168.74s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (166.63s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (166.00s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (165.62s)
--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (115.21s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (101.46s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (127.08s)
--- PASS: TestAccS3BucketNotification_queue (126.72s)
--- PASS: TestAccS3BucketNotification_topic (100.37s)
--- PASS: TestAccS3BucketNotification_update (183.60s)
--- PASS: TestAccS3BucketObjectDataSource_allParams (89.14s)
--- PASS: TestAccS3BucketObjectDataSource_basic (86.89s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (88.97s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (89.49s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (86.90s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (159.43s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (155.70s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (87.01s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (85.76s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (87.57s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (84.51s)
--- PASS: TestAccS3BucketObject_acl (247.49s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (91.31s)
--- PASS: TestAccS3BucketObject_content (102.28s)
--- PASS: TestAccS3BucketObject_contentBase64 (87.53s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (88.63s)
--- PASS: TestAccS3BucketObject_empty (100.05s)
--- PASS: TestAccS3BucketObject_etagEncryption (102.00s)
--- PASS: TestAccS3BucketObject_ignoreTags (165.10s)
--- PASS: TestAccS3BucketObject_kms (102.89s)
--- PASS: TestAccS3BucketObject_metadata (248.70s)
--- PASS: TestAccS3BucketObject_noNameNoKey (23.23s)
--- PASS: TestAccS3BucketObject_nonVersioned (101.27s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (90.12s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (237.67s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (158.55s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (235.73s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (301.36s)
--- PASS: TestAccS3BucketObject_source (99.29s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (174.97s)
--- PASS: TestAccS3BucketObject_sse (101.43s)
--- PASS: TestAccS3BucketObject_storageClass (390.54s)
--- PASS: TestAccS3BucketObject_tags (316.90s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (309.55s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (320.73s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (307.43s)
--- PASS: TestAccS3BucketObject_updateSameFile (162.11s)
--- PASS: TestAccS3BucketObject_updates (175.38s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (173.83s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (165.17s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (88.55s)
--- PASS: TestAccS3BucketObjectsDataSource_all (168.04s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (168.87s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (164.05s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (164.86s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (166.73s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (164.74s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (166.20s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (165.09s)
--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (81.39s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (181.22s)
--- PASS: TestAccS3BucketOwnershipControls_basic (105.59s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (89.89s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (364.47s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (274.46s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (290.29s)
--- PASS: TestAccS3BucketPolicy_basic (100.14s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (182.83s)
--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (77.96s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (102.16s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (252.47s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (250.34s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (87.51s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (250.51s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (247.26s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (541.10s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (493.25s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (479.91s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (141.50s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (358.11s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (359.47s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (408.09s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (406.22s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (402.71s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (403.55s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (396.39s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (365.66s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (237.20s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (407.70s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (311.74s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (402.11s)
--- PASS: TestAccS3BucketVersioning_MFADelete (65.24s)
--- PASS: TestAccS3BucketVersioning_basic (96.92s)
--- PASS: TestAccS3BucketVersioning_disappears (89.75s)
--- PASS: TestAccS3BucketVersioning_update (147.20s)
--- PASS: TestAccS3Bucket_Basic_acceleration (64.31s)
--- PASS: TestAccS3Bucket_Basic_basic (57.70s)
--- PASS: TestAccS3Bucket_Basic_emptyString (58.06s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (93.90s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (95.49s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (91.01s)
--- PASS: TestAccS3Bucket_Basic_generatedName (38.97s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (57.16s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (37.97s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (61.42s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (47.34s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (68.57s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (219.31s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (169.66s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (100.07s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (83.02s)
--- PASS: TestAccS3Bucket_Manage_objectLock (152.72s)
--- PASS: TestAccS3Bucket_Manage_versioning (150.60s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (70.04s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (66.08s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (261.23s)
--- PASS: TestAccS3Bucket_Replication_basic (294.07s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (75.54s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (166.14s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (164.38s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (221.56s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (218.53s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (299.15s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (111.91s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (165.99s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (156.91s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (157.88s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (54.48s)
--- PASS: TestAccS3Bucket_Security_corsDelete (65.36s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (77.44s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (148.50s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (102.27s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (53.55s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (52.16s)
--- PASS: TestAccS3Bucket_Security_grantToACL (71.79s)
--- PASS: TestAccS3Bucket_Security_logging (83.91s)
--- PASS: TestAccS3Bucket_Security_updateACL (59.89s)
--- PASS: TestAccS3Bucket_Security_updateGrant (100.46s)
--- PASS: TestAccS3Bucket_Tags_basic (37.46s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (57.71s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (135.65s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (167.82s)
--- PASS: TestAccS3Bucket_Web_redirect (151.87s)
--- PASS: TestAccS3Bucket_Web_routingRules (96.96s)
--- PASS: TestAccS3Bucket_Web_simple (156.53s)
--- PASS: TestBucketName (0.04s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestLoadBalancerListenerHash (0.00s)
--- PASS: TestValidLoadBalancerAccessLogsInterval (0.00s)
--- PASS: TestValidLoadBalancerHealthCheckTarget (0.00s)
--- PASS: TestValidLoadBalancerNameCanBeAnEmptyString (0.00s)
--- PASS: TestValidLoadBalancerNameCannotBeLongerThan32Characters (0.00s)
--- PASS: TestValidLoadBalancerNameCannotBeginWithHyphen (0.00s)
--- PASS: TestValidLoadBalancerNameCannotEndWithHyphen (0.00s)
--- PASS: TestValidLoadBalancerNameCannotHaveSpecialCharacters (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
```
