### PR TITLE
iam: ISO-friendly tagging

### DIFF
--- a/.changelog/22544.txt
+++ b/.changelog/22544.txt
@@ -3,5 +3,5 @@ resource/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, a
 ```
 
 ```release-note:enhancement
-data-source/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+data-source/aws_iam_role: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```

--- a/.changelog/22544.txt
+++ b/.changelog/22544.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
- resource/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
- ```
+resource/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:enhancement
+data-source/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22544.txt
+++ b/.changelog/22544.txt
@@ -5,3 +5,11 @@ resource/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, a
 ```release-note:enhancement
 data-source/aws_iam_role: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_iam_user: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:enhancement
+data-source/aws_iam_user: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22544.txt
+++ b/.changelog/22544.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ resource/aws_iam_role: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+ ```

--- a/internal/service/iam/consts.go
+++ b/internal/service/iam/consts.go
@@ -1,0 +1,5 @@
+package iam
+
+const (
+	ErrCodeAccessDenied = "AccessDenied"
+)

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
@@ -199,25 +200,21 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		request.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhen(
-		PropagationTimeout,
-		func() (interface{}, error) {
-			return conn.CreateRole(request)
-		},
-		func(err error) (bool, error) {
-			if tfawserr.ErrMessageContains(err, iam.ErrCodeMalformedPolicyDocumentException, "Invalid principal in policy") {
-				return true, err
-			}
+	output, err := retryCreateRole(conn, request)
 
-			return false, err
-		},
-	)
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+		log.Printf("[WARN] IAM Role (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		request.Tags = nil
+
+		output, err = retryCreateRole(conn, request)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error creating IAM Role (%s): %w", name, err)
 	}
 
-	roleName := aws.StringValue(outputRaw.(*iam.CreateRoleOutput).Role.RoleName)
+	roleName := aws.StringValue(output.Role.RoleName)
 
 	if v, ok := d.GetOk("inline_policy"); ok && v.(*schema.Set).Len() > 0 {
 		policies := expandRoleInlinePolicies(roleName, v.(*schema.Set).List())
@@ -234,6 +231,22 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(roleName)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if request.Tags == nil && len(tags) > 0 && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
+		err := roleUpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+			log.Printf("[WARN] error adding tags after create for IAM Role (%s): %s", d.Id(), err)
+			return resourceRoleRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating IAM Role (%s) tags: %w", d.Id(), err)
+		}
+	}
+
 	return resourceRoleRead(d, meta)
 }
 
@@ -277,17 +290,6 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("unique_id", role.RoleId)
 
-	tags := KeyValueTags(role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
-	}
-
 	assumeRolePolicy, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
 	if err != nil {
 		return err
@@ -317,6 +319,23 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("reading managed policies for IAM role %s, error: %s", d.Id(), err)
 	}
 	d.Set("managed_policy_arns", managedPolicies)
+
+	tags := KeyValueTags(role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+		log.Printf("[WARN] Unable to list tags for IAM Role %s: %s", d.Id(), err)
+		return nil
+	}
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
 
 	return nil
 }
@@ -401,14 +420,6 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := roleUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating IAM Role (%s) tags: %s", d.Id(), err)
-		}
-	}
-
 	if d.HasChange("inline_policy") && inlinePoliciesActualDiff(d) {
 		roleName := d.Get("name").(string)
 
@@ -472,6 +483,22 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if err := addRoleManagedPolicies(roleName, add, meta); err != nil {
 			return err
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		err := roleUpdateTags(conn, d.Id(), o, n)
+
+		// Some partitions may not support tagging, giving error
+		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+			log.Printf("[WARN] Unable to update tags for IAM Role %s: %s", d.Id(), err)
+			return resourceRoleRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating IAM Role (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -580,6 +607,33 @@ func deleteRoleInstanceProfiles(conn *iam.IAM, roleName string) error {
 	}
 
 	return nil
+}
+
+func retryCreateRole(conn *iam.IAM, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
+	outputRaw, err := tfresource.RetryWhen(
+		PropagationTimeout,
+		func() (interface{}, error) {
+			return conn.CreateRole(input)
+		},
+		func(err error) (bool, error) {
+			if tfawserr.ErrMessageContains(err, iam.ErrCodeMalformedPolicyDocumentException, "Invalid principal in policy") {
+				return true, err
+			}
+
+			return false, err
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	output, ok := outputRaw.(*iam.CreateRoleOutput)
+	if !ok || output == nil || aws.StringValue(output.Role.RoleName) == "" {
+		return nil, fmt.Errorf("create IAM role (%s) returned an empty result", aws.StringValue(input.RoleName))
+	}
+
+	return output, err
 }
 
 func readRolePolicyAttachments(conn *iam.IAM, roleName string) ([]*string, error) {

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -2,11 +2,14 @@ package iam
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -86,7 +89,6 @@ func dataSourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", output.Role.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("unique_id", output.Role.RoleId)
-	d.Set("tags", KeyValueTags(output.Role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	assumRolePolicy, err := url.QueryUnescape(aws.StringValue(output.Role.AssumeRolePolicyDocument))
 	if err != nil {
@@ -94,6 +96,19 @@ func dataSourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("assume_role_policy", assumRolePolicy); err != nil {
 		return fmt.Errorf("error setting assume_role_policy: %w", err)
+	}
+
+	tags := KeyValueTags(output.Role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+		log.Printf("[WARN] Unable to list tags for IAM Role %s: %s", d.Id(), err)
+		return nil
+	}
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	d.SetId(name)

--- a/internal/service/iam/user_data_source.go
+++ b/internal/service/iam/user_data_source.go
@@ -5,7 +5,9 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -65,7 +67,17 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", user.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("user_id", user.UserId)
-	if err := d.Set("tags", KeyValueTags(user.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+
+	tags := KeyValueTags(user.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+		log.Printf("[WARN] Unable to list tags for IAM User %s: %s", d.Id(), err)
+		return nil
+	}
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18898
Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

(* 3 pre-existing failures)

```console
% make testacc TESTS='TestAccIAMRoleDataSource_|TestAccIAMRole_' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRoleDataSource_|TestAccIAMRole_'  -timeout 180m
--- PASS: TestAccIAMRole_badJSON (6.76s)
--- FAIL: TestAccIAMRole_InlinePolicy_empty (24.54s)
--- PASS: TestAccIAMRole_disappears (30.32s)
--- PASS: TestAccIAMRoleDataSource_basic (35.38s)
--- PASS: TestAccIAMRole_nameGenerated (42.53s)
--- PASS: TestAccIAMRole_policiesForceDetach (43.53s)
--- FAIL: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (50.18s)
--- FAIL: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (54.42s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (58.48s)
--- PASS: TestAccIAMRole_basic (35.88s)
--- PASS: TestAccIAMRoleDataSource_tags (31.88s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (62.66s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (63.04s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (63.44s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (64.85s)
--- PASS: TestAccIAMRole_tags (65.48s)
--- PASS: TestAccIAMRole_maxSessionDuration (70.51s)
--- PASS: TestAccIAMRole_namePrefix (29.10s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (73.85s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (78.97s)
--- PASS: TestAccIAMRole_basicWithDescription (74.54s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (81.90s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (82.29s)
--- PASS: TestAccIAMRole_testNameChange (48.85s)
--- PASS: TestAccIAMRole_permissionsBoundary (103.02s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/iam	104.590s
% make testacc TESTS='TestAccIAMUserDataSource_|TestAccIAMUser_' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUserDataSource_|TestAccIAMUser_'  -timeout 180m
--- PASS: TestAccIAMUser_disappears (21.89s)
--- PASS: TestAccIAMUserDataSource_tags (24.78s)
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (29.05s)
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (29.16s)
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (29.17s)
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (29.32s)
--- PASS: TestAccIAMUserDataSource_basic (33.02s)
--- PASS: TestAccIAMUser_basic (41.29s)
--- PASS: TestAccIAMUser_tags (41.30s)
--- PASS: TestAccIAMUser_nameChange (41.36s)
--- PASS: TestAccIAMUser_pathChange (42.79s)
--- PASS: TestAccIAMUser_permissionsBoundary (68.50s)
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (85.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	87.366s
```

Output from acceptance testing (GovCloud):

(* 3 pre-existing failures)

```console
% make testacc TESTS='TestAccIAMRoleDataSource_|TestAccIAMRole_' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRoleDataSource_|TestAccIAMRole_'  -timeout 180m
--- PASS: TestAccIAMRole_badJSON (6.76s)
--- FAIL: TestAccIAMRole_InlinePolicy_empty (22.99s)
--- PASS: TestAccIAMRole_disappears (32.64s)
--- PASS: TestAccIAMRoleDataSource_basic (40.13s)
--- PASS: TestAccIAMRole_nameGenerated (40.66s)
--- PASS: TestAccIAMRole_basic (46.05s)
--- PASS: TestAccIAMRole_policiesForceDetach (48.69s)
--- FAIL: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (55.93s)
--- FAIL: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (59.20s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (63.66s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (66.74s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (68.63s)
--- PASS: TestAccIAMRole_namePrefix (36.32s)
--- PASS: TestAccIAMRole_tags (69.55s)
--- PASS: TestAccIAMRoleDataSource_tags (31.93s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (73.12s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (73.55s)
--- PASS: TestAccIAMRole_maxSessionDuration (73.74s)
--- PASS: TestAccIAMRole_testNameChange (76.04s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (82.27s)
--- PASS: TestAccIAMRole_basicWithDescription (90.10s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (93.27s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (67.37s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (81.44s)
--- PASS: TestAccIAMRole_permissionsBoundary (120.75s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/iam	122.301s
% make testacc TESTS='TestAccIAMUserDataSource_|TestAccIAMUser_' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUserDataSource_|TestAccIAMUser_'  -timeout 180m
--- PASS: TestAccIAMUserDataSource_basic (31.52s)
--- PASS: TestAccIAMUserDataSource_tags (31.59s)
--- PASS: TestAccIAMUser_ForceDestroy_loginProfile (37.72s)
--- PASS: TestAccIAMUser_disappears (37.97s)
--- PASS: TestAccIAMUser_ForceDestroy_sshKey (38.03s)
--- PASS: TestAccIAMUser_ForceDestroy_signingCertificate (38.17s)
--- PASS: TestAccIAMUser_ForceDestroy_accessKey (38.31s)
--- PASS: TestAccIAMUser_ForceDestroy_mfaDevice (38.49s)
--- PASS: TestAccIAMUser_nameChange (53.62s)
--- PASS: TestAccIAMUser_tags (53.96s)
--- PASS: TestAccIAMUser_basic (53.99s)
--- PASS: TestAccIAMUser_pathChange (54.18s)
--- PASS: TestAccIAMUser_permissionsBoundary (105.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	107.022s
```