### PR TITLE
eventbridge: ISO-friendly tagging

### DIFF
--- a/.changelog/22550.txt
+++ b/.changelog/22550.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_rule: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22550.txt
+++ b/.changelog/22550.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_cloudwatch_event_rule: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_cloudwatch_event_bus: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -69,6 +69,14 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating EventBridge event bus: %v", input)
 
 	_, err := conn.CreateEventBus(input)
+
+	// Some partitions may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+		log.Printf("[WARN] EventBridge Bus (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+		_, err = conn.CreateEventBus(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Creating EventBridge event bus (%s) failed: %w", eventBusName, err)
 	}
@@ -76,6 +84,20 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(eventBusName)
 
 	log.Printf("[INFO] EventBridge event bus (%s) created", d.Id())
+
+	// Post-create tagging supported in some partitions
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+			log.Printf("[WARN] error adding tags after create for EventBridge Bus (%s): %s", d.Id(), err)
+			return resourceBusRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating EventBridge Bus (%s) tags: %w", d.Id(), err)
+		}
+	}
 
 	return resourceBusRead(d, meta)
 }
@@ -106,9 +128,17 @@ func resourceBusRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", output.Name)
 
 	tags, err := ListTags(conn, aws.StringValue(output.Arn))
+
+	// ISO partitions may not support tagging, giving error
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+		log.Printf("[WARN] Unable to list tags for EventBridge Bus %s: %s", d.Id(), err)
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error listing tags for EventBridge event bus (%s): %w", d.Id(), err)
 	}
+
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
@@ -130,8 +160,15 @@ func resourceBusUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating CloudwWatch Events event bus (%s) tags: %w", arn, err)
+		err := UpdateTags(conn, arn, o, n)
+
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+			log.Printf("[WARN] Unable to update tags for EventBridge Bus %s: %s", d.Id(), err)
+			return resourceBusRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating EventBridge Bus tags: %w", err)
 		}
 	}
 

--- a/internal/service/events/consts.go
+++ b/internal/service/events/consts.go
@@ -1,5 +1,9 @@
 package events
 
 const (
+	ErrCodeAccessDenied = "AccessDenied"
+)
+
+const (
 	DefaultEventBusName = "default"
 )

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -120,23 +120,14 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Creating EventBridge Rule: %s", input)
-	// IAM Roles take some time to propagate
-	err = resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
-		_, err = conn.PutRule(input)
 
-		if tfawserr.ErrMessageContains(err, "ValidationException", "cannot be assumed by principal") {
-			return resource.RetryableError(err)
-		}
+	err = retryPutRule(conn, input)
 
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		_, err = conn.PutRule(input)
+	// Some partitions may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+		log.Printf("[WARN] EventBridge Rule (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+		err = retryPutRule(conn, input)
 	}
 
 	if err != nil {
@@ -144,6 +135,20 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(RuleCreateResourceID(aws.StringValue(input.EventBusName), aws.StringValue(input.Name)))
+
+	// Post-create tagging supported in some partitions
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+			log.Printf("[WARN] error adding tags after create for EventBridge Rule (%s): %s", d.Id(), err)
+			return resourceRuleRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating EventBridge Rule (%s) tags: %w", name, err)
+		}
+	}
 
 	return resourceRuleRead(d, meta)
 }
@@ -196,6 +201,12 @@ func resourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("is_enabled", enabled)
 
 	tags, err := ListTags(conn, arn)
+
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+		// ISO partitions may not support tagging, giving error
+		log.Printf("[WARN] Unable to list tags for EventBridge Rule %s: %s", d.Id(), err)
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for EventBridge Rule (%s): %w", arn, err)
@@ -257,8 +268,15 @@ func resourceRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating CloudwWatch Event Rule (%s) tags: %w", arn, err)
+		err := UpdateTags(conn, arn, o, n)
+
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+			log.Printf("[WARN] Unable to update tags for EventBridge Rule %s: %s", d.Id(), err)
+			return resourceRuleRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating EventBridge Rule tags: %w", err)
 		}
 	}
 
@@ -309,6 +327,28 @@ func resourceRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func retryPutRule(conn *eventbridge.EventBridge, input *eventbridge.PutRuleInput) error {
+	err := resource.Retry(tfiam.PropagationTimeout, func() *resource.RetryError {
+		_, err := conn.PutRule(input)
+
+		if tfawserr.ErrMessageContains(err, "ValidationException", "cannot be assumed by principal") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.PutRule(input)
+	}
+
+	return err
 }
 
 func buildPutRuleInputStruct(d *schema.ResourceData, name string) (*eventbridge.PutRuleInput, error) {

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -202,8 +202,8 @@ func resourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, arn)
 
+	// ISO partitions may not support tagging, giving error
 	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
-		// ISO partitions may not support tagging, giving error
 		log.Printf("[WARN] Unable to list tags for EventBridge Rule %s: %s", d.Id(), err)
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccEventsRule_ PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsRule_'  -timeout 180m
--- SKIP: TestAccEventsRule_partnerEventBus (0.00s)
--- PASS: TestAccEventsRule_scheduleAndPattern (30.65s)
--- PASS: TestAccEventsRule_namePrefix (30.74s)
--- PASS: TestAccEventsRule_Name_generated (30.78s)
--- PASS: TestAccEventsRule_eventBusARN (31.10s)
--- PASS: TestAccEventsRule_role (39.75s)
--- PASS: TestAccEventsRule_description (45.46s)
--- PASS: TestAccEventsRule_pattern (46.28s)
--- PASS: TestAccEventsRule_basic (58.69s)
--- PASS: TestAccEventsRule_isEnabled (59.40s)
--- PASS: TestAccEventsRule_eventBusName (63.28s)
--- PASS: TestAccEventsRule_tags (71.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	72.731s
% make testacc TESTS=TestAccEventsBus_ PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBus_'  -timeout 180m
--- SKIP: TestAccEventsBus_partnerEventSource (0.00s)
--- PASS: TestAccEventsBus_default (2.31s)
--- PASS: TestAccEventsBus_disappears (13.44s)
--- PASS: TestAccEventsBus_basic (42.18s)
--- PASS: TestAccEventsBus_tags (52.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	54.505s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccEventsRule_ PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsRule_'  -timeout 180m
--- SKIP: TestAccEventsRule_partnerEventBus (0.00s)
--- PASS: TestAccEventsRule_namePrefix (31.59s)
--- PASS: TestAccEventsRule_Name_generated (31.74s)
--- PASS: TestAccEventsRule_scheduleAndPattern (31.75s)
--- PASS: TestAccEventsRule_eventBusARN (32.35s)
--- PASS: TestAccEventsRule_role (39.47s)
--- PASS: TestAccEventsRule_description (51.54s)
--- PASS: TestAccEventsRule_pattern (51.69s)
--- PASS: TestAccEventsRule_isEnabled (71.67s)
--- PASS: TestAccEventsRule_basic (72.10s)
--- PASS: TestAccEventsRule_eventBusName (75.69s)
--- PASS: TestAccEventsRule_tags (86.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	88.872s
% make testacc TESTS=TestAccEventsBus_ PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBus_'  -timeout 180m
--- SKIP: TestAccEventsBus_partnerEventSource (0.00s)
--- PASS: TestAccEventsBus_default (2.39s)
--- PASS: TestAccEventsBus_disappears (16.42s)
--- PASS: TestAccEventsBus_basic (52.93s)
--- PASS: TestAccEventsBus_tags (67.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	68.867s
```