### PR TITLE
elbv2: ISO-friendly tagging

### DIFF
--- a/.changelog/22551.txt
+++ b/.changelog/22551.txt
@@ -17,3 +17,11 @@ resource/aws_lb: Attempt `tags`-on-create, fallback to tag after create, and all
 ```release-note:enhancement
 data-source/aws_lb: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_lb_target_group: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:enhancement
+data-source/aws_lb_target_group: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22551.txt
+++ b/.changelog/22551.txt
@@ -9,3 +9,7 @@ data-source/aws_lb_listener: Allow some `tags` errors to be non-fatal to support
 ```release-note:enhancement
 resource/aws_lb_listener_rule: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_lb: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22551.txt
+++ b/.changelog/22551.txt
@@ -13,3 +13,7 @@ resource/aws_lb_listener_rule: Attempt `tags`-on-create, fallback to tag after c
 ```release-note:enhancement
 resource/aws_lb: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+data-source/aws_lb: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22551.txt
+++ b/.changelog/22551.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lb_listener: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22551.txt
+++ b/.changelog/22551.txt
@@ -1,3 +1,11 @@
 ```release-note:enhancement
 resource/aws_lb_listener: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+data-source/aws_lb_listener: Allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```
+
+```release-note:enhancement
+resource/aws_lb_listener_rule: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/internal/service/elbv2/consts.go
+++ b/internal/service/elbv2/consts.go
@@ -1,0 +1,5 @@
+package elbv2
+
+const (
+	ErrCodeAccessDenied = "AccessDenied"
+)

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -432,37 +432,35 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	var output *elbv2.CreateListenerOutput
+	output, err := retryListenerCreate(conn, params)
 
-	err := resource.Retry(loadBalancerListenerCreateTimeout, func() *resource.RetryError {
-		var err error
-
-		output, err = conn.CreateListener(params)
-
-		if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeCertificateNotFoundException) {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		output, err = conn.CreateListener(params)
+	// Some partitions may not support tag-on-create
+	if params.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+		log.Printf("[WARN] ELBV2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
+		params.Tags = nil
+		output, err = retryListenerCreate(conn, params)
 	}
 
 	if err != nil {
 		return fmt.Errorf("error creating ELBv2 Listener (%s): %w", lbArn, err)
 	}
 
-	if output == nil || len(output.Listeners) == 0 {
-		return fmt.Errorf("error creating ELBv2 Listener: no listeners returned in response")
-	}
-
 	d.SetId(aws.StringValue(output.Listeners[0].ListenerArn))
+
+	// Post-create tagging supported in some partitions
+	if params.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
+			log.Printf("[WARN] error adding tags after create for ELBV2 Listener (%s): %s", d.Id(), err)
+			return resourceListenerRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ELBV2 Listener (%s) tags: %w", d.Id(), err)
+		}
+	}
 
 	return resourceListenerRead(d, meta)
 }
@@ -535,6 +533,11 @@ func resourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tags, err := ListTags(conn, d.Id())
+
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		log.Printf("[WARN] Unable to list tags for ELBV2 Listener %s: %s", d.Id(), err)
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
@@ -639,6 +642,12 @@ func resourceListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 			err = UpdateTags(conn, d.Id(), o, n)
 		}
 
+		// ISO partitions may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+			log.Printf("[WARN] Unable to update tags for ELBV2 Listener %s: %s", d.Id(), err)
+			return resourceListenerRead(d, meta)
+		}
+
 		if err != nil {
 			return fmt.Errorf("error updating LB (%s) tags: %w", d.Id(), err)
 		}
@@ -658,6 +667,40 @@ func resourceListenerDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func retryListenerCreate(conn *elbv2.ELBV2, params *elbv2.CreateListenerInput) (*elbv2.CreateListenerOutput, error) {
+	var output *elbv2.CreateListenerOutput
+
+	err := resource.Retry(loadBalancerListenerCreateTimeout, func() *resource.RetryError {
+		var err error
+
+		output, err = conn.CreateListener(params)
+
+		if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeCertificateNotFoundException) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		output, err = conn.CreateListener(params)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Listeners) == 0 {
+		return nil, fmt.Errorf("error creating ELBv2 Listener: no listeners returned in response")
+	}
+
+	return output, nil
 }
 
 func expandLbListenerActions(l []interface{}) ([]*elbv2.Action, error) {

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -436,7 +436,7 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions may not support tag-on-create
 	if params.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
-		log.Printf("[WARN] ELBV2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
+		log.Printf("[WARN] ELBv2 Listener (%s) create failed (%s) with tags. Trying create without tags.", lbArn, err)
 		params.Tags = nil
 		output, err = retryListenerCreate(conn, params)
 	}
@@ -453,12 +453,12 @@ func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-			log.Printf("[WARN] error adding tags after create for ELBV2 Listener (%s): %s", d.Id(), err)
+			log.Printf("[WARN] error adding tags after create for ELBv2 Listener (%s): %s", d.Id(), err)
 			return resourceListenerRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error creating ELBV2 Listener (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("error creating ELBv2 Listener (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -535,7 +535,7 @@ func resourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, d.Id())
 
 	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
-		log.Printf("[WARN] Unable to list tags for ELBV2 Listener %s: %s", d.Id(), err)
+		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return nil
 	}
 
@@ -644,7 +644,7 @@ func resourceListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// ISO partitions may not support tagging, giving error
 		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
-			log.Printf("[WARN] Unable to update tags for ELBV2 Listener %s: %s", d.Id(), err)
+			log.Printf("[WARN] Unable to update tags for ELBv2 Listener %s: %s", d.Id(), err)
 			return resourceListenerRead(d, meta)
 		}
 

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -510,50 +510,35 @@ func resourceListenerRuleCreate(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error creating LB Listener Rule for Listener (%s): %w", listenerArn, err)
 	}
 
-	var resp *elbv2.CreateRuleOutput
-	if v, ok := d.GetOk("priority"); ok {
-		var err error
-		params.Priority = aws.Int64(int64(v.(int)))
-		resp, err = conn.CreateRule(params)
-		if err != nil {
-			return fmt.Errorf("Error creating LB Listener Rule: %w", err)
-		}
-	} else {
-		var priority int64
-		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-			var err error
-			priority, err = highestListenerRulePriority(conn, listenerArn)
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-			params.Priority = aws.Int64(priority + 1)
-			resp, err = conn.CreateRule(params)
-			if err != nil {
-				if tfawserr.ErrMessageContains(err, elbv2.ErrCodePriorityInUseException, "") {
-					return resource.RetryableError(err)
-				}
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
-		if tfresource.TimedOut(err) {
-			priority, err = highestListenerRulePriority(conn, listenerArn)
-			if err != nil {
-				return fmt.Errorf("Error getting highest listener rule priority: %w", err)
-			}
-			params.Priority = aws.Int64(priority + 1)
-			resp, err = conn.CreateRule(params)
-		}
-		if err != nil {
-			return fmt.Errorf("Error creating LB Listener Rule: %w", err)
-		}
+	resp, err := retryListenerRuleCreate(conn, d, params, listenerArn)
+
+	// Some partitions may not support tag-on-create
+	if params.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+		log.Printf("[WARN] ELBv2 Listener Rule (%s) create failed (%s) with tags. Trying create without tags.", listenerArn, err)
+		params.Tags = nil
+		resp, err = retryListenerRuleCreate(conn, d, params, listenerArn)
 	}
 
-	if resp == nil || len(resp.Rules) == 0 {
-		return errors.New("Error creating LB Listener Rule: no rules returned in response")
+	if err != nil {
+		return fmt.Errorf("Error creating LB Listener Rule: %w", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Rules[0].RuleArn))
+
+	// Post-create tagging supported in some partitions
+	if params.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
+			log.Printf("[WARN] error adding tags after create for ELBv2 Listener Rule (%s): %s", d.Id(), err)
+			return resourceListenerRuleRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ELBv2 Listener Rule (%s) tags: %w", d.Id(), err)
+		}
+	}
 
 	return resourceListenerRuleRead(d, meta)
 }
@@ -599,23 +584,6 @@ func resourceListenerRuleRead(d *schema.ResourceData, meta interface{}) error {
 	rule := resp.Rules[0]
 
 	d.Set("arn", rule.RuleArn)
-
-	tags, err := ListTags(conn, d.Id())
-
-	if err != nil {
-		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
-	}
 
 	// The listener arn isn't in the response but can be derived from the rule arn
 	d.Set("listener_arn", ListenerARNFromRuleARN(aws.StringValue(rule.RuleArn)))
@@ -796,6 +764,29 @@ func resourceListenerRuleRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting condition: %w", err)
 	}
 
+	// tags at the end because, if not supported, will skip the rest of Read
+	tags, err := ListTags(conn, d.Id())
+
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		log.Printf("[WARN] Unable to list tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
 	return nil
 }
 
@@ -874,6 +865,12 @@ func resourceListenerRuleUpdate(d *schema.ResourceData, meta interface{}) error 
 			err = UpdateTags(conn, d.Id(), o, n)
 		}
 
+		// ISO partitions may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+			log.Printf("[WARN] Unable to update tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
+			return resourceListenerRuleRead(d, meta)
+		}
+
 		if err != nil {
 			return fmt.Errorf("error updating LB (%s) tags: %w", d.Id(), err)
 		}
@@ -892,6 +889,57 @@ func resourceListenerRuleDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error deleting LB Listener Rule: %w", err)
 	}
 	return nil
+}
+
+func retryListenerRuleCreate(conn *elbv2.ELBV2, d *schema.ResourceData, params *elbv2.CreateRuleInput, listenerARN string) (*elbv2.CreateRuleOutput, error) {
+	var resp *elbv2.CreateRuleOutput
+	if v, ok := d.GetOk("priority"); ok {
+		var err error
+		params.Priority = aws.Int64(int64(v.(int)))
+		resp, err = conn.CreateRule(params)
+
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var priority int64
+
+		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+			var err error
+			priority, err = highestListenerRulePriority(conn, listenerARN)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			params.Priority = aws.Int64(priority + 1)
+			resp, err = conn.CreateRule(params)
+			if err != nil {
+				if tfawserr.ErrMessageContains(err, elbv2.ErrCodePriorityInUseException, "") {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+
+		if tfresource.TimedOut(err) {
+			priority, err = highestListenerRulePriority(conn, listenerARN)
+			if err != nil {
+				return nil, fmt.Errorf("getting highest listener rule (%s) priority: %w", listenerARN, err)
+			}
+			params.Priority = aws.Int64(priority + 1)
+			resp, err = conn.CreateRule(params)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if resp == nil || len(resp.Rules) == 0 {
+		return nil, fmt.Errorf("creating LB Listener Rule (%s): no rules returned in response", listenerARN)
+	}
+
+	return resp, nil
 }
 
 func validListenerRulePriority(v interface{}, k string) (ws []string, errors []error) {

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -1041,6 +1041,10 @@ func TestAccELBV2ListenerRule_conditionUpdateMixed(t *testing.T) {
 	resourceName := "aws_lb_listener_rule.static"
 	frontEndListenerResourceName := "aws_lb_listener.front_end"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -500,6 +500,10 @@ func TestAccELBV2ListenerRule_priority(t *testing.T) {
 	lbName := fmt.Sprintf("testrule-basic-%s", sdkacctest.RandString(13))
 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -179,7 +179,7 @@ func TestAccELBV2Listener_forwardWeighted(t *testing.T) {
 	})
 }
 
-func TestAccELBV2Listener_basicUdp(t *testing.T) {
+func TestAccELBV2Listener_Protocol_upd(t *testing.T) {
 	var conf elbv2.Listener
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -251,7 +251,7 @@ func TestAccELBV2Listener_backwardsCompatibility(t *testing.T) {
 	})
 }
 
-func TestAccELBV2Listener_https(t *testing.T) {
+func TestAccELBV2Listener_Protocol_https(t *testing.T) {
 	var conf elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(2048)
 	resourceName := "aws_lb_listener.test"
@@ -552,7 +552,7 @@ func TestAccELBV2Listener_DefaultAction_order(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6171
-func TestAccELBV2Listener_DefaultActionOrder_recreates(t *testing.T) {
+func TestAccELBV2Listener_DefaultAction_orderRecreates(t *testing.T) {
 	var listener elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -297,6 +297,10 @@ func TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer(t *testing.T) {
 	lbResourceName := "aws_lb.test"
 	resourceName := "aws_lb_listener.test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   testAccErrorCheckSkipELBV2(t),
@@ -322,6 +326,10 @@ func TestAccELBV2Listener_Protocol_tls(t *testing.T) {
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -359,6 +359,14 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] ALB create configuration: %#v", elbOpts)
 
 	resp, err := conn.CreateLoadBalancer(elbOpts)
+
+	// Some partitions may not support tag-on-create
+	if elbOpts.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+		log.Printf("[WARN] ELBv2 Load Balancer (%s) create failed (%s) with tags. Trying create without tags.", name, err)
+		elbOpts.Tags = nil
+		resp, err = conn.CreateLoadBalancer(elbOpts)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating %s Load Balancer: %w", d.Get("load_balancer_type").(string), err)
 	}
@@ -374,6 +382,21 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 	_, err = waitLoadBalancerActive(conn, aws.StringValue(lb.LoadBalancerArn), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf("error waiting for Load Balancer (%s) to be active: %w", d.Get("name").(string), err)
+	}
+
+	// Post-create tagging supported in some partitions
+	if elbOpts.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+			log.Printf("[WARN] error adding tags after create for ELBv2 Load Balancer (%s): %s", d.Id(), err)
+			return resourceLoadBalancerUpdate(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating ELBv2 Load Balancer (%s) tags: %w", d.Id(), err)
+		}
 	}
 
 	return resourceLoadBalancerUpdate(d, meta)
@@ -409,33 +432,6 @@ func resourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ELBV2Conn
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		err := resource.Retry(loadBalancerTagPropagationTimeout, func() *resource.RetryError {
-			err := UpdateTags(conn, d.Id(), o, n)
-
-			if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeLoadBalancerNotFoundException) {
-				log.Printf("[DEBUG] Retrying tagging of LB (%s) after error: %s", d.Id(), err)
-				return resource.RetryableError(err)
-			}
-
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-
-			return nil
-		})
-
-		if tfresource.TimedOut(err) {
-			err = UpdateTags(conn, d.Id(), o, n)
-		}
-
-		if err != nil {
-			return fmt.Errorf("error updating LB (%s) tags: %w", d.Id(), err)
-		}
-	}
 
 	attributes := make([]*elbv2.LoadBalancerAttribute, 0)
 
@@ -584,6 +580,45 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 		_, err := conn.SetIpAddressType(params)
 		if err != nil {
 			return fmt.Errorf("failure Setting LB IP Address Type: %w", err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		err := resource.Retry(loadBalancerTagPropagationTimeout, func() *resource.RetryError {
+			err := UpdateTags(conn, d.Id(), o, n)
+
+			if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeLoadBalancerNotFoundException) {
+				log.Printf("[DEBUG] Retrying tagging of LB (%s) after error: %s", d.Id(), err)
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		})
+
+		if tfresource.TimedOut(err) {
+			err = UpdateTags(conn, d.Id(), o, n)
+		}
+
+		// ISO partitions may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+			log.Printf("[WARN] Unable to update tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
+
+			_, err := waitLoadBalancerActive(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return fmt.Errorf("error waiting for Load Balancer (%s) to be active: %w", d.Get("name").(string), err)
+			}
+
+			return resourceListenerRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error updating LB (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -789,23 +824,6 @@ func flattenResource(d *schema.ResourceData, meta interface{}, lb *elbv2.LoadBal
 		return fmt.Errorf("error setting subnet_mapping: %w", err)
 	}
 
-	tags, err := ListTags(conn, d.Id())
-
-	if err != nil {
-		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
-	}
-
 	attributesResp, err := conn.DescribeLoadBalancerAttributes(&elbv2.DescribeLoadBalancerAttributesInput{
 		LoadBalancerArn: aws.String(d.Id()),
 	})
@@ -863,6 +881,28 @@ func flattenResource(d *schema.ResourceData, meta interface{}, lb *elbv2.LoadBal
 
 	if err := d.Set("access_logs", []interface{}{accessLogMap}); err != nil {
 		return fmt.Errorf("error setting access_logs: %w", err)
+	}
+
+	tags, err := ListTags(conn, d.Id())
+
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
 	}
 
 	return nil

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -2,6 +2,7 @@ package elbv2
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -251,16 +252,6 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error setting subnet_mapping: %w", err)
 	}
 
-	tags, err := ListTags(conn, d.Id())
-
-	if err != nil {
-		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
-	}
-
-	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
-	}
-
 	attributesResp, err := conn.DescribeLoadBalancerAttributes(&elbv2.DescribeLoadBalancerAttributesInput{
 		LoadBalancerArn: aws.String(d.Id()),
 	})
@@ -311,6 +302,21 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 
 	if err := d.Set("access_logs", []interface{}{accessLogMap}); err != nil {
 		return fmt.Errorf("error setting access_logs: %w", err)
+	}
+
+	tags, err := ListTags(conn, d.Id())
+
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -487,6 +487,10 @@ func TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone(t *testing.T) 
 	lbName := fmt.Sprintf("testAccAWSlb-nlbcz-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb.lb_test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
@@ -528,6 +532,10 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 	lbName := fmt.Sprintf("testAccAWSalb-http2-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb.lb_test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
@@ -567,6 +575,10 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2(t *testing.T) 
 func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testAccAWSalb-headers-%s", sdkacctest.RandString(10))
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -609,6 +621,10 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection(t
 	lbName := fmt.Sprintf("testAccAWSalb-basic-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb.lb_test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
@@ -649,6 +665,10 @@ func TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen(t *testi
 	var pre, mid, post elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testAccAWSalb-basic-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb.lb_test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -698,6 +718,10 @@ func TestAccELBV2LoadBalancer_updatedSecurityGroups(t *testing.T) {
 	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb.lb_test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
@@ -727,6 +751,10 @@ func TestAccELBV2LoadBalancer_updatedSubnets(t *testing.T) {
 	var pre, post elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testAccAWSlb-basic-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb.lb_test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -823,6 +851,10 @@ func TestAccELBV2LoadBalancer_ALB_accessLogs(t *testing.T) {
 	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
 	resourceName := "aws_lb.test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
@@ -911,6 +943,10 @@ func TestAccELBV2LoadBalancer_ALBAccessLogs_prefix(t *testing.T) {
 	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
 	resourceName := "aws_lb.test"
 
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elbv2.EndpointsID),
@@ -980,6 +1016,10 @@ func TestAccELBV2LoadBalancer_NLB_accessLogs(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-access-logs-%s", sdkacctest.RandString(6))
 	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
 	resourceName := "aws_lb.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -1068,6 +1108,10 @@ func TestAccELBV2LoadBalancer_NLBAccessLogs_prefix(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-access-logs-%s", sdkacctest.RandString(6))
 	lbName := fmt.Sprintf("testAccAWSlbaccesslog-%s", sdkacctest.RandString(4))
 	resourceName := "aws_lb.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -1163,6 +1207,10 @@ func TestAccELBV2LoadBalancer_updateDesyncMitigationMode(t *testing.T) {
 	var pre, mid, post elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testaccawsalb-desync-%s", sdkacctest.RandString(4))
 	resourceName := "aws_lb.lb_test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccELBV2Listener_ PKG=elbv2 TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2Listener_' -short -timeout 180m
--- SKIP: TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer (0.00s)
--- SKIP: TestAccELBV2Listener_Protocol_tls (0.08s)
--- PASS: TestAccELBV2Listener_fixedResponse (172.41s)
--- PASS: TestAccELBV2Listener_backwardsCompatibility (174.12s)
--- PASS: TestAccELBV2Listener_DefaultAction_order (175.18s)
--- PASS: TestAccELBV2Listener_cognito (175.20s)
--- PASS: TestAccELBV2Listener_basic (175.18s)
--- PASS: TestAccELBV2Listener_Protocol_https (175.49s)
--- PASS: TestAccELBV2Listener_DefaultAction_orderRecreates (233.53s)
--- PASS: TestAccELBV2Listener_redirect (237.50s)
--- PASS: TestAccELBV2Listener_oidc (242.77s)
--- PASS: TestAccELBV2Listener_Protocol_upd (270.93s)
--- PASS: TestAccELBV2Listener_tags (282.85s)
--- PASS: TestAccELBV2Listener_forwardWeighted (287.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	289.414s
% make testacc TESTS=TestAccELBV2ListenerRule_ PKG=elbv2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRule_'  -timeout 180m
--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (3.71s)
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (25.00s)
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (176.54s)
--- PASS: TestAccELBV2ListenerRule_fixedResponse (180.63s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (188.49s)
--- PASS: TestAccELBV2ListenerRule_ActionOrder_recreates (190.15s)
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (201.80s)
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (202.06s)
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (217.33s)
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (221.71s)
--- PASS: TestAccELBV2ListenerRule_tags (236.93s)
--- PASS: TestAccELBV2ListenerRule_redirect (237.36s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (238.29s)
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (246.20s)
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (253.96s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (265.10s)
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (283.88s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (287.69s)
--- PASS: TestAccELBV2ListenerRule_basic (296.54s)
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (282.68s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMixed (347.42s)
--- PASS: TestAccELBV2ListenerRule_Action_order (180.00s)
--- PASS: TestAccELBV2ListenerRule_cognito (169.98s)
--- PASS: TestAccELBV2ListenerRule_oidc (190.46s)
--- PASS: TestAccELBV2ListenerRule_priority (507.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	513.696s
% make testacc TESTS=TestAccELBV2ListenerDataSource_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerDataSource_'  -timeout 180m
=== RUN   TestAccELBV2ListenerDataSource_basic
=== PAUSE TestAccELBV2ListenerDataSource_basic
=== RUN   TestAccELBV2ListenerDataSource_backwardsCompatibility
=== PAUSE TestAccELBV2ListenerDataSource_backwardsCompatibility
=== RUN   TestAccELBV2ListenerDataSource_https
=== PAUSE TestAccELBV2ListenerDataSource_https
=== RUN   TestAccELBV2ListenerDataSource_DefaultAction_forward
=== PAUSE TestAccELBV2ListenerDataSource_DefaultAction_forward
=== CONT  TestAccELBV2ListenerDataSource_basic
=== CONT  TestAccELBV2ListenerDataSource_https
=== CONT  TestAccELBV2ListenerDataSource_backwardsCompatibility
=== CONT  TestAccELBV2ListenerDataSource_DefaultAction_forward
--- PASS: TestAccELBV2ListenerDataSource_https (172.45s)
--- PASS: TestAccELBV2ListenerDataSource_basic (244.27s)
--- PASS: TestAccELBV2ListenerDataSource_DefaultAction_forward (250.55s)
--- PASS: TestAccELBV2ListenerDataSource_backwardsCompatibility (251.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	253.361s
% make testacc TESTS=TestAccELBV2LoadBalancer_ PKG=elbv2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer_'  -timeout 180m
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (1.57s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (120.23s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (176.94s)
--- PASS: TestAccELBV2LoadBalancer_generatedName (183.69s)
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (184.08s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (213.46s)
--- PASS: TestAccELBV2LoadBalancer_noSecurityGroup (226.47s)
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (226.82s)
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (233.17s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change (234.48s)
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (236.97s)
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (255.34s)
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (282.84s)
--- PASS: TestAccELBV2LoadBalancer_tags (299.63s)
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (339.47s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (350.38s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (355.95s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (361.99s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen (365.62s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (370.28s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (213.73s)
--- PASS: TestAccELBV2LoadBalancer_updatedIPAddressType (284.36s)
--- PASS: TestAccELBV2LoadBalancer_updatedSecurityGroups (408.85s)
--- PASS: TestAccELBV2LoadBalancer_updatedSubnets (305.15s)
--- PASS: TestAccELBV2LoadBalancer_NLBAccessLogs_prefix (335.53s)
--- PASS: TestAccELBV2LoadBalancer_ALB_accessLogs (335.98s)
--- PASS: TestAccELBV2LoadBalancer_ALBAccessLogs_prefix (344.55s)
--- PASS: TestAccELBV2LoadBalancer_NLB_accessLogs (400.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	586.089s
% make testacc TESTS=TestAccELBV2LoadBalancerDataSource_ PKG=elbv2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancerDataSource_'  -timeout 180m
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (1.34s)
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (187.16s)
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (252.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	253.878s
% make testacc TESTS='TestAccELBV2TargetGroup_|TestAccELBV2TargetGroupDataSource_' PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_|TestAccELBV2TargetGroupDataSource_'  -timeout 180m
--- PASS: TestAccELBV2TargetGroup_A_namePrefix (34.44s)
--- PASS: TestAccELBV2TargetGroup_enableHealthCheck (35.58s)
--- PASS: TestAccELBV2TargetGroup_generatedName (36.55s)
--- PASS: TestAccELBV2TargetGroup_namePrefix (39.02s)
--- PASS: TestAccELBV2TargetGroup_Defaults_application (39.69s)
--- PASS: TestAccELBV2TargetGroup_Defaults_network (41.91s)
--- PASS: TestAccELBV2TargetGroup_protocolGeneve (42.12s)
--- PASS: TestAccELBV2TargetGroup_changeVPCForceNew (51.75s)
--- PASS: TestAccELBV2TargetGroup_A_setAndUpdateSlowStart (54.99s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy (55.88s)
--- PASS: TestAccELBV2TargetGroup_A_lambda (20.91s)
--- PASS: TestAccELBV2TargetGroup_changePortForceNew (58.34s)
--- PASS: TestAccELBV2TargetGroup_changeNameForceNew (63.14s)
--- PASS: TestAccELBV2TargetGroup_A_updateHealthCheck (63.18s)
--- PASS: TestAccELBV2TargetGroup_preserveClientIPValid (63.76s)
--- PASS: TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination (63.81s)
--- PASS: TestAccELBV2TargetGroup_A_tags (64.09s)
--- PASS: TestAccELBV2TargetGroup_A_missingPortProtocolVPC (30.38s)
--- PASS: TestAccELBV2TargetGroup_A_generatedName (26.97s)
--- PASS: TestAccELBV2TargetGroup_changeProtocolForceNew (69.17s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersionGRPC_healthCheck (28.16s)
--- PASS: TestAccELBV2TargetGroup_protocolVersion (28.29s)
--- PASS: TestAccELBV2TargetGroup_A_updateLoadBalancingAlgorithmType (77.77s)
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (27.03s)
--- PASS: TestAccELBV2TargetGroup_A_lambdaMultiValueHeadersEnabled (51.40s)
--- PASS: TestAccELBV2TargetGroup_basicUdp (28.31s)
--- PASS: TestAccELBV2TargetGroup_basic (29.78s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroup (94.65s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersionHTTPGRPC_update (55.48s)
--- PASS: TestAccELBV2TargetGroup_Protocol_tls (26.39s)
--- PASS: TestAccELBV2TargetGroup_A_changeVPCForceNew (48.62s)
--- PASS: TestAccELBV2TargetGroup_A_changeProtocolForceNew (54.78s)
--- PASS: TestAccELBV2TargetGroup_A_changePortForceNew (51.99s)
--- PASS: TestAccELBV2TargetGroup_ProtocolTCPHealthCheck_protocol (51.99s)
--- PASS: TestAccELBV2TargetGroup_attrsOnCreate (50.07s)
--- PASS: TestAccELBV2TargetGroup_TCP_httpHealthCheck (50.20s)
--- PASS: TestAccELBV2TargetGroup_A_basic (27.53s)
--- PASS: TestAccELBV2TargetGroup_stickinessValidALB (50.71s)
--- PASS: TestAccELBV2TargetGroup_withoutHealthCheck (15.73s)
--- PASS: TestAccELBV2TargetGroup_stickinessDefaultALB (25.71s)
--- PASS: TestAccELBV2TargetGroup_tags (71.85s)
--- PASS: TestAccELBV2TargetGroup_A_updateStickinessEnabled (68.86s)
--- PASS: TestAccELBV2TargetGroup_updateHealthCheck (47.26s)
--- PASS: TestAccELBV2TargetGroup_A_changeNameForceNew (53.88s)
--- PASS: TestAccELBV2TargetGroup_updateStickinessEnabled (68.36s)
--- PASS: TestAccELBV2TargetGroup_stickinessInvalidNLB (34.12s)
--- PASS: TestAccELBV2TargetGroup_stickinessInvalidALB (51.10s)
--- PASS: TestAccELBV2TargetGroup_updateAppStickinessEnabled (65.89s)
--- PASS: TestAccELBV2TargetGroup_protocolGeneveNotSticky (44.96s)
--- PASS: TestAccELBV2TargetGroup_stickinessDefaultNLB (67.71s)
--- PASS: TestAccELBV2TargetGroup_stickinessValidNLB (109.74s)
--- PASS: TestAccELBV2TargetGroupDataSource_appCookie (171.69s)
--- PASS: TestAccELBV2TargetGroupDataSource_backwardsCompatibility (178.56s)
--- PASS: TestAccELBV2TargetGroupDataSource_basic (234.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	235.953s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccELBV2Listener_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2Listener_'  -timeout 180m
--- PASS: TestAccELBV2Listener_DefaultAction_orderRecreates (174.25s)
--- SKIP: TestAccELBV2Listener_cognito (192.16s)
--- PASS: TestAccELBV2Listener_fixedResponse (200.66s)
--- PASS: TestAccELBV2Listener_oidc (203.21s)
--- PASS: TestAccELBV2Listener_redirect (206.15s)
--- PASS: TestAccELBV2Listener_backwardsCompatibility (208.80s)
--- PASS: TestAccELBV2Listener_Protocol_https (227.49s)
--- PASS: TestAccELBV2Listener_tags (228.62s)
--- PASS: TestAccELBV2Listener_basic (228.74s)
--- PASS: TestAccELBV2Listener_forwardWeighted (232.28s)
--- PASS: TestAccELBV2Listener_DefaultAction_order (240.99s)
--- PASS: TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer (251.56s)
--- PASS: TestAccELBV2Listener_Protocol_tls (325.44s)
--- PASS: TestAccELBV2Listener_Protocol_upd (368.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	371.199s
% make testacc TESTS=TestAccELBV2ListenerDataSource_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerDataSource_'  -timeout 180m
--- PASS: TestAccELBV2ListenerDataSource_basic (173.90s)
--- PASS: TestAccELBV2ListenerDataSource_https (174.14s)
--- PASS: TestAccELBV2ListenerDataSource_backwardsCompatibility (224.24s)
--- PASS: TestAccELBV2ListenerDataSource_DefaultAction_forward (231.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	233.300s
% make testacc TESTS=TestAccELBV2ListenerRule_ PKG=elbv2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRule_'  -timeout 180m
--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (3.82s)
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (33.03s)
--- PASS: TestAccELBV2ListenerRule_basic (187.55s)
--- PASS: TestAccELBV2ListenerRule_oidc (187.95s)
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (188.63s)
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (191.00s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (204.42s)
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (214.03s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (218.35s)
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (218.41s)
--- PASS: TestAccELBV2ListenerRule_Action_order (223.89s)
--- PASS: TestAccELBV2ListenerRule_fixedResponse (227.45s)
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (229.73s)
--- PASS: TestAccELBV2ListenerRule_ActionOrder_recreates (237.44s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (238.84s)
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (243.77s)
--- SKIP: TestAccELBV2ListenerRule_cognito (244.05s)
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (256.07s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (262.18s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMixed (333.28s)
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (180.47s)
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (195.18s)
--- PASS: TestAccELBV2ListenerRule_redirect (392.58s)
--- PASS: TestAccELBV2ListenerRule_tags (229.92s)
--- PASS: TestAccELBV2ListenerRule_priority (449.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	455.680s
% make testacc TESTS='TestAccELBV2LoadBalancer_|TestAccELBV2LoadBalancerDataSource_' PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer_|TestAccELBV2LoadBalancerDataSource_'  -timeout 180m
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (2.05s)
--- PASS: TestAccELBV2LoadBalancer_noSecurityGroup (183.14s)
--- PASS: TestAccELBV2LoadBalancer_generatedName (194.91s)
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (232.69s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change (235.91s)
--- PASS: TestAccELBV2LoadBalancer_updatedSecurityGroups (246.37s)
--- PASS: TestAccELBV2LoadBalancer_updatedSubnets (264.43s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (275.33s)
--- PASS: TestAccELBV2LoadBalancer_updatedIPAddressType (277.04s)
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (283.02s)
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (0.57s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen (292.81s)
--- PASS: TestAccELBV2LoadBalancer_tags (302.58s)
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (309.17s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (311.86s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (313.04s)
--- PASS: TestAccELBV2LoadBalancer_ALBAccessLogs_prefix (315.25s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (337.36s)
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (185.11s)
--- PASS: TestAccELBV2LoadBalancer_NLBAccessLogs_prefix (371.80s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (372.06s)
--- PASS: TestAccELBV2LoadBalancer_ALB_accessLogs (373.62s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (113.36s)
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (215.90s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (166.46s)
--- PASS: TestAccELBV2LoadBalancer_NLB_accessLogs (442.09s)
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (213.12s)
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (176.75s)
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (216.88s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (233.69s)
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (194.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	474.517s
% make testacc TESTS='TestAccELBV2TargetGroup_|TestAccELBV2TargetGroupDataSource_' PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_|TestAccELBV2TargetGroupDataSource_'  -timeout 180m
--- PASS: TestAccELBV2TargetGroup_A_lambda (31.00s)
--- PASS: TestAccELBV2TargetGroup_basicUdp (39.48s)
--- PASS: TestAccELBV2TargetGroup_Protocol_tls (40.10s)
--- PASS: TestAccELBV2TargetGroup_A_namePrefix (40.13s)
--- PASS: TestAccELBV2TargetGroup_A_generatedName (42.17s)
--- PASS: TestAccELBV2TargetGroup_basic (42.86s)
--- PASS: TestAccELBV2TargetGroup_A_missingPortProtocolVPC (48.81s)
--- PASS: TestAccELBV2TargetGroup_A_setAndUpdateSlowStart (59.41s)
--- PASS: TestAccELBV2TargetGroup_A_updateHealthCheck (61.46s)
--- PASS: TestAccELBV2TargetGroup_withoutHealthCheck (18.87s)
--- PASS: TestAccELBV2TargetGroup_TCP_httpHealthCheck (64.02s)
--- PASS: TestAccELBV2TargetGroup_A_lambdaMultiValueHeadersEnabled (66.28s)
--- PASS: TestAccELBV2TargetGroup_changePortForceNew (66.30s)
--- PASS: TestAccELBV2TargetGroup_attrsOnCreate (66.96s)
--- PASS: TestAccELBV2TargetGroup_protocolGeneveNotSticky (68.11s)
--- PASS: TestAccELBV2TargetGroup_A_tags (68.15s)
--- PASS: TestAccELBV2TargetGroup_ProtocolTCPHealthCheck_protocol (69.32s)
--- PASS: TestAccELBV2TargetGroup_changeNameForceNew (71.97s)
--- PASS: TestAccELBV2TargetGroup_A_basic (29.84s)
--- PASS: TestAccELBV2TargetGroup_A_changeVPCForceNew (50.86s)
--- PASS: TestAccELBV2TargetGroup_A_updateStickinessEnabled (88.36s)
--- PASS: TestAccELBV2TargetGroup_A_updateLoadBalancingAlgorithmType (88.55s)
--- PASS: TestAccELBV2TargetGroup_A_changePortForceNew (55.54s)
--- PASS: TestAccELBV2TargetGroup_stickinessDefaultALB (30.25s)
--- PASS: TestAccELBV2TargetGroup_A_changeProtocolForceNew (59.92s)
--- PASS: TestAccELBV2TargetGroup_A_changeNameForceNew (59.32s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersionGRPC_healthCheck (29.76s)
--- PASS: TestAccELBV2TargetGroup_stickinessInvalidNLB (42.61s)
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (29.30s)
--- PASS: TestAccELBV2TargetGroup_updateHealthCheck (56.83s)
--- PASS: TestAccELBV2TargetGroup_namePrefix (30.51s)
--- PASS: TestAccELBV2TargetGroup_stickinessValidALB (55.17s)
--- PASS: TestAccELBV2TargetGroup_stickinessInvalidALB (61.89s)
--- PASS: TestAccELBV2TargetGroup_updateStickinessEnabled (80.14s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersionHTTPGRPC_update (59.82s)
--- PASS: TestAccELBV2TargetGroup_protocolGeneve (34.50s)
--- PASS: TestAccELBV2TargetGroup_generatedName (30.63s)
--- PASS: TestAccELBV2TargetGroup_Defaults_network (37.83s)
--- PASS: TestAccELBV2TargetGroup_updateAppStickinessEnabled (80.92s)
--- PASS: TestAccELBV2TargetGroup_tags (81.20s)
--- PASS: TestAccELBV2TargetGroup_Defaults_application (27.75s)
--- PASS: TestAccELBV2TargetGroup_enableHealthCheck (36.26s)
--- PASS: TestAccELBV2TargetGroup_stickinessDefaultNLB (81.32s)
--- PASS: TestAccELBV2TargetGroup_preserveClientIPValid (54.57s)
--- PASS: TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination (53.68s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy (53.83s)
--- PASS: TestAccELBV2TargetGroup_protocolVersion (26.67s)
--- PASS: TestAccELBV2TargetGroup_changeVPCForceNew (45.84s)
--- PASS: TestAccELBV2TargetGroup_changeProtocolForceNew (52.40s)
--- PASS: TestAccELBV2TargetGroupDataSource_basic (184.90s)
--- PASS: TestAccELBV2TargetGroup_stickinessValidNLB (121.92s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroup (78.38s)
--- PASS: TestAccELBV2TargetGroupDataSource_backwardsCompatibility (180.02s)
--- PASS: TestAccELBV2TargetGroupDataSource_appCookie (182.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	271.925s
```