### PR TITLE
Add aliases to cloudfront datasource

### DIFF
--- a/.changelog/22552.txt
+++ b/.changelog/22552.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_cloudfront_distribution: Add aliases
+```

--- a/.changelog/22552.txt
+++ b/.changelog/22552.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_cloudfront_distribution: Add aliases
+data-source/aws_cloudfront_distribution: Add `aliases` attribute
 ```

--- a/internal/service/cloudfront/distribution_data_source.go
+++ b/internal/service/cloudfront/distribution_data_source.go
@@ -95,7 +95,7 @@ func dataSourceDistributionRead(d *schema.ResourceData, meta interface{}) error 
 		if distributionConfig := distribution.DistributionConfig; distributionConfig != nil {
 			d.Set("enabled", distributionConfig.Enabled)
 			if aliases := distributionConfig.Aliases; aliases != nil {
-				d.Set("aliases", distribution.DistributionConfig.Aliases.Items)
+				d.Set("aliases", aliases.Items)
 			}
 		}
 	}

--- a/internal/service/cloudfront/distribution_data_source.go
+++ b/internal/service/cloudfront/distribution_data_source.go
@@ -86,7 +86,6 @@ func dataSourceDistributionRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("in_progress_validation_batches", distribution.InProgressInvalidationBatches)
 		d.Set("last_modified_time", aws.String(distribution.LastModifiedTime.String()))
 		d.Set("status", distribution.Status)
-		d.Set("aliases", distribution.DistributionConfig.Aliases.Items)
 		region := meta.(*conns.AWSClient).Region
 		if v, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && v.ID() == endpoints.AwsCnPartitionID {
 			d.Set("hosted_zone_id", cloudFrontCNRoute53ZoneID)
@@ -95,6 +94,9 @@ func dataSourceDistributionRead(d *schema.ResourceData, meta interface{}) error 
 		}
 		if distributionConfig := distribution.DistributionConfig; distributionConfig != nil {
 			d.Set("enabled", distributionConfig.Enabled)
+			if aliases := distributionConfig.Aliases; aliases != nil {
+				d.Set("aliases", distribution.DistributionConfig.Aliases.Items)
+			}
 		}
 	}
 	tags, err := ListTags(conn, d.Get("arn").(string))

--- a/internal/service/cloudfront/distribution_data_source.go
+++ b/internal/service/cloudfront/distribution_data_source.go
@@ -20,6 +20,11 @@ func DataSourceDistribution() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"aliases": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -81,6 +86,7 @@ func dataSourceDistributionRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("in_progress_validation_batches", distribution.InProgressInvalidationBatches)
 		d.Set("last_modified_time", aws.String(distribution.LastModifiedTime.String()))
 		d.Set("status", distribution.Status)
+		d.Set("aliases", distribution.DistributionConfig.Aliases.Items)
 		region := meta.(*conns.AWSClient).Region
 		if v, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && v.ID() == endpoints.AwsCnPartitionID {
 			d.Set("hosted_zone_id", cloudFrontCNRoute53ZoneID)

--- a/internal/service/cloudfront/distribution_data_source_test.go
+++ b/internal/service/cloudfront/distribution_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccCloudFrontDistributionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "in_progress_validation_batches", resourceName, "in_progress_validation_batches"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "aliases.#", resourceName, "aliases.#"),
 				),
 			},
 		},

--- a/website/docs/d/cloudfront_distribution.html.markdown
+++ b/website/docs/d/cloudfront_distribution.html.markdown
@@ -28,6 +28,8 @@ The following attributes are exported:
 
 * `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
 
+* `aliases` - A list that contains information about CNAMEs (alternate domain names), if any, for this distribution.
+
 * `arn` - The ARN (Amazon Resource Name) for the distribution. For example: arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5, where 123456789012 is your AWS account ID.
 
 * `status` - The current status of the distribution. `Deployed` if the


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21872

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccCloudFrontDistributionDataSource_basic" PKG_NAME="./internal/service/cloudfront" ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/cloudfront/... -v -count 1 -parallel 3  -run=TestAccCloudFrontDistributionDataSource_basic -timeout 180m
=== RUN   TestAccCloudFrontDistributionDataSource_basic
=== PAUSE TestAccCloudFrontDistributionDataSource_basic
=== CONT  TestAccCloudFrontDistributionDataSource_basic
--- PASS: TestAccCloudFrontDistributionDataSource_basic (425.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	426.966s
...
```
