### PR TITLE
Improve S3 bucket name validation

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -49,7 +49,16 @@ func ResourceBucket() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"bucket_prefix"},
-				ValidateFunc:  validation.StringLenBetween(0, 63),
+				ValidateFunc: validation.All(
+					// Between 3 and 63 characters in length
+					validation.StringLenBetween(3, 63),
+					validation.StringMatch(regexp.MustCompile(`^[0-9a-z-.]+$`), "only lowercase alphanumeric characters and hyphens allowed"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`), "must not be formatted as an IP address"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`^\.`), "cannot start with a period"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`^.*\.$`), "cannot end with a period"),
+					// Only one period between labels
+					validation.StringDoesNotContainAny(".."),
+				),
 			},
 			"bucket_prefix": {
 				Type:          schema.TypeString,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make test TEST=./internal/service/s3/
==> Checking that code complies with gofmt requirements...
go test ./internal/service/s3/  -timeout=5m
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	3.382s
```

Much of the validation was derived from - https://github.com/hashicorp/terraform-provider-aws/blob/13dfabe4e55e6e4f088350898d3bb5cffdcdfb64/internal/service/s3/validate.go#L15-L44