### PR TITLE
cloudwatch: ISO-friendly tagging

### DIFF
--- a/.changelog/22556.txt
+++ b/.changelog/22556.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_cloudwatch_composite_alarm: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22556.txt
+++ b/.changelog/22556.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_composite_alarm: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/.changelog/22556.txt
+++ b/.changelog/22556.txt
@@ -5,3 +5,7 @@ resource/aws_cloudwatch_composite_alarm: Attempt `tags`-on-create, fallback to t
 ```release-note:enhancement
 resource/aws_cloudwatch_metric_alarm: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
 ```
+
+```release-note:enhancement
+resource/aws_cloudwatch_metric_stream: Attempt `tags`-on-create, fallback to tag after create, and allow some `tags` errors to be non-fatal to support non-standard AWS partitions (i.e., ISO)
+```

--- a/internal/service/cloudwatch/composite_alarm.go
+++ b/internal/service/cloudwatch/composite_alarm.go
@@ -120,7 +120,8 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 
 	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
 	if input.Tags == nil && len(tags) > 0 {
-		err := UpdateTags(conn, d.Id(), nil, tags)
+		arn := d.Get("arn").(string)
+		err := UpdateTags(conn, arn, nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
@@ -129,7 +130,7 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		if err != nil {
-			return diag.Errorf("error creating CloudWatch Composite Alarm (%s) tags: %s", name, err)
+			return diag.Errorf("error creating CloudWatch Composite Alarm (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/cloudwatch/composite_alarm.go
+++ b/internal/service/cloudwatch/composite_alarm.go
@@ -100,11 +100,38 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 	input := expandPutCompositeAlarmInput(d, meta)
 
 	_, err := conn.PutCompositeAlarmWithContext(ctx, &input)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if input.Tags != nil && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
+		log.Printf("[WARN] CloudWatch Composite Alarm (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		input.Tags = nil
+
+		_, err = conn.PutCompositeAlarmWithContext(ctx, &input)
+	}
+
 	if err != nil {
 		return diag.Errorf("error creating CloudWatch Composite Alarm (%s): %s", name, err)
 	}
 
 	d.SetId(name)
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if input.Tags == nil && len(tags) > 0 {
+		err := UpdateTags(conn, d.Id(), nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
+			log.Printf("[WARN] error adding tags after create for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
+			return resourceCompositeAlarmRead(ctx, d, meta)
+		}
+
+		if err != nil {
+			return diag.Errorf("error creating CloudWatch Composite Alarm (%s) tags: %s", name, err)
+		}
+	}
 
 	return resourceCompositeAlarmRead(ctx, d, meta)
 }
@@ -156,6 +183,13 @@ func resourceCompositeAlarmRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	tags, err := ListTags(conn, aws.StringValue(alarm.AlarmArn))
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault) {
+		log.Printf("[WARN] Unable to list tags for CloudWatch Composite Alarm %s: %s", d.Id(), err)
+		return nil
+	}
+
 	if err != nil {
 		return diag.Errorf("error listing tags of alarm: %s", err)
 	}
@@ -189,8 +223,16 @@ func resourceCompositeAlarmUpdate(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, arn, o, n); err != nil {
-			return diag.Errorf("error updating tags: %s", err)
+		err := UpdateTags(conn, arn, o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault) {
+			log.Printf("[WARN] Unable to update tags for CloudWatch Composite Alarm %s: %s", arn, err)
+			return resourceCompositeAlarmRead(ctx, d, meta)
+		}
+
+		if err != nil {
+			return diag.Errorf("error updating CloudWatch Composite Alarm (%s) tags: %s", arn, err)
 		}
 	}
 

--- a/internal/service/cloudwatch/const.go
+++ b/internal/service/cloudwatch/const.go
@@ -1,6 +1,10 @@
 package cloudwatch
 
 const (
+	errCodeAccessDenied = "AccessDenied"
+)
+
+const (
 	lowSampleCountPercentilesEvaluate          = "evaluate"
 	lowSampleCountPercentilesmissingDataIgnore = "ignore"
 )

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -294,11 +294,40 @@ func resourceMetricAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Creating CloudWatch Metric Alarm: %#v", params)
 	_, err = conn.PutMetricAlarm(&params)
+
+	// Some partitions (i.e., ISO) may not support tag-on-create
+	if params.Tags != nil && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
+		log.Printf("[WARN] CloudWatch Metric Alarm (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		params.Tags = nil
+
+		_, err = conn.PutMetricAlarm(&params)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Creating metric alarm failed: %w", err)
 	}
+
 	d.SetId(d.Get("alarm_name").(string))
 	log.Println("[INFO] CloudWatch Metric Alarm created")
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
+	if params.Tags == nil && len(tags) > 0 {
+		arn := d.Get("arn").(string)
+		err := UpdateTags(conn, arn, nil, tags)
+
+		// If default tags only, log and continue. Otherwise, error.
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
+			log.Printf("[WARN] error adding tags after create for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
+			return resourceMetricAlarmRead(d, meta)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating CloudWatch Metric Alarm (%s) tags: %s", d.Id(), err)
+		}
+	}
 
 	return resourceMetricAlarmRead(d, meta)
 }
@@ -372,6 +401,12 @@ func resourceMetricAlarmRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault) {
+		log.Printf("[WARN] Unable to list tags for CloudWatch Metric Alarm %s: %s", d.Id(), err)
+		return nil
+	}
+
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)
@@ -399,7 +434,15 @@ func resourceMetricAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, arn, o, n); err != nil {
+		err := UpdateTags(conn, arn, o, n)
+
+		// Some partitions (i.e., ISO) may not support tagging, giving error
+		if tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault) {
+			log.Printf("[WARN] Unable to update tags for CloudWatch Metric Alarm %s: %s", arn, err)
+			return resourceMetricAlarmRead(d, meta)
+		}
+
+		if err != nil {
 			return fmt.Errorf("error updating CloudWatch Metric Alarm (%s) tags: %w", arn, err)
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #18593
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccCloudWatchCompositeAlarm_ PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchCompositeAlarm_'  -timeout 180m
--- PASS: TestAccCloudWatchCompositeAlarm_disappears (20.04s)
--- PASS: TestAccCloudWatchCompositeAlarm_basic (23.79s)
--- PASS: TestAccCloudWatchCompositeAlarm_updateAlarmRule (39.98s)
--- PASS: TestAccCloudWatchCompositeAlarm_description (40.27s)
--- PASS: TestAccCloudWatchCompositeAlarm_actionsEnabled (40.38s)
--- PASS: TestAccCloudWatchCompositeAlarm_allActions (42.97s)
--- PASS: TestAccCloudWatchCompositeAlarm_okActions (57.93s)
--- PASS: TestAccCloudWatchCompositeAlarm_alarmActions (58.02s)
--- PASS: TestAccCloudWatchCompositeAlarm_insufficientDataActions (58.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	59.533s
% make testacc TESTS=TestAccCloudWatchMetricAlarm_ PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_'  -timeout 180m
--- PASS: TestAccCloudWatchMetricAlarm_missingStatistic (8.44s)
--- PASS: TestAccCloudWatchMetricAlarm_disappears (18.27s)
--- PASS: TestAccCloudWatchMetricAlarm_dataPointsToAlarm (20.92s)
--- PASS: TestAccCloudWatchMetricAlarm_extendedStatistic (20.95s)
--- PASS: TestAccCloudWatchMetricAlarm_basic (23.15s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_swfAction (23.76s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic (26.04s)
--- PASS: TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (32.17s)
--- PASS: TestAccCloudWatchMetricAlarm_treatMissingData (43.94s)
--- PASS: TestAccCloudWatchMetricAlarm_tags (46.23s)
--- PASS: TestAccCloudWatchMetricAlarm_expression (79.77s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate (226.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	228.299s
% make testacc TESTS=TestAccCloudWatchMetricStream_ PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricStream_'  -timeout 180m
--- PASS: TestAccCloudWatchMetricStream_noName (19.99s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (20.31s)
--- PASS: TestAccCloudWatchMetricStream_includeFilters (20.34s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (20.42s)
--- PASS: TestAccCloudWatchMetricStream_tags (20.42s)
--- PASS: TestAccCloudWatchMetricStream_basic (137.60s)
--- PASS: TestAccCloudWatchMetricStream_update (150.95s)
--- PASS: TestAccCloudWatchMetricStream_updateName (261.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	262.424s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccCloudWatchCompositeAlarm_ PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchCompositeAlarm_'  -timeout 180m
--- PASS: TestAccCloudWatchCompositeAlarm_disappears (28.98s)
--- PASS: TestAccCloudWatchCompositeAlarm_basic (30.33s)
--- PASS: TestAccCloudWatchCompositeAlarm_description (56.80s)
--- PASS: TestAccCloudWatchCompositeAlarm_allActions (57.21s)
--- PASS: TestAccCloudWatchCompositeAlarm_actionsEnabled (57.42s)
--- PASS: TestAccCloudWatchCompositeAlarm_updateAlarmRule (57.48s)
--- PASS: TestAccCloudWatchCompositeAlarm_okActions (77.59s)
--- PASS: TestAccCloudWatchCompositeAlarm_alarmActions (77.81s)
--- PASS: TestAccCloudWatchCompositeAlarm_insufficientDataActions (77.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	79.566s
% make testacc TESTS=TestAccCloudWatchMetricAlarm_ PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_'  -timeout 180m
--- PASS: TestAccCloudWatchMetricAlarm_missingStatistic (9.19s)
--- PASS: TestAccCloudWatchMetricAlarm_disappears (19.08s)
--- PASS: TestAccCloudWatchMetricAlarm_extendedStatistic (22.76s)
--- PASS: TestAccCloudWatchMetricAlarm_dataPointsToAlarm (22.78s)
--- PASS: TestAccCloudWatchMetricAlarm_basic (25.79s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_swfAction (25.86s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic (29.38s)
--- PASS: TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (41.41s)
--- PASS: TestAccCloudWatchMetricAlarm_tags (57.46s)
--- PASS: TestAccCloudWatchMetricAlarm_treatMissingData (58.90s)
--- PASS: TestAccCloudWatchMetricAlarm_expression (104.35s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate (214.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	216.268s
% make testacc TESTS=TestAccCloudWatchMetricStream_ PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricStream_'  -timeout 180m
--- SKIP: TestAccCloudWatchMetricStream_includeFilters (70.10s)
--- SKIP: TestAccCloudWatchMetricStream_update (70.10s)
--- SKIP: TestAccCloudWatchMetricStream_tags (70.10s)
--- SKIP: TestAccCloudWatchMetricStream_excludeFilters (70.10s)
--- SKIP: TestAccCloudWatchMetricStream_namePrefix (70.10s)
--- SKIP: TestAccCloudWatchMetricStream_noName (70.11s)
--- SKIP: TestAccCloudWatchMetricStream_updateName (119.92s)
--- SKIP: TestAccCloudWatchMetricStream_basic (141.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	143.419s
```