### PR TITLE
r/aws_connect_queue

### DIFF
--- a/.changelog/22566.txt
+++ b/.changelog/22566.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_connect_queue
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -981,6 +981,7 @@ func Provider() *schema.Provider {
 			"aws_connect_instance":                    connect.ResourceInstance(),
 			"aws_connect_hours_of_operation":          connect.ResourceHoursOfOperation(),
 			"aws_connect_lambda_function_association": connect.ResourceLambdaFunctionAssociation(),
+			"aws_connect_queue":                       connect.ResourceQueue(),
 			"aws_connect_quick_connect":               connect.ResourceQuickConnect(),
 
 			"aws_cur_report_definition": cur.ResourceReportDefinition(),

--- a/internal/service/connect/queue.go
+++ b/internal/service/connect/queue.go
@@ -104,3 +104,53 @@ func ResourceQueue() *schema.Resource {
 	}
 }
 
+func expandOutboundCallerConfig(outboundCallerConfig []interface{}) *connect.OutboundCallerConfig {
+	if len(outboundCallerConfig) == 0 || outboundCallerConfig[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := outboundCallerConfig[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &connect.OutboundCallerConfig{}
+
+	if v, ok := tfMap["outbound_caller_id_name"].(string); ok && v != "" {
+		result.OutboundCallerIdName = aws.String(v)
+	}
+
+	// passing an empty string leads to an InvalidParameterException
+	if v, ok := tfMap["outbound_caller_id_number_id"].(string); ok && v != "" {
+		result.OutboundCallerIdNumberId = aws.String(v)
+	}
+
+	// passing an empty string leads to an InvalidParameterException
+	if v, ok := tfMap["outbound_flow_id"].(string); ok && v != "" {
+		result.OutboundFlowId = aws.String(v)
+	}
+
+	return result
+}
+
+func flattenOutboundCallerConfig(outboundCallerConfig *connect.OutboundCallerConfig) []interface{} {
+	if outboundCallerConfig == nil {
+		return []interface{}{}
+	}
+
+	values := map[string]interface{}{}
+
+	if v := outboundCallerConfig.OutboundCallerIdName; v != nil {
+		values["outbound_caller_id_name"] = aws.StringValue(v)
+	}
+
+	if v := outboundCallerConfig.OutboundCallerIdNumberId; v != nil {
+		values["outbound_caller_id_number_id"] = aws.StringValue(v)
+	}
+
+	if v := outboundCallerConfig.OutboundFlowId; v != nil {
+		values["outbound_flow_id"] = aws.StringValue(v)
+	}
+
+	return []interface{}{values}
+}

--- a/internal/service/connect/queue.go
+++ b/internal/service/connect/queue.go
@@ -42,6 +42,11 @@ func ResourceQueue() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"instance_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
 			"max_contacts": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -74,11 +79,6 @@ func ResourceQueue() *schema.Resource {
 						},
 					},
 				},
-			},
-			"instance_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"queue_id": {
 				Type:     schema.TypeString,

--- a/internal/service/connect/queue.go
+++ b/internal/service/connect/queue.go
@@ -104,6 +104,62 @@ func ResourceQueue() *schema.Resource {
 	}
 }
 
+func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ConnectConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	instanceID, queueID, err := QueueParseID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := conn.DescribeQueueWithContext(ctx, &connect.DescribeQueueInput{
+		InstanceId: aws.String(instanceID),
+		QueueId:    aws.String(queueID),
+	})
+
+	if !d.IsNewResource() && tfawserr.ErrMessageContains(err, connect.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Connect Queue (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting Connect Queue (%s): %w", d.Id(), err))
+	}
+
+	if resp == nil || resp.Queue == nil {
+		return diag.FromErr(fmt.Errorf("error getting Connect Queue (%s): empty response", d.Id()))
+	}
+
+	if err := d.Set("outbound_caller_config", flattenOutboundCallerConfig(resp.Queue.OutboundCallerConfig)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.Set("arn", resp.Queue.QueueArn)
+	d.Set("description", resp.Queue.Description)
+	d.Set("hours_of_operation_id", resp.Queue.HoursOfOperationId)
+	d.Set("instance_id", instanceID)
+	d.Set("max_contacts", resp.Queue.MaxContacts)
+	d.Set("name", resp.Queue.Name)
+	d.Set("queue_id", resp.Queue.QueueId)
+	d.Set("status", resp.Queue.Status)
+
+	tags := KeyValueTags(resp.Queue.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+	}
+
+	return nil
+}
 func expandOutboundCallerConfig(outboundCallerConfig []interface{}) *connect.OutboundCallerConfig {
 	if len(outboundCallerConfig) == 0 || outboundCallerConfig[0] == nil {
 		return nil
@@ -153,4 +209,14 @@ func flattenOutboundCallerConfig(outboundCallerConfig *connect.OutboundCallerCon
 	}
 
 	return []interface{}{values}
+}
+
+func QueueParseID(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected instanceID:queueID", id)
+	}
+
+	return parts[0], parts[1], nil
 }

--- a/internal/service/connect/queue.go
+++ b/internal/service/connect/queue.go
@@ -1,0 +1,106 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/connect"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func ResourceQueue() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceQueueCreate,
+		ReadContext:   resourceQueueRead,
+		UpdateContext: resourceQueueUpdate,
+		// Queues do not support deletion today. NoOp the Delete method.
+		// Users can rename their queues manually if they want.
+		DeleteContext: schema.NoopContext,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 250),
+			},
+			"hours_of_operation_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"max_contacts": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 127),
+			},
+			"outbound_caller_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"outbound_caller_id_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+						"outbound_caller_id_number_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"outbound_flow_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 500),
+						},
+					},
+				},
+			},
+			"instance_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"queue_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"quick_connect_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(connect.QueueStatus_Values(), false), // Valid Values: ENABLED | DISABLED
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -21,6 +21,7 @@ func TestAccConnectQueue_serial(t *testing.T) {
 		"basic":                        testAccQueue_basic,
 		"disappears":                   testAccQueue_disappears,
 		"update_hours_of_operation_id": testAccQueue_updateHoursOfOperationId,
+		"update_max_contacts":          testAccQueue_updateMaxContacts,
 	}
 
 	for name, tc := range testCases {
@@ -166,6 +167,61 @@ func testAccQueue_updateHoursOfOperationId(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttrPair(resourceName, "hours_of_operation_id", "data.aws_connect_hours_of_operation.test", "hours_of_operation_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
+					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueue_updateMaxContacts(t *testing.T) {
+	var v connect.DescribeQueueOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_queue.test"
+	originalMaxContacts := "1"
+	updatedMaxContacts := "2"
+
+	t.Skip("A bug in the service API has been reported")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueMaxContactsConfig(rName, rName2, originalMaxContacts),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "hours_of_operation_id", "data.aws_connect_hours_of_operation.test", "hours_of_operation_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "max_contacts", originalMaxContacts),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
+					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccQueueMaxContactsConfig(rName, rName2, updatedMaxContacts),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "hours_of_operation_id", "data.aws_connect_hours_of_operation.test", "hours_of_operation_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "max_contacts", updatedMaxContacts),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
 					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -20,3 +20,20 @@ data "aws_connect_hours_of_operation" "test" {
 }
 `, rName)
 }
+
+func testAccQueueBasicConfig(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccQueueBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_queue" "test" {
+  instance_id           = aws_connect_instance.test.id
+  name                  = %[1]q
+  description           = %[2]q
+  hours_of_operation_id = data.aws_connect_hours_of_operation.test.hours_of_operation_id
+
+  tags = {
+    "Name" = "Test Queue",
+  }
+}
+`, rName2, label))
+}

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -18,7 +18,8 @@ import (
 // Serialized acceptance tests due to Connect account limits (max 2 parallel tests)
 func TestAccConnectQueue_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"basic": testAccQueue_basic,
+		"basic":      testAccQueue_basic,
+		"disappears": testAccQueue_disappears,
 	}
 
 	for name, tc := range testCases {
@@ -75,6 +76,32 @@ func testAccQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
+			},
+		},
+	})
+}
+
+func testAccQueue_disappears(t *testing.T) {
+	var v connect.DescribeQueueOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_queue.test"
+
+	t.Skip("Queues do not support deletion today")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueBasicConfig(rName, rName2, "Disappear"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &v),
+					acctest.CheckResourceDisappears(acctest.Provider, tfconnect.ResourceQueue(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -1,0 +1,22 @@
+func testAccQueueBaseConfig(rName string) string {
+	// Use the aws_connect_hours_of_operation data source with the default "Basic Hours" that comes with connect instances.
+	// Because if a resource is used, Terraform will not be able to delete it since queues do not have support for the delete api
+	// yet but still references hours_of_operation_id. However, using the data source will result in the failure of the
+	// disppears test (removed till delete api is available) for the connect instance (We test disappears on the Connect instance
+	// instead of the queue since the queue does not support delete). The error is:
+	// Step 1/1 error: Error running post-apply plan: exit status 1
+	// Error: error finding Connect Hours of Operation Summary by name (Basic Hours): ResourceNotFoundException: Instance not found
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+}
+
+data "aws_connect_hours_of_operation" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = "Basic Hours"
+}
+`, rName)
+}

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -86,12 +86,11 @@ func testAccQueue_basic(t *testing.T) {
 }
 
 func testAccQueue_disappears(t *testing.T) {
+	t.Skip("Queues do not support deletion today")
 	var v connect.DescribeQueueOutput
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_queue.test"
-
-	t.Skip("Queues do not support deletion today")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -180,14 +179,13 @@ func testAccQueue_updateHoursOfOperationId(t *testing.T) {
 }
 
 func testAccQueue_updateMaxContacts(t *testing.T) {
+	t.Skip("A bug in the service API has been reported")
 	var v connect.DescribeQueueOutput
 	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_connect_queue.test"
 	originalMaxContacts := "1"
 	updatedMaxContacts := "2"
-
-	t.Skip("A bug in the service API has been reported")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -487,6 +485,7 @@ resource "aws_connect_queue" "test" {
 `, rName2, selectHoursOfOperationId))
 }
 
+//lint:ignore U1000 Ignore unused function temporarily
 func testAccQueueMaxContactsConfig(rName, rName2, maxContacts string) string {
 	return acctest.ConfigCompose(
 		testAccQueueBaseConfig(rName),

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -396,3 +396,23 @@ resource "aws_connect_queue" "test" {
 `, rName2, maxContacts))
 }
 
+func testAccQueueOutboundCallerConfig(rName, rName2, OutboundCallerIdName string) string {
+	return acctest.ConfigCompose(
+		testAccQueueBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_queue" "test" {
+  instance_id           = aws_connect_instance.test.id
+  name                  = %[1]q
+  description           = "Test update outbound caller config"
+  hours_of_operation_id = data.aws_connect_hours_of_operation.test.hours_of_operation_id
+
+  outbound_caller_config {
+    outbound_caller_id_name = %[2]q
+  }
+
+  tags = {
+    "Name" = "Test Queue",
+  }
+}
+`, rName2, OutboundCallerIdName))
+}

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -472,3 +472,21 @@ resource "aws_connect_queue" "test" {
 }
 `, rName2, OutboundCallerIdName))
 }
+
+func testAccQueueStatusConfig(rName, rName2, status string) string {
+	return acctest.ConfigCompose(
+		testAccQueueBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_queue" "test" {
+  instance_id           = aws_connect_instance.test.id
+  name                  = %[1]q
+  description           = "Test update status"
+  hours_of_operation_id = data.aws_connect_hours_of_operation.test.hours_of_operation_id
+  status                = %[2]q
+
+  tags = {
+    "Name" = "Test Queue",
+  }
+}
+`, rName2, status))
+}

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -18,8 +18,9 @@ import (
 // Serialized acceptance tests due to Connect account limits (max 2 parallel tests)
 func TestAccConnectQueue_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"basic":      testAccQueue_basic,
-		"disappears": testAccQueue_disappears,
+		"basic":                        testAccQueue_basic,
+		"disappears":                   testAccQueue_disappears,
+		"update_hours_of_operation_id": testAccQueue_updateHoursOfOperationId,
 	}
 
 	for name, tc := range testCases {
@@ -102,6 +103,74 @@ func testAccQueue_disappears(t *testing.T) {
 					acctest.CheckResourceDisappears(acctest.Provider, tfconnect.ResourceQueue(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccQueue_updateHoursOfOperationId(t *testing.T) {
+	var v connect.DescribeQueueOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_queue.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueHoursOfOperationConfig(rName, rName2, "first"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "hours_of_operation_id", "data.aws_connect_hours_of_operation.test", "hours_of_operation_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
+					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccQueueHoursOfOperationConfig(rName, rName2, "second"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "hours_of_operation_id", "aws_connect_hours_of_operation.test", "hours_of_operation_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
+					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccQueueHoursOfOperationConfig(rName, rName2, "first"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrPair(resourceName, "hours_of_operation_id", "data.aws_connect_hours_of_operation.test", "hours_of_operation_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "queue_id"),
+					resource.TestCheckResourceAttr(resourceName, "status", connect.QueueStatusEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
 			},
 		},
 	})

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -210,3 +210,46 @@ resource "aws_connect_queue" "test" {
 }
 `, rName2, label))
 }
+
+func testAccQueueHoursOfOperationConfig(rName, rName2, selectHoursOfOperationId string) string {
+	return acctest.ConfigCompose(
+		testAccQueueBaseConfig(rName),
+		fmt.Sprintf(`
+locals {
+  select_hours_of_operation_id = %[2]q
+}
+
+resource "aws_connect_hours_of_operation" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = %[1]q
+  description = "Example aws_connect_hours_of_operation to test updates"
+  time_zone   = "EST"
+
+  config {
+    day = "MONDAY"
+
+    end_time {
+      hours   = 23
+      minutes = 8
+    }
+
+    start_time {
+      hours   = 8
+      minutes = 0
+    }
+  }
+}
+
+resource "aws_connect_queue" "test" {
+  instance_id           = aws_connect_instance.test.id
+  name                  = %[1]q
+  description           = "Test update hours_of_operation_id"
+  hours_of_operation_id = local.select_hours_of_operation_id == "first" ? data.aws_connect_hours_of_operation.test.hours_of_operation_id : aws_connect_hours_of_operation.test.hours_of_operation_id
+
+  tags = {
+    "Name" = "Test Queue",
+  }
+}
+`, rName2, selectHoursOfOperationId))
+}
+

--- a/internal/service/connect/queue_test.go
+++ b/internal/service/connect/queue_test.go
@@ -322,3 +322,21 @@ resource "aws_connect_queue" "test" {
 `, rName2, selectHoursOfOperationId))
 }
 
+func testAccQueueMaxContactsConfig(rName, rName2, maxContacts string) string {
+	return acctest.ConfigCompose(
+		testAccQueueBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_queue" "test" {
+  instance_id           = aws_connect_instance.test.id
+  name                  = %[1]q
+  description           = "Test update max contacts"
+  hours_of_operation_id = data.aws_connect_hours_of_operation.test.hours_of_operation_id
+  max_contacts          = %[2]q
+
+  tags = {
+    "Name" = "Test Queue",
+  }
+}
+`, rName2, maxContacts))
+}
+

--- a/website/docs/r/connect_queue.html.markdown
+++ b/website/docs/r/connect_queue.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Connect"
+layout: "aws"
+page_title: "AWS: aws_connect_queue"
+description: |-
+  Provides details about a specific Amazon Connect Queue
+---
+
+# Resource: aws_connect_queue
+
+Provides an Amazon Connect Queue resource. For more information see
+[Amazon Connect: Getting Started](https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-get-started.html)
+
+~> **NOTE:** Due to The behaviour of Amazon Connect you cannot delete queues.
+
+## Example Usage
+
+```terraform
+resource "aws_connect_queue" "test" {
+  instance_id           = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name                  = "Example Name"
+  description           = "Example Description"
+  hours_of_operation_id = "12345678-1234-1234-1234-123456789012"
+
+  tags = {
+    "Name" = "Example Queue",
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Specifies the description of the Queue.
+* `hours_of_operation_id` - (Required) Specifies the identifier of the Hours of Operation.
+* `instance_id` - (Required) Specifies the identifier of the hosting Amazon Connect Instance.
+* `max_contacts` - (Optional) Specifies the maximum number of contacts that can be in the queue before it is considered full. Minimum value of 0.
+* `name` - (Required) Specifies the name of the Queue.
+* `outbound_caller_config` - (Required) A block that defines the outbound caller ID name, number, and outbound whisper flow. The Outbound Caller Config block is documented below.
+* `quick_connect_ids` - (Optional) Specifies a list of quick connects ids that determine the quick connects available to agents who are working the queue.
+* `status` - (Optional) Specifies the description of the Queue. Valid values are `ENABLED`, `DISABLED`.
+* `tags` - (Optional) Tags to apply to the Queue. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+A `outbound_caller_config` block supports the following arguments:
+
+* `outbound_caller_id_name` - (Optional) Specifies the caller ID name.
+* `outbound_caller_id_number_id` - (Optional) Specifies the caller ID number.
+* `outbound_flow_id` - (Optional) Specifies outbound whisper flow to be used during an outbound call.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the Queue.
+* `queue_id` - The identifier for the Queue.
+* `id` - The identifier of the hosting Amazon Connect Instance and identifier of the Queue separated by a colon (`:`).
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Amazon Connect Queues can be imported using the `instance_id` and `queue_id` separated by a colon (`:`), e.g.,
+
+```
+$ terraform import aws_connect_queue.example f1288a1f-6193-445a-b47e-af739b2:c1d4e5f6-1b3c-1b3c-1b3c-c1d4e5f6c1d4e5
+```

--- a/website/docs/r/connect_queue.html.markdown
+++ b/website/docs/r/connect_queue.html.markdown
@@ -15,6 +15,8 @@ Provides an Amazon Connect Queue resource. For more information see
 
 ## Example Usage
 
+### Basic
+
 ```terraform
 resource "aws_connect_queue" "test" {
   instance_id           = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
@@ -28,6 +30,24 @@ resource "aws_connect_queue" "test" {
 }
 ```
 
+### With Quick Connect IDs
+
+```terraform
+resource "aws_connect_queue" "test" {
+  instance_id           = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name                  = "Example Name"
+  description           = "Example Description"
+  hours_of_operation_id = "12345678-1234-1234-1234-123456789012"
+
+  quick_connect_ids = [
+    "12345678-abcd-1234-abcd-123456789012"
+  ]
+
+  tags = {
+    "Name" = "Example Queue with Quick Connect IDs",
+  }
+}
+```
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/connect_queue.html.markdown
+++ b/website/docs/r/connect_queue.html.markdown
@@ -48,6 +48,28 @@ resource "aws_connect_queue" "test" {
   }
 }
 ```
+
+### With Outbound Caller Config
+
+```terraform
+resource "aws_connect_queue" "test" {
+  instance_id           = "aaaaaaaa-bbbb-cccc-dddd-111111111111"
+  name                  = "Example Name"
+  description           = "Example Description"
+  hours_of_operation_id = "12345678-1234-1234-1234-123456789012"
+
+  outbound_caller_config = {
+    outbound_caller_id_name      = "example"
+    outbound_caller_id_number_id = "12345678-abcd-1234-abcd-123456789012"
+    outbound_flow_id             = "87654321-defg-1234-defg-987654321234"
+  }
+
+  tags = {
+    "Name" = "Example Queue with Outbound Caller Config",
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #21021

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccConnectQueue_serial PKG=connect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnectQueue_serial'  -timeout 180m
=== RUN   TestAccConnectQueue_serial
=== RUN   TestAccConnectQueue_serial/update_max_contacts
    queue_test.go:190: A bug in the service API has been reported
=== RUN   TestAccConnectQueue_serial/update_outbound_caller_config
=== RUN   TestAccConnectQueue_serial/update_status
=== RUN   TestAccConnectQueue_serial/basic
=== RUN   TestAccConnectQueue_serial/disappears
    queue_test.go:94: Queues do not support deletion today
=== RUN   TestAccConnectQueue_serial/update_hours_of_operation_id
--- PASS: TestAccConnectQueue_serial (678.45s)
    --- SKIP: TestAccConnectQueue_serial/update_max_contacts (0.00s)
    --- PASS: TestAccConnectQueue_serial/update_outbound_caller_config (158.45s)
    --- PASS: TestAccConnectQueue_serial/update_status (162.19s)
    --- PASS: TestAccConnectQueue_serial/basic (155.96s)
    --- SKIP: TestAccConnectQueue_serial/disappears (0.00s)
    --- PASS: TestAccConnectQueue_serial/update_hours_of_operation_id (201.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    686.313s

...
```
