### PR TITLE
fix AppRunner custom domain association after manual delete

### DIFF
--- a/.changelog/20222.txt
+++ b/.changelog/20222.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_custom_domain_association: Add the status `binding_certificate` as a valid target when waiting for creation.
+```

--- a/internal/service/apprunner/status.go
+++ b/internal/service/apprunner/status.go
@@ -16,6 +16,7 @@ const (
 	CustomDomainAssociationStatusCreating                        = "creating"
 	CustomDomainAssociationStatusDeleting                        = "deleting"
 	CustomDomainAssociationStatusPendingCertificateDNSValidation = "pending_certificate_dns_validation"
+	CustomDomainAssociationStatusBindingCertificate              = "binding_certificate"
 )
 
 func StatusAutoScalingConfiguration(ctx context.Context, conn *apprunner.AppRunner, arn string) resource.StateRefreshFunc {

--- a/internal/service/apprunner/wait.go
+++ b/internal/service/apprunner/wait.go
@@ -64,7 +64,7 @@ func WaitConnectionDeleted(ctx context.Context, conn *apprunner.AppRunner, name 
 func WaitCustomDomainAssociationCreated(ctx context.Context, conn *apprunner.AppRunner, domainName, serviceArn string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{CustomDomainAssociationStatusCreating},
-		Target:  []string{CustomDomainAssociationStatusPendingCertificateDNSValidation},
+		Target:  []string{CustomDomainAssociationStatusPendingCertificateDNSValidation, CustomDomainAssociationStatusBindingCertificate},
 		Refresh: StatusCustomDomain(ctx, conn, domainName, serviceArn),
 		Timeout: CustomDomainAssociationCreateTimeout,
 	}


### PR DESCRIPTION
Sometimes when the custom domain association is deleted and we want to recreate it, the status returned might be `binding_certificate` instead of the currently awaited status `pending_certificate_dns_validation`.

Why this status is being used instead of the other one is a black box to me but a wild guess I have is that AWS creates some kind of cache for those records and doesn't actually delete them, which creates some weird behavior when re-creating (like skipping a status?).

Anyway, without this fix there is no way to make the module behave properly again, even destroying the all AppRunner service ends up re-using the same custom domain association (unless you change the domain name offcourse).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20222

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppRunnerCustomDomainAssociation PKG=apprunner

...
```
