### PR TITLE
d/aws_cloudfront_origin_access_identity

### DIFF
--- a/.changelog/22572.txt
+++ b/.changelog/22572.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_cloudfront_origin_access_identity
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -381,6 +381,7 @@ func Provider() *schema.Provider {
 			"aws_cloudfront_distribution":                   cloudfront.DataSourceDistribution(),
 			"aws_cloudfront_function":                       cloudfront.DataSourceFunction(),
 			"aws_cloudfront_log_delivery_canonical_user_id": cloudfront.DataSourceLogDeliveryCanonicalUserID(),
+			"aws_cloudfront_origin_access_identity":         cloudfront.DataSourceOriginAccessIdentity(),
 			"aws_cloudfront_origin_request_policy":          cloudfront.DataSourceOriginRequestPolicy(),
 			"aws_cloudfront_response_headers_policy":        cloudfront.DataSourceResponseHeadersPolicy(),
 

--- a/internal/service/cloudfront/origin_access_identity_data_source.go
+++ b/internal/service/cloudfront/origin_access_identity_data_source.go
@@ -1,0 +1,78 @@
+package cloudfront
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceOriginAccessIdentity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOriginAccessIdentityRead,
+
+		Schema: map[string]*schema.Schema{
+			"comment": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Default:  nil,
+			},
+			"caller_reference": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cloudfront_access_identity_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"s3_canonical_user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceOriginAccessIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).CloudFrontConn
+	id := d.Get("id").(string)
+	params := &cloudfront.GetCloudFrontOriginAccessIdentityInput{
+		Id: aws.String(id),
+	}
+
+	resp, err := conn.GetCloudFrontOriginAccessIdentity(params)
+	if err != nil {
+		return err
+	}
+
+	// Update attributes from DistributionConfig
+	flattenOriginAccessIdentityConfig(d, resp.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig)
+	// Update other attributes outside of DistributionConfig
+	d.SetId(aws.StringValue(resp.CloudFrontOriginAccessIdentity.Id))
+	d.Set("etag", resp.ETag)
+	d.Set("s3_canonical_user_id", resp.CloudFrontOriginAccessIdentity.S3CanonicalUserId)
+	d.Set("cloudfront_access_identity_path", fmt.Sprintf("origin-access-identity/cloudfront/%s", *resp.CloudFrontOriginAccessIdentity.Id))
+	iamArn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "iam",
+		AccountID: "cloudfront",
+		Resource:  fmt.Sprintf("user/CloudFront Origin Access Identity %s", *resp.CloudFrontOriginAccessIdentity.Id),
+	}.String()
+	d.Set("iam_arn", iamArn)
+	return nil
+}

--- a/internal/service/cloudfront/origin_access_identity_data_source_test.go
+++ b/internal/service/cloudfront/origin_access_identity_data_source_test.go
@@ -1,0 +1,45 @@
+package cloudfront_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccCloudFrontOriginAccessIdentityDataSource_basic(t *testing.T) {
+	var origin cloudfront.GetCloudFrontOriginAccessIdentityOutput
+	dataSourceName := "data.aws_cloudfront_origin_access_identity.test"
+	resourceName := "aws_cloudfront_origin_access_identity.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(cloudfront.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cloudfront.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOriginAccessIdentityDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName, &origin),
+					resource.TestCheckResourceAttrPair(dataSourceName, "iam_arn", resourceName, "iam_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "comment", resourceName, "comment"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "caller_reference", resourceName, "caller_reference"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "s3_canonical_user_id", resourceName, "s3_canonical_user_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cloudfront_access_identity_path", resourceName, "cloudfront_access_identity_path"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
+				),
+			},
+		},
+	})
+}
+
+const testAccOriginAccessIdentityDataSourceConfig = `
+resource "aws_cloudfront_origin_access_identity" "test" {
+  comment = "some comment"
+}
+data "aws_cloudfront_origin_access_identity" "test" {
+  id = aws_cloudfront_origin_access_identity.test.id
+}
+`

--- a/website/docs/d/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_identity.html.markdown
@@ -1,0 +1,103 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_origin_access_identity"
+description: |-
+  Use this data source to retrieve information for an Amazon CloudFront origin access identity.
+---
+
+# Data Source: aws_cloudfront_origin_access_identity
+
+Use this data source to retrieve information for an Amazon CloudFront origin access identity.
+
+## Example Usage
+
+The following example below creates a CloudFront origin access identity.
+
+```terraform
+data "aws_cloudfront_origin_access_identity" "example" {
+  id = "EDFDVBD632BHDS5"
+}
+```
+
+## Argument Reference
+
+* `id` (Required) -  The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `caller_reference` - Internal value used by CloudFront to allow future
+   updates to the origin access identity.
+* `cloudfront_access_identity_path` - A shortcut to the full path for the
+   origin access identity to use in CloudFront, see below.
+* `comment` - An optional comment for the origin access identity.
+* `etag` - The current version of the origin access identity's information.
+   For example: `E2QWRUHAPOMQZL`.
+* `iam_arn` - A pre-generated ARN for use in S3 bucket policies (see below).
+   Example: `arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity
+   E2QWRUHAPOMQZL`.
+* `s3_canonical_user_id` - The Amazon S3 canonical user ID for the origin
+   access identity, which you use when giving the origin access identity read
+   permission to an object in Amazon S3.
+
+## Using With CloudFront
+
+Normally, when referencing an origin access identity in CloudFront, you need to
+prefix the ID with the `origin-access-identity/cloudfront/` special path.
+The `cloudfront_access_identity_path` allows this to be circumvented.
+The below snippet demonstrates use with the `s3_origin_config` structure for the
+[`aws_cloudfront_distribution`][3] resource:
+
+```terraform
+resource "aws_cloudfront_distribution" "example" {
+  # ... other configuration ...
+
+  origin {
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.example.cloudfront_access_identity_path
+    }
+  }
+}
+```
+
+### Updating your bucket policy
+
+Note that the AWS API may translate the `s3_canonical_user_id` `CanonicalUser`
+principal into an `AWS` IAM ARN principal when supplied in an
+[`aws_s3_bucket`][4] bucket policy, causing spurious diffs in Terraform. If
+you see this behaviour, use the `iam_arn` instead:
+
+```terraform
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.example.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.example.iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "example" {
+  bucket = aws_s3_bucket.example.id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
+```
+
+[1]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html
+[2]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
+[3]: /docs/providers/aws/r/cloudfront_distribution.html
+[4]: /docs/providers/aws/r/s3_bucket.html
+
+
+## Import
+
+Cloudfront Origin Access Identities can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_cloudfront_origin_access_identity.origin_access E74FTE3AEXAMPLE
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14258

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccCloudFrontOriginAccessIdentityDataSource_basic" PKG_NAME="./internal/service/cloudfront" ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/cloudfront/... -v -count 1 -parallel 3  -run=TestAccCloudFrontOriginAccessIdentityDataSource_basic -timeout 180m
=== RUN   TestAccCloudFrontOriginAccessIdentityDataSource_basic
=== PAUSE TestAccCloudFrontOriginAccessIdentityDataSource_basic
=== CONT  TestAccCloudFrontOriginAccessIdentityDataSource_basic
--- PASS: TestAccCloudFrontOriginAccessIdentityDataSource_basic (21.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	22.739s
```
