### PR TITLE
s3/bucket: Guard against object lock error

### DIFF
--- a/.changelog/22575.txt
+++ b/.changelog/22575.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add additional protection against `object_lock_configuration` causing errors in partitions (e.g., ISO) where not supported
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1312,7 +1312,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		log.Printf("[WARN] Unable to read S3 bucket (%s) object lock configuraton: %s", d.Id(), err)
+		log.Printf("[WARN] Unable to read S3 bucket (%s) object lock configuration: %s", d.Id(), err)
 	}
 
 	if err == nil {

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1304,9 +1304,18 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Object Lock configuration.
-	if conf, err := readS3ObjectLockConfiguration(conn, d.Id()); err != nil {
+	conf, err := readS3ObjectLockConfiguration(conn, d.Id())
+
+	// Object lock not supported in all partitions (extra guard, also guards in read func)
+	if err != nil && (meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID) {
 		return fmt.Errorf("error getting S3 Bucket Object Lock configuration: %s", err)
-	} else {
+	}
+
+	if err != nil {
+		log.Printf("[WARN] Unable to read S3 bucket (%s) object lock configuraton: %s", d.Id(), err)
+	}
+
+	if err == nil {
 		if err := d.Set("object_lock_configuration", conf); err != nil {
 			return fmt.Errorf("error setting object_lock_configuration: %s", err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18593

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccS3Bucket_ PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_'  -timeout 180m
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (24.03s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (39.07s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (41.00s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (42.00s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (44.75s)
--- PASS: TestAccS3Bucket_Basic_basic (48.99s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (49.07s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (49.32s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (61.82s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (65.81s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (66.12s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (68.93s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (69.34s)
--- PASS: TestAccS3Bucket_Security_corsDelete (35.04s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (42.99s)
--- PASS: TestAccS3Bucket_Security_logging (60.44s)
--- PASS: TestAccS3Bucket_Manage_objectLock (87.23s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (87.50s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (28.15s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (48.01s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (63.03s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (46.61s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (115.99s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (45.92s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (53.45s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (125.86s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (84.24s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (77.50s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (49.97s)
--- PASS: TestAccS3Bucket_Basic_generatedName (40.87s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (80.28s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (110.55s)
--- PASS: TestAccS3Bucket_Manage_versioning (94.38s)
--- PASS: TestAccS3Bucket_Security_grantToACL (69.85s)
--- PASS: TestAccS3Bucket_Web_routingRules (80.25s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (43.08s)
--- PASS: TestAccS3Bucket_Tags_basic (46.24s)
--- PASS: TestAccS3Bucket_Security_updateACL (72.93s)
--- PASS: TestAccS3Bucket_Basic_emptyString (36.60s)
--- PASS: TestAccS3Bucket_Replication_basic (189.82s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (65.31s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (69.59s)
--- PASS: TestAccS3Bucket_Basic_acceleration (74.41s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (197.67s)
--- PASS: TestAccS3Bucket_Web_simple (110.98s)
--- PASS: TestAccS3Bucket_Web_redirect (111.26s)
--- PASS: TestAccS3Bucket_Security_updateGrant (104.59s)
--- PASS: TestAccS3Bucket_Security_policy (100.49s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (239.36s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (122.08s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (166.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	306.973s
```
