### PR TITLE
r/s3_bucket_lifecycle_configuration: new resource

### DIFF
--- a/.changelog/22579.txt
+++ b/.changelog/22579.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_s3_bucket_lifecycle_configuration
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1626,6 +1626,7 @@ func Provider() *schema.Provider {
 			"aws_s3_bucket_cors_configuration":                s3.ResourceBucketCorsConfiguration(),
 			"aws_s3_bucket_intelligent_tiering_configuration": s3.ResourceBucketIntelligentTieringConfiguration(),
 			"aws_s3_bucket_inventory":                         s3.ResourceBucketInventory(),
+			"aws_s3_bucket_lifecycle_configuration":           s3.ResourceBucketLifecycleConfiguration(),
 			"aws_s3_bucket_logging":                           s3.ResourceBucketLogging(),
 			"aws_s3_bucket_metric":                            s3.ResourceBucketMetric(),
 			"aws_s3_bucket_notification":                      s3.ResourceBucketNotification(),

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -71,15 +71,14 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 										ValidateFunc: verify.ValidUTCTimestamp,
 									},
 									"days": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      0, // API returns 0
-										ValidateFunc: validation.IntAtLeast(1),
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  0, // API returns 0
 									},
 									"expired_object_delete_marker": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										Computed: true, // API returns false
+										Computed: true, // API returns false; conflicts with date and days
 									},
 								},
 							},
@@ -115,16 +114,14 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 										},
 									},
 									"object_size_greater_than": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      0, // API returns 0
-										ValidateFunc: validation.IntAtLeast(0),
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  0, // API returns 0
 									},
 									"object_size_less_than": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      0, // API returns 0
-										ValidateFunc: validation.IntAtLeast(1),
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  0, // API returns 0
 									},
 									"prefix": {
 										Type:     schema.TypeString,

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -275,10 +275,6 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 
 	d.SetId(bucket)
 
-	if err := waitForLifecycleConfigurationRulesStatus(ctx, conn, d.Id(), rules); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for S3 lifecycle configuration for bucket (%s) to reach expected rules status: %w", d.Id(), err))
-	}
-
 	return resourceBucketLifecycleConfigurationRead(ctx, d, meta)
 }
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -1,0 +1,368 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceBucketLifecycleConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBucketLifecycleConfigurationCreate,
+		ReadContext:   resourceBucketLifecycleConfigurationRead,
+		UpdateContext: resourceBucketLifecycleConfigurationUpdate,
+		DeleteContext: resourceBucketLifecycleConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 63),
+			},
+
+			"expected_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+
+			"rule": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"abort_incomplete_multipart_upload": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"days_after_initiation": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"expiration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"date": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidUTCTimestamp,
+									},
+									"days": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0, // API returns 0
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"expired_object_delete_marker": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true, // API returns false
+									},
+								},
+							},
+						},
+						"filter": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"and": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"object_size_greater_than": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(0),
+												},
+												"object_size_less_than": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+												"prefix": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"tags": tftags.TagsSchema(),
+											},
+										},
+									},
+									"object_size_greater_than": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0, // API returns 0
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"object_size_less_than": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0, // API returns 0
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"tag": {
+										Type:     schema.TypeList,
+										MaxItems: 1,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+
+						"noncurrent_version_expiration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"newer_noncurrent_versions": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"noncurrent_days": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
+						"noncurrent_version_transition": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"newer_noncurrent_versions": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"noncurrent_days": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"storage_class": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(s3.TransitionStorageClass_Values(), false),
+									},
+								},
+							},
+						},
+
+						"prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"status": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								LifecycleRuleStatusDisabled,
+								LifecycleRuleStatusEnabled,
+							}, false),
+						},
+
+						"transition": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"date": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: verify.ValidUTCTimestamp,
+									},
+									"days": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+									"storage_class": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(s3.TransitionStorageClass_Values(), false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket := d.Get("bucket").(string)
+
+	rules, err := ExpandLifecycleRules(d.Get("rule").(*schema.Set).List())
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating S3 Lifecycle Configuration for bucket (%s): %w", bucket, err))
+	}
+
+	input := &s3.PutBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucket),
+		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+			Rules: rules,
+		},
+	}
+
+	if v, ok := d.GetOk("expected_bucket_owner"); ok {
+		input.ExpectedBucketOwner = aws.String(v.(string))
+	}
+
+	_, err = verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.PutBucketLifecycleConfigurationWithContext(ctx, input)
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating S3 lifecycle configuration for bucket (%s): %w", bucket, err))
+	}
+
+	d.SetId(bucket)
+
+	if err := waitForLifecycleConfigurationRulesStatus(ctx, conn, d.Id(), rules); err != nil {
+		return diag.FromErr(fmt.Errorf("error waiting for S3 lifecycle configuration for bucket (%s) to reach expected rules status: %w", d.Id(), err))
+	}
+
+	return resourceBucketLifecycleConfigurationRead(ctx, d, meta)
+}
+
+func resourceBucketLifecycleConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	input := &s3.GetBucketLifecycleConfigurationInput{
+		Bucket: aws.String(d.Id()),
+	}
+
+	output, err := verify.RetryOnAWSCode(ErrCodeNoSuchLifecycleConfiguration, func() (interface{}, error) {
+		return conn.GetBucketLifecycleConfigurationWithContext(ctx, input)
+	})
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket Lifecycle Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting S3 Bucket Lifecycle Configuration for bucket (%s): %w", d.Id(), err))
+	}
+
+	lifecycleConfig, ok := output.(*s3.GetBucketLifecycleConfigurationOutput)
+
+	if !ok || lifecycleConfig == nil {
+		return diag.FromErr(fmt.Errorf("error reading S3 Bucket Lifecycle Configuration for bucket (%s): empty output", d.Id()))
+	}
+
+	d.Set("bucket", d.Id())
+	if err := d.Set("rule", FlattenLifecycleRules(lifecycleConfig.Rules)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting rule: %w", err))
+	}
+
+	return nil
+}
+
+func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	rules, err := ExpandLifecycleRules(d.Get("rule").(*schema.Set).List())
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating S3 Bucket Lifecycle Configuration rule: %w", err))
+	}
+
+	input := &s3.PutBucketLifecycleConfigurationInput{
+		Bucket: aws.String(d.Id()),
+		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+			Rules: rules,
+		},
+	}
+
+	_, err = verify.RetryOnAWSCode(ErrCodeNoSuchLifecycleConfiguration, func() (interface{}, error) {
+		return conn.PutBucketLifecycleConfigurationWithContext(ctx, input)
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating S3 lifecycle configuration for bucket (%s): %w", d.Id(), err))
+	}
+
+	if err := waitForLifecycleConfigurationRulesStatus(ctx, conn, d.Id(), rules); err != nil {
+		return diag.FromErr(fmt.Errorf("error waiting for S3 lifecycle configuration for bucket (%s) to reach expected rules status after update: %w", d.Id(), err))
+	}
+
+	return resourceBucketLifecycleConfigurationRead(ctx, d, meta)
+}
+
+func resourceBucketLifecycleConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	input := &s3.DeleteBucketLifecycleInput{
+		Bucket: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteBucketLifecycleWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration, s3.ErrCodeNoSuchBucket) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting S3 bucket lifecycle configuration for bucket (%s): %w", d.Id(), err))
+	}
+
+	return nil
+}

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -42,7 +42,7 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 			},
 
 			"rule": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -247,7 +247,7 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 	bucket := d.Get("bucket").(string)
 	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
 
-	rules, err := ExpandLifecycleRules(d.Get("rule").(*schema.Set).List())
+	rules, err := ExpandLifecycleRules(d.Get("rule").([]interface{}))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating S3 Lifecycle Configuration for bucket (%s): %w", bucket, err))
 	}
@@ -329,7 +329,7 @@ func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 
-	rules, err := ExpandLifecycleRules(d.Get("rule").(*schema.Set).List())
+	rules, err := ExpandLifecycleRules(d.Get("rule").([]interface{}))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating S3 Bucket Lifecycle Configuration rule: %w", err))
 	}

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -1,0 +1,860 @@
+package s3_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func TestAccS3BucketLifecycleConfiguration_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":      "1",
+						"expiration.0.days": "365",
+						"filter.#":          "1",
+						"id":                rName,
+						"status":            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucketLifecycleConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_update(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	dateUpdated := time.Date(currTime.Year()+1, currTime.Month(), currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+				),
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, date, "logs/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":      "1",
+						"expiration.0.date": date,
+						"filter.#":          "1",
+						"filter.0.prefix":   "logs/",
+						"id":                rName,
+						"status":            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, dateUpdated, "tmp/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":      "1",
+						"expiration.0.date": dateUpdated,
+						"filter.#":          "1",
+						"filter.0.prefix":   "tmp/",
+						"id":                rName,
+						"status":            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_DisableRule(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, tfs3.LifecycleRuleStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+				),
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, tfs3.LifecycleRuleStatusDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"status": tfs3.LifecycleRuleStatusDisabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, tfs3.LifecycleRuleStatusEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"status": tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_MultipleRules(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	date := time.Now()
+	expirationDate := time.Date(date.Year(), date.Month(), date.Day()+14, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_MultipleRulesConfig(rName, expirationDate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"id":                    "log",
+						"expiration.#":          "1",
+						"expiration.0.days":     "90",
+						"filter.#":              "1",
+						"filter.0.and.#":        "1",
+						"filter.0.and.0.prefix": "log/",
+						"filter.0.and.0.tags.%": "2",
+						"status":                tfs3.LifecycleRuleStatusEnabled,
+						"transition.#":          "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.transition.*", map[string]string{
+						"days":          "30",
+						"storage_class": s3.StorageClassStandardIa,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.transition.*", map[string]string{
+						"days":          "60",
+						"storage_class": s3.StorageClassGlacier,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"id":                "tmp",
+						"expiration.#":      "1",
+						"expiration.0.date": expirationDate,
+						"filter.#":          "1",
+						"filter.0.prefix":   "tmp/",
+						"status":            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionExpiration(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_NonCurrentVersionExpirationConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"noncurrent_version_expiration.#":                 "1",
+						"noncurrent_version_expiration.0.noncurrent_days": "90",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionTransition(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_NonCurrentVersionTransitionConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"noncurrent_version_transition.#": "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.noncurrent_version_transition.*", map[string]string{
+						"noncurrent_days": "30",
+						"storage_class":   s3.StorageClassStandardIa,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*.noncurrent_version_transition.*", map[string]string{
+						"noncurrent_days": "60",
+						"storage_class":   s3.StorageClassGlacier,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Ensure backwards compatible with now-deprecated "prefix" configuration
+func TestAccS3BucketLifecycleConfiguration_Prefix(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_Basic_PrefixConfig(rName, "path1/"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":      "1",
+						"expiration.0.days": "365",
+						"id":                rName,
+						"prefix":            "path1/",
+						"status":            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfig(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#": "1",
+						"expiration.0.expired_object_delete_marker": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfig(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#": "1",
+						"expiration.0.expired_object_delete_marker": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11420
+func TestAccS3BucketLifecycleConfiguration_RuleExpiration_EmptyBlock(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_RuleExpiration_EmptyConfigurationBlockConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15138
+func TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfig(rName, 7),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"abort_incomplete_multipart_upload.#":                       "1",
+						"abort_incomplete_multipart_upload.0.days_after_initiation": "7",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfig(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"abort_incomplete_multipart_upload.#":                       "1",
+						"abort_incomplete_multipart_upload.0.days_after_initiation": "5",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckBucketLifecycleConfigurationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_bucket_lifecycle_configuration" {
+			continue
+		}
+		input := &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(rs.Primary.ID)}
+
+		output, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+			return conn.GetBucketLifecycleConfiguration(input)
+		})
+
+		if tfawserr.ErrCodeEquals(err, tfs3.ErrCodeNoSuchLifecycleConfiguration, s3.ErrCodeNoSuchBucket) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if config, ok := output.(*s3.GetBucketLifecycleConfigurationOutput); ok && config != nil && len(config.Rules) != 0 {
+			return fmt.Errorf("S3 Lifecycle Configuration for bucket (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBucketLifecycleConfigurationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+		output, err := conn.GetBucketLifecycleConfiguration(&s3.GetBucketLifecycleConfigurationInput{
+			Bucket: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil {
+			return fmt.Errorf("S3 Bucket Replication Configuration for bucket (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccBucketLifecycleConfigurationBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id     = %[1]q
+    status = "Enabled"
+
+    expiration {
+      days = 365
+    }
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {}
+  }
+}
+`, rName)
+}
+
+func testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, status string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id     = %[1]q
+    status = %[2]q
+
+    expiration {
+      days = 365
+    }
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {}
+  }
+}
+`, rName, status)
+}
+
+func testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, date, prefix string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id     = %[1]q
+    status = "Enabled"
+
+    expiration {
+      date = %[2]q
+    }
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {
+      prefix = %[3]q
+    }
+  }
+}
+`, rName, date, prefix)
+}
+
+func testAccBucketLifecycleConfiguration_Basic_PrefixConfig(rName, prefix string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id = %[1]q
+
+    # One of prefix or filter required to ensure XML is well-formed
+    prefix = %[2]q
+    status = "Enabled"
+
+    expiration {
+      days = 365
+    }
+  }
+}
+`, rName, prefix)
+}
+
+func testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfig(rName string, expired bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id     = %[1]q
+    status = "Enabled"
+
+    expiration {
+      expired_object_delete_marker = %[2]t
+    }
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {}
+  }
+}
+`, rName, expired)
+}
+
+func testAccBucketLifecycleConfiguration_RuleExpiration_EmptyConfigurationBlockConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id     = %[1]q
+    status = "Enabled"
+
+    expiration {}
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {}
+  }
+}
+`, rName)
+}
+
+func testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfig(rName string, days int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    abort_incomplete_multipart_upload {
+      days_after_initiation = %[2]d
+    }
+
+    id     = %[1]q
+    status = "Enabled"
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {}
+  }
+}
+`, rName, days)
+}
+
+func testAccBucketLifecycleConfiguration_MultipleRulesConfig(rName, date string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = "log"
+
+    expiration {
+      days = 90
+    }
+
+    filter {
+      and {
+        prefix = "log/"
+
+        tags = {
+          key1 = "value1"
+          key2 = "value2"
+        }
+      }
+    }
+
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+  }
+
+  rule {
+    id = "tmp"
+
+    filter {
+      prefix = "tmp/"
+    }
+
+    expiration {
+      date = %[2]q
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName, date)
+}
+
+func testAccBucketLifecycleConfiguration_NonCurrentVersionExpirationConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = %[1]q
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {
+      prefix = "config/"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName)
+}
+
+func testAccBucketLifecycleConfiguration_NonCurrentVersionTransitionConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  acl    = "private"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id = %[1]q
+
+    # One of prefix or filter required to ensure XML is well-formed
+    filter {
+      prefix = "config/"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 60
+      storage_class   = "GLACIER"
+    }
+
+    status = "Enabled"
+  }
+}
+`, rName)
+}

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -511,13 +511,15 @@ func testAccCheckBucketLifecycleConfigurationExists(n string) resource.TestCheck
 			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 		}
 
-		output, err := conn.GetBucketLifecycleConfiguration(input)
+		output, err := verify.RetryOnAWSCode(tfs3.ErrCodeNoSuchLifecycleConfiguration, func() (interface{}, error) {
+			return conn.GetBucketLifecycleConfiguration(input)
+		})
 
 		if err != nil {
 			return err
 		}
 
-		if output == nil {
+		if config, ok := output.(*s3.GetBucketLifecycleConfigurationOutput); !ok || config == nil {
 			return fmt.Errorf("S3 Bucket Replication Configuration for bucket (%s) not found", rs.Primary.ID)
 		}
 

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -73,7 +73,7 @@ func TestAccS3BucketLifecycleConfiguration_disappears(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_update(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_FilterWithPrefix(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 	currTime := time.Now()
@@ -86,12 +86,6 @@ func TestAccS3BucketLifecycleConfiguration_update(t *testing.T) {
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccBucketLifecycleConfigurationBasicConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketLifecycleConfigurationExists(resourceName),
-				),
-			},
 			{
 				Config: testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, date, "logs/"),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/service/s3/enum.go
+++ b/internal/service/s3/enum.go
@@ -12,6 +12,9 @@ const (
 	BucketCannedACLLogDeliveryWrite = "log-delivery-write"
 
 	ErrCodeReplicationConfigurationNotFound = "ReplicationConfigurationNotFoundError"
+
+	LifecycleRuleStatusEnabled  = "Enabled"
+	LifecycleRuleStatusDisabled = "Disabled"
 )
 
 func BucketCannedACL_Values() []string {

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -6,6 +6,7 @@ package s3
 const (
 	ErrCodeNoSuchConfiguration                  = "NoSuchConfiguration"
 	ErrCodeNoSuchCORSConfiguration              = "NoSuchCORSConfiguration"
+	ErrCodeNoSuchLifecycleConfiguration         = "NoSuchLifecycleConfiguration"
 	ErrCodeNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
 	ErrCodeNoSuchWebsiteConfiguration           = "NoSuchWebsiteConfiguration"
 	ErrCodeOperationAborted                     = "OperationAborted"

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -1,8 +1,12 @@
 package s3
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
@@ -159,6 +163,278 @@ func ExpandFilter(l []interface{}) *s3.ReplicationRuleFilter {
 	}
 
 	return result
+}
+
+func ExpandLifecycleRuleAbortIncompleteMultipartUpload(m map[string]interface{}) *s3.AbortIncompleteMultipartUpload {
+	if len(m) == 0 {
+		return nil
+	}
+
+	result := &s3.AbortIncompleteMultipartUpload{}
+
+	if v, ok := m["days_after_initiation"].(int); ok {
+		result.DaysAfterInitiation = aws.Int64(int64(v))
+	}
+
+	return result
+}
+
+func ExpandLifecycleRuleExpiration(l []interface{}) (*s3.LifecycleExpiration, error) {
+	if len(l) == 0 {
+		return nil, nil
+	}
+
+	result := &s3.LifecycleExpiration{}
+
+	if l[0] == nil {
+		return result, nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	if v, ok := m["date"].(string); ok && v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing S3 Bucket Lifecycle Rule Expiration date: %w", err)
+		}
+		result.Date = aws.Time(t)
+	}
+
+	if v, ok := m["days"].(int); ok && v > 0 {
+		result.Days = aws.Int64(int64(v))
+	}
+
+	// This cannot be specified with Days or Date
+	if v, ok := m["expired_object_delete_marker"].(bool); ok && result.Date == nil && result.Days == nil {
+		result.ExpiredObjectDeleteMarker = aws.Bool(v)
+	}
+
+	return result, nil
+}
+
+// ExpandLifecycleRuleFilter ensures a Filter can have only 1 of prefix, tag, or and
+func ExpandLifecycleRuleFilter(l []interface{}) *s3.LifecycleRuleFilter {
+	if len(l) == 0 {
+		return nil
+	}
+
+	result := &s3.LifecycleRuleFilter{}
+
+	if l[0] == nil {
+		return result
+	}
+
+	m := l[0].(map[string]interface{})
+
+	if v, ok := m["and"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		result.And = ExpandLifecycleRuleFilterAndOperator(v[0].(map[string]interface{}))
+	}
+
+	if v, ok := m["object_size_greater_than"].(int); ok && v > 0 {
+		result.ObjectSizeGreaterThan = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["object_size_less_than"].(int); ok && v > 0 {
+		result.ObjectSizeLessThan = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["tag"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		tags := Tags(tftags.New(v[0]).IgnoreAWS())
+		if len(tags) > 0 {
+			result.Tag = tags[0]
+		}
+	}
+
+	if v, ok := m["prefix"].(string); ok && result.And == nil && result.Tag == nil {
+		result.Prefix = aws.String(v)
+	}
+
+	return result
+}
+
+func ExpandLifecycleRuleFilterAndOperator(m map[string]interface{}) *s3.LifecycleRuleAndOperator {
+	if len(m) == 0 {
+		return nil
+	}
+
+	result := &s3.LifecycleRuleAndOperator{}
+
+	if v, ok := m["object_size_greater_than"].(int); ok && v > 0 {
+		result.ObjectSizeGreaterThan = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["object_size_less_than"].(int); ok && v > 0 {
+		result.ObjectSizeLessThan = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["prefix"].(string); ok {
+		result.Prefix = aws.String(v)
+	}
+
+	if v, ok := m["tags"].(map[string]interface{}); ok && len(v) > 0 {
+		tags := Tags(tftags.New(v).IgnoreAWS())
+		if len(tags) > 0 {
+			result.Tags = tags
+		}
+	}
+
+	return result
+}
+
+func ExpandLifecycleRuleNoncurrentVersionExpiration(m map[string]interface{}) *s3.NoncurrentVersionExpiration {
+	if len(m) == 0 {
+		return nil
+	}
+
+	result := &s3.NoncurrentVersionExpiration{}
+
+	if v, ok := m["newer_noncurrent_versions"].(int); ok && v > 0 {
+		result.NewerNoncurrentVersions = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["noncurrent_days"].(int); ok {
+		result.NoncurrentDays = aws.Int64(int64(v))
+	}
+
+	return result
+}
+
+func ExpandLifecycleRuleNoncurrentVersionTransitions(l []interface{}) []*s3.NoncurrentVersionTransition {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	var results []*s3.NoncurrentVersionTransition
+
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		transition := &s3.NoncurrentVersionTransition{}
+
+		if v, ok := tfMap["newer_noncurrent_versions"].(int); ok && v > 0 {
+			transition.NewerNoncurrentVersions = aws.Int64(int64(v))
+		}
+
+		if v, ok := tfMap["noncurrent_days"].(int); ok {
+			transition.NoncurrentDays = aws.Int64(int64(v))
+		}
+
+		if v, ok := tfMap["storage_class"].(string); ok && v != "" {
+			transition.StorageClass = aws.String(v)
+		}
+
+		results = append(results, transition)
+	}
+
+	return results
+}
+
+func ExpandLifecycleRuleTransitions(l []interface{}) ([]*s3.Transition, error) {
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	var results []*s3.Transition
+
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		transition := &s3.Transition{}
+
+		if v, ok := tfMap["date"].(string); ok && v != "" {
+			t, err := time.Parse(time.RFC3339, v)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing S3 Bucket Lifecycle Rule Transition date: %w", err)
+			}
+			transition.Date = aws.Time(t)
+		}
+
+		if v, ok := tfMap["days"].(int); ok && v > 0 {
+			transition.Days = aws.Int64(int64(v))
+		}
+
+		if v, ok := tfMap["storage_class"].(string); ok && v != "" {
+			transition.StorageClass = aws.String(v)
+		}
+
+		results = append(results, transition)
+	}
+
+	return results, nil
+}
+
+func ExpandLifecycleRules(l []interface{}) ([]*s3.LifecycleRule, error) {
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	var results []*s3.LifecycleRule
+
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		result := &s3.LifecycleRule{}
+
+		if v, ok := tfMap["abort_incomplete_multipart_upload"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			result.AbortIncompleteMultipartUpload = ExpandLifecycleRuleAbortIncompleteMultipartUpload(v[0].(map[string]interface{}))
+		}
+
+		if v, ok := tfMap["expiration"].([]interface{}); ok && len(v) > 0 {
+			expiration, err := ExpandLifecycleRuleExpiration(v)
+			if err != nil {
+				return nil, err
+			}
+			result.Expiration = expiration
+		}
+
+		if v, ok := tfMap["filter"].([]interface{}); ok && len(v) > 0 {
+			result.Filter = ExpandLifecycleRuleFilter(v)
+		}
+
+		if v, ok := tfMap["id"].(string); ok {
+			result.ID = aws.String(v)
+		}
+
+		if v, ok := tfMap["noncurrent_version_expiration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			result.NoncurrentVersionExpiration = ExpandLifecycleRuleNoncurrentVersionExpiration(v[0].(map[string]interface{}))
+		}
+
+		if v, ok := tfMap["noncurrent_version_transition"].(*schema.Set); ok && v.Len() > 0 {
+			result.NoncurrentVersionTransitions = ExpandLifecycleRuleNoncurrentVersionTransitions(v.List())
+		}
+
+		if v, ok := tfMap["prefix"].(string); ok && result.Filter == nil {
+			result.Prefix = aws.String(v)
+		}
+
+		if v, ok := tfMap["status"].(string); ok && v != "" {
+			result.Status = aws.String(v)
+		}
+
+		if v, ok := tfMap["transition"].(*schema.Set); ok && v.Len() > 0 {
+			transitions, err := ExpandLifecycleRuleTransitions(v.List())
+			if err != nil {
+				return nil, err
+			}
+			result.Transitions = transitions
+		}
+
+		results = append(results, result)
+	}
+
+	return results, nil
 }
 
 func ExpandMetrics(l []interface{}) *s3.Metrics {
@@ -508,6 +784,246 @@ func FlattenFilter(filter *s3.ReplicationRuleFilter) []interface{} {
 	}
 
 	return []interface{}{m}
+}
+
+func FlattenLifecycleRules(rules []*s3.LifecycleRule) []interface{} {
+	if len(rules) == 0 {
+		return []interface{}{}
+	}
+
+	var results []interface{}
+
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if rule.AbortIncompleteMultipartUpload != nil {
+			m["abort_incomplete_multipart_upload"] = FlattenLifecycleRuleAbortIncompleteMultipartUpload(rule.AbortIncompleteMultipartUpload)
+		}
+
+		if rule.Expiration != nil {
+			m["expiration"] = FlattenLifecycleRuleExpiration(rule.Expiration)
+		}
+
+		if rule.Filter != nil {
+			m["filter"] = FlattenLifecycleRuleFilter(rule.Filter)
+		}
+
+		if rule.ID != nil {
+			m["id"] = aws.StringValue(rule.ID)
+		}
+
+		if rule.NoncurrentVersionExpiration != nil {
+			m["noncurrent_version_expiration"] = FlattenLifecycleRuleNoncurrentVersionExpiration(rule.NoncurrentVersionExpiration)
+		}
+
+		if rule.NoncurrentVersionTransitions != nil {
+			m["noncurrent_version_transition"] = FlattenLifecycleRuleNoncurrentVersionTransitions(rule.NoncurrentVersionTransitions)
+		}
+
+		if rule.Prefix != nil {
+			m["prefix"] = aws.StringValue(rule.Prefix)
+		}
+
+		if rule.Status != nil {
+			m["status"] = aws.StringValue(rule.Status)
+		}
+
+		if rule.Transitions != nil {
+			m["transition"] = FlattenLifecycleRuleTransitions(rule.Transitions)
+		}
+
+		results = append(results, m)
+	}
+
+	return results
+}
+
+func FlattenLifecycleRuleAbortIncompleteMultipartUpload(u *s3.AbortIncompleteMultipartUpload) []interface{} {
+	if u == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if u.DaysAfterInitiation != nil {
+		m["days_after_initiation"] = int(aws.Int64Value(u.DaysAfterInitiation))
+	}
+
+	return []interface{}{m}
+}
+
+func FlattenLifecycleRuleExpiration(expiration *s3.LifecycleExpiration) []interface{} {
+	if expiration == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if expiration.Days != nil {
+		m["days"] = int(aws.Int64Value(expiration.Days))
+	}
+
+	if expiration.Date != nil {
+		m["date"] = expiration.Date.Format(time.RFC3339)
+	}
+
+	if expiration.ExpiredObjectDeleteMarker != nil {
+		m["expired_object_delete_marker"] = aws.BoolValue(expiration.ExpiredObjectDeleteMarker)
+	}
+
+	return []interface{}{m}
+}
+
+func FlattenLifecycleRuleFilter(filter *s3.LifecycleRuleFilter) []interface{} {
+	if filter == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if filter.And != nil {
+		m["and"] = FlattenLifecycleRuleFilterAndOperator(filter.And)
+	}
+
+	if filter.ObjectSizeGreaterThan != nil {
+		m["object_size_greater_than"] = int(aws.Int64Value(filter.ObjectSizeGreaterThan))
+	}
+
+	if filter.ObjectSizeLessThan != nil {
+		m["object_size_less_than"] = int(aws.Int64Value(filter.ObjectSizeLessThan))
+	}
+
+	if filter.Prefix != nil {
+		m["prefix"] = aws.StringValue(filter.Prefix)
+	}
+
+	if filter.Tag != nil {
+		m["tag"] = FlattenLifecycleRuleFilterTag(filter.Tag)
+	}
+
+	return []interface{}{m}
+}
+
+func FlattenLifecycleRuleFilterAndOperator(andOp *s3.LifecycleRuleAndOperator) []interface{} {
+	if andOp == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if andOp.ObjectSizeGreaterThan != nil {
+		m["object_size_greater_than"] = int(aws.Int64Value(andOp.ObjectSizeGreaterThan))
+	}
+
+	if andOp.ObjectSizeLessThan != nil {
+		m["object_size_less_than"] = int(aws.Int64Value(andOp.ObjectSizeLessThan))
+	}
+
+	if andOp.Prefix != nil {
+		m["prefix"] = aws.StringValue(andOp.Prefix)
+	}
+
+	if andOp.Tags != nil {
+		m["tags"] = KeyValueTags(andOp.Tags).IgnoreAWS().Map()
+	}
+
+	return []interface{}{m}
+}
+
+func FlattenLifecycleRuleFilterTag(tag *s3.Tag) []interface{} {
+	if tag == nil {
+		return []interface{}{}
+	}
+
+	t := KeyValueTags([]*s3.Tag{tag}).IgnoreAWS().Map()
+
+	return []interface{}{t}
+}
+
+func FlattenLifecycleRuleNoncurrentVersionExpiration(expiration *s3.NoncurrentVersionExpiration) []interface{} {
+	if expiration == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if expiration.NewerNoncurrentVersions != nil {
+		m["newer_noncurrent_versions"] = int(aws.Int64Value(expiration.NewerNoncurrentVersions))
+	}
+
+	if expiration.NoncurrentDays != nil {
+		m["noncurrent_days"] = int(aws.Int64Value(expiration.NoncurrentDays))
+	}
+
+	return []interface{}{m}
+}
+
+func FlattenLifecycleRuleNoncurrentVersionTransitions(transitions []*s3.NoncurrentVersionTransition) []interface{} {
+	if len(transitions) == 0 {
+		return []interface{}{}
+	}
+
+	var results []interface{}
+
+	for _, transition := range transitions {
+		if transition == nil {
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if transition.NewerNoncurrentVersions != nil {
+			m["newer_noncurrent_versions"] = int(aws.Int64Value(transition.NewerNoncurrentVersions))
+		}
+
+		if transition.NoncurrentDays != nil {
+			m["noncurrent_days"] = int(aws.Int64Value(transition.NoncurrentDays))
+		}
+
+		if transition.StorageClass != nil {
+			m["storage_class"] = aws.StringValue(transition.StorageClass)
+		}
+
+		results = append(results, m)
+	}
+
+	return results
+}
+
+func FlattenLifecycleRuleTransitions(transitions []*s3.Transition) []interface{} {
+	if len(transitions) == 0 {
+		return []interface{}{}
+	}
+
+	var results []interface{}
+
+	for _, transition := range transitions {
+		if transition == nil {
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if transition.Date != nil {
+			m["date"] = transition.Date.Format(time.RFC3339)
+		}
+
+		if transition.Days != nil {
+			m["days"] = int(aws.Int64Value(transition.Days))
+		}
+
+		if transition.StorageClass != nil {
+			m["storage_class"] = aws.StringValue(transition.StorageClass)
+		}
+
+		results = append(results, m)
+	}
+
+	return results
 }
 
 func FlattenMetrics(metrics *s3.Metrics) []interface{} {

--- a/internal/service/s3/status.go
+++ b/internal/service/s3/status.go
@@ -1,0 +1,55 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func lifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket string, rules []*s3.LifecycleRule) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &s3.GetBucketLifecycleConfigurationInput{
+			Bucket: aws.String(bucket),
+		}
+
+		output, err := conn.GetBucketLifecycleConfigurationWithContext(ctx, input)
+
+		if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil {
+			return nil, "", &resource.NotFoundError{
+				Message:     "Empty result",
+				LastRequest: input,
+			}
+		}
+
+		for _, expectedRule := range rules {
+			found := false
+
+			for _, actualRule := range output.Rules {
+				if aws.StringValue(actualRule.ID) != aws.StringValue(expectedRule.ID) {
+					continue
+				}
+				found = true
+				if aws.StringValue(actualRule.Status) != aws.StringValue(expectedRule.Status) {
+					return output, LifecycleConfigurationRulesStatusNotReady, nil
+				}
+			}
+
+			if !found {
+				return output, LifecycleConfigurationRulesStatusNotReady, nil
+			}
+		}
+
+		return output, LifecycleConfigurationRulesStatusReady, nil
+	}
+}

--- a/internal/service/s3/status.go
+++ b/internal/service/s3/status.go
@@ -5,14 +5,18 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func lifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket string, rules []*s3.LifecycleRule) resource.StateRefreshFunc {
+func lifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string, rules []*s3.LifecycleRule) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		input := &s3.GetBucketLifecycleConfigurationInput{
 			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 		}
 
 		output, err := conn.GetBucketLifecycleConfigurationWithContext(ctx, input)

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -1,17 +1,38 @@
 package s3
 
 import (
+	"context"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 const (
-	bucketCreatedTimeout = 2 * time.Minute
-	propagationTimeout   = 1 * time.Minute
+	bucketCreatedTimeout                          = 2 * time.Minute
+	propagationTimeout                            = 1 * time.Minute
+	lifecycleConfigurationRulesPropagationTimeout = 2 * time.Minute
+
+	// LifecycleConfigurationRulesStatusReady occurs when all configured rules reach their desired state (Enabled or Disabled)
+	LifecycleConfigurationRulesStatusReady = "READY"
+	// LifecycleConfigurationRulesStatusNotReady occurs when all configured rules have not reached their desired state (Enabled or Disabled)
+	LifecycleConfigurationRulesStatusNotReady = "NOT_READY"
 )
 
 func retryWhenBucketNotFound(f func() (interface{}, error)) (interface{}, error) {
 	return tfresource.RetryWhenAWSErrCodeEquals(propagationTimeout, f, s3.ErrCodeNoSuchBucket)
+}
+
+func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket string, rules []*s3.LifecycleRule) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"", LifecycleConfigurationRulesStatusNotReady},
+		Target:  []string{LifecycleConfigurationRulesStatusReady},
+		Refresh: lifecycleConfigurationRulesStatus(ctx, conn, bucket, rules),
+		Timeout: lifecycleConfigurationRulesPropagationTimeout,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
 }

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -24,11 +24,11 @@ func retryWhenBucketNotFound(f func() (interface{}, error)) (interface{}, error)
 	return tfresource.RetryWhenAWSErrCodeEquals(propagationTimeout, f, s3.ErrCodeNoSuchBucket)
 }
 
-func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket string, rules []*s3.LifecycleRule) error {
+func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string, rules []*s3.LifecycleRule) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"", LifecycleConfigurationRulesStatusNotReady},
 		Target:  []string{LifecycleConfigurationRulesStatusReady},
-		Refresh: lifecycleConfigurationRulesStatus(ctx, conn, bucket, rules),
+		Refresh: lifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules),
 		Timeout: lifecycleConfigurationRulesPropagationTimeout,
 	}
 

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -1,0 +1,214 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_lifecycle_configuration"
+description: |-
+Provides a S3 bucket lifecycle configuration resource.
+---
+
+# Resource: aws_s3_bucket_lifecycle_configuration
+
+Provides an independent configuration resource for S3 bucket [lifecycle configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html).
+
+## Example Usage
+
+```terraform
+resource "aws_s3_bucket" "bucket" {
+  bucket = "my-bucket"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bucket-config" {
+  bucket = aws_s3_bucket.bucket.bucket
+
+  rule {
+    id = "log"
+
+    expiration {
+      days = 90
+    }
+
+    filter {
+      and {
+        prefix = "log/"
+
+        tags = {
+          rule      = "log"
+          autoclean = "true"
+        }
+      }
+    }
+
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+  }
+
+  rule {
+    id = "tmp"
+
+    filter {
+      prefix = "tmp/"
+    }
+
+    expiration {
+      date = "2023-01-13T00:00:00Z"
+    }
+
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket" "versioning_bucket" {
+  bucket = "my-versioning-bucket"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "versioning-bucket-config" {
+  bucket = aws_s3_bucket.versioning_bucket.bucket
+
+  rule {
+    id = "config"
+
+    filter {
+      prefix = "config/"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 60
+      storage_class   = "GLACIER"
+    }
+
+    status = "Enabled"
+  }
+}
+```
+
+## Usage Notes
+
+~> **NOTE:** To avoid conflicts always add the following lifecycle object to the `aws_s3_bucket` resource of the source bucket.
+
+This resource implements the same features that are provided by the `lifecycle_rule` object of the [`aws_s3_bucket` resource](s3_bucket.html). To avoid conflicts or unexpected apply results, a lifecycle configuration is needed on the `aws_s3_bucket` to ignore changes to the internal `lifecycle_rule` object.  Failure to add the `lifecycle` configuration to the `aws_s3_bucket` will result in conflicting state results.
+
+```
+lifecycle {
+  ignore_changes = [
+    lifecycle_rule
+  ]
+}
+```
+
+The `aws_s3_bucket_lifecycle_configuration` resource provides the following features that are not available in the [`aws_s3_bucket` resource](s3_bucket.html):
+
+* `filter` - Added to the `rule` configuration block [documented below](#filter).
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the source S3 bucket you want Amazon S3 to monitor.
+* `expected_bucket_owner` - (Optional) The account ID of the expected bucket owner. If the bucket is owned by a different account, the request will fail with an HTTP 403 (Access Denied) error.
+* `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
+
+### rule
+
+The `rule` configuration block supports the following arguments:
+
+* `abort_incomplete_multipart_upload` - (Optional) Configuration block that specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload [documented below](#abort_incomplete_multipart_upload).
+* `expiration` - (Optional) Configuration block that specifies the expiration for the lifecycle of the object in the form of date, days and, whether the object has a delete marker [documented below](#expiration).
+* `filter` - (Optional, Required if `prefix` not specified) Configuration block used to identify objects that a Lifecycle Rule applies to [documented below](#filter).
+* `id` - (Required) Unique identifier for the rule. The value cannot be longer than 255 characters.
+* `noncurrent_version_expiration` - (Optional) Configuration block that specifies when noncurrent object versions expire [documented below](#noncurrent_version_expiration).
+* `noncurrent_version_transition` - (Optional) Set of configuration blocks that specify the transition rule for the lifecycle rule that describes when noncurrent objects transition to a specific storage class [documented below](#noncurrent_version_transition).
+* `prefix` - (Optional, Required if `filter` not specified) Prefix identifying one or more objects to which the rule applies. This has been deprecated by Amazon S3 and `filter` should be used instead.
+* `status` - (Required) Whether the rule is currently being applied. Valid values: `Enabled` or `Disabled`.
+* `transition` - (Optional) Set of configuration blocks that specify when an Amazon S3 object transitions to a specified storage class [documented below](#transition).
+
+### abort_incomplete_multipart_upload
+
+The `abort_incomplete_multipart_upload` configuration block supports the following arguments:
+
+* `days_after_initiation` - The number of days after which Amazon S3 aborts an incomplete multipart upload.
+
+### expiration
+
+The `expiration` configuration block supports the following arguments:
+
+* `date` - (Optional) The date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.
+* `days` - (Optional) The lifetime, in days, of the objects that are subject to the rule. The value must be a non-zero positive integer.
+* `expired_object_delete_marker` - (Optional, Conflicts with `date` and `days`) Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set to `true`, the delete marker will be expired; if set to `false` the policy takes no action.
+
+### filter
+
+The `filter` configuration block supports the following arguments:
+
+* `and`- (Optional) Configuration block used to apply a logical `AND` to two or more predicates. The Lifecycle Rule will apply to any object matching all of the predicates configured inside the `and` block.
+* `object_size_greater_than` - (Optional) Minimum object size to which the rule applies.
+* `object_size_less_than` - (Optional) Maximum object size to which the rule applies.
+* `prefix` - (Optional) Prefix identifying one or more objects to which the rule applies.
+* `tag` - (Optional) A configuration block for specifying a tag key and value [documented below](#tag).
+
+### noncurrent_version_expiration
+
+The `noncurrent_version_expiration` configuration block supports the following arguments:
+
+* `newer_noncurrent_versions` - (Optional) The number of noncurrent versions Amazon S3 will retain. Must be a non-zero positive integer.
+* `noncurrent_days` - (Optional) The number of days an object is noncurrent before Amazon S3 can perform the associated action. Must be a positive integer.
+
+### noncurrent_version_transition
+
+The `noncurrent_version_transition` configuration block supports the following arguments:
+
+* `newer_noncurrent_versions` - (Optional) The number of noncurrent versions Amazon S3 will retain.
+* `noncurrent_days` - (Optional) The number of days an object is noncurrent before Amazon S3 can perform the associated action.
+* `storage_class` - (Required) The class of storage used to store the object. Valid Values: `GLACIER`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `DEEP_ARCHIVE`, `GLACIER_IR`.
+
+### transition
+
+The `transition` configuration block supports the following arguments:
+
+* `date` - (Optional) The date objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.
+* `days` - (Optional) The number of days after creation when objects are transitioned to the specified storage class. The value must be a positive integer.
+* `storage_class` - The class of storage used to store the object. Valid Values: `GLACIER`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `DEEP_ARCHIVE`, `GLACIER_IR`.
+
+### tag
+
+The `tag` configuration block supports the following arguments:
+
+* `key` - (Required) Name of the object key.
+* `value` - (Required) Value of the tag.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The S3 source bucket name.
+
+## Import
+
+S3 bucket lifecycle configuration can be imported using the `bucket`, e.g.
+
+```sh
+$ terraform import aws_s3_bucket_lifecycle_configuration.example bucket-name
+```

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -3,7 +3,7 @@ subcategory: "S3"
 layout: "aws"
 page_title: "AWS: aws_s3_bucket_lifecycle_configuration"
 description: |-
-Provides a S3 bucket lifecycle configuration resource.
+  Provides a S3 bucket lifecycle configuration resource.
 ---
 
 # Resource: aws_s3_bucket_lifecycle_configuration

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -129,7 +129,7 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the source S3 bucket you want Amazon S3 to monitor.
 * `expected_bucket_owner` - (Optional) The account ID of the expected bucket owner. If the bucket is owned by a different account, the request will fail with an HTTP 403 (Access Denied) error.
-* `rule` - (Required) Set of configuration blocks describing the rules managing the replication [documented below](#rule).
+* `rule` - (Required) List of configuration blocks describing the rules managing the replication [documented below](#rule).
 
 ### rule
 

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -203,7 +203,7 @@ The `tag` configuration block supports the following arguments:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The S3 source bucket name.
+* `id` - The `bucket` or `bucket` and `expected_bucket_owner` separated by a comma (`,`) if the latter is provided.
 
 ## Import
 
@@ -211,4 +211,10 @@ S3 bucket lifecycle configuration can be imported using the `bucket`, e.g.
 
 ```sh
 $ terraform import aws_s3_bucket_lifecycle_configuration.example bucket-name
+```
+
+In addition, S3 bucket lifecycle configuration can be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_lifecycle_configuration.example bucket-name,123456789012
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/4418
Relates #20433
Closes https://github.com/hashicorp/terraform-provider-aws/issues/6188
Closes https://github.com/hashicorp/terraform-provider-aws/issues/283

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (294.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Prefix (337.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_EmptyBlock (337.09s)
--- PASS: TestAccS3BucketLifecycleConfiguration_NonCurrentVersionExpiration (357.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_MultipleRules (366.20s)
--- PASS: TestAccS3BucketLifecycleConfiguration_NonCurrentVersionTransition (366.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (367.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload (454.52s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly (456.94s)
--- PASS: TestAccS3BucketLifecycleConfiguration_update (550.75s)
--- PASS: TestAccS3BucketLifecycleConfiguration_DisableRule (551.39s)
```
