### PR TITLE
ec2/subnet: Availability zone ID not supported in all partitions

### DIFF
--- a/.changelog/22580.txt
+++ b/.changelog/22580.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_subnet: Protect against errors when `availability_zone_id` is not supported in a partition (e.g., ISO)
+```

--- a/internal/service/ec2/subnet.go
+++ b/internal/service/ec2/subnet.go
@@ -145,10 +145,16 @@ func resourceSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateSubnetInput{
-		AvailabilityZone:   aws.String(d.Get("availability_zone").(string)),
-		AvailabilityZoneId: aws.String(d.Get("availability_zone_id").(string)),
-		TagSpecifications:  ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSubnet),
-		VpcId:              aws.String(d.Get("vpc_id").(string)),
+		TagSpecifications: ec2TagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSubnet),
+		VpcId:             aws.String(d.Get("vpc_id").(string)),
+	}
+
+	if v, ok := d.GetOk("availability_zone"); ok {
+		input.AvailabilityZone = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("availability_zone_id"); ok {
+		input.AvailabilityZoneId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("cidr_block"); ok {

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -55,7 +55,7 @@ The arguments of this data source act as filters for querying the available subn
 The following arguments are optional:
 
 * `availability_zone` - (Optional) Availability zone where the subnet must reside.
-* `availability_zone_id` - (Optional) ID of the Availability Zone for the subnet.
+* `availability_zone_id` - (Optional) ID of the Availability Zone for the subnet. This argument is not supported in all regions or partitions. If necessary, use `availability_zone` instead.
 * `cidr_block` - (Optional) CIDR block of the desired subnet.
 * `default_for_az` - (Optional) Whether the desired subnet must be the default subnet for its associated availability zone.
 * `filter` - (Optional) Configuration block. Detailed below.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -51,8 +51,8 @@ The following arguments are supported:
 * `assign_ipv6_address_on_creation` - (Optional) Specify true to indicate
     that network interfaces created in the specified subnet should be
     assigned an IPv6 address. Default is `false`
-* `availability_zone` - (Optional) The AZ for the subnet.
-* `availability_zone_id` - (Optional) The AZ ID of the subnet.
+* `availability_zone` - (Optional) AZ for the subnet.
+* `availability_zone_id` - (Optional) AZ ID of the subnet. This argument is not supported in all regions or partitions. If necessary, use `availability_zone` instead.
 * `cidr_block` - (Optional) The IPv4 CIDR block for the subnet.
 * `customer_owned_ipv4_pool` - (Optional) The customer owned IPv4 address pool. Typically used with the `map_customer_owned_ip_on_launch` argument. The `outpost_arn` argument must be specified when configured.
 * `enable_dns64` - (Optional) Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. Default: `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #18593

Output from acceptance testing:

```console
% make testacc TESTS=TestAccEC2Subnet_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Subnet_'  -timeout 180m
--- SKIP: TestAccEC2Subnet_customerOwnedIPv4Pool (2.08s)
--- SKIP: TestAccEC2Subnet_outpost (2.08s)
--- SKIP: TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch (2.33s)
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag (7.76s)
--- PASS: TestAccEC2Subnet_disappears (51.34s)
--- PASS: TestAccEC2Subnet_basic (56.08s)
--- PASS: TestAccEC2Subnet_availabilityZoneID (56.18s)
--- PASS: TestAccEC2Subnet_ipv6Native (65.43s)
--- PASS: TestAccEC2Subnet_DefaultTags_updateToProviderOnly (83.95s)
--- PASS: TestAccEC2Subnet_DefaultTags_updateToResourceOnly (86.71s)
--- PASS: TestAccEC2Subnet_ignoreTags (96.45s)
--- PASS: TestAccEC2Subnet_defaultAndIgnoreTags (97.21s)
--- PASS: TestAccEC2Subnet_updateTagsKnownAtApply (98.50s)
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag (106.86s)
--- PASS: TestAccEC2Subnet_tags (107.68s)
--- PASS: TestAccEC2Subnet_enableIPv6 (111.45s)
--- PASS: TestAccEC2Subnet_ipv6 (111.70s)
--- PASS: TestAccEC2Subnet_DefaultTags_providerOnly (112.44s)
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag (112.76s)
--- PASS: TestAccEC2Subnet_mapPublicIPOnLaunch (130.21s)
--- PASS: TestAccEC2Subnet_enableDNS64 (130.88s)
--- PASS: TestAccEC2Subnet_privateDnsNameOptionsOnLaunch (174.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	177.807s
```

GovCloud:
```console
% make testacc TESTS=TestAccEC2Subnet_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Subnet_'  -timeout 180m
--- SKIP: TestAccEC2Subnet_customerOwnedIPv4Pool (2.09s)
--- SKIP: TestAccEC2Subnet_mapCustomerOwnedIPOnLaunch (2.17s)
--- SKIP: TestAccEC2Subnet_outpost (2.44s)
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_duplicateTag (4.75s)
--- PASS: TestAccEC2Subnet_disappears (34.91s)
--- PASS: TestAccEC2Subnet_basic (37.66s)
--- PASS: TestAccEC2Subnet_availabilityZoneID (39.15s)
--- PASS: TestAccEC2Subnet_ipv6Native (52.40s)
--- PASS: TestAccEC2Subnet_DefaultTags_updateToProviderOnly (57.43s)
--- PASS: TestAccEC2Subnet_DefaultTags_updateToResourceOnly (58.35s)
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_nonOverlappingTag (66.88s)
--- PASS: TestAccEC2Subnet_DefaultTags_providerOnly (68.55s)
--- PASS: TestAccEC2Subnet_DefaultTagsProviderAndResource_overlappingTag (70.74s)
--- PASS: TestAccEC2Subnet_ignoreTags (72.86s)
--- PASS: TestAccEC2Subnet_defaultAndIgnoreTags (72.91s)
--- PASS: TestAccEC2Subnet_updateTagsKnownAtApply (75.43s)
--- PASS: TestAccEC2Subnet_tags (84.90s)
--- PASS: TestAccEC2Subnet_enableIPv6 (90.12s)
--- PASS: TestAccEC2Subnet_ipv6 (90.22s)
--- PASS: TestAccEC2Subnet_mapPublicIPOnLaunch (119.75s)
--- PASS: TestAccEC2Subnet_enableDNS64 (123.11s)
--- PASS: TestAccEC2Subnet_privateDnsNameOptionsOnLaunch (174.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	176.301s
```
