### PR TITLE
b-aws_dynamodb_table

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -108,8 +108,7 @@ func ResourceTable() *schema.Resource {
 			},
 			"billing_mode": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Default:  dynamodb.BillingModeProvisioned,
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					dynamodb.BillingModePayPerRequest,
 					dynamodb.BillingModeProvisioned,


### PR DESCRIPTION
Because billing_mode defaults to "PROVISIONED", the attributes "read_capacity" and "write_capacity" are both also required. Require the user set "billing_mode" instead of setting a default key. Fixes issue [22558](https://github.com/hashicorp/terraform-provider-aws/issues/22558).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [22558](https://github.com/hashicorp/terraform-provider-aws/issues/22558)

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=dynamodb

...
```
