### PR TITLE
Allow multi arguments in lifecycle policy block

### DIFF
--- a/.changelog/21862.txt
+++ b/.changelog/21862.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_efs_file_system: no longer multi lifecycle block allowed, all attributs must be put in one lifecycle block
+```

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -349,9 +349,9 @@ func TestAccEFSFileSystem_lifecyclePolicy(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(resourceName, &desc),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_ia", efs.TransitionToIARulesAfter30Days),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.0.transition_to_primary_storage_class", efs.TransitionToPrimaryStorageClassRulesAfter1Access),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_policy.1.transition_to_ia", efs.TransitionToIARulesAfter30Days),
 				),
 			},
 		},
@@ -609,9 +609,6 @@ func testAccFileSystemWithLifecyclePolicyMultiConfig(lpName1, lpVal1, lpName2, l
 resource "aws_efs_file_system" "test" {
   lifecycle_policy {
     %[1]s = %[2]q
-  }
-
-  lifecycle_policy {
     %[3]s = %[4]q
   }
 }

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -32,6 +32,7 @@ resource "aws_efs_file_system" "foo_with_lifecyle_policy" {
 
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"
+    transition_to_primary_storage_class = "AFTER_1_ACCESS"
   }
 }
 ```


### PR DESCRIPTION
### About this change

This PR implements the change requested in #21862 about `lifecycle_policy` for EFS.

Before, you need create two `lifecycle_policy` (according to the AWS API), but is not natural.
```
resource "aws_efs_file_system" "foo_with_lifecyle_policy" {
  creation_token = "my-product"

  lifecycle_policy {
    transition_to_ia = "AFTER_30_DAYS"
  }

  lifecycle_policy {
    transition_to_primary_storage_class = "AFTER_1_ACCESS"
  }
}
```

Now, must be write like this:
```
resource "aws_efs_file_system" "foo_with_lifecyle_policy" {
  creation_token = "my-product"

  lifecycle_policy {
    transition_to_ia = "AFTER_30_DAYS"
    transition_to_primary_storage_class = "AFTER_1_ACCESS"
  }
}
```

WARNING: this PR introduce a breaking change!

Closes #21862

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


### Acceptance Testing

Output from acceptance testing:

```
$ make testacc TESTS=TestAccEFSFileSystem_lifecyclePolicy PKG=efs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 20 -run='TestAccEFSFileSystem_lifecyclePolicy'  -timeout 180m
=== RUN   TestAccEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccEFSFileSystem_lifecyclePolicy
=== CONT  TestAccEFSFileSystem_lifecyclePolicy
--- PASS: TestAccEFSFileSystem_lifecyclePolicy (138.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/efs        138.915s
```