### PR TITLE
r/s3_bucket: read-only `logging` argument

### DIFF
--- a/.changelog/22599.txt
+++ b/.changelog/22599.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket: The `logging` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_logging` resource instead.
+```

--- a/.changelog/22599.txt
+++ b/.changelog/22599.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_s3_bucket: The `logging` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_logging` resource instead.
 ```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -243,8 +243,9 @@ func ResourceBucket() *schema.Resource {
 			},
 
 			"logging": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Deprecated: "Use the aws_s3_bucket_logging resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"target_bucket": {
@@ -259,7 +260,6 @@ func ResourceBucket() *schema.Resource {
 						},
 					},
 				},
-				Deprecated: "Use the aws_s3_bucket_logging resource instead",
 			},
 
 			"lifecycle_rule": {

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1029,6 +1029,8 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("logging", flattenBucketLoggingEnabled(logging.LoggingEnabled)); err != nil {
 			return fmt.Errorf("error setting logging: %s", err)
 		}
+	} else {
+		d.Set("logging", nil)
 	}
 
 	// Read the lifecycle configuration

--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -396,12 +396,6 @@ resource "aws_s3_bucket" "log_bucket" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
   acl    = "private"
-
-  lifecycle {
-    ignore_changes = [
-      logging
-    ]
-  }
 }
 
 resource "aws_s3_bucket_logging" "test" {
@@ -418,12 +412,6 @@ func testAccBucketLoggingUpdateConfig(rName, targetBucketName, targetPrefix stri
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
   acl    = "private"
-
-  lifecycle {
-    ignore_changes = [
-      logging
-    ]
-  }
 }
 
 resource "aws_s3_bucket" "log_bucket" {
@@ -452,12 +440,6 @@ resource "aws_s3_bucket" "log_bucket" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
   acl    = "private"
-
-  lifecycle {
-    ignore_changes = [
-      logging
-    ]
-  }
 }
 
 resource "aws_s3_bucket_logging" "test" {
@@ -487,12 +469,6 @@ resource "aws_s3_bucket" "log_bucket" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
   acl    = "private"
-
-  lifecycle {
-    ignore_changes = [
-      logging
-    ]
-  }
 }
 
 resource "aws_s3_bucket_logging" "test" {
@@ -524,12 +500,6 @@ resource "aws_s3_bucket" "log_bucket" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
   acl    = "private"
-
-  lifecycle {
-    ignore_changes = [
-      logging
-    ]
-  }
 }
 
 resource "aws_s3_bucket_logging" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -706,33 +706,6 @@ func TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled(t *testing.T) {
 	})
 }
 
-func TestAccS3Bucket_Security_logging(t *testing.T) {
-	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
-	resourceName := "aws_s3_bucket.bucket"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckBucketDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBucketWithLoggingConfig(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(resourceName),
-					testAccCheckBucketLogging(resourceName, "aws_s3_bucket.log_bucket", "log/"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
-			},
-		},
-	})
-}
-
 func TestAccS3Bucket_Manage_lifecycleBasic(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	resourceName := "aws_s3_bucket.bucket"
@@ -2627,49 +2600,6 @@ func testAccCheckBucketPolicy(n string, policy string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckBucketLogging(n, b, p string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs := s.RootModule().Resources[n]
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
-
-		out, err := conn.GetBucketLogging(&s3.GetBucketLoggingInput{
-			Bucket: aws.String(rs.Primary.ID),
-		})
-
-		if err != nil {
-			return fmt.Errorf("GetBucketLogging error: %v", err)
-		}
-
-		if out.LoggingEnabled == nil {
-			return fmt.Errorf("logging not enabled for bucket: %s", rs.Primary.ID)
-		}
-
-		tb := s.RootModule().Resources[b]
-
-		if v := out.LoggingEnabled.TargetBucket; v == nil {
-			if tb.Primary.ID != "" {
-				return fmt.Errorf("bad target bucket, found nil, expected: %s", tb.Primary.ID)
-			}
-		} else {
-			if *v != tb.Primary.ID {
-				return fmt.Errorf("bad target bucket, expected: %s, got %s", tb.Primary.ID, *v)
-			}
-		}
-
-		if v := out.LoggingEnabled.TargetPrefix; v == nil {
-			if p != "" {
-				return fmt.Errorf("bad target prefix, found nil, expected: %s", p)
-			}
-		} else {
-			if *v != p {
-				return fmt.Errorf("bad target prefix, expected: %s, got %s", p, *v)
-			}
-		}
-
-		return nil
-	}
-}
-
 func testAccCheckBucketReplicationRules(n string, rules []*s3.ReplicationRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[n]
@@ -3184,45 +3114,6 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 `, bucketName, enabled, mfaDelete)
-}
-
-func testAccBucketWithLoggingConfig(bucketName string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "log_bucket" {
-  bucket = "%[1]s-log"
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
-}
-
-resource "aws_s3_bucket_acl" "log_bucket" {
-  bucket = aws_s3_bucket.log_bucket.id
-  acl    = "log-delivery-write"
-}
-
-resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
-
-  logging {
-    target_bucket = aws_s3_bucket.log_bucket.id
-    target_prefix = "log/"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      grant,
-    ]
-  }
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-`, bucketName)
 }
 
 func testAccBucketWithLifecycleConfig(bucketName string) string {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -61,31 +61,8 @@ resource "aws_s3_bucket_acl" "example" {
 
 ### Enable Logging
 
-```terraform
-resource "aws_s3_bucket" "log_bucket" {
-  bucket = "my-tf-log-bucket"
-}
-
-resource "aws_s3_bucket_acl" "log_bucket_acl" {
-  bucket = aws_s3_bucket.log_bucket.id
-  acl    = "log-delivery-write"
-}
-
-resource "aws_s3_bucket" "b" {
-  bucket = "my-tf-test-bucket"
-
-  logging {
-    # The log bucket must have its ACL configured first
-    target_bucket = aws_s3_bucket_acl.log_bucket_acl.bucket
-    target_prefix = "log/"
-  }
-}
-
-resource "aws_s3_bucket_acl" "b_bucket_acl" {
-  bucket = aws_s3_bucket.b.id
-  acl    = "private"
-}
-```
+The `logging` argument is read-only as of version 4.0 of the Terraform AWS Provider.
+See the [`aws_s3_bucket_logging` resource](s3_bucket_logging.html.markdown) for configuration details.
 
 ### Using object lifecycle
 
@@ -356,7 +333,6 @@ The following arguments are supported:
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
-* `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 * `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 * `replication_configuration` - (Optional) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 * `server_side_encryption_configuration` - (Optional) A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
@@ -366,11 +342,6 @@ The `versioning` object supports the following:
 
 * `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
 * `mfa_delete` - (Optional) Enable MFA delete for either `Change the versioning state of your bucket` or `Permanently delete an object version`. Default is `false`. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS
-
-The `logging` object supports the following:
-
-* `target_bucket` - (Required) The name of the bucket that will receive the log objects.
-* `target_prefix` - (Optional) To specify a key prefix for log objects.
 
 The `lifecycle_rule` object supports the following:
 
@@ -537,6 +508,9 @@ In addition to all arguments above, the following attributes are exported:
     * `expose_headers` - Set of headers in the response that customers are able to access from their applications.
     * `max_age_seconds` The time in seconds that browser can cache the response for a preflight request.
 * `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+* `logging` - The [logging parameters](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) for the bucket.
+    * `target_bucket` - The name of the bucket that receives the log objects.
+    * `target_prefix` - The prefix for all log object keys/
 * `region` - The AWS region this bucket resides in.
 * `request_payer` - Either `BucketOwner` or `Requester` that pays for the download and request fees.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (14.78s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (168.58s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (166.48s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (168.05s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (167.91s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (168.18s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (102.32s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (15.07s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (98.83s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (98.62s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (153.67s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (236.27s)

--- PASS: TestAccS3BucketDataSource_basic (87.40s)
--- PASS: TestAccS3BucketDataSource_website (87.20s)

--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (382.30s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (100.87s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (87.85s)

--- PASS: TestAccS3BucketInventory_basic (101.10s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (100.30s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (100.27s)

--- PASS: TestAccS3BucketMetric_basic (95.17s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (15.38s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (165.10s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (165.09s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (162.74s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (163.97s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (165.16s)

--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (115.77s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (100.99s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (126.62s)
--- PASS: TestAccS3BucketNotification_queue (127.67s)
--- PASS: TestAccS3BucketNotification_topic (99.94s)
--- PASS: TestAccS3BucketNotification_update (181.88s)

--- PASS: TestAccS3BucketObjectDataSource_allParams (86.49s)
--- PASS: TestAccS3BucketObjectDataSource_basic (87.17s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (85.69s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (87.27s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (86.62s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (155.75s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (157.55s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (88.96s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (86.35s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (87.04s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (85.60s)

--- PASS: TestAccS3BucketObject_acl (247.88s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (88.78s)
--- PASS: TestAccS3BucketObject_content (100.44s)
--- PASS: TestAccS3BucketObject_contentBase64 (87.25s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (91.70s)
--- PASS: TestAccS3BucketObject_empty (99.68s)
--- PASS: TestAccS3BucketObject_etagEncryption (102.58s)
--- PASS: TestAccS3BucketObject_ignoreTags (160.50s)
--- PASS: TestAccS3BucketObject_kms (102.17s)
--- PASS: TestAccS3BucketObject_metadata (243.76s)
--- PASS: TestAccS3BucketObject_noNameNoKey (22.70s)
--- PASS: TestAccS3BucketObject_nonVersioned (99.27s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (88.93s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (232.11s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (161.38s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (234.48s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (304.73s)
--- PASS: TestAccS3BucketObject_source (103.33s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (173.90s)
--- PASS: TestAccS3BucketObject_sse (103.10s)
--- PASS: TestAccS3BucketObject_storageClass (391.86s)
--- PASS: TestAccS3BucketObject_tags (309.71s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (305.02s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (316.65s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (303.64s)
--- PASS: TestAccS3BucketObject_updateSameFile (162.94s)
--- PASS: TestAccS3BucketObject_updates (177.22s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (175.10s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (167.65s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (89.80s)

--- PASS: TestAccS3BucketObjectsDataSource_all (163.71s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (163.96s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (163.26s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (163.77s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (163.40s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (164.13s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (165.05s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (171.15s)

--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (77.14s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (178.81s)
--- PASS: TestAccS3BucketOwnershipControls_basic (103.05s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (90.08s)

--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (368.80s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (273.46s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (287.48s)

--- PASS: TestAccS3BucketPolicy_basic (102.48s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (183.07s)

--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (75.66s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (102.56s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (249.10s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (247.44s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (89.32s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (248.85s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (247.47s)

--- PASS: TestAccS3BucketReplicationConfiguration_basic (537.57s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (491.49s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (477.93s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (141.64s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (358.99s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (360.25s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (404.50s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (404.81s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (399.03s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (400.97s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (395.47s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (364.62s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (233.91s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (405.36s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (312.84s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (401.10s)

--- PASS: TestAccS3BucketVersioning_MFADelete (66.95s)
--- PASS: TestAccS3BucketVersioning_basic (92.83s)
--- PASS: TestAccS3BucketVersioning_disappears (85.25s)
--- PASS: TestAccS3BucketVersioning_update (139.35s)

--- PASS: TestAccS3Bucket_Basic_acceleration (69.02s)
--- PASS: TestAccS3Bucket_Basic_basic (58.50s)
--- PASS: TestAccS3Bucket_Basic_emptyString (56.01s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (92.78s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (90.26s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (89.22s)
--- PASS: TestAccS3Bucket_Basic_generatedName (37.72s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (67.82s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (38.50s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (62.36s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (46.46s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (72.86s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (221.53s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (168.24s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (98.28s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (84.69s)
--- PASS: TestAccS3Bucket_Manage_objectLock (147.94s)
--- PASS: TestAccS3Bucket_Manage_versioning (154.99s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (75.17s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (68.92s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (251.29s)
--- PASS: TestAccS3Bucket_Replication_basic (293.40s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (74.62s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (161.50s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (162.30s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (221.38s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (212.94s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (293.34s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (110.01s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (161.91s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (154.24s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (156.42s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (73.54s)
--- PASS: TestAccS3Bucket_Security_corsDelete (67.75s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (84.70s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (152.59s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (133.35s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (55.45s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (52.48s)
--- PASS: TestAccS3Bucket_Security_grantToACL (80.73s)
--- PASS: TestAccS3Bucket_Security_policy (97.24s)
--- PASS: TestAccS3Bucket_Security_updateACL (60.79s)
--- PASS: TestAccS3Bucket_Security_updateGrant (107.23s)
--- PASS: TestAccS3Bucket_Tags_basic (37.79s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (57.79s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (131.62s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (169.38s)
--- PASS: TestAccS3Bucket_Web_redirect (161.89s)
--- PASS: TestAccS3Bucket_Web_routingRules (97.19s)
--- PASS: TestAccS3Bucket_Web_simple (149.98s)

--- PASS: TestBucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.03s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
```
