### PR TITLE
r/s3_bucket: read-only `versioning` argument

### DIFF
--- a/.changelog/22606.txt
+++ b/.changelog/22606.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket: The `versioning` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_versioning` resource instead.
+```

--- a/.changelog/22606.txt
+++ b/.changelog/22606.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_s3_bucket: The `versioning` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_versioning` resource instead.
 ```

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -641,9 +641,12 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
   force_destroy = true
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -499,9 +499,12 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
   force_destroy = true
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/internal/service/kafkaconnect/custom_plugin_test.go
+++ b/internal/service/kafkaconnect/custom_plugin_test.go
@@ -260,13 +260,19 @@ func testAccCustomPluginConfigObjectVersion(name string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_object" "test" {
+  # Must have versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket = aws_s3_bucket.test.id
   key    = %[1]q
   source = "test-fixtures/mongodb-connector.jar"

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3416,13 +3416,19 @@ resource "aws_s3_bucket" "artifacts" {
   bucket        = "%s"
   acl           = "private"
   force_destroy = true
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_object" "o" {
+  # Must have versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.artifacts]
+
   bucket = aws_s3_bucket.artifacts.bucket
   key    = "%s"
   source = "%s"

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -519,9 +519,12 @@ resource "aws_security_group" "test" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
   acl    = "private"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -533,6 +536,9 @@ resource "aws_s3_bucket_public_access_block" "test" {
 }
 
 resource "aws_s3_object" "dags" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket       = aws_s3_bucket.test.id
   acl          = "private"
   key          = "dags/"
@@ -578,6 +584,7 @@ resource "aws_iam_role_policy" "test" {
 }
 POLICY
 }
+
 
 `, rName)
 }
@@ -795,6 +802,9 @@ resource "aws_mwaa_environment" "test" {
 }
 
 resource "aws_s3_object" "plugins" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket  = aws_s3_bucket.test.id
   acl     = "private"
   key     = "plugins.zip"

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -220,21 +220,20 @@ func ResourceBucket() *schema.Resource {
 			},
 
 			"versioning": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "Use the aws_s3_bucket_versioning resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							Type:       schema.TypeBool,
+							Computed:   true,
+							Deprecated: "Use the aws_s3_bucket_versioning resource instead",
 						},
 						"mfa_delete": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							Type:       schema.TypeBool,
+							Computed:   true,
+							Deprecated: "Use the aws_s3_bucket_versioning resource instead",
 						},
 					},
 				},
@@ -748,23 +747,6 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 		})
 		if err != nil {
 			return fmt.Errorf("error updating S3 Bucket (%s) tags: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("versioning") {
-		v := d.Get("versioning").([]interface{})
-
-		if d.IsNewResource() {
-			if versioning := expandVersioningWhenIsNewResource(v); versioning != nil {
-				err := resourceBucketInternalVersioningUpdate(conn, d.Id(), versioning)
-				if err != nil {
-					return err
-				}
-			}
-		} else {
-			if err := resourceBucketInternalVersioningUpdate(conn, d.Id(), expandVersioning(v)); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -1369,23 +1351,6 @@ func resourceBucketACLUpdate(conn *s3.S3, d *schema.ResourceData) error {
 	})
 	if err != nil {
 		return fmt.Errorf("Error putting S3 ACL: %s", err)
-	}
-
-	return nil
-}
-
-func resourceBucketInternalVersioningUpdate(conn *s3.S3, bucket string, versioningConfig *s3.VersioningConfiguration) error {
-	input := &s3.PutBucketVersioningInput{
-		Bucket:                  aws.String(bucket),
-		VersioningConfiguration: versioningConfig,
-	}
-
-	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.PutBucketVersioning(input)
-	})
-
-	if err != nil {
-		return fmt.Errorf("error putting S3 versioning for bucket (%s): %w", bucket, err)
 	}
 
 	return nil
@@ -2232,71 +2197,6 @@ func expandS3ObjectLockConfiguration(vConf []interface{}) *s3.ObjectLockConfigur
 }
 
 // Versioning functions
-
-func expandVersioning(l []interface{}) *s3.VersioningConfiguration {
-	if len(l) == 0 || l[0] == nil {
-		return nil
-	}
-
-	tfMap, ok := l[0].(map[string]interface{})
-
-	if !ok {
-		return nil
-	}
-
-	output := &s3.VersioningConfiguration{}
-
-	if v, ok := tfMap["enabled"].(bool); ok {
-		if v {
-			output.Status = aws.String(s3.BucketVersioningStatusEnabled)
-		} else {
-			output.Status = aws.String(s3.BucketVersioningStatusSuspended)
-		}
-	}
-
-	if v, ok := tfMap["mfa_delete"].(bool); ok {
-		if v {
-			output.MFADelete = aws.String(s3.MFADeleteEnabled)
-		} else {
-			output.MFADelete = aws.String(s3.MFADeleteDisabled)
-		}
-	}
-
-	return output
-}
-
-func expandVersioningWhenIsNewResource(l []interface{}) *s3.VersioningConfiguration {
-	if len(l) == 0 || l[0] == nil {
-		return nil
-	}
-
-	tfMap, ok := l[0].(map[string]interface{})
-
-	if !ok {
-		return nil
-	}
-
-	output := &s3.VersioningConfiguration{}
-
-	// Only set and return a non-nil VersioningConfiguration with at least one of
-	// MFADelete or Status enabled as the PutBucketVersioning API request
-	// does not need to be made for new buckets that don't require versioning.
-	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4494
-
-	if v, ok := tfMap["enabled"].(bool); ok && v {
-		output.Status = aws.String(s3.BucketVersioningStatusEnabled)
-	}
-
-	if v, ok := tfMap["mfa_delete"].(bool); ok && v {
-		output.MFADelete = aws.String(s3.MFADeleteEnabled)
-	}
-
-	if output.MFADelete == nil && output.Status == nil {
-		return nil
-	}
-
-	return output
-}
 
 func flattenVersioning(versioning *s3.GetBucketVersioningOutput) []interface{} {
 	if versioning == nil {

--- a/internal/service/s3/bucket_object_data_source_test.go
+++ b/internal/service/s3/bucket_object_data_source_test.go
@@ -548,13 +548,19 @@ func testAccBucketObjectDataSourceConfig_allParams(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.object_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket = aws_s3_bucket.object_bucket.bucket
   key    = "tf-testing-obj-%[1]d-all-params"
 
@@ -586,16 +592,22 @@ func testAccBucketObjectDataSourceConfig_objectLockLegalHoldOff(randInt int) str
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.object_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket                        = aws_s3_bucket.object_bucket.bucket
   key                           = "tf-testing-obj-%[1]d"
   content                       = "Hello World"
@@ -614,16 +626,22 @@ func testAccBucketObjectDataSourceConfig_objectLockLegalHoldOn(randInt int, reta
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.object_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket                        = aws_s3_bucket.object_bucket.bucket
   key                           = "tf-testing-obj-%[1]d"
   content                       = "Hello World"

--- a/internal/service/s3/bucket_object_test.go
+++ b/internal/service/s3/bucket_object_test.go
@@ -2131,19 +2131,24 @@ resource "aws_kms_key" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.test.arn
-        sse_algorithm     = "aws:kms"
-      }
-      bucket_key_enabled = true
+resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.test.arn
+      sse_algorithm     = "aws:kms"
     }
+    bucket_key_enabled = true
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket SSE enabled first
+  depends_on = [aws_s3_bucket_server_side_encryption_configuration.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
   content = %q
@@ -2160,17 +2165,23 @@ resource "aws_kms_key" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.test.arn
-        sse_algorithm     = "aws:kms"
-      }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.test.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket SSE enabled first
+  depends_on = [aws_s3_bucket_server_side_encryption_configuration.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
   content = %[2]q

--- a/internal/service/s3/bucket_object_test.go
+++ b/internal/service/s3/bucket_object_test.go
@@ -474,7 +474,7 @@ func TestAccS3BucketObject_updatesWithVersioningViaAccessPoint(t *testing.T) {
 		CheckDestroy: testAccCheckBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketObjectConfig_updateableViaAccessPoint(rName, true, sourceInitial),
+				Config: testAccBucketObjectConfig_updateableViaAccessPoint(rName, s3.BucketVersioningStatusEnabled, sourceInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketObjectExists(resourceName, &originalObj),
 					testAccCheckBucketObjectBody(&originalObj, "initial versioned object state"),
@@ -483,7 +483,7 @@ func TestAccS3BucketObject_updatesWithVersioningViaAccessPoint(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBucketObjectConfig_updateableViaAccessPoint(rName, true, sourceModified),
+				Config: testAccBucketObjectConfig_updateableViaAccessPoint(rName, s3.BucketVersioningStatusEnabled, sourceModified),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketObjectExists(resourceName, &modifiedObj),
 					testAccCheckBucketObjectBody(&modifiedObj, "modified versioned object"),
@@ -1720,13 +1720,19 @@ func testAccBucketObjectConfig_updateable(rName string, bucketVersioning bool, s
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket_3" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = %[2]t
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.object_bucket_3.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket = aws_s3_bucket.object_bucket_3.bucket
   key    = "updateable-key"
   source = %[3]q
@@ -1735,13 +1741,16 @@ resource "aws_s3_bucket_object" "object" {
 `, rName, bucketVersioning, source)
 }
 
-func testAccBucketObjectConfig_updateableViaAccessPoint(rName string, bucketVersioning bool, source string) string {
+func testAccBucketObjectConfig_updateableViaAccessPoint(rName, bucketVersioning, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = %[2]t
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = %[2]q
   }
 }
 
@@ -1751,6 +1760,9 @@ resource "aws_s3_access_point" "test" {
 }
 
 resource "aws_s3_bucket_object" "test" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket = aws_s3_access_point.test.arn
   key    = "updateable-key"
   source = %[3]q
@@ -1795,13 +1807,19 @@ func testAccBucketObjectConfig_acl(rName string, content, acl string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
   content = %[2]q
@@ -1829,13 +1847,19 @@ func testAccBucketObjectConfig_withTags(rName, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = %[2]q
   content = %[3]q
@@ -1853,13 +1877,19 @@ func testAccBucketObjectConfig_withUpdatedTags(rName, key, content string) strin
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = %[2]q
   content = %[3]q
@@ -1878,13 +1908,19 @@ func testAccBucketObjectConfig_withNoTags(rName, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = %[2]q
   content = %[3]q
@@ -1915,16 +1951,22 @@ func testAccBucketObjectConfig_noObjectLockLegalHold(rName string, content strin
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket        = aws_s3_bucket.test.bucket
   key           = "test-key"
   content       = %[2]q
@@ -1938,16 +1980,22 @@ func testAccBucketObjectConfig_withObjectLockLegalHold(rName string, content, le
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket                        = aws_s3_bucket.test.bucket
   key                           = "test-key"
   content                       = %[2]q
@@ -1962,16 +2010,22 @@ func testAccBucketObjectConfig_noObjectLockRetention(rName string, content strin
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket        = aws_s3_bucket.test.bucket
   key           = "test-key"
   content       = %[2]q
@@ -1985,16 +2039,22 @@ func testAccBucketObjectConfig_withObjectLockRetention(rName string, content, re
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket                        = aws_s3_bucket.test.bucket
   key                           = "test-key"
   content                       = %[2]q

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -974,24 +974,33 @@ POLICY
 resource "aws_s3_bucket" "destination" {
   provider = "awsalternate"
   bucket   = "%[1]s-destination"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination" {
+  bucket = aws_s3_bucket.destination.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket" "source" {
   bucket = "%[1]s-source"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
   }
-}`, rName)
+}
+`, rName)
 }
 
 func testAccBucketReplicationConfigurationBasic(rName, storageClass string) string {
 	return testAccBucketReplicationConfigurationBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1012,6 +1021,8 @@ func testAccBucketReplicationConfigurationRTC(rName string) string {
 	return acctest.ConfigCompose(testAccBucketReplicationConfigurationBase(rName),
 		`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1046,6 +1057,8 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 func testAccBucketReplicationConfigurationReplicaMods(rName string) string {
 	return testAccBucketReplicationConfigurationBase(rName) + `
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1078,22 +1091,36 @@ func testAccBucketReplicationConfigurationWithMultipleDestinationsEmptyFilter(rN
 resource "aws_s3_bucket" "destination2" {
   provider = "awsalternate"
   bucket   = "%[1]s-destination2"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination2" {
+  bucket = aws_s3_bucket.destination2.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket" "destination3" {
   provider = "awsalternate"
   bucket   = "%[1]s-destination3"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination3" {
+  bucket = aws_s3_bucket.destination3.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  # Must have bucket versioning enabled first
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_versioning.destination,
+    aws_s3_bucket_versioning.destination2,
+    aws_s3_bucket_versioning.destination3
+  ]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1147,7 +1174,6 @@ resource "aws_s3_bucket_replication_configuration" "test" {
       storage_class = "ONEZONE_IA"
     }
   }
-
 }`, rName))
 }
 
@@ -1158,22 +1184,30 @@ func testAccBucketReplicationConfigurationWithMultipleDestinationsNonEmptyFilter
 resource "aws_s3_bucket" "destination2" {
   provider = "awsalternate"
   bucket   = "%[1]s-destination2"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination2" {
+  bucket = aws_s3_bucket.destination2.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket" "destination3" {
   provider = "awsalternate"
   bucket   = "%[1]s-destination3"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination3" {
+  bucket = aws_s3_bucket.destination3.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1214,7 +1248,6 @@ resource "aws_s3_bucket_replication_configuration" "test" {
       storage_class = "STANDARD_IA"
     }
   }
-
 }`, rName))
 }
 
@@ -1225,13 +1258,18 @@ func testAccBucketReplicationConfigurationWithMultipleDestinationsTwoDestination
 resource "aws_s3_bucket" "destination2" {
   provider = "awsalternate"
   bucket   = "%[1]s-destination2"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination2" {
+  bucket = aws_s3_bucket.destination2.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1284,6 +1322,8 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1316,6 +1356,8 @@ func testAccBucketReplicationConfigurationWithAccessControlTranslation(rName str
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1342,6 +1384,8 @@ func testAccBucketReplicationConfigurationRulesDestination(rName string) string 
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1370,6 +1414,8 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1403,6 +1449,8 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 func testAccBucketReplicationConfigurationWithoutStorageClass(rName string) string {
 	return testAccBucketReplicationConfigurationBase(rName) + `
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1421,6 +1469,8 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 func testAccBucketReplicationConfigurationWithV2ConfigurationNoTags(rName string) string {
 	return testAccBucketReplicationConfigurationBase(rName) + `
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1468,22 +1518,30 @@ POLICY
 
 resource "aws_s3_bucket" "destination" {
   bucket = %[2]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination" {
+  bucket = aws_s3_bucket.destination.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket" "source" {
   bucket = %[1]q
   acl    = "private"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1533,22 +1591,30 @@ POLICY
 
 resource "aws_s3_bucket" "destination" {
   bucket = %[2]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "destination" {
+  bucket = aws_s3_bucket.destination.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket" "source" {
   bucket = %[1]q
   acl    = "private"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1582,6 +1648,8 @@ func testAccBucketReplicationConfiguration_filter_tag(rName, key, value string) 
 		testAccBucketReplicationConfigurationBase(rName),
 		fmt.Sprintf(`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1613,6 +1681,8 @@ func testAccBucketReplicationConfiguration_filter_andOperator_tags(rName, key1, 
 		testAccBucketReplicationConfigurationBase(rName),
 		fmt.Sprintf(`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1646,6 +1716,8 @@ func testAccBucketReplicationConfiguration_filter_andOperator_prefixAndTags(rNam
 		testAccBucketReplicationConfigurationBase(rName),
 		fmt.Sprintf(`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1678,6 +1750,8 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 func testAccBucketReplicationConfiguration_schemaV2DestinationMetrics_statusOnly(rName, storageClass string) string {
 	return testAccBucketReplicationConfigurationBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 
@@ -1709,6 +1783,8 @@ func testAccBucketReplicationConfigurationWithoutPrefix(rName string) string {
 		testAccBucketReplicationConfigurationBase(rName),
 		`
 resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
 

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -4,6 +4,7 @@ package s3
 // https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#pkg-constants
 
 const (
+	ErrCodeInvalidBucketState                        = "InvalidBucketState"
 	ErrCodeMethodNotAllowed                          = "MethodNotAllowed"
 	ErrCodeNoSuchBucketPolicy                        = "NoSuchBucketPolicy"
 	ErrCodeNoSuchConfiguration                       = "NoSuchConfiguration"

--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -577,13 +577,19 @@ func testAccObjectDataSourceConfig_allParams(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "object_bucket" {
+  bucket = aws_s3_bucket.object_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_object" "object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.object_bucket]
+
   bucket = aws_s3_bucket.object_bucket.bucket
   key    = "tf-testing-obj-%[1]d-all-params"
 
@@ -615,12 +621,15 @@ func testAccObjectDataSourceConfig_objectLockLegalHoldOff(randInt int) string {
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "object_bucket" {
+  bucket = aws_s3_bucket.object_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -643,12 +652,15 @@ func testAccObjectDataSourceConfig_objectLockLegalHoldOn(randInt int, retainUnti
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "object_bucket" {
+  bucket = aws_s3_bucket.object_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -1677,9 +1677,12 @@ func testAccObjectConfig_updateable(rName string, bucketVersioning bool, source 
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket_3" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = %[2]t
+resource "aws_s3_bucket_versioning" "object_bucket_3" {
+  bucket = aws_s3_bucket.object_bucket_3.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1696,9 +1699,12 @@ func testAccObjectConfig_updateableViaAccessPoint(rName string, bucketVersioning
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = %[2]t
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1752,9 +1758,12 @@ func testAccObjectConfig_acl(rName string, content, acl string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1786,9 +1795,12 @@ func testAccObjectConfig_withTags(rName, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1810,9 +1822,12 @@ func testAccObjectConfig_withUpdatedTags(rName, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1835,9 +1850,12 @@ func testAccObjectConfig_withNoTags(rName, key, content string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1872,12 +1890,15 @@ func testAccObjectConfig_noObjectLockLegalHold(rName string, content string) str
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1895,12 +1916,15 @@ func testAccObjectConfig_withObjectLockLegalHold(rName string, content, legalHol
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1919,12 +1943,15 @@ func testAccObjectConfig_noObjectLockRetention(rName string, content string) str
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -1942,12 +1969,15 @@ func testAccObjectConfig_withObjectLockRetention(rName string, content, retainUn
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -2058,19 +2058,24 @@ resource "aws_kms_key" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.test.arn
-        sse_algorithm     = "aws:kms"
-      }
-      bucket_key_enabled = true
+resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.test.arn
+      sse_algorithm     = "aws:kms"
     }
+    bucket_key_enabled = true
   }
 }
 
 resource "aws_s3_object" "object" {
+  # Must have bucket SSE enabled first
+  depends_on = [aws_s3_bucket_server_side_encryption_configuration.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
   content = %q
@@ -2087,17 +2092,23 @@ resource "aws_kms_key" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.test.arn
-        sse_algorithm     = "aws:kms"
-      }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.test.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }
 
 resource "aws_s3_object" "object" {
+  # Must have bucket SSE enabled first
+  depends_on = [aws_s3_bucket_server_side_encryption_configuration.test]
+
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
   content = %[2]q

--- a/internal/service/signer/signing_job_data_source_test.go
+++ b/internal/service/signer/signing_job_data_source_test.go
@@ -42,13 +42,15 @@ resource "aws_signer_signing_profile" "test" {
 }
 
 resource "aws_s3_bucket" "source" {
-  bucket = "%[1]s-source"
-
-  versioning {
-    enabled = true
-  }
-
+  bucket        = "%[1]s-source"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket" "destination" {
@@ -57,6 +59,9 @@ resource "aws_s3_bucket" "destination" {
 }
 
 resource "aws_s3_object" "source" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.bucket
   key    = "lambdatest.zip"
   source = "test-fixtures/lambdatest.zip"

--- a/internal/service/signer/signing_job_test.go
+++ b/internal/service/signer/signing_job_test.go
@@ -51,13 +51,15 @@ resource "aws_signer_signing_profile" "test" {
 }
 
 resource "aws_s3_bucket" "source" {
-  bucket = "%[1]s-source"
-
-  versioning {
-    enabled = true
-  }
-
+  bucket        = "%[1]s-source"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket" "destination" {
@@ -66,6 +68,9 @@ resource "aws_s3_bucket" "destination" {
 }
 
 resource "aws_s3_object" "source" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.source]
+
   bucket = aws_s3_bucket.source.bucket
   key    = "lambdatest.zip"
   source = "test-fixtures/lambdatest.zip"

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -637,12 +637,15 @@ resource "aws_s3_bucket" "test" {
   acl           = "private"
   force_destroy = true
 
-  versioning {
-    enabled = true
-  }
-
   tags = {
     Name = %[1]q
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
@@ -803,6 +806,9 @@ resource "aws_synthetics_canary" "test" {
 func testAccCanaryBasicConfig(rName string) string {
 	return acctest.ConfigCompose(testAccCanaryBaseConfig(rName), fmt.Sprintf(`
 resource "aws_synthetics_canary" "test" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   name                 = %[1]q
   artifact_s3_location = "s3://${aws_s3_bucket.test.bucket}/"
   execution_role_arn   = aws_iam_role.test.arn
@@ -957,6 +963,9 @@ resource "aws_synthetics_canary" "test" {
 }
 
 resource "aws_s3_object" "test" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.test]
+
   bucket = aws_s3_bucket.test.bucket
   key    = %[1]q
   source = "test-fixtures/lambdatest.zip"

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -1318,6 +1318,64 @@ The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
 ```
 
+### `versioning` Argument deprecation
+
+Switch your Terraform configuration to the `aws_s3_bucket_versioning` resource instead.
+
+For example, given this previous configuration:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+  versioning {
+    enabled = true
+  }
+}
+```
+
+It will receive the following error after upgrading:
+
+```
+│ Error: Value for unconfigurable attribute
+│
+│   with aws_s3_bucket.example,
+│   on main.tf line 1, in resource "aws_s3_bucket" "example":
+│    1: resource "aws_s3_bucket" "example" {
+│
+│ Can't configure a value for "versioning": its value will be decided automatically based on the result of applying this configuration.
+```
+
+Since the `versioning` argument changed to read-only, the recommendation is to update the configuration to use the `aws_s3_bucket_versioning`
+resource and remove any references to `versioning` and its nested arguments in the `aws_s3_bucket` resource:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+```
+
+It is then recommended running `terraform import` on each new resource to prevent data loss, e.g.
+
+```shell
+$ terraform import aws_s3_bucket_versioning.example example
+aws_s3_bucket_versioning.example: Importing from ID "example"...
+aws_s3_bucket_versioning.example: Import prepared!
+  Prepared aws_s3_bucket_versioning for import
+aws_s3_bucket_versioning.example: Refreshing state... [id=example]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
 ### `website`, `website_domain`, and `website_endpoint` Argument deprecation
 
 Switch your Terraform configuration to the `aws_s3_bucket_website_configuration` resource instead.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -44,20 +44,8 @@ See the [`aws_s3_bucket_cors_configuration` resource](s3_bucket_cors_configurati
 
 ### Using versioning
 
-```terraform
-resource "aws_s3_bucket" "b" {
-  bucket = "my-tf-test-bucket"
-
-  versioning {
-    enabled = true
-  }
-}
-
-resource "aws_s3_bucket_acl" "example" {
-  bucket = aws_s3_bucket.b.id
-  acl    = "private"
-}
-```
+The `versioning` argument is read-only as of version 4.0 of the Terraform AWS Provider.
+See the [`aws_s3_bucket_versioning` resource](s3_bucket_versioning.html.markdown) for configuration details.
 
 ### Enable Logging
 
@@ -111,13 +99,7 @@ The following arguments are supported:
 * `grant` - (Optional) An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
 * `tags` - (Optional) A map of tags to assign to the bucket. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
-* `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 * `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
-
-The `versioning` object supports the following:
-
-* `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
-* `mfa_delete` - (Optional) Enable MFA delete for either `Change the versioning state of your bucket` or `Permanently delete an object version`. Default is `false`. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS
 
 The `grant` object supports the following:
 
@@ -222,6 +204,9 @@ In addition to all arguments above, the following attributes are exported:
             * `sse_algorithm` - (required) The server-side encryption algorithm used.
         * `bucket_key_enabled` - (Optional) Whether an [Amazon S3 Bucket Key](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) is used for SSE-KMS.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `versioning` - The [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) state of the bucket.
+    * `enabled` - Whether versioning is enabled.
+    * `mfa_delete` - Whether MFA delete is enabled.
 * `website` - The website configuration, if configured.
     * `error_document` - The name of the error document for the website.
     * `index_document` - The name of the index document for the website.

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -70,13 +70,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket-config" {
 resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "my-versioning-bucket"
   acl    = "private"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.versioning_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "versioning-bucket-config" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.versioning]
+
   bucket = aws_s3_bucket.versioning_bucket.bucket
 
   rule {

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -89,16 +89,23 @@ resource "aws_s3_bucket" "examplebucket" {
   bucket = "examplebuckettftest"
   acl    = "private"
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.examplebucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_object" "example" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.example]
+
   key    = "someobject"
   bucket = aws_s3_bucket.examplebucket.id
   source = "important.txt"

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -87,16 +87,19 @@ resource "aws_s3_bucket" "examplebucket" {
   bucket = "examplebuckettftest"
   acl    = "private"
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
-resource "aws_s3_object" "example" {
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.examplebucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "examplebucket_object" {
   key    = "someobject"
   bucket = aws_s3_bucket.examplebucket.id
   source = "important.txt"

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -100,6 +100,9 @@ resource "aws_s3_bucket_versioning" "example" {
 }
 
 resource "aws_s3_object" "examplebucket_object" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.example]
+
   key    = "someobject"
   bucket = aws_s3_bucket.examplebucket.id
   source = "important.txt"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433
Preceded by https://github.com/hashicorp/terraform-provider-aws/pull/5132
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccSyntheticsCanary_StartCanary_codeChanges (106.18s)
--- PASS: TestAccSyntheticsCanary_artifactEncryption (81.56s)
--- PASS: TestAccSyntheticsCanary_basic (126.11s)
--- PASS: TestAccSyntheticsCanary_disappears (270.06s)
--- PASS: TestAccSyntheticsCanary_run (129.72s)
--- PASS: TestAccSyntheticsCanary_runTracing (97.99s)
--- PASS: TestAccSyntheticsCanary_runtimeVersion (160.74s)
--- PASS: TestAccSyntheticsCanary_s3 (261.51s)
--- PASS: TestAccSyntheticsCanary_startCanary (109.43s)
--- PASS: TestAccSyntheticsCanary_vpc (2100.24s)
--- PASS: TestAccSyntheticsCanary_tags (108.12s)

--- PASS: TestAccAPIGatewayDomainNameDataSource_basic (140.77s)
--- PASS: TestAccAPIGatewayDomainName_disappears (26.83s)
--- PASS: TestAccAPIGatewayDomainName_regionalCertificateARN (128.30s)
--- PASS: TestAccAPIGatewayDomainName_securityPolicy (70.09s)
--- PASS: TestAccAPIGatewayDomainName_tags (113.63s)

--- PASS: TestAccAPIGatewayV2DomainName_basic (690.64s)
--- PASS: TestAccAPIGatewayV2DomainName_disappears (442.05s)
--- PASS: TestAccAPIGatewayV2DomainName_tags (262.47s)
--- PASS: TestAccAPIGatewayV2DomainName_updateCertificate (512.81s)

--- PASS: TestAccKafkaConnectCustomPluginDataSource_basic (76.36s)
--- PASS: TestAccKafkaConnectCustomPlugin_basic (74.70s)
--- PASS: TestAccKafkaConnectCustomPlugin_contentType (93.52s)
--- PASS: TestAccKafkaConnectCustomPlugin_description (71.83s)
--- PASS: TestAccKafkaConnectCustomPlugin_objectVersion (72.25s)

--- PASS: TestAccLambdaFunctionDataSource_alias (106.83s)
--- PASS: TestAccLambdaFunctionDataSource_architectures (104.38s)
--- PASS: TestAccLambdaFunctionDataSource_basic (105.93s)
--- PASS: TestAccLambdaFunctionDataSource_environment (105.90s)
--- PASS: TestAccLambdaFunctionDataSource_fileSystem (396.58s)
--- PASS: TestAccLambdaFunctionDataSource_layers (98.92s)
--- PASS: TestAccLambdaFunctionDataSource_version (91.70s)
--- PASS: TestAccLambdaFunctionDataSource_vpc (476.88s)

--- PASS: TestAccLambdaFunctionEventInvokeConfig_DestinationOnFailure_destination (200.01s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_DestinationOnSuccess_destination (189.50s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Destination_remove (172.57s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Destination_swap (169.73s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Disappears_lambdaFunction (93.63s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Disappears_lambdaFunctionEventInvoke (94.20s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_FunctionName_arn (104.47s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_QualifierFunctionName_arn (101.26s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Qualifier_aliasName (104.68s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Qualifier_functionVersion (94.25s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Qualifier_latest (96.52s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_basic (102.77s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_maximumEventAgeInSeconds (144.38s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_maximumRetryAttempts (224.50s)

--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (110.30s)
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (101.29s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (83.66s)
--- PASS: TestAccLambdaFunction_S3Update_basic (80.99s)
--- PASS: TestAccLambdaFunction_S3Update_unversioned (78.00s)
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (301.22s)
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (1543.59s)
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (1348.89s)
--- PASS: TestAccLambdaFunction_VPC_withInvocation (270.01s)
--- PASS: TestAccLambdaFunction_Zip_validation (8.53s)
--- PASS: TestAccLambdaFunction_architectures (168.65s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (164.85s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (158.54s)
--- PASS: TestAccLambdaFunction_basic (95.11s)
--- PASS: TestAccLambdaFunction_codeSigning (238.85s)
--- PASS: TestAccLambdaFunction_concurrency (169.52s)
--- PASS: TestAccLambdaFunction_concurrencyCycle (224.18s)
--- PASS: TestAccLambdaFunction_deadLetter (174.92s)
--- PASS: TestAccLambdaFunction_deadLetterUpdated (174.37s)
--- PASS: TestAccLambdaFunction_disablePublish (159.95s)
--- PASS: TestAccLambdaFunction_disappears (89.03s)
--- PASS: TestAccLambdaFunction_emptyVPC (55.82s)
--- PASS: TestAccLambdaFunction_enablePublish (210.02s)
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (171.54s)
--- PASS: TestAccLambdaFunction_envVariables (285.01s)
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (36.19s)
--- PASS: TestAccLambdaFunction_fileSystem (654.39s)
--- PASS: TestAccLambdaFunction_layers (104.54s)
--- PASS: TestAccLambdaFunction_layersUpdate (140.65s)
--- PASS: TestAccLambdaFunction_localUpdate (84.12s)
--- PASS: TestAccLambdaFunction_nilDeadLetter (41.09s)
--- PASS: TestAccLambdaFunction_runtimes (426.18s)
--- PASS: TestAccLambdaFunction_s3 (64.86s)
--- PASS: TestAccLambdaFunction_tags (92.07s)
--- PASS: TestAccLambdaFunction_tracing (152.86s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (161.91s)
--- PASS: TestAccLambdaFunction_versioned (102.20s)
--- PASS: TestAccLambdaFunction_versionedUpdate (225.75s)
--- PASS: TestAccLambdaFunction_vpc (428.91s)
--- PASS: TestAccLambdaFunction_vpcRemoval (269.40s)
--- PASS: TestAccLambdaFunction_vpcUpdate (670.95s)

--- PASS: TestAccMWAAEnvironment_airflowOptions (3625.80s)
--- PASS: TestAccMWAAEnvironment_basic (2183.48s)
--- PASS: TestAccMWAAEnvironment_disappears (2131.30s)
--- PASS: TestAccMWAAEnvironment_full (2005.08s)
--- PASS: TestAccMWAAEnvironment_log (2922.35s)
--- PASS: TestAccMWAAEnvironment_pluginsS3ObjectVersion (2894.48s)

--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (15.27s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (170.61s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (170.12s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (173.28s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (168.21s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (171.71s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (104.94s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (15.51s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (104.01s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (102.49s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (156.95s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (249.56s)

--- PASS: TestAccS3BucketDataSource_basic (91.08s)
--- PASS: TestAccS3BucketDataSource_website (91.58s)

--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (385.84s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (103.55s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (86.63s)

--- PASS: TestAccS3BucketInventory_basic (105.25s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (103.03s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (103.35s)

--- PASS: TestAccS3BucketMetric_basic (102.96s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (16.25s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (171.05s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (169.50s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (169.48s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (171.71s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (169.72s)

--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (116.97s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (100.55s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (118.74s)
--- PASS: TestAccS3BucketNotification_queue (127.71s)
--- PASS: TestAccS3BucketNotification_topic (99.71s)
--- PASS: TestAccS3BucketNotification_update (186.15s)

--- PASS: TestAccS3BucketObjectDataSource_allParams (92.35s)
--- PASS: TestAccS3BucketObjectDataSource_basic (89.08s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (89.74s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (90.39s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (90.53s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (159.14s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (160.37s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (91.84s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (87.51s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (90.06s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (88.40s)

--- PASS: TestAccS3BucketObject_acl (254.78s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (94.74s)
--- PASS: TestAccS3BucketObject_content (101.41s)
--- PASS: TestAccS3BucketObject_contentBase64 (87.64s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (94.45s)
--- PASS: TestAccS3BucketObject_empty (100.39s)
--- PASS: TestAccS3BucketObject_etagEncryption (101.19s)
--- PASS: TestAccS3BucketObject_ignoreTags (165.24s)
--- PASS: TestAccS3BucketObject_kms (101.10s)
--- PASS: TestAccS3BucketObject_metadata (252.14s)
--- PASS: TestAccS3BucketObject_noNameNoKey (24.48s)
--- PASS: TestAccS3BucketObject_nonVersioned (101.17s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (94.09s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (240.51s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (168.08s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (240.92s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (313.10s)
--- PASS: TestAccS3BucketObject_source (102.12s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (176.44s)
--- PASS: TestAccS3BucketObject_sse (100.38s)
--- PASS: TestAccS3BucketObject_storageClass (398.75s)
--- PASS: TestAccS3BucketObject_tags (321.27s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (312.68s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (324.23s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (310.26s)
--- PASS: TestAccS3BucketObject_updateSameFile (163.03s)
--- PASS: TestAccS3BucketObject_updates (174.78s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (175.37s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (162.71s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (88.02s)

--- PASS: TestAccS3BucketObjectsDataSource_all (171.65s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (174.72s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (168.75s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (169.07s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (169.57s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (165.57s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (171.38s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (165.48s)

--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (78.52s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (182.04s)
--- PASS: TestAccS3BucketOwnershipControls_basic (102.61s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (89.54s)

--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (385.23s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (274.07s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (290.82s)
--- PASS: TestAccS3BucketPolicy_basic (105.20s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (187.53s)

--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (80.41s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (107.62s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (257.09s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (256.24s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (91.52s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (256.46s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (256.59s)

--- PASS: TestAccS3BucketReplicationConfiguration_basic (553.19s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (498.55s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (491.88s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (143.87s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (384.81s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (369.33s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (407.94s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (408.23s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (402.69s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (402.48s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (397.85s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (370.48s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (234.97s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (407.45s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (328.23s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (401.99s)

--- PASS: TestAccS3BucketVersioning_MFADelete (67.36s)
--- PASS: TestAccS3BucketVersioning_basic (105.48s)
--- PASS: TestAccS3BucketVersioning_disappears (96.21s)
--- PASS: TestAccS3BucketVersioning_update (142.36s)

--- PASS: TestAccS3Bucket_Basic_acceleration (69.85s)
--- PASS: TestAccS3Bucket_Basic_basic (70.03s)
--- PASS: TestAccS3Bucket_Basic_emptyString (69.02s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (95.26s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (95.58s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (96.34s)
--- PASS: TestAccS3Bucket_Basic_generatedName (40.49s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (74.27s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (44.31s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (65.42s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (52.39s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (224.97s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (169.96s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (94.09s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (79.95s)
--- PASS: TestAccS3Bucket_Manage_objectLock (151.23s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (180.92s)
--- PASS: TestAccS3Bucket_Replication_basic (295.99s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (71.98s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (161.75s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (167.99s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (222.45s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (219.80s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (250.26s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (113.02s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (164.36s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (153.88s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (163.48s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (84.98s)
--- PASS: TestAccS3Bucket_Security_corsDelete (72.53s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (84.62s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (144.35s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (139.04s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (71.24s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (64.31s)
--- PASS: TestAccS3Bucket_Security_grantToACL (92.76s)
--- PASS: TestAccS3Bucket_Security_logging (90.47s)
--- PASS: TestAccS3Bucket_Security_policy (114.83s)
--- PASS: TestAccS3Bucket_Security_updateACL (68.61s)
--- PASS: TestAccS3Bucket_Security_updateGrant (138.14s)
--- PASS: TestAccS3Bucket_Tags_basic (48.67s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (72.65s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (155.48s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (187.07s)
--- PASS: TestAccS3Bucket_Web_redirect (174.88s)
--- PASS: TestAccS3Bucket_Web_routingRules (111.10s)
--- PASS: TestAccS3Bucket_Web_simple (164.73s)

--- PASS: TestBucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestFlattenImageConfigShouldNotFailWithEmptyImageConfig (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)

--- SKIP: TestAccAPIGatewayDomainName_certificateARN (0.00s)
--- SKIP: TestAccAPIGatewayDomainName_certificateName (0.00s)
--- SKIP: TestAccAPIGatewayDomainName_mutualTLSAuthentication (0.00s)
--- SKIP: TestAccAPIGatewayDomainName_regionalCertificateName (0.00s)

--- SKIP: TestAccAPIGatewayV2DomainName_mutualTLSAuthentication (0.00s)

--- SKIP: TestAccLambdaFunctionDataSource_image (1.07s)

--- SKIP: TestAccLambdaFunction_image (0.94s)

--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)

--- SKIP: TestAccSignerSigningJobDataSource_basic (0.75s)

--- SKIP: TestAccSignerSigningJob_basic (0.87s)
```
