### PR TITLE
r/s3_bucket: read-only `acceleration_status` argument

### DIFF
--- a/.changelog/22610.txt
+++ b/.changelog/22610.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket: The `acceleration_status` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_accelerate_configuration` resource instead.
+```

--- a/.changelog/22610.txt
+++ b/.changelog/22610.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_s3_bucket: The `acceleration_status` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_accelerate_configuration` resource instead.
 ```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -381,10 +381,9 @@ func ResourceBucket() *schema.Resource {
 			},
 
 			"acceleration_status": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(s3.BucketAccelerateStatus_Values(), false),
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use the aws_s3_bucket_accelerate_configuration resource instead",
 			},
 
 			"request_payer": {
@@ -804,12 +803,6 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("acceleration_status") {
-		if err := resourceBucketAccelerationUpdate(conn, d); err != nil {
-			return err
-		}
-	}
-
 	if d.HasChange("replication_configuration") {
 		if err := resourceBucketInternalReplicationConfigurationUpdate(conn, d); err != nil {
 			return err
@@ -1007,9 +1000,10 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	// Amazon S3 Transfer Acceleration might not be supported in the region
-	if err != nil && !tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") && !tfawserr.ErrMessageContains(err, "UnsupportedArgument", "") {
-		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument) {
+		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %w", err)
 	}
+
 	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {
 		d.Set("acceleration_status", accelerate.Status)
 	}
@@ -1644,28 +1638,6 @@ func resourceBucketInternalLoggingUpdate(conn *s3.S3, d *schema.ResourceData) er
 	})
 	if err != nil {
 		return fmt.Errorf("Error putting S3 logging: %s", err)
-	}
-
-	return nil
-}
-
-func resourceBucketAccelerationUpdate(conn *s3.S3, d *schema.ResourceData) error {
-	bucket := d.Get("bucket").(string)
-	enableAcceleration := d.Get("acceleration_status").(string)
-
-	i := &s3.PutBucketAccelerateConfigurationInput{
-		Bucket: aws.String(bucket),
-		AccelerateConfiguration: &s3.AccelerateConfiguration{
-			Status: aws.String(enableAcceleration),
-		},
-	}
-	log.Printf("[DEBUG] S3 put bucket acceleration: %#v", i)
-
-	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.PutBucketAccelerateConfiguration(i)
-	})
-	if err != nil {
-		return fmt.Errorf("Error putting S3 acceleration: %s", err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_accelerate_configuration_test.go
+++ b/internal/service/s3/bucket_accelerate_configuration_test.go
@@ -192,12 +192,6 @@ func testAccBucketAccelerateConfigurationBasicConfig(bucketName, status string) 
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-
-  lifecycle {
-    ignore_changes = [
-      acceleration_status
-    ]
-  }
 }
 
 resource "aws_s3_bucket_accelerate_configuration" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -367,43 +366,6 @@ func TestAccS3Bucket_Basic_generatedName(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy", "acl", "bucket_prefix"},
-			},
-		},
-	})
-}
-
-func TestAccS3Bucket_Basic_acceleration(t *testing.T) {
-	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
-	resourceName := "aws_s3_bucket.bucket"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckPartitionHasService(cloudfront.EndpointsID, t)
-		},
-		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckBucketDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBucketWithAccelerationConfig(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "acceleration_status", "Enabled"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
-			},
-			{
-				Config: testAccBucketWithoutAccelerationConfig(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "acceleration_status", "Suspended"),
-				),
 			},
 		},
 	})
@@ -3041,24 +3003,6 @@ resource "aws_s3_bucket_acl" "test6" {
   acl    = "private"
 }
 `, randInt)
-}
-
-func testAccBucketWithAccelerationConfig(bucketName string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
-  bucket              = %[1]q
-  acceleration_status = "Enabled"
-}
-`, bucketName)
-}
-
-func testAccBucketWithoutAccelerationConfig(bucketName string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
-  bucket              = %[1]q
-  acceleration_status = "Suspended"
-}
-`, bucketName)
 }
 
 func testAccBucketWithPolicyConfig(bucketName, partition string) string {

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -4,6 +4,7 @@ package s3
 // https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#pkg-constants
 
 const (
+	ErrCodeMethodNotAllowed                          = "MethodNotAllowed"
 	ErrCodeNoSuchConfiguration                       = "NoSuchConfiguration"
 	ErrCodeNoSuchCORSConfiguration                   = "NoSuchCORSConfiguration"
 	ErrCodeNoSuchLifecycleConfiguration              = "NoSuchLifecycleConfiguration"
@@ -13,4 +14,5 @@ const (
 	ErrCodeObjectLockConfigurationNotFound           = "ObjectLockConfigurationNotFoundError"
 	ErrCodeOperationAborted                          = "OperationAborted"
 	ErrCodeServerSideEncryptionConfigurationNotFound = "ServerSideEncryptionConfigurationNotFoundError"
+	ErrCodeUnsupportedArgument                       = "UnsupportedArgument"
 )

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -689,6 +689,60 @@ To help distribute the management of S3 bucket settings via independent resource
 have become read-only. Configurations dependent on these arguments should be updated to use the corresponding `aws_s3_bucket_*` resource.
 Once updated, new `aws_s3_bucket_*` resources should be imported into Terraform state.
 
+### `acceleration_status` Argument deprecation
+
+Switch your Terraform configuration to the `aws_s3_bucket_accelerate_configuration` resource instead.
+
+For example, given this previous configuration:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+  acceleration_status = "Enabled"
+}
+```
+
+It will receive the following error after upgrading:
+
+```
+│ Error: Value for unconfigurable attribute
+│
+│   with aws_s3_bucket.example,
+│   on main.tf line 1, in resource "aws_s3_bucket" "example":
+│    1: resource "aws_s3_bucket" "example" {
+│
+│ Can't configure a value for "acceleration_status": its value will be decided automatically based on the result of applying this configuration.
+```
+
+Since the `acceleration_status` argument changed to read-only, the recommendation is to update the configuration to use the `aws_s3_bucket_accelerate_configuration`
+resource and remove any reference to `acceleration_status` in the `aws_s3_bucket` resource:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+}
+
+resource "aws_s3_bucket_accelerate_configuration" "example" {
+  bucket = aws_s3_bucket.example.id
+  status = "Enabled"
+}
+```
+
+It is then recommended running `terraform import` on each new resource to prevent data loss, e.g.
+
+```shell
+$ terraform import aws_s3_bucket_accelerate_configuration.example example
+aws_s3_bucket_accelerate_configuration.example: Importing from ID "example"...
+aws_s3_bucket_accelerate_configuration.example: Import prepared!
+  Prepared aws_s3_bucket_accelerate_configuration for import
+aws_s3_bucket_accelerate_configuration.example: Refreshing state... [id=example]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
 ### `cors_rule` Argument deprecation
 
 Switch your Terraform configuration to the `aws_s3_bucket_cors_configuration` resource instead.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -358,15 +358,9 @@ The following arguments are supported:
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 * `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 * `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
-* `acceleration_status` - (Optional) Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
-Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
-the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
-developer guide for more information.
 * `replication_configuration` - (Optional) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 * `server_side_encryption_configuration` - (Optional) A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
 * `object_lock_configuration` - (Optional) A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
-
-~> **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
 
 The `versioning` object supports the following:
 
@@ -532,6 +526,7 @@ Once you create a bucket with S3 Object Lock enabled, you can't disable Object L
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the bucket.
+* `acceleration_status` - (Optional) The accelerate configuration status of the bucket. Not available in `cn-north-1` or `us-gov-west-1`.
 * `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 * `bucket_regional_domain_name` - The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (15.92s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (170.79s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (173.46s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (174.41s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (173.31s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (173.51s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (103.19s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (15.04s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (102.43s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (103.17s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (158.84s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (250.25s)

--- PASS: TestAccS3BucketDataSource_basic (93.30s)
--- PASS: TestAccS3BucketDataSource_website (92.71s)

--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (388.23s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (104.63s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (92.88s)

--- PASS: TestAccS3BucketInventory_basic (105.09s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (105.51s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (104.33s)

--- PASS: TestAccS3BucketMetric_basic (102.63s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (16.29s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (172.37s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (174.48s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (174.31s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (172.99s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (171.45s)

--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (120.11s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (104.80s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (129.65s)
--- PASS: TestAccS3BucketNotification_queue (132.34s)
--- PASS: TestAccS3BucketNotification_topic (102.56s)
--- PASS: TestAccS3BucketNotification_update (188.99s)

--- PASS: TestAccS3BucketObjectDataSource_allParams (91.84s)
--- PASS: TestAccS3BucketObjectDataSource_basic (87.66s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (94.17s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (91.41s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (91.21s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (162.88s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (163.53s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (92.44s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (88.20s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (92.39s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (92.30s)

--- PASS: TestAccS3BucketObject_acl (255.57s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (94.12s)
--- PASS: TestAccS3BucketObject_content (103.96s)
--- PASS: TestAccS3BucketObject_contentBase64 (89.63s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (93.29s)
--- PASS: TestAccS3BucketObject_empty (104.30s)
--- PASS: TestAccS3BucketObject_etagEncryption (102.77s)
--- PASS: TestAccS3BucketObject_ignoreTags (170.08s)
--- PASS: TestAccS3BucketObject_kms (102.29s)
--- PASS: TestAccS3BucketObject_metadata (257.10s)
--- PASS: TestAccS3BucketObject_noNameNoKey (23.41s)
--- PASS: TestAccS3BucketObject_nonVersioned (100.87s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (95.84s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (244.29s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (170.47s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (242.77s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (317.22s)
--- PASS: TestAccS3BucketObject_source (104.04s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (177.44s)
--- PASS: TestAccS3BucketObject_sse (105.50s)
--- PASS: TestAccS3BucketObject_storageClass (406.67s)
--- PASS: TestAccS3BucketObject_tags (328.40s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (319.54s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (325.90s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (316.99s)
--- PASS: TestAccS3BucketObject_updateSameFile (165.69s)
--- PASS: TestAccS3BucketObject_updates (178.30s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (175.50s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (167.00s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (90.98s)

--- PASS: TestAccS3BucketObjectsDataSource_all (171.09s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (170.17s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (169.88s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (171.78s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (169.30s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (171.63s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (173.14s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (172.91s)

--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (79.30s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (185.89s)
--- PASS: TestAccS3BucketOwnershipControls_basic (106.87s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (90.36s)

--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (377.74s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (283.23s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (296.42s)

--- PASS: TestAccS3BucketPolicy_basic (105.43s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (187.38s)

--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (80.78s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (107.47s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (256.33s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (251.33s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (91.81s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (252.53s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (249.35s)

--- PASS: TestAccS3BucketReplicationConfiguration_basic (546.66s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (496.87s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (484.87s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (143.70s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (362.20s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (364.50s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (408.50s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (406.62s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (398.14s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (399.96s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (394.49s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (371.39s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (236.91s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (408.63s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (317.60s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (400.40s)

--- PASS: TestAccS3BucketVersioning_MFADelete (58.56s)
--- PASS: TestAccS3BucketVersioning_basic (97.08s)
--- PASS: TestAccS3BucketVersioning_disappears (87.84s)
--- PASS: TestAccS3BucketVersioning_update (145.05s)

--- PASS: TestAccS3Bucket_Basic_basic (62.94s)
--- PASS: TestAccS3Bucket_Basic_emptyString (62.95s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (96.49s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (95.48s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (96.41s)
--- PASS: TestAccS3Bucket_Basic_generatedName (35.14s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (66.70s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (39.08s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (62.93s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (49.48s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (69.01s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (232.74s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (182.17s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (108.62s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (91.56s)
--- PASS: TestAccS3Bucket_Manage_objectLock (151.91s)
--- PASS: TestAccS3Bucket_Manage_versioning (155.82s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (75.79s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (68.90s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (256.45s)
--- PASS: TestAccS3Bucket_Replication_basic (307.43s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (85.43s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (176.64s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (172.64s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (230.81s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (220.84s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (298.67s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (115.22s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (171.72s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (160.59s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (166.47s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (61.88s)
--- PASS: TestAccS3Bucket_Security_corsDelete (66.00s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (87.10s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (160.55s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (121.05s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (58.93s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (56.78s)
--- PASS: TestAccS3Bucket_Security_grantToACL (77.11s)
--- PASS: TestAccS3Bucket_Security_logging (99.01s)
--- PASS: TestAccS3Bucket_Security_policy (95.44s)
--- PASS: TestAccS3Bucket_Security_updateACL (58.94s)
--- PASS: TestAccS3Bucket_Security_updateGrant (103.94s)
--- PASS: TestAccS3Bucket_Tags_basic (38.09s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (62.16s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (140.13s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (176.02s)
--- PASS: TestAccS3Bucket_Web_redirect (169.72s)
--- PASS: TestAccS3Bucket_Web_routingRules (105.39s)
--- PASS: TestAccS3Bucket_Web_simple (166.59s)

--- PASS: TestBucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
```
