### PR TITLE
r/s3_bucket:  read-only `object_lock_configuration` `rule` argument

### DIFF
--- a/.changelog/22612.txt
+++ b/.changelog/22612.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket: The `object_lock_configuration` `rule` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_object_lock_configuration` resource instead.
+```

--- a/.changelog/22612.txt
+++ b/.changelog/22612.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_s3_bucket: The `object_lock_configuration` `rule` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_object_lock_configuration` resource instead.
 ```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -603,6 +603,7 @@ func ResourceBucket() *schema.Resource {
 			"object_lock_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1045,10 +1045,16 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if err != nil {
+		log.Printf("[WARN] Unable to read S3 bucket (%s) Object Lock Configuration: %s", d.Id(), err)
+	}
+
 	if output, ok := resp.(*s3.GetObjectLockConfigurationOutput); ok {
 		if err := d.Set("object_lock_configuration", flattenS3ObjectLockConfiguration(output.ObjectLockConfiguration)); err != nil {
 			return fmt.Errorf("error setting object_lock_configuration: %w", err)
 		}
+	} else {
+		d.Set("object_lock_configuration", nil)
 	}
 
 	// Add the region as an attribute

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -614,34 +614,33 @@ func ResourceBucket() *schema.Resource {
 						},
 
 						"rule": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:       schema.TypeList,
+							Computed:   true,
+							Deprecated: "Use the aws_s3_bucket_object_lock_configuration resource instead",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"default_retention": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										MaxItems: 1,
+										Type:       schema.TypeList,
+										Computed:   true,
+										Deprecated: "Use the aws_s3_bucket_object_lock_configuration resource instead",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"mode": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringInSlice(s3.ObjectLockRetentionMode_Values(), false),
+													Type:       schema.TypeString,
+													Computed:   true,
+													Deprecated: "Use the aws_s3_bucket_object_lock_configuration resource instead",
 												},
 
 												"days": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(1),
+													Type:       schema.TypeInt,
+													Computed:   true,
+													Deprecated: "Use the aws_s3_bucket_object_lock_configuration resource instead",
 												},
 
 												"years": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.IntAtLeast(1),
+													Type:       schema.TypeInt,
+													Computed:   true,
+													Deprecated: "Use the aws_s3_bucket_object_lock_configuration resource instead",
 												},
 											},
 										},
@@ -1033,20 +1032,22 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Object Lock configuration.
-	conf, err := readS3ObjectLockConfiguration(conn, d.Id())
+	resp, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.GetObjectLockConfiguration(&s3.GetObjectLockConfigurationInput{
+			Bucket: aws.String(d.Id()),
+		})
+	})
 
 	// Object lock not supported in all partitions (extra guard, also guards in read func)
-	if err != nil && (meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID) {
-		return fmt.Errorf("error getting S3 Object Lock configuration: %s", err)
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeObjectLockConfigurationNotFound) {
+		if meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID || meta.(*conns.AWSClient).Partition == endpoints.AwsUsGovPartitionID {
+			return fmt.Errorf("error getting S3 Bucket (%s) Object Lock configuration: %w", d.Id(), err)
+		}
 	}
 
-	if err != nil {
-		log.Printf("[WARN] Unable to read S3 bucket (%s) object lock configuration: %s", d.Id(), err)
-	}
-
-	if err == nil {
-		if err := d.Set("object_lock_configuration", conf); err != nil {
-			return fmt.Errorf("error setting object_lock_configuration: %s", err)
+	if output, ok := resp.(*s3.GetObjectLockConfigurationOutput); ok {
+		if err := d.Set("object_lock_configuration", flattenS3ObjectLockConfiguration(output.ObjectLockConfiguration)); err != nil {
+			return fmt.Errorf("error setting object_lock_configuration: %w", err)
 		}
 	}
 
@@ -2137,27 +2138,6 @@ type S3Website struct {
 // S3 Object Lock functions.
 //
 
-func readS3ObjectLockConfiguration(conn *s3.S3, bucket string) ([]interface{}, error) {
-	resp, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.GetObjectLockConfiguration(&s3.GetObjectLockConfigurationInput{
-			Bucket: aws.String(bucket),
-		})
-	})
-	if err != nil {
-		// Certain S3 implementations do not include this API
-		if tfawserr.ErrMessageContains(err, "MethodNotAllowed", "") {
-			return nil, nil
-		}
-
-		if tfawserr.ErrMessageContains(err, "ObjectLockConfigurationNotFoundError", "") {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return flattenS3ObjectLockConfiguration(resp.(*s3.GetObjectLockConfigurationOutput).ObjectLockConfiguration), nil
-}
-
 func expandS3ObjectLockConfiguration(vConf []interface{}) *s3.ObjectLockConfiguration {
 	if len(vConf) == 0 || vConf[0] == nil {
 		return nil
@@ -2169,28 +2149,6 @@ func expandS3ObjectLockConfiguration(vConf []interface{}) *s3.ObjectLockConfigur
 
 	if vObjectLockEnabled, ok := mConf["object_lock_enabled"].(string); ok && vObjectLockEnabled != "" {
 		conf.ObjectLockEnabled = aws.String(vObjectLockEnabled)
-	}
-
-	if vRule, ok := mConf["rule"].([]interface{}); ok && len(vRule) > 0 {
-		mRule := vRule[0].(map[string]interface{})
-
-		if vDefaultRetention, ok := mRule["default_retention"].([]interface{}); ok && len(vDefaultRetention) > 0 && vDefaultRetention[0] != nil {
-			mDefaultRetention := vDefaultRetention[0].(map[string]interface{})
-
-			conf.Rule = &s3.ObjectLockRule{
-				DefaultRetention: &s3.DefaultRetention{},
-			}
-
-			if vMode, ok := mDefaultRetention["mode"].(string); ok && vMode != "" {
-				conf.Rule.DefaultRetention.Mode = aws.String(vMode)
-			}
-			if vDays, ok := mDefaultRetention["days"].(int); ok && vDays > 0 {
-				conf.Rule.DefaultRetention.Days = aws.Int64(int64(vDays))
-			}
-			if vYears, ok := mDefaultRetention["years"].(int); ok && vYears > 0 {
-				conf.Rule.DefaultRetention.Years = aws.Int64(int64(vYears))
-			}
-		}
 	}
 
 	return conf

--- a/internal/service/s3/bucket_object_lock_configuration_test.go
+++ b/internal/service/s3/bucket_object_lock_configuration_test.go
@@ -189,12 +189,6 @@ resource "aws_s3_bucket" "test" {
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
-
-  lifecycle {
-    ignore_changes = [
-      object_lock_configuration
-    ]
-  }
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "test" {
@@ -217,12 +211,6 @@ resource "aws_s3_bucket" "test" {
 
   object_lock_configuration {
     object_lock_enabled = "Enabled"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      object_lock_configuration
-    ]
   }
 }
 

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -1279,7 +1279,7 @@ resource "aws_s3_bucket_acl" "test" {
 
 func testAccObjectLockEnabledNoDefaultRetention(bucketName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "arbitrary" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 
   object_lock_configuration {
@@ -1296,12 +1296,15 @@ resource "aws_s3_bucket" "test" {
   acl           = "private"
   force_destroy = true
 
-  versioning {
-    enabled = true
-  }
-
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "test" {
+  bucket = aws_s3_bucket.test.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 `, bucketName)

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -394,7 +394,7 @@ func TestAccS3Bucket_Basic_shouldFailNotFound(t *testing.T) {
 
 func TestAccS3Bucket_Manage_objectLock(t *testing.T) {
 	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
-	resourceName := "aws_s3_bucket.arbitrary"
+	resourceName := "aws_s3_bucket.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
@@ -417,16 +417,33 @@ func TestAccS3Bucket_Manage_objectLock(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
 			},
+		},
+	})
+}
+
+func TestAccS3Bucket_Manage_objectLockWithVersioning(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectLockEnabledWithDefaultRetention(bucketName),
+				Config: testAccBucketConfig_objectLockEnabledWithVersioning(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", "Enabled"),
-					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.0.default_retention.0.mode", "COMPLIANCE"),
-					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.0.default_retention.0.days", "3"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
 			},
 		},
 	})
@@ -1272,20 +1289,19 @@ resource "aws_s3_bucket" "arbitrary" {
 `, bucketName)
 }
 
-func testAccObjectLockEnabledWithDefaultRetention(bucketName string) string {
+func testAccBucketConfig_objectLockEnabledWithVersioning(bucketName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "arbitrary" {
-  bucket = %[1]q
+resource "aws_s3_bucket" "test" {
+  bucket        = "%s"
+  acl           = "private"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
 
   object_lock_configuration {
     object_lock_enabled = "Enabled"
-
-    rule {
-      default_retention {
-        mode = "COMPLIANCE"
-        days = 3
-      }
-    }
   }
 }
 `, bucketName)

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -1002,6 +1002,78 @@ The resources that were imported are shown above. These resources are now in
 your Terraform state and will henceforth be managed by Terraform.
 ```
 
+### `object_lock_configuration` `rule` Argument deprecation
+
+Switch your Terraform configuration to the `aws_s3_bucket_object_lock_configuration` resource instead.
+
+For example, given this previous configuration:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+
+    rule {
+      default_retention {
+        mode = "COMPLIANCE"
+        days = 3
+      }
+    }
+  }
+}
+```
+
+It will receive the following error after upgrading:
+
+```
+│ Error: Value for unconfigurable attribute
+│
+│   with aws_s3_bucket.example,
+│   on main.tf line 1, in resource "aws_s3_bucket" "example":
+│    1: resource "aws_s3_bucket" "example" {
+│
+│ Can't configure a value for "object_lock_configuration.0.rule": its value will be decided automatically based on the result of applying this configuration.
+```
+
+Since the `rule` argument of the `object_lock_configuration` configuration block changed to read-only, the recommendation is to update the configuration to use the `aws_s3_bucket_object_lock_configuration`
+resource and remove any references to `rule` and its nested arguments in the `aws_s3_bucket` resource:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  rule {
+    default_retention {
+      mode = "COMPLIANCE"
+      days = 3
+    }
+  }
+}
+```
+
+It is then recommended running `terraform import` on each new resource to prevent data loss, e.g.
+
+```shell
+$ terraform import aws_s3_bucket_object_lock_configuration.example example
+aws_s3_bucket_object_lock_configuration.example: Importing from ID "example"...
+aws_s3_bucket_object_lock_configuration.example: Import prepared!
+  Prepared aws_s3_bucket_object_lock_configuration for import
+aws_s3_bucket_object_lock_configuration.example: Refreshing state... [id=example]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
 ### `policy` Argument deprecation
 
 Switch your Terraform configuration to the `aws_s3_bucket_policy` resource instead.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -111,19 +111,6 @@ The `grant` object supports the following:
 The `object_lock_configuration` object supports the following:
 
 * `object_lock_enabled` - (Required) Indicates whether this bucket has an Object Lock configuration enabled. Valid value is `Enabled`.
-* `rule` - (Optional) The Object Lock rule in place for this bucket.
-
-The `rule` object supports the following:
-
-* `default_retention` - (Required) The default retention period that you want to apply to new objects placed in this bucket.
-
-The `default_retention` object supports the following:
-
-* `mode` - (Required) The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are `GOVERNANCE` and `COMPLIANCE`.
-* `days` - (Optional) The number of days that you want to specify for the default retention period.
-* `years` - (Optional) The number of years that you want to specify for the default retention period.
-
-Either `days` or `years` must be specified, but not both.
 
 ~> **NOTE on `object_lock_configuration`:** You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support.
 When you create a bucket with S3 Object Lock enabled, Amazon S3 automatically enables versioning for the bucket.
@@ -167,6 +154,12 @@ In addition to all arguments above, the following attributes are exported:
 * `logging` - The [logging parameters](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) for the bucket.
     * `target_bucket` - The name of the bucket that receives the log objects.
     * `target_prefix` - The prefix for all log object keys/
+* `object_lock_configuration` - The [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) configuration.
+    * `rule` - The Object Lock rule in place for this bucket.
+        * `default_retention` - The default retention period applied to new objects placed in this bucket.
+            * `mode` - The default Object Lock retention mode applied to new objects placed in this bucket.
+            * `days` - The number of days specified for the default retention period.
+            * `years` - The number of years specified for the default retention period.
 * `policy` - The [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document.
 * `region` - The AWS region this bucket resides in.
 * `replication_configuration` - The [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (13.92s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (167.33s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (165.82s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (167.76s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (167.56s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (160.88s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (100.14s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (14.67s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (99.36s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (97.80s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (151.52s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (236.28s)

--- PASS: TestAccS3BucketDataSource_basic (86.06s)
--- PASS: TestAccS3BucketDataSource_website (84.48s)

--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (367.86s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (96.53s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (85.73s)

--- PASS: TestAccS3BucketInventory_basic (100.45s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (98.18s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (99.96s)

--- PASS: TestAccS3BucketMetric_basic (95.80s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (14.29s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (162.68s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (163.69s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (163.36s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (164.93s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (165.52s)

--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (121.52s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (98.08s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (116.27s)
--- PASS: TestAccS3BucketNotification_queue (127.38s)
--- PASS: TestAccS3BucketNotification_topic (95.83s)
--- PASS: TestAccS3BucketNotification_update (183.00s)

--- PASS: TestAccS3BucketObjectDataSource_allParams (84.55s)
--- PASS: TestAccS3BucketObjectDataSource_basic (83.72s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (85.93s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (86.69s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (88.32s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (159.48s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (157.96s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (84.97s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (85.54s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (87.79s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (84.67s)

--- PASS: TestAccS3BucketObject_acl (243.46s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (88.52s)
--- PASS: TestAccS3BucketObject_content (101.12s)
--- PASS: TestAccS3BucketObject_contentBase64 (87.83s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (87.93s)
--- PASS: TestAccS3BucketObject_empty (101.73s)
--- PASS: TestAccS3BucketObject_etagEncryption (100.98s)
--- PASS: TestAccS3BucketObject_ignoreTags (158.02s)
--- PASS: TestAccS3BucketObject_kms (101.32s)
--- PASS: TestAccS3BucketObject_metadata (240.68s)
--- PASS: TestAccS3BucketObject_noNameNoKey (22.74s)
--- PASS: TestAccS3BucketObject_nonVersioned (99.47s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (90.02s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (230.61s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (157.80s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (230.74s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (301.07s)
--- PASS: TestAccS3BucketObject_source (98.90s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (167.01s)
--- PASS: TestAccS3BucketObject_sse (100.39s)
--- PASS: TestAccS3BucketObject_storageClass (388.15s)
--- PASS: TestAccS3BucketObject_tags (312.40s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (300.06s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (314.85s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (299.74s)
--- PASS: TestAccS3BucketObject_updateSameFile (153.92s)
--- PASS: TestAccS3BucketObject_updates (171.55s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (168.42s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (159.10s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (87.42s)

--- PASS: TestAccS3BucketObjectsDataSource_all (161.01s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (163.66s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (163.77s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (163.79s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (163.93s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (161.79s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (164.68s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (163.92s)

--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (78.67s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (175.29s)
--- PASS: TestAccS3BucketOwnershipControls_basic (103.28s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (89.18s)

--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (348.83s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (268.33s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (289.46s)

--- PASS: TestAccS3BucketPolicy_basic (103.15s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (179.30s)

--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (77.95s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (106.18s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (246.84s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (247.22s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (87.84s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (243.87s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (241.83s)

--- PASS: TestAccS3BucketReplicationConfiguration_basic (530.22s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (481.88s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (471.18s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (134.79s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (346.61s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (357.55s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (405.67s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (402.42s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (399.21s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (398.94s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (391.53s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (366.07s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (234.62s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (403.77s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (306.94s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (396.88s)

--- PASS: TestAccS3BucketVersioning_MFADelete (57.62s)
--- PASS: TestAccS3BucketVersioning_basic (91.56s)
--- PASS: TestAccS3BucketVersioning_disappears (83.46s)
--- PASS: TestAccS3BucketVersioning_update (92.56s)

--- PASS: TestAccS3Bucket_Basic_acceleration (54.81s)
--- PASS: TestAccS3Bucket_Basic_basic (53.94s)
--- PASS: TestAccS3Bucket_Basic_emptyString (52.46s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (92.45s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (95.24s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (87.26s)
--- PASS: TestAccS3Bucket_Basic_generatedName (31.30s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (46.27s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (32.32s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (48.24s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (33.17s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (64.61s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (215.84s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (168.65s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (95.09s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (77.29s)
--- PASS: TestAccS3Bucket_Manage_objectLock (106.00s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (106.39s)
--- PASS: TestAccS3Bucket_Manage_versioning (125.90s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (67.29s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (62.46s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (242.24s)
--- PASS: TestAccS3Bucket_Replication_basic (274.46s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (71.90s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (156.40s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (159.71s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (204.77s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (205.43s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (279.92s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (111.72s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (160.79s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (156.29s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (156.96s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (46.35s)
--- PASS: TestAccS3Bucket_Security_corsDelete (59.96s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (73.52s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (145.11s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (92.98s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (45.01s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (46.63s)
--- PASS: TestAccS3Bucket_Security_grantToACL (50.79s)
--- PASS: TestAccS3Bucket_Security_logging (75.42s)
--- PASS: TestAccS3Bucket_Security_policy (67.41s)
--- PASS: TestAccS3Bucket_Security_updateACL (46.98s)
--- PASS: TestAccS3Bucket_Security_updateGrant (70.12s)
--- PASS: TestAccS3Bucket_Tags_basic (31.67s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (49.34s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (116.76s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (145.80s)
--- PASS: TestAccS3Bucket_Web_redirect (104.47s)
--- PASS: TestAccS3Bucket_Web_routingRules (79.46s)
--- PASS: TestAccS3Bucket_Web_simple (99.90s)

--- PASS: TestBucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
```
