### PR TITLE
r/s3_bucket: read-only `request_payer` argument

### DIFF
--- a/.changelog/22613.txt
+++ b/.changelog/22613.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket: The `request_payer` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_request_payment_configuration` resource instead.
+```

--- a/.changelog/22613.txt
+++ b/.changelog/22613.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_s3_bucket: The `request_payer` argument has been deprecated and is now read-only. Use the `aws_s3_bucket_request_payment_configuration` resource instead.
 ```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -382,10 +382,9 @@ func ResourceBucket() *schema.Resource {
 			},
 
 			"request_payer": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(s3.Payer_Values(), false),
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use the aws_s3_bucket_request_payment_configuration resource instead",
 			},
 
 			"replication_configuration": {
@@ -807,12 +806,6 @@ func resourceBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("acceleration_status") {
 		if err := resourceBucketAccelerationUpdate(conn, d); err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("request_payer") {
-		if err := resourceBucketRequestPayerUpdate(conn, d); err != nil {
 			return err
 		}
 	}
@@ -1753,28 +1746,6 @@ func resourceBucketAccelerationUpdate(conn *s3.S3, d *schema.ResourceData) error
 	})
 	if err != nil {
 		return fmt.Errorf("Error putting S3 acceleration: %s", err)
-	}
-
-	return nil
-}
-
-func resourceBucketRequestPayerUpdate(conn *s3.S3, d *schema.ResourceData) error {
-	bucket := d.Get("bucket").(string)
-	payer := d.Get("request_payer").(string)
-
-	i := &s3.PutBucketRequestPaymentInput{
-		Bucket: aws.String(bucket),
-		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
-			Payer: aws.String(payer),
-		},
-	}
-	log.Printf("[DEBUG] S3 put bucket request payer: %#v", i)
-
-	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.PutBucketRequestPayment(i)
-	})
-	if err != nil {
-		return fmt.Errorf("Error putting S3 request payer: %s", err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_request_payment_configuration_test.go
+++ b/internal/service/s3/bucket_request_payment_configuration_test.go
@@ -189,12 +189,6 @@ func testAccBucketRequestPaymentConfigurationBasicConfig(rName, payer string) st
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-
-  lifecycle {
-    ignore_changes = [
-      request_payer
-    ]
-  }
 }
 
 resource "aws_s3_bucket_request_payment_configuration" "test" {

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -689,6 +689,60 @@ To help distribute the management of S3 bucket settings via independent resource
 have become read-only. Configurations dependent on these arguments should be updated to use the corresponding `aws_s3_bucket_*` resource.
 Once updated, new `aws_s3_bucket_*` resources should be imported into Terraform state.
 
+### `request_payer` Argument deprecation
+
+Switch your Terraform configuration to the `aws_s3_bucket_request_payment_configuration` resource instead.
+
+For example, given this previous configuration:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+  request_payer = "Requester"
+}
+```
+
+It will receive the following error after upgrading:
+
+```
+│ Error: Value for unconfigurable attribute
+│
+│   with aws_s3_bucket.example,
+│   on main.tf line 1, in resource "aws_s3_bucket" "example":
+│    1: resource "aws_s3_bucket" "example" {
+│
+│ Can't configure a value for "request_payer": its value will be decided automatically based on the result of applying this configuration.
+```
+
+Since the `request_payer` argument changed to read-only, the recommendation is to update the configuration to use the `aws_s3_bucket_request_payment_configuration`
+resource and remove any reference to `request_payer` in the `aws_s3_bucket` resource:
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+}
+
+resource "aws_s3_bucket_request_payment_configuration" "example" {
+  bucket = aws_s3_bucket.example.id
+  payer  = "Requester"
+}
+```
+
+It is then recommended running `terraform import` on each new resource to prevent data loss, e.g.
+
+```shell
+$ terraform import aws_s3_bucket_request_payment_configuration.example example
+aws_s3_bucket_request_payment_configuration.example: Importing from ID "example"...
+aws_s3_bucket_request_payment_configuration.example: Import prepared!
+  Prepared aws_s3_bucket_request_payment_configuration for import
+aws_s3_bucket_request_payment_configuration.example: Refreshing state... [id=example]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
 ### `website`, `website_domain`, and `website_endpoint` Argument deprecation
 
 Switch your Terraform configuration to the `aws_s3_bucket_website_configuration` resource instead.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -376,7 +376,6 @@ The following arguments are supported:
 * `logging` - (Optional) A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
 * `lifecycle_rule` - (Optional) A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
 * `acceleration_status` - (Optional) Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
-* `request_payer` - (Optional) Specifies who should bear the cost of Amazon S3 data transfer.
 Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
 the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
 developer guide for more information.
@@ -563,6 +562,7 @@ In addition to all arguments above, the following attributes are exported:
 * `bucket_regional_domain_name` - The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
 * `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 * `region` - The AWS region this bucket resides in.
+* `request_payer` - Either `BucketOwner` or `Requester` that pays for the download and request fees.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
 * `website` - The website configuration, if configured.
     * `error_document` - The name of the error document for the website.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (16.31s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (173.68s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (169.69s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (173.14s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (170.47s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (171.69s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (103.50s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (15.29s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (103.74s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (102.27s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (157.94s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (243.40s)

--- PASS: TestAccS3BucketDataSource_basic (91.85s)
--- PASS: TestAccS3BucketDataSource_website (90.14s)

--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (380.33s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (102.69s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (90.45s)

--- PASS: TestAccS3BucketInventory_basic (101.98s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (101.66s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (102.98s)

--- PASS: TestAccS3BucketMetric_basic (101.70s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (15.89s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (168.83s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (168.35s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (169.35s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (169.40s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (169.66s)

--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (118.09s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (102.58s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (126.87s)
--- PASS: TestAccS3BucketNotification_queue (130.25s)
--- PASS: TestAccS3BucketNotification_topic (100.74s)
--- PASS: TestAccS3BucketNotification_update (187.21s)

--- PASS: TestAccS3BucketObjectDataSource_allParams (89.32s)
--- PASS: TestAccS3BucketObjectDataSource_basic (87.33s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (90.27s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (89.18s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (90.59s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (155.96s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (161.08s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (92.20s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (87.86s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (90.19s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (87.79s)

--- PASS: TestAccS3BucketObject_acl (251.17s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (93.17s)
--- PASS: TestAccS3BucketObject_content (99.40s)
--- PASS: TestAccS3BucketObject_contentBase64 (89.08s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (94.21s)
--- PASS: TestAccS3BucketObject_empty (103.26s)
--- PASS: TestAccS3BucketObject_etagEncryption (98.60s)
--- PASS: TestAccS3BucketObject_ignoreTags (169.46s)
--- PASS: TestAccS3BucketObject_kms (101.22s)
--- PASS: TestAccS3BucketObject_metadata (249.90s)
--- PASS: TestAccS3BucketObject_noNameNoKey (24.45s)
--- PASS: TestAccS3BucketObject_nonVersioned (100.74s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (91.00s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (241.45s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (166.03s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (240.41s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (312.30s)
--- PASS: TestAccS3BucketObject_source (102.65s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (173.25s)
--- PASS: TestAccS3BucketObject_sse (102.00s)
--- PASS: TestAccS3BucketObject_storageClass (394.53s)
--- PASS: TestAccS3BucketObject_tags (328.94s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (309.65s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (323.67s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (309.83s)
--- PASS: TestAccS3BucketObject_updateSameFile (163.03s)
--- PASS: TestAccS3BucketObject_updates (175.36s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (174.10s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (163.30s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (86.60s)

--- PASS: TestAccS3BucketObjectsDataSource_all (173.41s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (173.04s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (171.15s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (170.85s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (171.44s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (167.83s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (170.08s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (168.14s)

--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (79.33s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (183.71s)
--- PASS: TestAccS3BucketOwnershipControls_basic (103.02s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (91.51s)

--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (372.66s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (271.44s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (294.43s)

--- PASS: TestAccS3BucketPolicy_basic (102.35s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (187.48s)

--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (77.59s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (105.39s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (250.46s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (254.27s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (91.09s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (253.52s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (249.89s)

--- PASS: TestAccS3BucketReplicationConfiguration_basic (540.64s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (494.84s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (486.51s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (141.74s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (366.45s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (363.38s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (407.56s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (408.67s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (400.92s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (403.87s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (395.35s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (363.91s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (233.62s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (408.12s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (320.73s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (398.66s)

--- PASS: TestAccS3BucketVersioning_MFADelete (63.78s)
--- PASS: TestAccS3BucketVersioning_basic (101.01s)
--- PASS: TestAccS3BucketVersioning_disappears (89.84s)
--- PASS: TestAccS3BucketVersioning_update (141.46s)

--- PASS: TestAccS3Bucket_Basic_acceleration (69.50s)
--- PASS: TestAccS3Bucket_Basic_basic (60.40s)
--- PASS: TestAccS3Bucket_Basic_emptyString (58.41s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (99.82s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (99.96s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (100.05s)
--- PASS: TestAccS3Bucket_Basic_generatedName (34.83s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (69.07s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (39.80s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (50.01s)

--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (71.04s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (232.34s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (180.18s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (104.93s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (86.20s)
--- PASS: TestAccS3Bucket_Manage_objectLock (154.98s)
--- PASS: TestAccS3Bucket_Manage_versioning (151.80s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (81.01s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (70.02s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (253.00s)
--- PASS: TestAccS3Bucket_Replication_basic (307.82s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (77.47s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (171.42s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (171.99s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (230.33s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (220.82s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (297.91s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (118.79s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (174.11s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (161.50s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (166.81s)
--- PASS: TestAccS3Bucket_Security_aclToGrant (56.07s)
--- PASS: TestAccS3Bucket_Security_corsDelete (72.98s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (84.92s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (158.92s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (118.38s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (58.93s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (61.87s)
--- PASS: TestAccS3Bucket_Security_grantToACL (83.03s)
--- PASS: TestAccS3Bucket_Security_logging (94.47s)
--- PASS: TestAccS3Bucket_Security_policy (90.44s)
--- PASS: TestAccS3Bucket_Security_updateACL (57.50s)
--- PASS: TestAccS3Bucket_Security_updateGrant (109.66s)
--- PASS: TestAccS3Bucket_Tags_basic (39.64s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (59.31s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (136.32s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (169.10s)
--- PASS: TestAccS3Bucket_Web_redirect (173.83s)
--- PASS: TestAccS3Bucket_Web_routingRules (105.18s)
--- PASS: TestAccS3Bucket_Web_simple (166.50s)

--- PASS: TestBucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.00s)
```
