### PR TITLE
resource/aws_dynamodb_table: Add special case for changing billing mode with autoscaling

### DIFF
--- a/.changelog/22630.txt
+++ b/.changelog/22630.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add special case handling when switching `billing_mode` from `PAY_PER_REQUEST` to `PROVISIONED` and provisioned throughput is ignored.
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+const dynamoDbProvisionedThroughputMinValue = 1
+
 func ResourceTable() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -43,7 +45,7 @@ func ResourceTable() *schema.Resource {
 			Update: schema.DefaultTimeout(updateTableTimeoutTotal),
 		},
 
-		CustomizeDiff: customdiff.Sequence(
+		CustomizeDiff: customdiff.All(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 				return validStreamSpec(diff)
 			},
@@ -67,6 +69,20 @@ func ResourceTable() *schema.Resource {
 					}
 				}
 				return nil
+			},
+			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+				if v := diff.Get("restore_source_name"); v != "" {
+					return nil
+				}
+
+				var errs *multierror.Error
+				if err := validateDynamoDbProvisionedThroughputField(diff, "read_capacity"); err != nil {
+					errs = multierror.Append(errs, err)
+				}
+				if err := validateDynamoDbProvisionedThroughputField(diff, "write_capacity"); err != nil {
+					errs = multierror.Append(errs, err)
+				}
+				return errs.ErrorOrNil()
 			},
 			verify.SetTagsDiff,
 		),
@@ -108,13 +124,10 @@ func ResourceTable() *schema.Resource {
 				},
 			},
 			"billing_mode": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  dynamodb.BillingModeProvisioned,
-				ValidateFunc: validation.StringInSlice([]string{
-					dynamodb.BillingModePayPerRequest,
-					dynamodb.BillingModeProvisioned,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      dynamodb.BillingModeProvisioned,
+				ValidateFunc: validation.StringInSlice(dynamodb.BillingMode_Values(), false),
 			},
 			"global_secondary_index": {
 				Type:     schema.TypeSet,
@@ -402,7 +415,7 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 
 			for _, gsiObject := range gsiSet.List() {
 				gsi := gsiObject.(map[string]interface{})
-				if err := validateDynamoDbProvisionedThroughput(gsi, billingModeOverride); err != nil {
+				if err := validateDynamoDbGSIProvisionedThroughput(gsi, billingModeOverride); err != nil {
 					return fmt.Errorf("failed to create GSI: %w", err)
 				}
 
@@ -463,10 +476,6 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 			"read_capacity":  d.Get("read_capacity"),
 		}
 
-		if err := validateDynamoDbProvisionedThroughput(capacityMap, billingMode); err != nil {
-			return err
-		}
-
 		req.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(capacityMap, billingMode)
 
 		if v, ok := d.GetOk("attribute"); ok {
@@ -485,7 +494,7 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 
 			for _, gsiObject := range gsiSet.List() {
 				gsi := gsiObject.(map[string]interface{})
-				if err := validateDynamoDbProvisionedThroughput(gsi, billingMode); err != nil {
+				if err := validateDynamoDbGSIProvisionedThroughput(gsi, billingMode); err != nil {
 					return fmt.Errorf("failed to create GSI: %w", err)
 				}
 
@@ -707,7 +716,9 @@ func resourceTableRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).DynamoDBConn
-	billingMode := d.Get("billing_mode").(string)
+	o, n := d.GetChange("billing_mode")
+	billingMode := n.(string)
+	oldBillingMode := o.(string)
 
 	// Global Secondary Index operations must occur in multiple phases
 	// to prevent various error scenarios. If there are no detected required
@@ -765,12 +776,8 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 			"read_capacity":  d.Get("read_capacity"),
 		}
 
-		if err := validateDynamoDbProvisionedThroughput(capacityMap, billingMode); err != nil {
-			return err
-		}
-
 		input.BillingMode = aws.String(billingMode)
-		input.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(capacityMap, billingMode)
+		input.ProvisionedThroughput = expandDynamoDbProvisionedThroughputUpdate(d.Id(), capacityMap, billingMode, oldBillingMode)
 	}
 
 	if d.HasChanges("stream_enabled", "stream_view_type") {
@@ -1091,7 +1098,7 @@ func UpdateDiffGSI(oldGsi, newGsi []interface{}, billingMode string) (ops []*dyn
 	for _, gsidata := range newGsi {
 		m := gsidata.(map[string]interface{})
 		// validate throughput input early, to avoid unnecessary processing
-		if e = validateDynamoDbProvisionedThroughput(m, billingMode); e != nil {
+		if e = validateDynamoDbGSIProvisionedThroughput(m, billingMode); e != nil {
 			return
 		}
 		newGsis[m["name"].(string)] = m
@@ -1529,15 +1536,28 @@ func expandDynamoDbGlobalSecondaryIndex(data map[string]interface{}, billingMode
 }
 
 func expandDynamoDbProvisionedThroughput(data map[string]interface{}, billingMode string) *dynamodb.ProvisionedThroughput {
+	return expandDynamoDbProvisionedThroughputUpdate("", data, billingMode, "")
+}
 
+func expandDynamoDbProvisionedThroughputUpdate(id string, data map[string]interface{}, billingMode, oldBillingMode string) *dynamodb.ProvisionedThroughput {
 	if billingMode == dynamodb.BillingModePayPerRequest {
 		return nil
 	}
 
 	return &dynamodb.ProvisionedThroughput{
-		WriteCapacityUnits: aws.Int64(int64(data["write_capacity"].(int))),
-		ReadCapacityUnits:  aws.Int64(int64(data["read_capacity"].(int))),
+		ReadCapacityUnits:  aws.Int64(expandDynamoDbProvisionedThroughputField(id, data, "read_capacity", billingMode, oldBillingMode)),
+		WriteCapacityUnits: aws.Int64(expandDynamoDbProvisionedThroughputField(id, data, "write_capacity", billingMode, oldBillingMode)),
 	}
+}
+
+func expandDynamoDbProvisionedThroughputField(id string, data map[string]interface{}, key, billingMode, oldBillingMode string) int64 {
+	v := data[key].(int)
+	if v == 0 && billingMode == dynamodb.BillingModeProvisioned && oldBillingMode == dynamodb.BillingModePayPerRequest {
+		log.Printf("[WARN] Overriding %[1]s on DynamoDB Table (%[2]s) to %[3]d. Switching from billing mode %[4]q to %[5]q without value for %[1]s. Assuming changes are being ignored.",
+			key, id, dynamoDbProvisionedThroughputMinValue, oldBillingMode, billingMode)
+		v = dynamoDbProvisionedThroughputMinValue
+	}
+	return int64(v)
 }
 
 func expandDynamoDbProjection(data map[string]interface{}) *dynamodb.Projection {
@@ -1662,7 +1682,7 @@ func validateDynamoDbTableAttributes(d *schema.ResourceDiff) error {
 	return err.ErrorOrNil()
 }
 
-func validateDynamoDbProvisionedThroughput(data map[string]interface{}, billingMode string) error {
+func validateDynamoDbGSIProvisionedThroughput(data map[string]interface{}, billingMode string) error {
 	// if billing mode is PAY_PER_REQUEST, don't need to validate the throughput settings
 	if billingMode == dynamodb.BillingModePayPerRequest {
 		return nil
@@ -1683,5 +1703,24 @@ func validateDynamoDbProvisionedThroughput(data map[string]interface{}, billingM
 		return fmt.Errorf("read capacity must be > 0 when billing mode is %s", dynamodb.BillingModeProvisioned)
 	}
 
+	return nil
+}
+
+func validateDynamoDbProvisionedThroughputField(diff *schema.ResourceDiff, key string) error {
+	oldBillingMode, billingMode := diff.GetChange("billing_mode")
+	v := diff.Get(key).(int)
+	if billingMode == dynamodb.BillingModeProvisioned {
+		if v < dynamoDbProvisionedThroughputMinValue {
+			// Assuming the field is ignored, likely due to autoscaling
+			if oldBillingMode == dynamodb.BillingModePayPerRequest {
+				return nil
+			}
+			return fmt.Errorf("%s must be at least 1 when billing_mode is %q", key, billingMode)
+		}
+	} else if billingMode == dynamodb.BillingModePayPerRequest && oldBillingMode != dynamodb.BillingModeProvisioned {
+		if v != 0 {
+			return fmt.Errorf("%s can not be set when billing_mode is %q", key, dynamodb.BillingModePayPerRequest)
+		}
+	}
 	return nil
 }

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -402,7 +403,7 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 			for _, gsiObject := range gsiSet.List() {
 				gsi := gsiObject.(map[string]interface{})
 				if err := validateDynamoDbProvisionedThroughput(gsi, billingModeOverride); err != nil {
-					return fmt.Errorf("failed to create GSI: %v", err)
+					return fmt.Errorf("failed to create GSI: %w", err)
 				}
 
 				gsiObject := expandDynamoDbGlobalSecondaryIndex(gsi, billingModeOverride)
@@ -444,7 +445,7 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if output == nil || output.TableDescription == nil {
-			return fmt.Errorf("error creating DynamoDB Table: empty response")
+			return errors.New("error creating DynamoDB Table: empty response")
 		}
 
 	} else {
@@ -485,7 +486,7 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 			for _, gsiObject := range gsiSet.List() {
 				gsi := gsiObject.(map[string]interface{})
 				if err := validateDynamoDbProvisionedThroughput(gsi, billingMode); err != nil {
-					return fmt.Errorf("failed to create GSI: %v", err)
+					return fmt.Errorf("failed to create GSI: %w", err)
 				}
 
 				gsiObject := expandDynamoDbGlobalSecondaryIndex(gsi, billingMode)
@@ -538,7 +539,7 @@ func resourceTableCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if output == nil || output.TableDescription == nil {
-			return fmt.Errorf("error creating DynamoDB Table: empty response")
+			return errors.New("error creating DynamoDB Table: empty response")
 		}
 	}
 

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -331,7 +331,7 @@ func TestAccDynamoDBTable_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -368,7 +368,7 @@ func TestAccDynamoDBTable_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table1),
 					acctest.CheckResourceDisappears(acctest.Provider, tfdynamodb.ResourceTable(), resourceName),
 				),
@@ -391,7 +391,7 @@ func TestAccDynamoDBTable_Disappears_payPerRequestWithGSI(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_payPerRequestWithGSI(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table1),
 					acctest.CheckResourceDisappears(acctest.Provider, tfdynamodb.ResourceTable(), resourceName),
 				),
@@ -399,7 +399,7 @@ func TestAccDynamoDBTable_Disappears_payPerRequestWithGSI(t *testing.T) {
 			},
 			{
 				Config: testAccBilling_payPerRequestWithGSI(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table2),
 				),
 			},
@@ -425,7 +425,7 @@ func TestAccDynamoDBTable_extended(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInitialStateConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					testAccCheckInitialTableConf(resourceName),
 				),
@@ -437,7 +437,7 @@ func TestAccDynamoDBTable_extended(t *testing.T) {
 			},
 			{
 				Config: testAccAddSecondaryGSIConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "hash_key", "TestTableHashKey"),
@@ -499,7 +499,7 @@ func TestAccDynamoDBTable_enablePITR(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInitialStateConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					testAccCheckInitialTableConf(resourceName),
 				),
@@ -511,7 +511,7 @@ func TestAccDynamoDBTable_enablePITR(t *testing.T) {
 			},
 			{
 				Config: testAccConfig_backup(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "point_in_time_recovery.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "point_in_time_recovery.0.enabled", "true"),
@@ -534,7 +534,7 @@ func TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_payPerRequest(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModePayPerRequest),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "0"),
@@ -548,7 +548,7 @@ func TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned(t *testing.T) {
 			},
 			{
 				Config: testAccBilling_provisioned(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "5"),
@@ -572,7 +572,7 @@ func TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges(t 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_payPerRequest(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModePayPerRequest),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "0"),
@@ -586,7 +586,7 @@ func TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges(t 
 			},
 			{
 				Config: testAccBilling_provisioned_ignoreChanges(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "1"),
@@ -610,7 +610,7 @@ func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_provisioned(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "5"),
@@ -624,7 +624,7 @@ func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest(t *testing.T) {
 			},
 			{
 				Config: testAccBilling_payPerRequest(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModePayPerRequest),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "0"),
@@ -648,7 +648,7 @@ func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges(t 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_provisioned(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "5"),
@@ -662,7 +662,7 @@ func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges(t 
 			},
 			{
 				Config: testAccBilling_payPerRequest_ignoreChanges(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModePayPerRequest),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "0"),
@@ -686,7 +686,7 @@ func TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_payPerRequestWithGSI(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModePayPerRequest),
 					resource.TestCheckResourceAttr(resourceName, "read_capacity", "0"),
@@ -700,7 +700,7 @@ func TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned(t *testing.T
 			},
 			{
 				Config: testAccBilling_provisionedWithGSI(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),
 				),
@@ -722,7 +722,7 @@ func TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBilling_provisionedWithGSI(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),
 				),
@@ -734,7 +734,7 @@ func TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest(t *testing.T
 			},
 			{
 				Config: testAccBilling_payPerRequestWithGSI(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModePayPerRequest),
 				),
@@ -756,7 +756,7 @@ func TestAccDynamoDBTable_streamSpecification(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamSpecificationConfig(rName, true, "KEYS_ONLY"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
@@ -771,7 +771,7 @@ func TestAccDynamoDBTable_streamSpecification(t *testing.T) {
 			},
 			{
 				Config: testAccStreamSpecificationConfig(rName, false, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "stream_view_type", ""),
@@ -811,7 +811,7 @@ func TestAccDynamoDBTable_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTagsConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					testAccCheckInitialTableConf(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -840,7 +840,7 @@ func TestAccDynamoDBTable_gsiUpdateCapacity(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGsiUpdateConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "global_secondary_index.#", "3"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
@@ -867,7 +867,7 @@ func TestAccDynamoDBTable_gsiUpdateCapacity(t *testing.T) {
 			},
 			{
 				Config: testAccGsiUpdatedCapacityConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "global_secondary_index.#", "3"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
@@ -904,7 +904,7 @@ func TestAccDynamoDBTable_gsiUpdateOtherAttributes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGsiUpdateConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "global_secondary_index.#", "3"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
@@ -943,7 +943,7 @@ func TestAccDynamoDBTable_gsiUpdateOtherAttributes(t *testing.T) {
 			},
 			{
 				Config: testAccGsiUpdatedOtherAttributesConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "global_secondary_index.#", "3"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
@@ -994,7 +994,7 @@ func TestAccDynamoDBTable_lsiNonKeyAttributes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLsiNonKeyAttributesConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "local_secondary_index.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "local_secondary_index.*", map[string]string{
@@ -1029,7 +1029,7 @@ func TestAccDynamoDBTable_gsiUpdateNonKeyAttributes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGsiUpdatedOtherAttributesConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "global_secondary_index.#", "3"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
@@ -1069,7 +1069,7 @@ func TestAccDynamoDBTable_gsiUpdateNonKeyAttributes(t *testing.T) {
 			},
 			{
 				Config: testAccGsiUpdatedNonKeyAttributesConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
 						"hash_key":             "att4",
@@ -1122,7 +1122,7 @@ func TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGsiMultipleNonKeyAttributesConfig(rName, attributes),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "global_secondary_index.*", map[string]string{
 						"hash_key":             "att1",
@@ -1166,7 +1166,7 @@ func TestAccDynamoDBTable_TTL_enabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTimeToLiveConfig(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "ttl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", "true"),
@@ -1196,7 +1196,7 @@ func TestAccDynamoDBTable_TTL_disabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTimeToLiveConfig(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "ttl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", "false"),
@@ -1209,7 +1209,7 @@ func TestAccDynamoDBTable_TTL_disabled(t *testing.T) {
 			},
 			{
 				Config: testAccTimeToLiveConfig(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "ttl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", "true"),
@@ -1232,7 +1232,7 @@ func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOneAttributeConfig(rName, "firstKey", "firstKey", "S"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 				),
 			},
@@ -1243,19 +1243,19 @@ func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
 			},
 			{ // Attribute type change
 				Config: testAccOneAttributeConfig(rName, "firstKey", "firstKey", "N"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 				),
 			},
 			{ // New attribute addition (index update)
 				Config: testAccTwoAttributesConfig(rName, "firstKey", "secondKey", "firstKey", "N", "secondKey", "S"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 				),
 			},
 			{ // Attribute removal (index update)
 				Config: testAccOneAttributeConfig(rName, "firstKey", "firstKey", "S"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 				),
 			},
@@ -1276,7 +1276,7 @@ func TestAccDynamoDBTable_lsiUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLSIConfig(rName, "lsi-original"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 				),
 			},
@@ -1287,7 +1287,7 @@ func TestAccDynamoDBTable_lsiUpdate(t *testing.T) {
 			},
 			{ // Change name of local secondary index
 				Config: testAccLSIConfig(rName, "lsi-changed"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 				),
 			},
@@ -1335,7 +1335,7 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInitialStateWithEncryptionBYOKConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confBYOK),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
@@ -1349,7 +1349,7 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 			},
 			{
 				Config: testAccInitialStateWithEncryptionAmazonCMKConfig(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confEncDisabled),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "0"),
 					func(s *terraform.State) error {
@@ -1362,7 +1362,7 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 			},
 			{
 				Config: testAccInitialStateWithEncryptionAmazonCMKConfig(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confEncEnabled),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
@@ -1396,7 +1396,7 @@ func TestAccDynamoDBTable_Replica_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTableReplica2Config(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
 				),
@@ -1409,14 +1409,14 @@ func TestAccDynamoDBTable_Replica_multiple(t *testing.T) {
 			},
 			{
 				Config: testAccTableReplica0Config(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "0"),
 				),
 			},
 			{
 				Config: testAccTableReplica2Config(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
 				),
@@ -1442,7 +1442,7 @@ func TestAccDynamoDBTable_Replica_single(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTableReplica1Config(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 				),
@@ -1455,14 +1455,14 @@ func TestAccDynamoDBTable_Replica_single(t *testing.T) {
 			},
 			{
 				Config: testAccTableReplica0Config(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "0"),
 				),
 			},
 			{
 				Config: testAccTableReplica1Config(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 				),
@@ -1492,7 +1492,7 @@ func TestAccDynamoDBTable_Replica_singleWithCMK(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTableReplicaWithCMKConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "replica.0.kms_key_arn", kmsKeyReplicaResourceName, "arn"),
@@ -1517,7 +1517,7 @@ func TestAccDynamoDBTable_tableClassInfrequentAccess(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTableClassConfig(rName, "STANDARD_INFREQUENT_ACCESS"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "table_class", "STANDARD_INFREQUENT_ACCESS"),
 				),
@@ -1529,7 +1529,7 @@ func TestAccDynamoDBTable_tableClassInfrequentAccess(t *testing.T) {
 			},
 			{
 				Config: testAccTableClassConfig(rName, "STANDARD"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &table),
 					resource.TestCheckResourceAttr(resourceName, "table_class", "STANDARD"),
 				),
@@ -1557,7 +1557,7 @@ func TestAccDynamoDBTable_backup_encryption(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDynamoDbBackupConfigInitialStateWithEncryption(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confBYOK),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
@@ -1592,7 +1592,7 @@ func TestAccDynamoDBTable_backup_overrideEncryption(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDynamoDbBackupConfigInitialStateWithOverrideEncryption(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &confBYOK),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
@@ -1674,7 +1674,7 @@ func testAccCheckInitialTableExists(n string, table *dynamodb.DescribeTableOutpu
 }
 
 func testAccCheckInitialTableConf(resourceName string) resource.TestCheckFunc {
-	return resource.ComposeTestCheckFunc(
+	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceName, "hash_key", "TestTableHashKey"),
 		resource.TestCheckResourceAttr(resourceName, "range_key", "TestTableRangeKey"),
 		resource.TestCheckResourceAttr(resourceName, "billing_mode", dynamodb.BillingModeProvisioned),

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -413,6 +413,10 @@ func TestAccDynamoDBTable_Disappears_payPerRequestWithGSI(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_extended(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -598,6 +602,10 @@ func TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges(t 
 }
 
 func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -636,6 +644,10 @@ func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -892,6 +904,10 @@ func TestAccDynamoDBTable_gsiUpdateCapacity(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_gsiUpdateOtherAttributes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1017,6 +1033,10 @@ func TestAccDynamoDBTable_lsiNonKeyAttributes(t *testing.T) {
 
 // https://github.com/hashicorp/terraform-provider-aws/issues/566
 func TestAccDynamoDBTable_gsiUpdateNonKeyAttributes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1220,6 +1240,10 @@ func TestAccDynamoDBTable_TTL_disabled(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_attributeUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1321,6 +1345,10 @@ func TestAccDynamoDBTable_attributeUpdateValidation(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_encryption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var confBYOK, confEncEnabled, confEncDisabled dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1380,6 +1408,10 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_Replica_multiple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var table dynamodb.DescribeTableOutput
 	var providers []*schema.Provider
 	resourceName := "aws_dynamodb_table.test"
@@ -1426,6 +1458,10 @@ func TestAccDynamoDBTable_Replica_multiple(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_Replica_single(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	var providers []*schema.Provider
 	resourceName := "aws_dynamodb_table.test"
@@ -1472,6 +1508,10 @@ func TestAccDynamoDBTable_Replica_single(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_Replica_singleWithCMK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf dynamodb.DescribeTableOutput
 	var providers []*schema.Provider
 	resourceName := "aws_dynamodb_table.test"
@@ -1544,6 +1584,10 @@ func TestAccDynamoDBTable_tableClassInfrequentAccess(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_backup_encryption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var confBYOK dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1579,6 +1623,10 @@ func TestAccDynamoDBTable_backup_encryption(t *testing.T) {
 }
 
 func TestAccDynamoDBTable_backup_overrideEncryption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var confBYOK dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -11,7 +11,7 @@ import (
 const (
 	kinesisStreamingDestinationActiveTimeout   = 5 * time.Minute
 	kinesisStreamingDestinationDisabledTimeout = 5 * time.Minute
-	createTableTimeout                         = 20 * time.Minute
+	createTableTimeout                         = 25 * time.Minute
 	updateTableTimeoutTotal                    = 60 * time.Minute
 	replicaUpdateTimeout                       = 30 * time.Minute
 	updateTableTimeout                         = 20 * time.Minute

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -11,7 +11,7 @@ import (
 const (
 	kinesisStreamingDestinationActiveTimeout   = 5 * time.Minute
 	kinesisStreamingDestinationDisabledTimeout = 5 * time.Minute
-	createTableTimeout                         = 25 * time.Minute
+	createTableTimeout                         = 30 * time.Minute
 	updateTableTimeoutTotal                    = 60 * time.Minute
 	replicaUpdateTimeout                       = 30 * time.Minute
 	updateTableTimeout                         = 20 * time.Minute


### PR DESCRIPTION
DynamoDB tables support two billing modes, `PAY_PER_REQUEST` and `PROVISIONED`. When using `PAY_PER_REQUEST`, provisioned throughput cannot be configured, whereas when using `PROVISIONED`, provisioned throughput must be set.

When using autoscaling for DynamoDB tables, the provisioned throughput values should ignore changes. However, if the table is switched from `PAY_PER_REQUEST` to `PROVISIONED` with ignored provisioned throughput values, no values are provided to the provider, which causes a failure.

Since the `ignore_changes` setting cannot be made conditional, this PR adds special handling when switching from `PAY_PER_REQUEST` to `PROVISIONED` and there are no values for `read_capacity` and `write_capacity`. The provider assumes that the table is configured with autoscaling and sets the provisioned throughput to the minimum value of `1`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14155
Closes #13693
Supersedes #22585

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDynamoDBTable_ PKG=dynamodb

--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (78.54s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (9.34s)
--- PASS: TestAccDynamoDBTable_basic (179.36s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (182.87s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (186.03s)
--- PASS: TestAccDynamoDBTable_tags (188.36s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (234.44s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (256.84s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (272.00s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (276.29s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (285.01s)
--- PASS: TestAccDynamoDBTable_streamSpecification (221.42s)
--- PASS: TestAccDynamoDBTable_disappears (69.44s)
--- PASS: TestAccDynamoDBTable_enablePITR (175.23s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (181.07s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (142.49s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (143.14s)
--- PASS: TestAccDynamoDBTable_encryption (411.61s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (143.95s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (428.79s)
--- PASS: TestAccDynamoDBTable_extended (259.55s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (542.88s)
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (751.76s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (721.22s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (932.18s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (937.44s)
--- PASS: TestAccDynamoDBTable_backup_encryption (944.25s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (1132.56s)
--- PASS: TestAccDynamoDBTable_Replica_single (1234.86s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1291.82s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (2470.07s)
```
