### PR TITLE
Document valid values for sagemaker domain retention policy

### DIFF
--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -145,7 +145,7 @@ The following arguments are supported:
 
 ### Retention Policy
 
-* `home_efs_file_system` - (Optional) The retention policy for data stored on an Amazon Elastic File System (EFS) volume. Default value is `Retain`.
+* `home_efs_file_system` - (Optional) The retention policy for data stored on an Amazon Elastic File System (EFS) volume. Valid values are `Retain` or `Delete`.  Default value is `Retain`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
None

I'm documenting the other valid value for the `aws_sagemaker_domain` retention policy, which I found is `Delete` after looking at the [aws-go-sdk source code](https://github.com/aws/aws-sdk-go/blob/main/service/sagemaker/api.go) (search for the const `RetentionTypeDelete`), which is then used [here](https://github.com/hashicorp/terraform-provider-aws/blob/3c1fd63d8e058f05beecbac4c70b52877d8a5eb6/internal/service/sagemaker/domain.go#L277) by the provider

```terraform
retention_policy {
    home_efs_file_system = "Retain | Delete"
}
```

