### PR TITLE
r/autoscaling_attachment: deprecate `alb_target_group_arn` and add `lb_target_group_arn`

### DIFF
--- a/.changelog/22662.txt
+++ b/.changelog/22662.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/aws_autoscaling_attachment: The `alb_target_group_arn` argument has been deprecated. All configurations using `alb_target_group_arn` should be updated to use the new `lb_target_group_arn` argument instead
+```
+
+```release-note:enhancement
+resource/aws_autoscaling_attachment: Add `lb_target_group_arn` argument
+```

--- a/internal/service/autoscaling/attachment.go
+++ b/internal/service/autoscaling/attachment.go
@@ -31,9 +31,18 @@ func ResourceAttachment() *schema.Resource {
 			},
 
 			"alb_target_group_arn": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				Deprecated:    "Use lb_target_group_arn instead",
+				ConflictsWith: []string{"lb_target_group_arn"},
+			},
+
+			"lb_target_group_arn": {
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"alb_target_group_arn"},
 			},
 		},
 	}
@@ -65,7 +74,20 @@ func resourceAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[INFO] registering asg %s with ALB Target Group %s", asgName, v.(string))
 
 		if _, err := conn.AttachLoadBalancerTargetGroups(attachOpts); err != nil {
-			return fmt.Errorf("Failure attaching AutoScaling Group %s with ALB Target Group: %s: %s", asgName, v.(string), err)
+			return fmt.Errorf("failure attaching AutoScaling Group %s with ALB Target Group: %s: %w", asgName, v.(string), err)
+		}
+	}
+
+	if v, ok := d.GetOk("lb_target_group_arn"); ok {
+		attachOpts := &autoscaling.AttachLoadBalancerTargetGroupsInput{
+			AutoScalingGroupName: aws.String(asgName),
+			TargetGroupARNs:      []*string{aws.String(v.(string))},
+		}
+
+		log.Printf("[INFO] registering asg %s with LB Target Group %s", asgName, v.(string))
+
+		if _, err := conn.AttachLoadBalancerTargetGroups(attachOpts); err != nil {
+			return fmt.Errorf("failure attaching AutoScaling Group %s with LB Target Group: %s: %w", asgName, v.(string), err)
 		}
 	}
 
@@ -123,6 +145,22 @@ func resourceAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if v, ok := d.GetOk("lb_target_group_arn"); ok {
+		found := false
+		for _, i := range asg.TargetGroupARNs {
+			if v.(string) == aws.StringValue(i) {
+				d.Set("lb_target_group_arn", v.(string))
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			log.Printf("[WARN] Association for %s was not found in ASG association", v.(string))
+			d.SetId("")
+		}
+	}
+
 	return nil
 }
 
@@ -138,7 +176,7 @@ func resourceAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 
 		log.Printf("[INFO] Deleting ELB %s association from: %s", v.(string), asgName)
 		if _, err := conn.DetachLoadBalancers(detachOpts); err != nil {
-			return fmt.Errorf("Failure detaching AutoScaling Group %s with Elastic Load Balancer: %s: %s", asgName, v.(string), err)
+			return fmt.Errorf("failure detaching AutoScaling Group %s with Elastic Load Balancer: %s: %w", asgName, v.(string), err)
 		}
 	}
 
@@ -150,7 +188,19 @@ func resourceAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 
 		log.Printf("[INFO] Deleting ALB Target Group %s association from: %s", v.(string), asgName)
 		if _, err := conn.DetachLoadBalancerTargetGroups(detachOpts); err != nil {
-			return fmt.Errorf("Failure detaching AutoScaling Group %s with ALB Target Group: %s: %s", asgName, v.(string), err)
+			return fmt.Errorf("failure detaching AutoScaling Group %s with ALB Target Group: %s: %w", asgName, v.(string), err)
+		}
+	}
+
+	if v, ok := d.GetOk("lb_target_group_arn"); ok {
+		detachOpts := &autoscaling.DetachLoadBalancerTargetGroupsInput{
+			AutoScalingGroupName: aws.String(asgName),
+			TargetGroupARNs:      []*string{aws.String(v.(string))},
+		}
+
+		log.Printf("[INFO] Deleting LB Target Group %s association from: %s", v.(string), asgName)
+		if _, err := conn.DetachLoadBalancerTargetGroups(detachOpts); err != nil {
+			return fmt.Errorf("failure detaching AutoScaling Group %s with LB Target Group: %s: %w", asgName, v.(string), err)
 		}
 	}
 

--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -60,7 +60,8 @@ The following arguments are supported:
 
 * `autoscaling_group_name` - (Required) Name of ASG to associate with the ELB.
 * `elb` - (Optional) The name of the ELB.
-* `alb_target_group_arn` - (Optional) The ARN of an ALB Target Group.
+* `alb_target_group_arn` - (Optional, **Deprecated** use `lb_target_group_arn` instead) The ARN of an ALB Target Group.
+* `lb_target_group_arn` - (Optional) The ARN of a load balancer target group.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/5407
Relates #20433

### Description

* Deprecation of `alb_target_group_arn` for removal in 5.0

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAutoScalingAttachment_elb (115.07s)
--- PASS: TestAccAutoScalingAttachment_albTargetGroup (131.43s)
```
