### PR TITLE
r/aws_ecr_lifecycle_policy - fix change detection bug

### DIFF
--- a/.changelog/22665.txt
+++ b/.changelog/22665.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecr_lifecycle_policy: Fix diffs in `policy` when no changes are detected
+```

--- a/internal/service/ecr/lifecycle_policy.go
+++ b/internal/service/ecr/lifecycle_policy.go
@@ -191,10 +191,10 @@ type lifecyclePolicyRuleAction struct {
 }
 
 type lifecyclePolicyRule struct {
-	RulePriority *int64                        `locationName:"countNumber" type:"integer" required:"true"`
+	RulePriority *int64                        `locationName:"rulePriority" type:"integer" required:"true"`
 	Description  *string                       `locationName:"description" type:"string"`
-	Selection    *lifecyclePolicyRuleSelection `location:"selection" type:"structure" required:"true"`
-	Action       *lifecyclePolicyRuleAction    `location:"action" type:"structure" required:"true"`
+	Selection    *lifecyclePolicyRuleSelection `locationName:"selection" type:"structure" required:"true"`
+	Action       *lifecyclePolicyRuleAction    `locationName:"action" type:"structure" required:"true"`
 }
 
 type lifecyclePolicy struct {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22641.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccECRLifecyclePolicy_ PKG_NAME=internal/service/ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRLifecyclePolicy_'  -timeout 180m
=== RUN   TestAccECRLifecyclePolicy_basic
=== PAUSE TestAccECRLifecyclePolicy_basic
=== RUN   TestAccECRLifecyclePolicy_ignoreEquivalent
=== PAUSE TestAccECRLifecyclePolicy_ignoreEquivalent
=== RUN   TestAccECRLifecyclePolicy_detectDiff
=== PAUSE TestAccECRLifecyclePolicy_detectDiff
=== CONT  TestAccECRLifecyclePolicy_basic
=== CONT  TestAccECRLifecyclePolicy_ignoreEquivalent
=== CONT  TestAccECRLifecyclePolicy_detectDiff
--- PASS: TestAccECRLifecyclePolicy_basic (33.08s)
--- PASS: TestAccECRLifecyclePolicy_detectDiff (43.92s)
--- PASS: TestAccECRLifecyclePolicy_ignoreEquivalent (44.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        51.051s
```
