### PR TITLE
r/elasticache_replication_group: deprecations/addition of args to align with API

### DIFF
--- a/.changelog/22666.txt
+++ b/.changelog/22666.txt
@@ -1,0 +1,23 @@
+```release-note:note
+resource/aws_elasticache_replication_group: The `number_cache_clusters` argument has been deprecated. All configurations using `number_cache_clusters` should be updated to use the `num_cache_clusters` argument instead
+```
+
+```release-note:enhancement
+resource/aws_elasticache_replication_group: Add `num_cache_clusters` argument
+```
+
+```release-note:note
+resource/aws_elasticache_replication_group: The `replication_group_description` argument has been deprecated. All configurations using `replication_group_description` should be updated to use the `description` argument instead
+```
+
+```release-note:enhancement
+resource/aws_elasticache_replication_group: Add `description` argument
+```
+
+```release-note:note
+resource/aws_elasticache_replication_group: The `cluster_mode` argument has been deprecated. All configurations using `cluster_mode` should be updated to use the root-level `num_node_groups` and `replicas_per_node_group` arguments instead
+```
+
+```release-note:enhancement
+resource/aws_elasticache_replication_group: Add `num_node_groups` and `replicas_per_node_group` arguments
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -80,21 +80,26 @@ func ResourceReplicationGroup() *schema.Resource {
 				Computed: true,
 			},
 			"cluster_mode": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"num_node_groups", "replicas_per_node_group"},
+				Deprecated:    "Use num_node_groups and replicas_per_node_group instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"num_node_groups": {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Computed:      true,
-							ConflictsWith: []string{"number_cache_clusters", "global_replication_group_id"},
+							ConflictsWith: []string{"num_node_groups", "number_cache_clusters", "num_cache_clusters", "global_replication_group_id"},
+							Deprecated:    "Use root-level num_node_groups instead",
 						},
 						"replicas_per_node_group": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:          schema.TypeInt,
+							Required:      true,
+							ConflictsWith: []string{"replicas_per_node_group"},
+							Deprecated:    "Use root-level replicas_per_node_group instead",
 						},
 					},
 				},
@@ -108,6 +113,11 @@ func ResourceReplicationGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+			"description": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"replication_group_description"},
 			},
 			"engine": {
 				Type:         schema.TypeString,
@@ -132,7 +142,8 @@ func ResourceReplicationGroup() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 				ConflictsWith: []string{
-					"cluster_mode.0.num_node_groups", // should/will be top-level "num_node_groups"
+					"cluster_mode.0.num_node_groups",
+					"num_node_groups",
 					"parameter_group_name",
 					"engine",
 					"engine_version",
@@ -175,11 +186,24 @@ func ResourceReplicationGroup() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"num_cache_clusters": {
+				Type:          schema.TypeInt,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"cluster_mode.0.num_node_groups", "num_node_groups", "number_cache_clusters"},
+			},
+			"num_node_groups": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"cluster_mode", "number_cache_clusters", "num_cache_clusters", "global_replication_group_id"},
+			},
 			"number_cache_clusters": {
 				Type:          schema.TypeInt,
 				Computed:      true,
 				Optional:      true,
-				ConflictsWith: []string{"cluster_mode.0.num_node_groups"},
+				ConflictsWith: []string{"cluster_mode.0.num_node_groups", "num_cache_clusters", "num_node_groups"},
+				Deprecated:    "Use num_cache_clusters instead",
 			},
 			"parameter_group_name": {
 				Type:     schema.TypeString,
@@ -209,9 +233,16 @@ func ResourceReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"replicas_per_node_group": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"cluster_mode"},
+			},
 			"replication_group_description": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"description"},
+				Deprecated:    "Use description instead",
 			},
 			"replication_group_id": {
 				Type:         schema.TypeString,
@@ -318,8 +349,11 @@ func ResourceReplicationGroup() *schema.Resource {
 			CustomizeDiffElastiCacheEngineVersion,
 			customdiff.ComputedIf("member_clusters", func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
 				return diff.HasChange("number_cache_clusters") ||
+					diff.HasChange("num_cache_clusters") ||
 					diff.HasChange("cluster_mode.0.num_node_groups") ||
-					diff.HasChange("cluster_mode.0.replicas_per_node_group")
+					diff.HasChange("cluster_mode.0.replicas_per_node_group") ||
+					diff.HasChange("num_node_groups") ||
+					diff.HasChange("replicas_per_node_group")
 			}),
 			verify.SetTagsDiff,
 		),
@@ -332,14 +366,17 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	params := &elasticache.CreateReplicationGroupInput{
-		ReplicationGroupId:          aws.String(d.Get("replication_group_id").(string)),
-		ReplicationGroupDescription: aws.String(d.Get("replication_group_description").(string)),
-		AutoMinorVersionUpgrade:     aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
-		Tags:                        Tags(tags.IgnoreAWS()),
+		ReplicationGroupId:      aws.String(d.Get("replication_group_id").(string)),
+		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
+		Tags:                    Tags(tags.IgnoreAWS()),
 	}
 
 	if v, ok := d.GetOk("data_tiering_enabled"); ok {
 		params.DataTieringEnabled = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		params.ReplicationGroupDescription = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("global_replication_group_id"); ok {
@@ -369,6 +406,10 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("port"); ok {
 		params.Port = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("replication_group_description"); ok {
+		params.ReplicationGroupDescription = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("subnet_group_name"); ok {
@@ -440,8 +481,20 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	if v, ok := d.GetOk("num_node_groups"); ok && v != 0 {
+		params.NumNodeGroups = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("replicas_per_node_group"); ok {
+		params.ReplicasPerNodeGroup = aws.Int64(int64(v.(int)))
+	}
+
 	if cacheClusters, ok := d.GetOk("number_cache_clusters"); ok {
 		params.NumCacheClusters = aws.Int64(int64(cacheClusters.(int)))
+	}
+
+	if numCacheClusters, ok := d.GetOk("num_cache_clusters"); ok {
+		params.NumCacheClusters = aws.Int64(int64(numCacheClusters.(int)))
 	}
 
 	if userGroupIds := d.Get("user_group_ids").(*schema.Set); userGroupIds.Len() > 0 {
@@ -521,14 +574,20 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("kms_key_id", rgp.KmsKeyId)
+	d.Set("description", rgp.Description)
 	d.Set("replication_group_description", rgp.Description)
 	d.Set("number_cache_clusters", len(rgp.MemberClusters))
+	d.Set("num_cache_clusters", len(rgp.MemberClusters))
 	if err := d.Set("member_clusters", flex.FlattenStringSet(rgp.MemberClusters)); err != nil {
 		return fmt.Errorf("error setting member_clusters: %w", err)
 	}
 	if err := d.Set("cluster_mode", flattenElasticacheNodeGroupsToClusterMode(rgp.NodeGroups)); err != nil {
 		return fmt.Errorf("error setting cluster_mode attribute: %w", err)
 	}
+
+	d.Set("num_node_groups", len(rgp.NodeGroups))
+	d.Set("replicas_per_node_group", len(rgp.NodeGroups[0].NodeGroupMembers)-1)
+
 	d.Set("cluster_enabled", rgp.ClusterEnabled)
 	d.Set("replication_group_id", rgp.ReplicationGroupId)
 	d.Set("arn", rgp.ARN)
@@ -610,13 +669,24 @@ func resourceReplicationGroupRead(d *schema.ResourceData, meta interface{}) erro
 func resourceReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ElastiCacheConn
 
-	if d.HasChanges("cluster_mode.0.num_node_groups", "cluster_mode.0.replicas_per_node_group") {
+	if d.HasChanges(
+		"cluster_mode.0.num_node_groups",
+		"cluster_mode.0.replicas_per_node_group",
+		"num_node_groups",
+		"replicas_per_node_group",
+	) {
 		err := elasticacheReplicationGroupModifyShardConfiguration(conn, d)
 		if err != nil {
 			return fmt.Errorf("error modifying ElastiCache Replication Group (%s) shard configuration: %w", d.Id(), err)
 		}
 	} else if d.HasChange("number_cache_clusters") {
-		err := elasticacheReplicationGroupModifyNumCacheClusters(conn, d)
+		// TODO: remove when number_cache_clusters is removed from resource schema
+		err := elasticacheReplicationGroupModifyNumCacheClusters(conn, d, "number_cache_clusters")
+		if err != nil {
+			return fmt.Errorf("error modifying ElastiCache Replication Group (%s) clusters: %w", d.Id(), err)
+		}
+	} else if d.HasChange("num_cache_clusters") {
+		err := elasticacheReplicationGroupModifyNumCacheClusters(conn, d, "num_cache_clusters")
 		if err != nil {
 			return fmt.Errorf("error modifying ElastiCache Replication Group (%s) clusters: %w", d.Id(), err)
 		}
@@ -626,6 +696,11 @@ func resourceReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	params := &elasticache.ModifyReplicationGroupInput{
 		ApplyImmediately:   aws.Bool(d.Get("apply_immediately").(bool)),
 		ReplicationGroupId: aws.String(d.Id()),
+	}
+
+	if d.HasChange("description") {
+		params.ReplicationGroupDescription = aws.String(d.Get("description").(string))
+		requestUpdate = true
 	}
 
 	if d.HasChange("replication_group_description") {
@@ -877,14 +952,28 @@ func flattenElasticacheNodeGroupsToClusterMode(nodeGroups []*elasticache.NodeGro
 
 func elasticacheReplicationGroupModifyShardConfiguration(conn *elasticache.ElastiCache, d *schema.ResourceData) error {
 	if d.HasChange("cluster_mode.0.num_node_groups") {
-		err := elasticacheReplicationGroupModifyShardConfigurationNumNodeGroups(conn, d)
+		err := elasticacheReplicationGroupModifyShardConfigurationNumNodeGroups(conn, d, "cluster_mode.0.num_node_groups")
 		if err != nil {
 			return err
 		}
 	}
 
 	if d.HasChange("cluster_mode.0.replicas_per_node_group") {
-		err := elasticacheReplicationGroupModifyShardConfigurationReplicasPerNodeGroup(conn, d)
+		err := elasticacheReplicationGroupModifyShardConfigurationReplicasPerNodeGroup(conn, d, "cluster_mode.0.replicas_per_node_group")
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("num_node_groups") {
+		err := elasticacheReplicationGroupModifyShardConfigurationNumNodeGroups(conn, d, "num_node_groups")
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("replicas_per_node_group") {
+		err := elasticacheReplicationGroupModifyShardConfigurationReplicasPerNodeGroup(conn, d, "replicas_per_node_group")
 		if err != nil {
 			return err
 		}
@@ -893,8 +982,8 @@ func elasticacheReplicationGroupModifyShardConfiguration(conn *elasticache.Elast
 	return nil
 }
 
-func elasticacheReplicationGroupModifyShardConfigurationNumNodeGroups(conn *elasticache.ElastiCache, d *schema.ResourceData) error {
-	o, n := d.GetChange("cluster_mode.0.num_node_groups")
+func elasticacheReplicationGroupModifyShardConfigurationNumNodeGroups(conn *elasticache.ElastiCache, d *schema.ResourceData, argument string) error {
+	o, n := d.GetChange(argument)
 	oldNumNodeGroups := o.(int)
 	newNumNodeGroups := n.(int)
 
@@ -929,8 +1018,8 @@ func elasticacheReplicationGroupModifyShardConfigurationNumNodeGroups(conn *elas
 	return nil
 }
 
-func elasticacheReplicationGroupModifyShardConfigurationReplicasPerNodeGroup(conn *elasticache.ElastiCache, d *schema.ResourceData) error {
-	o, n := d.GetChange("cluster_mode.0.replicas_per_node_group")
+func elasticacheReplicationGroupModifyShardConfigurationReplicasPerNodeGroup(conn *elasticache.ElastiCache, d *schema.ResourceData, argument string) error {
+	o, n := d.GetChange(argument)
 	oldReplicas := o.(int)
 	newReplicas := n.(int)
 
@@ -967,8 +1056,8 @@ func elasticacheReplicationGroupModifyShardConfigurationReplicasPerNodeGroup(con
 	return nil
 }
 
-func elasticacheReplicationGroupModifyNumCacheClusters(conn *elasticache.ElastiCache, d *schema.ResourceData) error {
-	o, n := d.GetChange("number_cache_clusters")
+func elasticacheReplicationGroupModifyNumCacheClusters(conn *elasticache.ElastiCache, d *schema.ResourceData, argument string) error {
+	o, n := d.GetChange(argument)
 	oldNumberCacheClusters := o.(int)
 	newNumberCacheClusters := n.(int)
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -177,10 +177,10 @@ The following arguments are optional:
 * `transit_encryption_enabled` - (Optional) Whether to enable encryption in transit.
 * `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one.
 
-### cluster_mode
+### cluster_mode (**DEPRECATED**)
 
-* `num_node_groups` - (Optional) Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. Required unless `global_replication_group_id` is set.
-* `replicas_per_node_group` - (Required) Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will trigger an online resizing operation before other settings modifications.
+* `num_node_groups` - (Optional, **Deprecated** use root-level `num_node_groups` instead) Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. Required unless `global_replication_group_id` is set.
+* `replicas_per_node_group` - (Required, **Deprecated** use root-level `replicas_per_node_group` instead) Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will trigger an online resizing operation before other settings modifications.
 
 ## Attributes Reference
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -180,7 +180,7 @@ The following arguments are optional:
 ### cluster_mode (**DEPRECATED**)
 
 * `num_node_groups` - (Optional, **Deprecated** use root-level `num_node_groups` instead) Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. Required unless `global_replication_group_id` is set.
-* `replicas_per_node_group` - (Required, **Deprecated** use root-level `replicas_per_node_group` instead) Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will trigger an online resizing operation before other settings modifications.
+* `replicas_per_node_group` - (Optional, Required with `cluster_mode` `num_node_groups`, **Deprecated** use root-level `replicas_per_node_group` instead) Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will trigger an online resizing operation before other settings modifications.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/18440

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2895.64s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (3412.37s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2444.71s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (3785.57s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (2259.96s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (1284.76s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (986.34s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (2407.81s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (4297.71s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1119.46s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3564.32s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2326.51s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2346.31s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3332.60s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (1769.28s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (1724.35s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1297.06s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1826.56s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1786.72s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (2260.38s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1712.56s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (2057.71s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (16.64s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (994.98s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (5.78s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (1265.41s)
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (1.93s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (657.04s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (604.91s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (716.55s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (1202.86s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (1771.62s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1065.53s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (1227.82s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (2913.70s)
--- PASS: TestAccElastiCacheReplicationGroup_redisClusterInVPC2 (1631.10s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (1402.61s)
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (940.81s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (1104.66s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (1346.08s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1555.67s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (1943.29s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (2123.66s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (1161.08s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (1813.47s)
```
