### PR TITLE
s3/bucket: add new_versions to noncurrent_version_expiration within lifecycle_rule

### DIFF
--- a/.changelog/22680.txt
+++ b/.changelog/22680.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add `new_versions` argument to `noncurrent_version_expiration` within `lifecycle_rule`
+```

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -1339,6 +1339,7 @@ func TestAccS3Bucket_Manage_lifecycleBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.prefix", "path1/"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.noncurrent_version_expiration.0.days", "365"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.noncurrent_version_expiration.0.newer_versions", "0"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "lifecycle_rule.0.noncurrent_version_transition.*", map[string]string{
 						"days":          "30",
 						"storage_class": "STANDARD_IA",
@@ -1351,6 +1352,7 @@ func TestAccS3Bucket_Manage_lifecycleBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.prefix", "path2/"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.noncurrent_version_expiration.0.days", "365"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.noncurrent_version_expiration.0.newer_versions", "3"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.2.prefix", "path3/"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "lifecycle_rule.2.noncurrent_version_transition.*", map[string]string{
@@ -4114,7 +4116,8 @@ resource "aws_s3_bucket" "bucket" {
     enabled = false
 
     noncurrent_version_expiration {
-      days = 365
+      days           = 365
+      newer_versions = 3
     }
   }
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -430,6 +430,7 @@ The `transition` object supports the following
 The `noncurrent_version_expiration` object supports the following
 
 * `days` (Required) Specifies the number of days noncurrent object versions expire.
+* `newer_versions` (Optional) Specifies how many noncurrent versions Amazon S3 will retain. If there are this many more recent noncurrent versions, Amazon S3 will take the associated action.
 
 The `noncurrent_version_transition` object supports the following
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22561

This adds the `newer_versions` attribute to the `noncurrent_version_expiration` block in S3 lifecycle rules.

[The API docs on NoncurrentVersionExpiration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule-noncurrentversionexpiration.html) use the terms `NoncurrentDays` and `NewerNoncurrentVersions`. The existing Terraform attribute is simply `days` so I simplified the new field to `newer_versions` to be similar. Let me know if you think it should be `newer_noncurrent_versions` to be more explicit.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccS3Bucket_Manage_lifecycleBasic PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_Manage_lifecycleBasic'  -timeout 180m
=== RUN   TestAccS3Bucket_Manage_lifecycleBasic
=== PAUSE TestAccS3Bucket_Manage_lifecycleBasic
=== CONT  TestAccS3Bucket_Manage_lifecycleBasic
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (94.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 94.728s
...
```
