### PR TITLE
Fix naming docs minor issue

### DIFF
--- a/docs/contributing/naming.md
+++ b/docs/contributing/naming.md
@@ -145,23 +145,22 @@ There are three types of tests in the AWS Provider: (regular) acceptance tests, 
 
 Acceptance test names have a minimum of two (e.g., `TestAccBackupPlan_tags`) or a maximum of three (e.g., `TestAccDynamoDBTable_Replica_multiple`) parts, joined with underscores:
 
-1. First part: All have a _prefix_ (i.e., `TestAcc`), _service name_ (e.g., `Backup`, `DynamoDB`), and _resource name_ (e.g., `Plan`, `Table`), [MixedCaps](#mixedcaps) without underscores between.
+1. First part: All have a _prefix_ (i.e., `TestAcc`), _service name_ (e.g., `Backup`, `DynamoDB`), and _resource name_ (e.g., `Plan`, `Table`), [MixedCaps](#mixedcaps) without underscores between. Do not include "AWS" or "Aws" in the name.
 2. Middle part (Optional): _Test group_ (e.g., `Replica`), uppercase, [MixedCaps](#mixedcaps). Consider a metaphor where tests are chapters in a book. If it is helpful, tests can be grouped together like chapters in a book that are sometimes grouped into parts or sections of the book.
 3. Last part: _Test identifier_ (e.g., `basic`, `tags`, or `multiple`), lowercase, [mixedCaps](#mixedcaps)). The identifier should make the test's purpose clear but be concise. For example, the identifier `conflictsWithCloudFrontDefaultCertificate` (41 characters) conveys no more information than `conflictDefaultCertificate` (26 characters), since "CloudFront" is implied and "with" is _always_ implicit. Avoid words that convey no meaning or whose meaning is implied. For example, "with" (e.g., `_withTags`) is not needed because we imply the name is telling us what the test is _with_. `withTags` can be simplified to `tags`.
-4. Do not include "AWS" or "Aws" in the name.
 
 ### Serialized Acceptance Test Rule
 
-The names of serialized acceptance tests follow all the regular acceptance test name rules **_except_** serialized acceptance test names:
+The names of serialized acceptance tests follow the regular [acceptance test name rule](#acceptance-test-rule) **_except_** serialized acceptance test names:
 
 1. Start with `testAcc` instead of `TestAcc`
 2. Do not include the name of the service (e.g., a serialized acceptance test would be called `testAccApp_basic` not `testAccAmplifyApp_basic`).
 
 ### Unit Test Rule
 
-Unit test names follow the same rule as acceptance test names except unit test names:
+Unit test names follow the same [rule](#acceptance-test-rule) as acceptance test names except unit test names:
 
-1. Start with `Test` not `TestAcc`
+1. Start with `Test`, not `TestAcc`
 2. Do not include the name of the service
 3. Usually do not have any underscores
 4. If they test a function, should include the function name (e.g., a unit test of `ExpandListener()` should be called `TestExpandListener()`)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
