### PR TITLE
Disable code signing in lambda for ap-southeast-3

### DIFF
--- a/.changelog/22693.txt
+++ b/.changelog/22693.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Prevent errors when attempting to configure code signing in the `ap-southeast-3` AWS Region
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -852,12 +852,13 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	// Currently, this functionality is not enabled in ap-northeast-3 (Osaka) region
+	// Currently, this functionality is not enabled in ap-northeast-3 (Osaka) and ap-southeast-3 (Jakarta) region
 	// and returns ambiguous error codes (e.g. AccessDeniedException)
 	// so we cannot just ignore the error as would typically.
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	if meta.(*conns.AWSClient).Region == endpoints.ApNortheast3RegionID {
+	if meta.(*conns.AWSClient).Region == endpoints.ApNortheast3RegionID ||
+		meta.(*conns.AWSClient).Region == endpoints.ApSoutheast3RegionID {
 		return nil
 	}
 

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -848,7 +848,7 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	// Currently, this functionality is only enabled in AWS Commercial partition
 	// and other partitions return ambiguous error codes (e.g. AccessDeniedException
 	// in AWS GovCloud (US)) so we cannot just ignore the error as would typically.
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
+	if partition := meta.(*conns.AWSClient).Partition; partition != endpoints.AwsPartitionID {
 		return nil
 	}
 
@@ -857,8 +857,7 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	// so we cannot just ignore the error as would typically.
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	if meta.(*conns.AWSClient).Region == endpoints.ApNortheast3RegionID ||
-		meta.(*conns.AWSClient).Region == endpoints.ApSoutheast3RegionID {
+	if region := meta.(*conns.AWSClient).Region; region == endpoints.ApNortheast3RegionID || region == endpoints.ApSoutheast3RegionID {
 		return nil
 	}
 

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -164,8 +164,10 @@ func TestAccLambdaFunction_codeSigning(t *testing.T) {
 
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	if got, want := acctest.Region(), endpoints.ApNortheast3RegionID; got == want {
-		t.Skipf("Lambda code signing config is not supported in %s region", got)
+	for _, want := range []string{endpoints.ApNortheast3RegionID, endpoints.ApSoutheast3RegionID} {
+		if got := acctest.Region(); got == want {
+			t.Skipf("Lambda code signing config is not supported in %s region", got)
+		}
 	}
 
 	var conf lambda.GetFunctionOutput


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22692

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccLambdaFunction_codeSigning PKG=lambda

(Failed to run. Asked for AWS credentials for running acceptance testing)
...
```
