### PR TITLE
lambda: Add long-running test guards

### DIFF
--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -705,18 +705,17 @@ func testAccErrorCheckSkipService(t *testing.T) resource.ErrorCheckFunc {
 
 #### Long-Running Test Guards
 
-For any acceptance tests that typically run longer than 300 seconds (5 minutes), add a `-short` test guard before the `resource.ParallelTest()` (or `resource.Test()`) statement.
+For any acceptance tests that typically run longer than 300 seconds (5 minutes), add a `-short` test guard at the top of the test function.
 
 For example:
 
 ```go
 func TestAccExampleThing_longRunningTest(t *testing.T) {
-  rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-  resourceName := "aws_example_thing.test"
-
   if testing.Short() {
     t.Skip("skipping long-running test in short mode")
   }
+
+  // ... omitted for brevity ...
 
   resource.ParallelTest(t, resource.TestCase{
     // ... omitted for brevity ...

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -438,6 +438,10 @@ func TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds(t *testing.
 }
 
 func TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.EventSourceMappingConfiguration
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_event_source_mapping.test"
@@ -714,6 +718,10 @@ func TestAccLambdaEventSourceMapping_Kinesis_destination(t *testing.T) {
 }
 
 func TestAccLambdaEventSourceMapping_msk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var v lambda.EventSourceMappingConfiguration
 	resourceName := "aws_lambda_event_source_mapping.test"
 	eventSourceResourceName := "aws_msk_cluster.test"
@@ -802,6 +810,10 @@ func TestAccLambdaEventSourceMapping_selfManagedKafka(t *testing.T) {
 }
 
 func TestAccLambdaEventSourceMapping_activeMQ(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var v lambda.EventSourceMappingConfiguration
 	resourceName := "aws_lambda_event_source_mapping.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -840,6 +852,10 @@ func TestAccLambdaEventSourceMapping_activeMQ(t *testing.T) {
 }
 
 func TestAccLambdaEventSourceMapping_rabbitMQ(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var v lambda.EventSourceMappingConfiguration
 	resourceName := "aws_lambda_event_source_mapping.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -878,6 +894,10 @@ func TestAccLambdaEventSourceMapping_rabbitMQ(t *testing.T) {
 }
 
 func TestAccLambdaEventSourceMapping_SQS_filterCriteria(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.EventSourceMappingConfiguration
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_event_source_mapping.test"

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestAccLambdaFunctionDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_lambda_function.test"
 	resourceName := "aws_lambda_function.test"
@@ -121,6 +125,10 @@ func TestAccLambdaFunctionDataSource_layers(t *testing.T) {
 }
 
 func TestAccLambdaFunctionDataSource_vpc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_lambda_function.test"
 	resourceName := "aws_lambda_function.test"
@@ -168,6 +176,10 @@ func TestAccLambdaFunctionDataSource_environment(t *testing.T) {
 }
 
 func TestAccLambdaFunctionDataSource_fileSystem(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_lambda_function.test"
 	resourceName := "aws_lambda_function.test"

--- a/internal/service/lambda/function_event_invoke_config_test.go
+++ b/internal/service/lambda/function_event_invoke_config_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestAccLambdaFunctionEventInvokeConfig_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	lambdaFunctionResourceName := "aws_lambda_function.test"
 	resourceName := "aws_lambda_function_event_invoke_config.test"
@@ -94,6 +98,10 @@ func TestAccLambdaFunctionEventInvokeConfig_Disappears_lambdaFunctionEventInvoke
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_DestinationOnFailure_destination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function_event_invoke_config.test"
 	sqsQueueResourceName := "aws_sqs_queue.test"
@@ -133,6 +141,10 @@ func TestAccLambdaFunctionEventInvokeConfig_DestinationOnFailure_destination(t *
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_DestinationOnSuccess_destination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function_event_invoke_config.test"
 	sqsQueueResourceName := "aws_sqs_queue.test"
@@ -172,6 +184,10 @@ func TestAccLambdaFunctionEventInvokeConfig_DestinationOnSuccess_destination(t *
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_Destination_remove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function_event_invoke_config.test"
 	sqsQueueResourceName := "aws_sqs_queue.test"
@@ -208,6 +224,10 @@ func TestAccLambdaFunctionEventInvokeConfig_Destination_remove(t *testing.T) {
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_Destination_swap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function_event_invoke_config.test"
 	sqsQueueResourceName := "aws_sqs_queue.test"
@@ -246,6 +266,10 @@ func TestAccLambdaFunctionEventInvokeConfig_Destination_swap(t *testing.T) {
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_FunctionName_arn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	lambdaFunctionResourceName := "aws_lambda_function.test"
 	resourceName := "aws_lambda_function_event_invoke_config.test"
@@ -274,6 +298,10 @@ func TestAccLambdaFunctionEventInvokeConfig_FunctionName_arn(t *testing.T) {
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_QualifierFunctionName_arn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	lambdaFunctionResourceName := "aws_lambda_function.test"
 	resourceName := "aws_lambda_function_event_invoke_config.test"
@@ -302,6 +330,10 @@ func TestAccLambdaFunctionEventInvokeConfig_QualifierFunctionName_arn(t *testing
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_maximumEventAgeInSeconds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function_event_invoke_config.test"
 
@@ -335,6 +367,10 @@ func TestAccLambdaFunctionEventInvokeConfig_maximumEventAgeInSeconds(t *testing.
 }
 
 func TestAccLambdaFunctionEventInvokeConfig_maximumRetryAttempts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function_event_invoke_config.test"
 

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -74,6 +74,10 @@ func TestAccLambdaFunction_basic(t *testing.T) {
 }
 
 func TestAccLambdaFunction_unpublishedCodeUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf1, conf2 lambda.GetFunctionOutput
 
 	initialFilename := "test-fixtures/lambdatest.zip"
@@ -226,6 +230,10 @@ func TestAccLambdaFunction_codeSigning(t *testing.T) {
 }
 
 func TestAccLambdaFunction_concurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -270,6 +278,10 @@ func TestAccLambdaFunction_concurrency(t *testing.T) {
 }
 
 func TestAccLambdaFunction_concurrencyCycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -344,6 +356,10 @@ func TestAccLambdaFunction_expectFilenameAndS3Attributes(t *testing.T) {
 }
 
 func TestAccLambdaFunction_envVariables(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -407,6 +423,10 @@ func TestAccLambdaFunction_envVariables(t *testing.T) {
 }
 
 func TestAccLambdaFunction_EnvironmentVariables_noValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function.test"
@@ -435,6 +455,10 @@ func TestAccLambdaFunction_EnvironmentVariables_noValue(t *testing.T) {
 }
 
 func TestAccLambdaFunction_encryptedEnvVariables(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -482,6 +506,10 @@ func TestAccLambdaFunction_encryptedEnvVariables(t *testing.T) {
 }
 
 func TestAccLambdaFunction_versioned(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -520,6 +548,10 @@ func TestAccLambdaFunction_versioned(t *testing.T) {
 }
 
 func TestAccLambdaFunction_versionedUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	path, zipFile, err := createTempFile("lambda_localUpdate")
@@ -602,6 +634,10 @@ func TestAccLambdaFunction_versionedUpdate(t *testing.T) {
 }
 
 func TestAccLambdaFunction_enablePublish(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf1, conf2, conf3 lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -666,6 +702,10 @@ func TestAccLambdaFunction_enablePublish(t *testing.T) {
 }
 
 func TestAccLambdaFunction_disablePublish(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf1, conf2 lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -719,6 +759,10 @@ func TestAccLambdaFunction_disablePublish(t *testing.T) {
 }
 
 func TestAccLambdaFunction_deadLetter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -770,6 +814,10 @@ func TestAccLambdaFunction_deadLetter(t *testing.T) {
 }
 
 func TestAccLambdaFunction_deadLetterUpdated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -815,6 +863,10 @@ func TestAccLambdaFunction_deadLetterUpdated(t *testing.T) {
 }
 
 func TestAccLambdaFunction_nilDeadLetter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rString := sdkacctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_nil_dlcfg_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_nil_dlcfg_%s", rString)
@@ -837,6 +889,10 @@ func TestAccLambdaFunction_nilDeadLetter(t *testing.T) {
 }
 
 func TestAccLambdaFunction_fileSystem(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
 
@@ -965,6 +1021,10 @@ func TestAccLambdaFunction_image(t *testing.T) {
 }
 
 func TestAccLambdaFunction_architectures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
 
@@ -1018,6 +1078,10 @@ func TestAccLambdaFunction_architectures(t *testing.T) {
 }
 
 func TestAccLambdaFunction_architecturesUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
 
@@ -1071,6 +1135,10 @@ func TestAccLambdaFunction_architecturesUpdate(t *testing.T) {
 }
 
 func TestAccLambdaFunction_architecturesWithLayer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
 
@@ -1125,6 +1193,10 @@ func TestAccLambdaFunction_architecturesWithLayer(t *testing.T) {
 }
 
 func TestAccLambdaFunction_tracing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
 		t.Skipf("Lambda tracing config is not supported in %s partition", got)
 	}
@@ -1176,6 +1248,10 @@ func TestAccLambdaFunction_tracing(t *testing.T) {
 // value and the kms_key_arn check begins failing, the documentation should be updated.
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6366
 func TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var function1 lambda.GetFunctionOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1206,6 +1282,10 @@ func TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables(t *testing.T) {
 }
 
 func TestAccLambdaFunction_layers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1243,6 +1323,10 @@ func TestAccLambdaFunction_layers(t *testing.T) {
 }
 
 func TestAccLambdaFunction_layersUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1291,6 +1375,10 @@ func TestAccLambdaFunction_layersUpdate(t *testing.T) {
 }
 
 func TestAccLambdaFunction_vpc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1330,6 +1418,10 @@ func TestAccLambdaFunction_vpc(t *testing.T) {
 }
 
 func TestAccLambdaFunction_vpcRemoval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1366,6 +1458,10 @@ func TestAccLambdaFunction_vpcRemoval(t *testing.T) {
 }
 
 func TestAccLambdaFunction_vpcUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1419,6 +1515,10 @@ func TestAccLambdaFunction_vpcUpdate(t *testing.T) {
 // See https://github.com/hashicorp/terraform/issues/5767
 // and https://github.com/hashicorp/terraform/issues/10272
 func TestAccLambdaFunction_VPC_withInvocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1454,6 +1554,10 @@ func TestAccLambdaFunction_VPC_withInvocation(t *testing.T) {
 // See https://github.com/hashicorp/terraform-provider-aws/issues/17385
 // When the vpc config doesn't change the version shouldn't change
 func TestAccLambdaFunction_VPCPublishNo_changes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1495,6 +1599,10 @@ func TestAccLambdaFunction_VPCPublishNo_changes(t *testing.T) {
 // See https://github.com/hashicorp/terraform-provider-aws/issues/17385
 // When the vpc config changes the version should change
 func TestAccLambdaFunction_VPCPublishHas_changes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1537,6 +1645,10 @@ func TestAccLambdaFunction_VPCPublishHas_changes(t *testing.T) {
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/10044
 func TestAccLambdaFunction_VPC_properIAMDependencies(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var function lambda.GetFunctionOutput
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1631,6 +1743,10 @@ func TestAccLambdaFunction_s3(t *testing.T) {
 }
 
 func TestAccLambdaFunction_localUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	path, zipFile, err := createTempFile("lambda_localUpdate")
@@ -1695,6 +1811,10 @@ func TestAccLambdaFunction_localUpdate(t *testing.T) {
 }
 
 func TestAccLambdaFunction_LocalUpdate_nameOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf lambda.GetFunctionOutput
 
 	rString := sdkacctest.RandString(8)
@@ -1943,6 +2063,10 @@ func TestAccLambdaFunction_tags(t *testing.T) {
 }
 
 func TestAccLambdaFunction_runtimes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -225,6 +225,10 @@ func TestAccLambdaPermission_StatementID_duplicate(t *testing.T) {
 }
 
 func TestAccLambdaPermission_withRawFunctionName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var statement tflambda.PolicyStatement
 
 	rString := sdkacctest.RandString(8)

--- a/internal/service/lambda/provisioned_concurrency_config_test.go
+++ b/internal/service/lambda/provisioned_concurrency_config_test.go
@@ -92,6 +92,10 @@ func TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaProvisionedConcu
 }
 
 func TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_provisioned_concurrency_config.test"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22701

Output from acceptance testing:

```console
% make testacc TESTS=TestAccLambda PKG=lambda
...
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	5926.363s
% make testacc TESTS=TestAccLambda PKG=lambda TESTARGS=-short
...
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	540.399s
```
