### PR TITLE
r/internet_gateway: Prevent giving up on wait for attachement too early

### DIFF
--- a/.changelog/22713.txt
+++ b/.changelog/22713.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_internet_gateway: No longer give up before the attachment timeout (4m) timeout is exceeded (previously it was giving up after 20 not found checks).
+resource/aws_internet_gateway: No longer give up before the attachment timeout (4m) is exceeded (previously it was giving up after 20 not found checks).
 ```

--- a/.changelog/22713.txt
+++ b/.changelog/22713.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/internet_gateway: The aws_internet_gateway resource does no longer give up before the internet_gateway attached timeout (4m) timeout is exceeded (previously it was giving up after 20 not found checks).
+```

--- a/.changelog/22713.txt
+++ b/.changelog/22713.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/internet_gateway: The aws_internet_gateway resource does no longer give up before the internet_gateway attached timeout (4m) timeout is exceeded (previously it was giving up after 20 not found checks).
+resource/aws_internet_gateway: No longer give up before the attachment timeout (4m) timeout is exceeded (previously it was giving up after 20 not found checks).
 ```

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -25,8 +25,8 @@ const (
 	RouteNotFoundChecks                        = 1000 // Should exceed any reasonable custom timeout value.
 	RouteTableNotFoundChecks                   = 1000 // Should exceed any reasonable custom timeout value.
 	RouteTableAssociationCreatedNotFoundChecks = 1000 // Should exceed any reasonable custom timeout value.
-
-	SecurityGroupNotFoundChecks = 1000 // Should exceed any reasonable custom timeout value.
+	SecurityGroupNotFoundChecks                = 1000 // Should exceed any reasonable custom timeout value.
+	InternetGatewayNotFoundChecks              = 1000 // Should exceed any reasonable custom timeout value.
 )
 
 const (
@@ -1148,10 +1148,11 @@ const (
 
 func WaitInternetGatewayAttached(conn *ec2.EC2, internetGatewayID, vpcID string, timeout time.Duration) (*ec2.InternetGatewayAttachment, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.AttachmentStatusAttaching},
-		Target:  []string{InternetGatewayAttachmentStateAvailable},
-		Timeout: timeout,
-		Refresh: StatusInternetGatewayAttachmentState(conn, internetGatewayID, vpcID),
+		Pending:        []string{ec2.AttachmentStatusAttaching},
+		Target:         []string{InternetGatewayAttachmentStateAvailable},
+		Timeout:        timeout,
+		NotFoundChecks: InternetGatewayNotFoundChecks,
+		Refresh:        StatusInternetGatewayAttachmentState(conn, internetGatewayID, vpcID),
 	}
 
 	outputRaw, err := stateConf.WaitForState()


### PR DESCRIPTION
Signed-off-by: ialidzhikov <i.alidjikov@gmail.com>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22711

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
