### PR TITLE
ISO Tags: Improve error handling

### DIFF
--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -37,3 +37,11 @@ data-source/aws_lb: Further refine tag error handling for ISO regions
 ```release-note:bug
 resource/aws_lb: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+data-source/aws_lb: Further refine tag error handling for ISO regions
+```
+
+```release-note:bug
+data-source/aws_lb_target_group: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_cloudwatch_event_rule: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+resource/aws_cloudwatch_event_bus: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -13,3 +13,7 @@ resource/aws_cloudwatch_composite_alarm: Further refine tag error handling for I
 ```release-note:bug
 resource/aws_cloudwatch_metric_alarm: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+resource/aws_cloudwatch_metric_stream: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -21,3 +21,8 @@ resource/aws_cloudwatch_metric_stream: Further refine tag error handling for ISO
 ```release-note:bug
 data-source/aws_lb_listener: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+resource/aws_lb_listener_rule: Further refine tag error handling for ISO regions
+```
+

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -45,3 +45,7 @@ data-source/aws_lb: Further refine tag error handling for ISO regions
 ```release-note:bug
 data-source/aws_lb_target_group: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+resource/aws_lb_target_group: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -29,3 +29,7 @@ resource/aws_lb_listener_rule: Further refine tag error handling for ISO regions
 ```release-note:bug
 resource/aws_lb_listener: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+data-source/aws_lb: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_rule: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -26,3 +26,6 @@ data-source/aws_lb_listener: Further refine tag error handling for ISO regions
 resource/aws_lb_listener_rule: Further refine tag error handling for ISO regions
 ```
 
+```release-note:bug
+resource/aws_lb_listener: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -33,3 +33,7 @@ resource/aws_lb_listener: Further refine tag error handling for ISO regions
 ```release-note:bug
 data-source/aws_lb: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+resource/aws_lb: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -5,3 +5,11 @@ resource/aws_cloudwatch_event_rule: Further refine tag error handling for ISO re
 ```release-note:bug
 resource/aws_cloudwatch_event_bus: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+resource/aws_cloudwatch_composite_alarm: Further refine tag error handling for ISO regions
+```
+
+```release-note:bug
+resource/aws_cloudwatch_metric_alarm: Further refine tag error handling for ISO regions
+```

--- a/.changelog/22717.txt
+++ b/.changelog/22717.txt
@@ -17,3 +17,7 @@ resource/aws_cloudwatch_metric_alarm: Further refine tag error handling for ISO 
 ```release-note:bug
 resource/aws_cloudwatch_metric_stream: Further refine tag error handling for ISO regions
 ```
+
+```release-note:bug
+data-source/aws_lb_listener: Further refine tag error handling for ISO regions
+```

--- a/internal/service/cloudwatch/composite_alarm.go
+++ b/internal/service/cloudwatch/composite_alarm.go
@@ -102,7 +102,7 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 	_, err := conn.PutCompositeAlarmWithContext(ctx, &input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] CloudWatch Composite Alarm (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 
@@ -129,7 +129,7 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 		err = UpdateTags(conn, aws.StringValue(alarm.AlarmArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] error adding tags after create for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 			return resourceCompositeAlarmRead(ctx, d, meta)
 		}
@@ -191,7 +191,7 @@ func resourceCompositeAlarmRead(ctx context.Context, d *schema.ResourceData, met
 	tags, err := ListTags(conn, aws.StringValue(alarm.AlarmArn))
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for CloudWatch Composite Alarm %s: %s", d.Id(), err)
 		return nil
 	}
@@ -232,7 +232,7 @@ func resourceCompositeAlarmUpdate(ctx context.Context, d *schema.ResourceData, m
 		err := UpdateTags(conn, arn, o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if tfawserr.ErrCodeContains(err, errCodeAccessDenied) || tfawserr.ErrCodeContains(err, cloudwatch.ErrCodeInternalServiceFault) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for CloudWatch Composite Alarm %s: %s", arn, err)
 			return resourceCompositeAlarmRead(ctx, d, meta)
 		}

--- a/internal/service/cloudwatch/consts.go
+++ b/internal/service/cloudwatch/consts.go
@@ -1,10 +1,6 @@
 package cloudwatch
 
 const (
-	errCodeAccessDenied = "AccessDenied"
-)
-
-const (
 	lowSampleCountPercentilesEvaluate          = "evaluate"
 	lowSampleCountPercentilesmissingDataIgnore = "ignore"
 )

--- a/internal/service/elbv2/consts.go
+++ b/internal/service/elbv2/consts.go
@@ -1,5 +1,0 @@
-package elbv2
-
-const (
-	ErrCodeAccessDenied = "AccessDenied"
-)

--- a/internal/service/elbv2/listener_data_source.go
+++ b/internal/service/elbv2/listener_data_source.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceListener() *schema.Resource {
@@ -341,7 +341,7 @@ func dataSourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -513,7 +513,7 @@ func resourceListenerRuleCreate(d *schema.ResourceData, meta interface{}) error 
 	resp, err := retryListenerRuleCreate(conn, d, params, listenerArn)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] ELBv2 Listener Rule (%s) create failed (%s) with tags. Trying create without tags.", listenerArn, err)
 		params.Tags = nil
 		resp, err = retryListenerRuleCreate(conn, d, params, listenerArn)
@@ -529,7 +529,7 @@ func resourceListenerRuleCreate(d *schema.ResourceData, meta interface{}) error 
 	if params.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
 			log.Printf("[WARN] error adding tags after create for ELBv2 Listener Rule (%s): %s", d.Id(), err)
 			return resourceListenerRuleRead(d, meta)
@@ -767,7 +767,7 @@ func resourceListenerRuleRead(d *schema.ResourceData, meta interface{}) error {
 	// tags at the end because, if not supported, will skip the rest of Read
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
 		return nil
 	}
@@ -866,7 +866,7 @@ func resourceListenerRuleUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
 			return resourceListenerRuleRead(d, meta)
 		}

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -361,7 +361,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 	resp, err := conn.CreateLoadBalancer(elbOpts)
 
 	// Some partitions may not support tag-on-create
-	if elbOpts.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+	if elbOpts.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] ELBv2 Load Balancer (%s) create failed (%s) with tags. Trying create without tags.", name, err)
 		elbOpts.Tags = nil
 		resp, err = conn.CreateLoadBalancer(elbOpts)
@@ -389,7 +389,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error 
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] error adding tags after create for ELBv2 Load Balancer (%s): %s", d.Id(), err)
 			return resourceLoadBalancerUpdate(d, meta)
 		}
@@ -606,7 +606,7 @@ func resourceLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 
 			_, err := waitLoadBalancerActive(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
@@ -885,7 +885,7 @@ func flattenResource(d *schema.ResourceData, meta interface{}, lb *elbv2.LoadBal
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/load_balancer_data_source.go
+++ b/internal/service/elbv2/load_balancer_data_source.go
@@ -306,7 +306,7 @@ func dataSourceLoadBalancerRead(d *schema.ResourceData, meta interface{}) error 
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Load Balancer %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -378,7 +378,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.CreateTargetGroup(params)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] ELBv2 Target Group (%s) create failed (%s) with tags. Trying create without tags.", groupName, err)
 		params.Tags = nil
 		resp, err = conn.CreateTargetGroup(params)
@@ -535,7 +535,7 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
 		// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] error adding tags after create for ELBv2 Target Group (%s): %s", d.Id(), err)
 			return resourceTargetGroupRead(d, meta)
 		}
@@ -796,7 +796,7 @@ func resourceTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// ISO partitions may not support tagging, giving error
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for ELBv2 Target Group %s: %s", d.Id(), err)
 			return resourceTargetGroupRead(d, meta)
 		}
@@ -985,7 +985,7 @@ func flattenTargetGroupResource(d *schema.ResourceData, meta interface{}, target
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/elbv2/target_group_data_source.go
+++ b/internal/service/elbv2/target_group_data_source.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceTargetGroup() *schema.Resource {
@@ -268,7 +268,7 @@ func dataSourceTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	tags, err := ListTags(conn, d.Id())
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeInvalidConfigurationRequestException) || tfawserr.ErrCodeContains(err, elbv2.ErrCodeOperationNotPermittedException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ELBv2 Target Group %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -71,7 +71,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CreateEventBus(input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] EventBridge Bus (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 		output, err = conn.CreateEventBus(input)
@@ -89,7 +89,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, aws.StringValue(output.EventBusArn), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] error adding tags after create for EventBridge Bus (%s): %s", d.Id(), err)
 			return resourceBusRead(d, meta)
 		}
@@ -130,7 +130,7 @@ func resourceBusRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, aws.StringValue(output.Arn))
 
 	// ISO partitions may not support tagging, giving error
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for EventBridge Bus %s: %s", d.Id(), err)
 		return nil
 	}
@@ -162,7 +162,7 @@ func resourceBusUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, arn, o, n)
 
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for EventBridge Bus %s: %s", d.Id(), err)
 			return resourceBusRead(d, meta)
 		}

--- a/internal/service/events/consts.go
+++ b/internal/service/events/consts.go
@@ -1,10 +1,6 @@
 package events
 
 const (
-	ErrCodeAccessDenied = "AccessDenied"
-)
-
-const (
 	DefaultEventBusName = "default"
 )
 

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -124,7 +124,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	arn, err := retryPutRule(conn, input)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] EventBridge Rule (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 		arn, err = retryPutRule(conn, input)
@@ -140,7 +140,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, arn, nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] error adding tags after create for EventBridge Rule (%s): %s", d.Id(), err)
 			return resourceRuleRead(d, meta)
 		}
@@ -203,7 +203,7 @@ func resourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// ISO partitions may not support tagging, giving error
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for EventBridge Rule %s: %s", d.Id(), err)
 		return nil
 	}
@@ -270,7 +270,7 @@ func resourceRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		err := UpdateTags(conn, arn, o, n)
 
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeInternalException) || tfawserr.ErrCodeContains(err, eventbridge.ErrCodeOperationDisabledException) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for EventBridge Rule %s: %s", d.Id(), err)
 			return resourceRuleRead(d, meta)
 		}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -35,12 +35,13 @@ func checkYAMLString(yamlString interface{}) (string, error) {
 }
 
 const (
-	ErrCodeAccessDenied               = "AccessDenied"
-	ErrCodeUnknownOperation           = "UnknownOperationException"
-	ErrCodeValidationError            = "ValidationError"
-	ErrCodeOperationDisabledException = "OperationDisabledException"
-	ErrCodeInternalException          = "InternalException"
-	ErrCodeInternalServiceFault       = "InternalServiceError"
+	ErrCodeAccessDenied                   = "AccessDenied"
+	ErrCodeUnknownOperation               = "UnknownOperationException"
+	ErrCodeValidationError                = "ValidationError"
+	ErrCodeOperationDisabledException     = "OperationDisabledException"
+	ErrCodeInternalException              = "InternalException"
+	ErrCodeInternalServiceFault           = "InternalServiceError"
+	ErrCodeOperationNotPermittedException = "OperationNotPermitted"
 )
 
 func CheckISOErrorTagsUnsupported(err error) bool {
@@ -65,6 +66,10 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrCodeContains(err, ErrCodeInternalServiceFault) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeOperationNotPermittedException) {
 		return true
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -40,6 +40,7 @@ const (
 	ErrCodeValidationError            = "ValidationError"
 	ErrCodeOperationDisabledException = "OperationDisabledException"
 	ErrCodeInternalException          = "InternalException"
+	ErrCodeInternalServiceFault       = "InternalServiceError"
 )
 
 func CheckISOErrorTagsUnsupported(err error) bool {
@@ -60,6 +61,10 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrCodeContains(err, ErrCodeInternalException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeInternalServiceFault) {
 		return true
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -35,12 +35,14 @@ func checkYAMLString(yamlString interface{}) (string, error) {
 }
 
 const (
-	ErrCodeAccessDenied     = "AccessDenied"
-	ErrCodeUnknownOperation = "UnknownOperationException"
-	ErrCodeValidationError  = "ValidationError"
+	ErrCodeAccessDenied               = "AccessDenied"
+	ErrCodeUnknownOperation           = "UnknownOperationException"
+	ErrCodeValidationError            = "ValidationError"
+	ErrCodeOperationDisabledException = "OperationDisabledException"
+	ErrCodeInternalException          = "InternalException"
 )
 
-func checkISOErrorTagsUnsupported(err error) bool {
+func CheckISOErrorTagsUnsupported(err error) bool {
 	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) {
 		return true
 	}
@@ -50,6 +52,14 @@ func checkISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "not support tagging") {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeOperationDisabledException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeInternalException) {
 		return true
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"gopkg.in/yaml.v2"
 )
 
@@ -31,4 +32,26 @@ func checkYAMLString(yamlString interface{}) (string, error) {
 	err := yaml.Unmarshal([]byte(s), &y)
 
 	return s, err
+}
+
+const (
+	ErrCodeAccessDenied     = "AccessDenied"
+	ErrCodeUnknownOperation = "UnknownOperationException"
+	ErrCodeValidationError  = "ValidationError"
+)
+
+func checkISOErrorTagsUnsupported(err error) bool {
+	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeUnknownOperation) {
+		return true
+	}
+
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "not support tagging") {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22532

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS='TestAccCloudWatchCompositeAlarm|TestAccCloudWatchMetricAlarm|TestAccCloudWatchMetricStream' PKG=cloudwatch TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchCompositeAlarm|TestAccCloudWatchMetricAlarm|TestAccCloudWatchMetricStream' -short -timeout 180m
--- PASS: TestAccCloudWatchMetricAlarm_missingStatistic (18.39s)
--- PASS: TestAccCloudWatchMetricAlarm_disappears (36.47s)
--- PASS: TestAccCloudWatchMetricAlarm_extendedStatistic (43.57s)
--- PASS: TestAccCloudWatchMetricAlarm_dataPointsToAlarm (44.07s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_swfAction (51.55s)
--- PASS: TestAccCloudWatchCompositeAlarm_basic (52.38s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (53.16s)
--- PASS: TestAccCloudWatchMetricStream_noName (53.37s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (53.54s)
--- PASS: TestAccCloudWatchMetricStream_tags (53.55s)
--- PASS: TestAccCloudWatchMetricStream_includeFilters (53.74s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic (54.16s)
--- PASS: TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (68.23s)
--- PASS: TestAccCloudWatchMetricAlarm_basic (36.11s)
--- PASS: TestAccCloudWatchCompositeAlarm_disappears (27.79s)
--- PASS: TestAccCloudWatchCompositeAlarm_updateAlarmRule (82.38s)
--- PASS: TestAccCloudWatchMetricAlarm_tags (93.01s)
--- PASS: TestAccCloudWatchMetricAlarm_treatMissingData (93.52s)
--- PASS: TestAccCloudWatchCompositeAlarm_description (60.70s)
--- PASS: TestAccCloudWatchCompositeAlarm_allActions (64.18s)
--- PASS: TestAccCloudWatchCompositeAlarm_actionsEnabled (58.28s)
--- PASS: TestAccCloudWatchCompositeAlarm_okActions (80.02s)
--- PASS: TestAccCloudWatchMetricStream_basic (132.29s)
--- PASS: TestAccCloudWatchCompositeAlarm_alarmActions (83.20s)
--- PASS: TestAccCloudWatchCompositeAlarm_insufficientDataActions (84.51s)
--- PASS: TestAccCloudWatchMetricAlarm_expression (154.63s)
--- PASS: TestAccCloudWatchMetricStream_update (191.27s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate (220.64s)
--- PASS: TestAccCloudWatchMetricStream_updateName (312.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	314.169s
% make testacc TESTS='TestAccEventsBus|TestAccEventsRule' PKG=events TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBus|TestAccEventsRule' -short -timeout 180m
    bus_test.go:170: Environment variable EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME is not set
--- SKIP: TestAccEventsBus_partnerEventSource (0.00s)
    rule_test.go:440: Environment variable EVENT_BRIDGE_PARTNER_EVENT_BUS_NAME is not set
--- SKIP: TestAccEventsRule_partnerEventBus (0.00s)
--- PASS: TestAccEventsBus_default (4.14s)
--- PASS: TestAccEventsBus_disappears (28.61s)
--- PASS: TestAccEventsRule_Name_generated (37.77s)
--- PASS: TestAccEventsRule_namePrefix (37.93s)
--- PASS: TestAccEventsRule_scheduleAndPattern (38.62s)
--- PASS: TestAccEventsRule_eventBusARN (39.02s)
--- PASS: TestAccEventsRule_role (45.68s)
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (47.73s)
--- PASS: TestAccEventsRule_pattern (56.80s)
--- PASS: TestAccEventsRule_description (57.03s)
--- PASS: TestAccEventsBusPolicy_basic (57.13s)
--- PASS: TestAccEventsRule_basic (69.74s)
--- PASS: TestAccEventsBus_basic (70.71s)
--- PASS: TestAccEventsRule_isEnabled (70.92s)
--- PASS: TestAccEventsRule_eventBusName (73.83s)
--- PASS: TestAccEventsBus_tags (82.67s)
--- PASS: TestAccEventsRule_tags (83.56s)
--- PASS: TestAccEventsBusPolicy_disappears (147.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	148.813s
% make testacc TESTS='TestAccELBV2Listener|TestAccELBV2LoadBalancer|TestAccELBV2TargetGroup' PKG=elbv2 TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2Listener|TestAccELBV2LoadBalancer|TestAccELBV2TargetGroup' -short -timeout 180m
--- SKIP: TestAccELBV2ListenerRule_priority (0.00s)
--- SKIP: TestAccELBV2ListenerRule_conditionUpdateMixed (0.00s)
--- SKIP: TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer (0.00s)
--- SKIP: TestAccELBV2Listener_Protocol_tls (0.05s)
--- SKIP: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWafFailOpen (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_updatedSecurityGroups (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_updatedSubnets (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_ALB_accessLogs (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_ALBAccessLogs_prefix (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_NLB_accessLogs (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_NLBAccessLogs_prefix (0.00s)
--- SKIP: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (0.00s)
--- PASS: TestAccELBV2TargetGroup_withoutHealthCheck (24.26s)
--- PASS: TestAccELBV2TargetGroup_namePrefix (36.01s)
--- PASS: TestAccELBV2TargetGroup_protocolGeneve (37.42s)
--- PASS: TestAccELBV2TargetGroup_stickinessDefaultALB (39.37s)
--- PASS: TestAccELBV2TargetGroup_stickinessInvalidNLB (42.74s)
--- PASS: TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination (52.30s)
--- PASS: TestAccELBV2TargetGroup_updateHealthCheck (53.19s)
--- PASS: TestAccELBV2TargetGroup_stickinessInvalidALB (55.75s)
--- PASS: TestAccELBV2TargetGroup_stickinessValidALB (55.75s)
--- PASS: TestAccELBV2TargetGroup_preserveClientIPValid (56.47s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy (59.55s)
--- PASS: TestAccELBV2TargetGroup_protocolGeneveNotSticky (60.60s)
--- PASS: TestAccELBV2TargetGroup_A_lambdaMultiValueHeadersEnabled (61.87s)
--- PASS: TestAccELBV2TargetGroup_updateAppStickinessEnabled (75.82s)
--- PASS: TestAccELBV2TargetGroup_updateStickinessEnabled (75.87s)
--- PASS: TestAccELBV2TargetGroup_stickinessDefaultNLB (78.95s)
--- PASS: TestAccELBV2TargetGroup_A_namePrefix (29.17s)
--- PASS: TestAccELBV2TargetGroup_tags (81.82s)
--- PASS: TestAccELBV2TargetGroup_A_missingPortProtocolVPC (30.17s)
--- PASS: TestAccELBV2TargetGroup_generatedName (29.00s)
--- PASS: TestAccELBV2TargetGroup_A_updateHealthCheck (49.99s)
--- PASS: TestAccELBV2TargetGroup_Defaults_application (27.36s)
--- PASS: TestAccELBV2TargetGroup_A_tags (51.18s)
--- PASS: TestAccELBV2TargetGroup_enableHealthCheck (34.69s)
--- PASS: TestAccELBV2TargetGroup_A_setAndUpdateSlowStart (51.37s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroup (94.28s)
--- PASS: TestAccELBV2TargetGroup_Defaults_network (35.05s)
--- PASS: TestAccELBV2TargetGroup_A_updateStickinessEnabled (73.11s)
--- PASS: TestAccELBV2TargetGroup_A_updateLoadBalancingAlgorithmType (71.39s)
--- PASS: TestAccELBV2TargetGroup_basic (32.32s)
--- PASS: TestAccELBV2TargetGroup_Protocol_tls (26.92s)
--- PASS: TestAccELBV2TargetGroup_changeVPCForceNew (52.59s)
--- PASS: TestAccELBV2TargetGroup_basicUdp (34.87s)
--- PASS: TestAccELBV2TargetGroup_protocolVersion (27.58s)
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (29.69s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersionGRPC_healthCheck (34.41s)
--- PASS: TestAccELBV2TargetGroup_stickinessValidNLB (126.32s)
--- PASS: TestAccELBV2TargetGroup_changePortForceNew (50.73s)
--- PASS: TestAccELBV2TargetGroup_attrsOnCreate (48.75s)
--- PASS: TestAccELBV2TargetGroup_TCP_httpHealthCheck (48.52s)
--- PASS: TestAccELBV2TargetGroup_A_lambda (17.42s)
--- PASS: TestAccELBV2TargetGroup_changeProtocolForceNew (60.90s)
--- PASS: TestAccELBV2TargetGroup_ProtocolTCPHealthCheck_protocol (48.89s)
--- PASS: TestAccELBV2TargetGroup_changeNameForceNew (59.06s)
--- SKIP: TestAccELBV2LoadBalancerDataSource_outpost (0.72s)
--- PASS: TestAccELBV2TargetGroup_A_generatedName (23.07s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersionHTTPGRPC_update (58.52s)
--- PASS: TestAccELBV2TargetGroupAttachment_lambda (35.86s)
--- PASS: TestAccELBV2TargetGroup_A_basic (23.65s)
--- PASS: TestAccELBV2TargetGroup_A_changeVPCForceNew (39.58s)
--- PASS: TestAccELBV2TargetGroup_A_changePortForceNew (43.69s)
--- PASS: TestAccELBV2TargetGroup_A_changeProtocolForceNew (46.89s)
--- PASS: TestAccELBV2TargetGroup_A_changeNameForceNew (46.80s)
--- PASS: TestAccELBV2ListenerCertificate_basic (202.90s)
--- PASS: TestAccELBV2TargetGroupAttachment_port (121.42s)
--- PASS: TestAccELBV2TargetGroupAttachment_ipAddress (126.46s)
--- PASS: TestAccELBV2TargetGroupAttachment_disappears (120.81s)
--- PASS: TestAccELBV2TargetGroupAttachment_backwardsCompatibility (133.67s)
--- PASS: TestAccELBV2TargetGroupAttachment_basic (120.74s)
--- PASS: TestAccELBV2LoadBalancerDataSource_backwardsCompatibility (271.74s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (198.89s)
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (0.66s)
--- PASS: TestAccELBV2TargetGroupDataSource_basic (237.51s)
--- PASS: TestAccELBV2TargetGroupDataSource_appCookie (249.29s)
--- PASS: TestAccELBV2Listener_DefaultAction_orderRecreates (210.04s)
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (213.27s)
--- PASS: TestAccELBV2Listener_DefaultAction_order (232.26s)
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (247.99s)
--- PASS: TestAccELBV2LoadBalancer_noSecurityGroup (212.91s)
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancerSubnet_change (221.80s)
--- PASS: TestAccELBV2TargetGroupDataSource_backwardsCompatibility (301.83s)
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (242.33s)
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (266.84s)
--- PASS: TestAccELBV2Listener_oidc (243.96s)
--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (0.80s)
--- PASS: TestAccELBV2Listener_cognito (220.78s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (109.10s)
--- PASS: TestAccELBV2Listener_fixedResponse (222.29s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (224.37s)
--- PASS: TestAccELBV2LoadBalancer_generatesNameForZeroValue (222.77s)
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (183.52s)
--- PASS: TestAccELBV2LoadBalancer_updatedIPAddressType (294.65s)
--- PASS: TestAccELBV2LoadBalancer_generatedName (203.20s)
--- PASS: TestAccELBV2Listener_redirect (181.16s)
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (18.91s)
--- PASS: TestAccELBV2Listener_Protocol_https (171.02s)
--- PASS: TestAccELBV2LoadBalancer_tags (325.08s)
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (186.61s)
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (186.16s)
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (231.81s)
--- PASS: TestAccELBV2Listener_backwardsCompatibility (189.47s)
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (198.83s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (263.29s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (161.16s)
--- PASS: TestAccELBV2Listener_tags (214.30s)
--- PASS: TestAccELBV2Listener_forwardWeighted (228.14s)
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (224.18s)
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (173.32s)
--- PASS: TestAccELBV2ListenerRule_redirect (231.60s)
--- PASS: TestAccELBV2ListenerRule_ActionOrder_recreates (173.64s)
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (179.73s)
--- PASS: TestAccELBV2Listener_Protocol_upd (340.78s)
--- PASS: TestAccELBV2Listener_basic (231.16s)
--- PASS: TestAccELBV2ListenerRule_basic (178.44s)
--- PASS: TestAccELBV2ListenerRule_tags (244.12s)
--- PASS: TestAccELBV2ListenerDataSource_https (223.58s)
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (249.25s)
--- PASS: TestAccELBV2ListenerRule_Action_order (188.12s)
--- PASS: TestAccELBV2ListenerDataSource_DefaultAction_forward (227.20s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (225.45s)
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (229.78s)
--- PASS: TestAccELBV2ListenerCertificate_multiple (237.61s)
--- PASS: TestAccELBV2ListenerRule_cognito (179.48s)
--- PASS: TestAccELBV2ListenerDataSource_backwardsCompatibility (243.20s)
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (246.24s)
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (266.55s)
--- PASS: TestAccELBV2ListenerRule_oidc (271.72s)
--- PASS: TestAccELBV2ListenerRule_fixedResponse (197.34s)
--- PASS: TestAccELBV2ListenerCertificate_CertificateARN_underscores (198.06s)
--- PASS: TestAccELBV2ListenerCertificate_disappears (185.84s)
--- PASS: TestAccELBV2ListenerDataSource_basic (325.33s)
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (272.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	999.621s
```
