### PR TITLE
r/instance: prevent panic when instance does not have block devices

### DIFF
--- a/.changelog/22719.txt
+++ b/.changelog/22719.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Prevent panic when reading the instance's block device mappings
+```

--- a/internal/service/ec2/instance.go
+++ b/internal/service/ec2/instance.go
@@ -1899,36 +1899,45 @@ func readBlockDevices(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.
 		return err
 	}
 
-	// This handles cases where the root device block is of type "EBS"
-	// and #readBlockDevicesFromInstance only returns 1 reference to a block-device
-	// stored in ibds["root"]
-	if _, ok := d.GetOk("ebs_block_device"); ok {
-		if len(ibds["ebs"].([]map[string]interface{})) == 0 {
-			ebs := make(map[string]interface{})
-			for k, v := range ibds["root"].(map[string]interface{}) {
-				ebs[k] = v
+	var ebsBlockDevices []map[string]interface{}
+	var rootBlockDevice []interface{}
+
+	if ibds != nil {
+		if v, ok := ibds["ebs"].([]map[string]interface{}); ok {
+			// This handles cases where the root device block is of type "EBS"
+			// and #readBlockDevicesFromInstance only returns 1 reference to a block-device
+			// stored in ibds["root"]
+			if len(v) == 0 {
+				ebs := make(map[string]interface{})
+
+				rootMap, ok := ibds["root"].(map[string]interface{})
+				if ok {
+					for k, v := range rootMap {
+						ebs[k] = v
+					}
+				}
+
+				if snapshotId, ok := ibds["snapshot_id"].(string); ok {
+					ebs["snapshot_id"] = snapshotId
+				}
+
+				ebsBlockDevices = []map[string]interface{}{ebs}
+			} else {
+				ebsBlockDevices = v
 			}
-			ebs["snapshot_id"] = ibds["snapshot_id"]
-			ibds["ebs"] = append(ibds["ebs"].([]map[string]interface{}), ebs)
+		}
+
+		if v, ok := ibds["root"].(map[string]interface{}); ok {
+			rootBlockDevice = []interface{}{v}
 		}
 	}
 
-	if err := d.Set("ebs_block_device", ibds["ebs"]); err != nil {
+	if err := d.Set("ebs_block_device", ebsBlockDevices); err != nil {
 		return err
 	}
 
-	// This handles the import case which needs to be defaulted to empty
-	if _, ok := d.GetOk("root_block_device"); !ok {
-		if err := d.Set("root_block_device", []interface{}{}); err != nil {
-			return err
-		}
-	}
-
-	if ibds["root"] != nil {
-		roots := []interface{}{ibds["root"]}
-		if err := d.Set("root_block_device", roots); err != nil {
-			return err
-		}
+	if err := d.Set("root_block_device", rootBlockDevice); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/service/ec2/instance.go
+++ b/internal/service/ec2/instance.go
@@ -1902,7 +1902,7 @@ func readBlockDevices(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.
 	var ebsBlockDevices []map[string]interface{}
 	var rootBlockDevice []interface{}
 
-	if ibds != nil {
+	if _, ok := d.GetOk("ebs_block_device"); ok && ibds != nil {
 		if v, ok := ibds["ebs"].([]map[string]interface{}); ok {
 			// This handles cases where the root device block is of type "EBS"
 			// and #readBlockDevicesFromInstance only returns 1 reference to a block-device

--- a/internal/service/ec2/instance_test.go
+++ b/internal/service/ec2/instance_test.go
@@ -306,6 +306,33 @@ func TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType(t *testing
 	})
 }
 
+// TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed verifies block device mappings
+// removed outside terraform no longer result in a panic.
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/20821
+func TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed(t *testing.T) {
+	var instance ec2.Instance
+	resourceName := "aws_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigEBSAndRootBlockDevice,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &instance),
+					// Instance must be stopped before detaching a root block device
+					testAccCheckStopInstance(&instance),
+					testAccCheckDetachVolumes(&instance),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_RootBlockDevice_kmsKeyARN(t *testing.T) {
 	var instance ec2.Instance
 	kmsKeyResourceName := "aws_kms_key.test"
@@ -3854,6 +3881,37 @@ func testAccCheckStopInstance(instance *ec2.Instance) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckDetachVolumes(instance *ec2.Instance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acctest.Provider.Meta().(*conns.AWSClient)
+		conn := client.EC2Conn
+
+		for _, bd := range instance.BlockDeviceMappings {
+			if bd.Ebs != nil && bd.Ebs.VolumeId != nil {
+				name := aws.StringValue(bd.DeviceName)
+				volID := aws.StringValue(bd.Ebs.VolumeId)
+				instanceID := aws.StringValue(instance.InstanceId)
+
+				// Make sure in correct state before detaching
+				if err := tfec2.WaitVolumeAttachmentAttached(conn, name, volID, instanceID); err != nil {
+					return err
+				}
+
+				r := tfec2.ResourceVolumeAttachment()
+				d := r.Data(nil)
+				d.Set("device_name", name)
+				d.Set("volume_id", volID)
+				d.Set("instance_id", instanceID)
+
+				if err := r.Delete(d, client); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+}
+
 func TestInstanceHostIDSchema(t *testing.T) {
 	actualSchema := tfec2.ResourceInstance().Schema["host_id"]
 	expectedSchema := &schema.Schema{
@@ -5044,6 +5102,27 @@ resource "aws_instance" "test" {
   }
 }
 `)
+
+var testAccInstanceConfigEBSAndRootBlockDevice = acctest.ConfigCompose(
+	acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
+	fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+
+  instance_type = "t2.medium"
+
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 9
+    delete_on_termination = true
+  }
+
+  ebs_block_device {
+    device_name = "/dev/sdb"
+    volume_size = 9
+  }
+}
+`))
 
 func testAccInstanceConfigBlockDeviceTagsVolumeTags() string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), `

--- a/internal/service/ec2/instance_test.go
+++ b/internal/service/ec2/instance_test.go
@@ -5105,7 +5105,7 @@ resource "aws_instance" "test" {
 
 var testAccInstanceConfigEBSAndRootBlockDevice = acctest.ConfigCompose(
 	acctest.ConfigLatestAmazonLinuxHvmEbsAmi(),
-	fmt.Sprintf(`
+	`
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 
@@ -5122,7 +5122,7 @@ resource "aws_instance" "test" {
     volume_size = 9
   }
 }
-`))
+`)
 
 func testAccInstanceConfigBlockDeviceTagsVolumeTags() string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinuxHvmEbsAmi(), `

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -1521,3 +1521,19 @@ func WaitEBSSnapshotTierArchive(conn *ec2.EC2, id string) (*ec2.SnapshotTierStat
 		return detail.(*ec2.SnapshotTierStatus), nil
 	}
 }
+
+// WaitVolumeAttachmentAttached waits for a VolumeAttachment to return Attached
+func WaitVolumeAttachmentAttached(conn *ec2.EC2, name, volumeID, instanceID string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{ec2.VolumeAttachmentStateAttaching},
+		Target:     []string{ec2.VolumeAttachmentStateAttached},
+		Refresh:    volumeAttachmentStateRefreshFunc(conn, name, volumeID, instanceID),
+		Timeout:    5 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reworks https://github.com/hashicorp/terraform-provider-aws/pull/16694
Closes #16689
Closes #16477
Closes https://github.com/hashicorp/terraform-provider-aws/issues/17284
Closes #20821
Closes #22660 
Closes https://github.com/hashicorp/terraform-provider-aws/issues/19779

New test before code change:
```
=== RUN   TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
=== PAUSE TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
=== CONT  TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
panic: interface conversion: interface {} is nil, not []map[string]interface {}

goroutine 856 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.readBlockDevices(0xc001e4e180, 0xc002e43440, 0xc0005227c0, 0x0, 0x0)
	/Users/apinilla/Documents/test/go/src/github.com/hashicorp/terraform-provider-aws/internal/service/ec2/instance.go:1906 +0x799
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.resourceInstanceRead(0xc001e4e180, 0x91e1980, 0xc0003a2a80, 0x102f37b0, 0xc000594000)
	/Users/apinilla/Documents/test/go/src/github.com/hashicorp/terraform-provider-aws/internal/service/ec2/instance.go:1118 +0x1ce6
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000e35b20, 0xb587f58, 0xc0025ac0c0, 0xc001e4e180, 0x91e1980, 0xc0003a2a80, 0x0, 0x0, 0x0)
	/Users/apinilla/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:346 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000e35b20, 0xb587f58, 0xc0025ac0c0, 0xc0027d20d0, 0x91e1980, 0xc0003a2a80, 0xc003376900, 0x0, 0x0, 0x0)
	/Users/apinilla/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/resource.go:635 +0x1cb
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc0027d8378, 0xb587f58, 0xc0025ac0c0, 0xc0025ac100, 0xa546200, 0x12, 0x0)
	/Users/apinilla/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/schema/grpc_provider.go:576 +0x47d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc0027e6280, 0xb588000, 0xc0025ac0c0, 0xc0025a80c0, 0x0, 0x0, 0x0)
	/Users/apinilla/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:553 +0x322
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0xa2a5f80, 0xc0027e6280, 0xb588000, 0xc002592db0, 0xc0025a8060, 0x0, 0xb588000, 0xc002592db0, 0xc0025aa800, 0x734)
	/Users/apinilla/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000579dc0, 0xb5b6198, 0xc00234d200, 0xc0008d7400, 0xc0027e8630, 0x102adb30, 0x0, 0x0, 0x0)
	/Users/apinilla/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000579dc0, 0xb5b6198, 0xc00234d200, 0xc0008d7400, 0x0)
	/Users/apinilla/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0017f7ad0, 0xc000579dc0, 0xb5b6198, 0xc00234d200, 0xc0008d7400)
	/Users/apinilla/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/apinilla/go/pkg/mod/google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	123.063s
FAIL
make: *** [testacc] Error 1
```

New test with code change:
```
--- PASS: TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed (148.43s)
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (177.91s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyTarget (159.57s)
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (108.55s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPrivate (117.39s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPublic (113.77s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPrivate (139.65s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPublic (131.57s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePrivate (122.24s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePublic (124.29s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (206.44s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (199.21s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_withAttachedVolume (208.54s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_none (122.74s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_open (124.66s)
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (127.88s)
--- PASS: TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable (129.53s)
--- PASS: TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint (425.63s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits (117.70s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits (114.32s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited (123.74s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits (170.21s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2 (110.58s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3 (105.76s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint (182.08s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable (130.73s)
--- PASS: TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable (125.82s)
--- PASS: TestAccEC2Instance_CreditSpecification_standardCPUCredits (117.74s)
--- PASS: TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits (135.40s)
--- PASS: TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard (111.64s)
--- PASS: TestAccEC2Instance_CreditSpecification_updateCPUCredits (207.57s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (36.00s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (35.01s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_kmsKeyARN (107.61s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1 (170.70s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2 (167.74s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3 (155.43s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination (124.09s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize (163.00s)
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (101.97s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyAll (153.04s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination (131.09s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifySize (159.02s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyType (165.33s)
--- PASS: TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices (225.40s)
--- PASS: TestAccEC2Instance_Empty_privateIP (143.17s)
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (177.43s)
--- PASS: TestAccEC2Instance_GetPasswordData_trueToFalse (210.50s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (137.90s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (124.89s)
--- PASS: TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion (166.68s)
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (66.97s)
--- PASS: TestAccEC2Instance_LaunchTemplate_overrideTemplate (92.14s)
--- PASS: TestAccEC2Instance_LaunchTemplate_setSpecificVersion (127.69s)
--- PASS: TestAccEC2Instance_LaunchTemplate_swapIDAndName (126.40s)
--- PASS: TestAccEC2Instance_LaunchTemplate_updateTemplateVersion (222.15s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs (115.57s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate (172.63s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs (79.29s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate (187.28s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs (212.21s)
--- PASS: TestAccEC2Instance_RootBlockDevice_kmsKeyARN (139.35s)
--- PASS: TestAccEC2Instance_UserData_emptyStringToUnspecified (135.95s)
--- PASS: TestAccEC2Instance_UserData_unspecifiedToEmptyString (130.18s)
--- PASS: TestAccEC2Instance_addSecondaryInterface (371.02s)
--- PASS: TestAccEC2Instance_addSecurityGroupNetworkInterface (391.66s)
--- PASS: TestAccEC2Instance_associatePublicIPAndPrivateIP (124.99s)
--- PASS: TestAccEC2Instance_atLeastOneOtherEBSVolume (208.07s)
--- PASS: TestAccEC2Instance_basic (88.62s)
--- PASS: TestAccEC2Instance_blockDevices (110.58s)
--- PASS: TestAccEC2Instance_changeInstanceType (227.64s)
--- PASS: TestAccEC2Instance_disableAPITermination (176.73s)
--- PASS: TestAccEC2Instance_disappears (323.73s)
--- PASS: TestAccEC2Instance_enclaveOptions (235.40s)
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (270.69s)
--- PASS: TestAccEC2Instance_gp2IopsDevice (108.85s)
--- PASS: TestAccEC2Instance_gp2WithIopsValue (35.29s)
--- PASS: TestAccEC2Instance_gp3RootBlockDevice (112.21s)
--- PASS: TestAccEC2Instance_hibernation (208.08s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgID (143.25s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgName (130.54s)
--- PASS: TestAccEC2Instance_instanceProfileChange (250.33s)
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (28.26s)
--- PASS: TestAccEC2Instance_keyPairCheck (144.26s)
--- PASS: TestAccEC2Instance_metadataOptions (162.97s)
--- PASS: TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups (134.61s)
--- PASS: TestAccEC2Instance_networkInstanceSecurityGroups (117.23s)
--- PASS: TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs (112.02s)
--- PASS: TestAccEC2Instance_noAMIEphemeralDevices (153.23s)
--- PASS: TestAccEC2Instance_placementGroup (134.06s)
--- PASS: TestAccEC2Instance_placementPartitionNumber (144.89s)
--- PASS: TestAccEC2Instance_primaryNetworkInterface (124.09s)
--- PASS: TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck (108.13s)
--- PASS: TestAccEC2Instance_privateIP (141.78s)
--- PASS: TestAccEC2Instance_rootBlockDeviceMismatch (240.58s)
--- PASS: TestAccEC2Instance_rootInstanceStore (136.10s)
--- PASS: TestAccEC2Instance_sourceDestCheck (210.97s)
--- PASS: TestAccEC2Instance_tags (118.13s)
--- PASS: TestAccEC2Instance_userDataBase64 (137.57s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (126.96s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (155.08s)
--- SKIP: TestAccEC2Instance_inEC2Classic (2.11s)
--- SKIP: TestAccEC2Instance_outpost (1.30s)
```
