### PR TITLE
r/aws_vpc_dhcp_options_association: Support `default` DHCP Options ID

### DIFF
--- a/.changelog/22722.txt
+++ b/.changelog/22722.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_dhcp_options_association: Support `default` DHCP Options ID
+```

--- a/internal/service/ec2/vpc_dhcp_options_association.go
+++ b/internal/service/ec2/vpc_dhcp_options_association.go
@@ -154,9 +154,17 @@ func VPCDHCPOptionsAssociationCreateResourceID(dhcpOptionsID, vpcID string) stri
 func VPCDHCPOptionsAssociationParseResourceID(id string) (string, string, error) {
 	parts := strings.Split(id, vpcDHCPOptionsAssociationResourceIDSeparator)
 
-	// DHCP Options ID and VPC ID themselves contain '-'.
-	if len(parts) == 4 && parts[0] != "" && parts[1] != "" && parts[2] != "" && parts[3] != "" {
-		return strings.Join([]string{parts[0], parts[1]}, vpcDHCPOptionsAssociationResourceIDSeparator), strings.Join([]string{parts[2], parts[3]}, vpcDHCPOptionsAssociationResourceIDSeparator), nil
+	// The DHCP Options ID either contains '-' or is the special value "default".
+	// The VPC ID contains '-'.
+	switch n := len(parts); n {
+	case 3:
+		if parts[0] == DefaultDHCPOptionsID && parts[1] != "" && parts[2] != "" {
+			return parts[0], strings.Join([]string{parts[1], parts[2]}, vpcDHCPOptionsAssociationResourceIDSeparator), nil
+		}
+	case 4:
+		if parts[0] != "" && parts[1] != "" && parts[2] != "" && parts[3] != "" {
+			return strings.Join([]string{parts[0], parts[1]}, vpcDHCPOptionsAssociationResourceIDSeparator), strings.Join([]string{parts[2], parts[3]}, vpcDHCPOptionsAssociationResourceIDSeparator), nil
+		}
 	}
 
 	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected DHCPOptionsID%[2]sVPCID", id, vpcDHCPOptionsAssociationResourceIDSeparator)

--- a/internal/service/ec2/vpc_dhcp_options_association_test.go
+++ b/internal/service/ec2/vpc_dhcp_options_association_test.go
@@ -106,6 +106,32 @@ func TestAccEC2VPCDHCPOptionsAssociation_disappears(t *testing.T) {
 	})
 }
 
+func TestAccEC2VPCDHCPOptionsAssociation_default(t *testing.T) {
+	resourceName := "aws_vpc_dhcp_options_association.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVPCDHCPOptionsAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCDHCPOptionsAssociationDefaultConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCDHCPOptionsAssociationExist(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccVPCDHCPOptionsAssociationVPCImportIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccVPCDHCPOptionsAssociationVPCImportIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -201,6 +227,23 @@ resource "aws_vpc_dhcp_options" "test" {
 resource "aws_vpc_dhcp_options_association" "test" {
   vpc_id          = aws_vpc.test.id
   dhcp_options_id = aws_vpc_dhcp_options.test.id
+}
+`, rName)
+}
+
+func testAccVPCDHCPOptionsAssociationDefaultConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "test" {
+  vpc_id          = aws_vpc.test.id
+  dhcp_options_id = "default"
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #22716.

Prior to the fix:

```console
% make testacc TESTARGS='-run=TestAccEC2VPCDHCPOptionsAssociation_default' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2VPCDHCPOptionsAssociation_default -timeout 180m
=== RUN   TestAccEC2VPCDHCPOptionsAssociation_default
=== PAUSE TestAccEC2VPCDHCPOptionsAssociation_default
=== CONT  TestAccEC2VPCDHCPOptionsAssociation_default
    vpc_dhcp_options_association_test.go:113: Step 1/2 error: Error running apply: exit status 1
        
        Error: unexpected format for ID (default-vpc-0c3d3a2ecaff91a69), expected DHCPOptionsID-VPCID
        
          with aws_vpc_dhcp_options_association.test,
          on terraform_plugin_test.tf line 15, in resource "aws_vpc_dhcp_options_association" "test":
          15: resource "aws_vpc_dhcp_options_association" "test" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: unexpected format for ID (default-vpc-0c3d3a2ecaff91a69), expected DHCPOptionsID-VPCID
        
--- FAIL: TestAccEC2VPCDHCPOptionsAssociation_default (13.84s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        17.503s
FAIL
make: *** [testacc] Error 1
```

Output from acceptance testing:

```console
% make testacc TESTARGS='-run=TestAccEC2VPCDHCPOptionsAssociation_' PKG=ec2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2VPCDHCPOptionsAssociation_ -timeout 180m
=== RUN   TestAccEC2VPCDHCPOptionsAssociation_basic
=== PAUSE TestAccEC2VPCDHCPOptionsAssociation_basic
=== RUN   TestAccEC2VPCDHCPOptionsAssociation_Disappears_vpc
=== PAUSE TestAccEC2VPCDHCPOptionsAssociation_Disappears_vpc
=== RUN   TestAccEC2VPCDHCPOptionsAssociation_Disappears_dhcp
=== PAUSE TestAccEC2VPCDHCPOptionsAssociation_Disappears_dhcp
=== RUN   TestAccEC2VPCDHCPOptionsAssociation_disappears
=== PAUSE TestAccEC2VPCDHCPOptionsAssociation_disappears
=== RUN   TestAccEC2VPCDHCPOptionsAssociation_default
=== PAUSE TestAccEC2VPCDHCPOptionsAssociation_default
=== CONT  TestAccEC2VPCDHCPOptionsAssociation_basic
=== CONT  TestAccEC2VPCDHCPOptionsAssociation_disappears
=== CONT  TestAccEC2VPCDHCPOptionsAssociation_default
=== CONT  TestAccEC2VPCDHCPOptionsAssociation_Disappears_dhcp
=== CONT  TestAccEC2VPCDHCPOptionsAssociation_Disappears_vpc
--- PASS: TestAccEC2VPCDHCPOptionsAssociation_Disappears_vpc (21.84s)
--- PASS: TestAccEC2VPCDHCPOptionsAssociation_disappears (25.71s)
--- PASS: TestAccEC2VPCDHCPOptionsAssociation_Disappears_dhcp (26.49s)
--- PASS: TestAccEC2VPCDHCPOptionsAssociation_default (28.16s)
--- PASS: TestAccEC2VPCDHCPOptionsAssociation_basic (28.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        33.742s
```
