### PR TITLE
d/aws_imagebuilder_infrastructure_configurations - new data source

### DIFF
--- a/.changelog/22723.txt
+++ b/.changelog/22723.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_imagebuilder_infrastructure_configurations
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -564,14 +564,15 @@ func Provider() *schema.Provider {
 			"aws_identitystore_group": identitystore.DataSourceGroup(),
 			"aws_identitystore_user":  identitystore.DataSourceUser(),
 
-			"aws_imagebuilder_component":                    imagebuilder.DataSourceComponent(),
-			"aws_imagebuilder_components":                   imagebuilder.DataSourceComponents(),
-			"aws_imagebuilder_distribution_configuration":   imagebuilder.DataSourceDistributionConfiguration(),
-			"aws_imagebuilder_image":                        imagebuilder.DataSourceImage(),
-			"aws_imagebuilder_image_pipeline":               imagebuilder.DataSourceImagePipeline(),
-			"aws_imagebuilder_image_recipe":                 imagebuilder.DataSourceImageRecipe(),
-			"aws_imagebuilder_image_recipes":                imagebuilder.DataSourceImageRecipes(),
-			"aws_imagebuilder_infrastructure_configuration": imagebuilder.DataSourceInfrastructureConfiguration(),
+			"aws_imagebuilder_component":                     imagebuilder.DataSourceComponent(),
+			"aws_imagebuilder_components":                    imagebuilder.DataSourceComponents(),
+			"aws_imagebuilder_distribution_configuration":    imagebuilder.DataSourceDistributionConfiguration(),
+			"aws_imagebuilder_image":                         imagebuilder.DataSourceImage(),
+			"aws_imagebuilder_image_pipeline":                imagebuilder.DataSourceImagePipeline(),
+			"aws_imagebuilder_image_recipe":                  imagebuilder.DataSourceImageRecipe(),
+			"aws_imagebuilder_image_recipes":                 imagebuilder.DataSourceImageRecipes(),
+			"aws_imagebuilder_infrastructure_configuration":  imagebuilder.DataSourceInfrastructureConfiguration(),
+			"aws_imagebuilder_infrastructure_configurations": imagebuilder.DataSourceInfrastructureConfigurations(),
 
 			"aws_inspector_rules_packages": inspector.DataSourceRulesPackages(),
 

--- a/internal/service/imagebuilder/infrastructure_configurations_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configurations_data_source.go
@@ -1,0 +1,73 @@
+package imagebuilder
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceInfrastructureConfigurations() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceInfrastructureConfigurationsRead,
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": dataSourceFiltersSchema(),
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceInfrastructureConfigurationsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ImageBuilderConn
+
+	input := &imagebuilder.ListInfrastructureConfigurationsInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = buildFiltersDataSource(v.(*schema.Set))
+	}
+
+	var results []*imagebuilder.InfrastructureConfigurationSummary
+
+	err := conn.ListInfrastructureConfigurationsPages(input, func(page *imagebuilder.ListInfrastructureConfigurationsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, infrastructureConfigurationSummary := range page.InfrastructureConfigurationSummaryList {
+			if infrastructureConfigurationSummary == nil {
+				continue
+			}
+
+			results = append(results, infrastructureConfigurationSummary)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Image Builder Infrastructure Configurations: %w", err)
+	}
+
+	var arns, names []string
+
+	for _, r := range results {
+		arns = append(arns, aws.StringValue(r.Arn))
+		names = append(names, aws.StringValue(r.Name))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/imagebuilder/infrastructure_configurations_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configurations_data_source.go
@@ -2,6 +2,7 @@ package imagebuilder
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/imagebuilder"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/service/imagebuilder/infrastructure_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/infrastructure_configurations_data_source_test.go
@@ -1,0 +1,54 @@
+package imagebuilder_test
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"testing"
+)
+
+func TestAccImageBuilderInfrastructureConfigurationsDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_imagebuilder_infrastructure_configurations.test"
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckInfrastructureConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigInfrastructureConfigurations_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arns.0", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigInfrastructureConfigurations_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  name = %[1]q
+  instance_profile_name = aws_iam_instance_profile.test.name
+}
+
+data "aws_imagebuilder_infrastructure_configurations" "test" {
+  filter {
+    name = "name"
+    values = [aws_imagebuilder_infrastructure_configuration.test.name]
+  }
+}
+`, rName)
+}

--- a/internal/service/imagebuilder/infrastructure_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/infrastructure_configurations_data_source_test.go
@@ -2,11 +2,12 @@ package imagebuilder_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/service/imagebuilder"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"testing"
 )
 
 func TestAccImageBuilderInfrastructureConfigurationsDataSource_filter(t *testing.T) {
@@ -40,13 +41,13 @@ resource "aws_iam_instance_profile" "test" {
 }
 
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
-  name = %[1]q
+  name                  = %[1]q
   instance_profile_name = aws_iam_instance_profile.test.name
 }
 
 data "aws_imagebuilder_infrastructure_configurations" "test" {
   filter {
-    name = "name"
+    name   = "name"
     values = [aws_imagebuilder_infrastructure_configuration.test.name]
   }
 }

--- a/website/docs/d/imagebuilder_infrastructure_configurations.html.markdown
+++ b/website/docs/d/imagebuilder_infrastructure_configurations.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Image Builder"
+layout: "aws"
+page_title: "AWS: aws_imagebuilder_infrastructure_configurations"
+description: |-
+    Get information on Image Builder Infrastructure Configurations.
+---
+
+# Data Source: aws_imagebuilder_infrastructure_configurations
+
+Use this data source to get the ARNs and names of Image Builder Infrastructure Configurations matching the specified criteria.
+
+## Example Usage
+
+```terraform
+data "aws_imagebuilder_infrastructure_configurations" "example" {
+  filter {
+    name   = "name"
+    values = ["example"]
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+## filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListInfrastructureConfigurations API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListInfrastructureConfigurations.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `arns` - Set of ARNs of the matched Image Builder Infrastructure Configurations.
+* `names` - Set of names of the matched Image Builder Infrastructure Configurations.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #17035.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderInfrastructureConfigurationsDataSource_filter" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderInfrastructureConfigurationsDataSource_filter -timeout 180m
=== RUN   TestAccImageBuilderInfrastructureConfigurationsDataSource_filter
=== PAUSE TestAccImageBuilderInfrastructureConfigurationsDataSource_filter
=== CONT  TestAccImageBuilderInfrastructureConfigurationsDataSource_filter
--- PASS: TestAccImageBuilderInfrastructureConfigurationsDataSource_filter (39.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       46.061s
```
