### PR TITLE
aws_vpc: Don't propagate errors from `FindVPCMainRouteTable` et al.

### DIFF
--- a/internal/service/ec2/vpc_data_source.go
+++ b/internal/service/ec2/vpc_data_source.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -177,13 +178,12 @@ func dataSourceVPCRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("enable_dns_support", v)
 	}
 
-	routeTable, err := FindVPCMainRouteTable(conn, d.Id())
-
-	if err != nil {
-		return fmt.Errorf("error reading EC2 VPC (%s) main Route Table: %w", d.Id(), err)
+	if v, err := FindVPCMainRouteTable(conn, d.Id()); err != nil {
+		log.Printf("[WARN] Error reading EC2 VPC (%s) main Route Table: %s", d.Id(), err)
+		d.Set("main_route_table_id", nil)
+	} else {
+		d.Set("main_route_table_id", v.RouteTableId)
 	}
-
-	d.Set("main_route_table_id", routeTable.RouteTableId)
 
 	cidrAssociations := []interface{}{}
 	for _, v := range vpc.CidrBlockAssociationSet {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #22708.
Relates #22709.

Output from acceptance testing:

```console
% make testacc TESTARGS='-run=TestAccVPC_\|TestAccEC2VPCDataSource_ -short' PKG=ec2 ACCTEST_PARALLELISM=4 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 4  -run=TestAccVPC_\|TestAccEC2VPCDataSource_ -short -timeout 180m
=== RUN   TestAccEC2VPCDataSource_basic
=== PAUSE TestAccEC2VPCDataSource_basic
=== RUN   TestAccEC2VPCDataSource_CIDRBlockAssociations_multiple
=== PAUSE TestAccEC2VPCDataSource_CIDRBlockAssociations_multiple
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== RUN   TestAccVPC_disappears
=== PAUSE TestAccVPC_disappears
=== RUN   TestAccVPC_tags
=== PAUSE TestAccVPC_tags
=== RUN   TestAccVPC_DefaultTags_providerOnly
=== PAUSE TestAccVPC_DefaultTags_providerOnly
=== RUN   TestAccVPC_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPC_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPC_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPC_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_overlappingTag
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_overlappingTag
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_duplicateTag
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_duplicateTag
=== RUN   TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges
=== PAUSE TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges
=== RUN   TestAccVPC_DynamicResourceTags_ignoreChanges
=== PAUSE TestAccVPC_DynamicResourceTags_ignoreChanges
=== RUN   TestAccVPC_defaultAndIgnoreTags
=== PAUSE TestAccVPC_defaultAndIgnoreTags
=== RUN   TestAccVPC_ignoreTags
=== PAUSE TestAccVPC_ignoreTags
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== RUN   TestAccVPC_updateDNSHostnames
=== PAUSE TestAccVPC_updateDNSHostnames
=== RUN   TestAccVPC_bothDNSOptionsSet
=== PAUSE TestAccVPC_bothDNSOptionsSet
=== RUN   TestAccVPC_disabledDNSSupport
=== PAUSE TestAccVPC_disabledDNSSupport
=== RUN   TestAccVPC_classicLinkOptionSet
=== PAUSE TestAccVPC_classicLinkOptionSet
=== RUN   TestAccVPC_classicLinkDNSSupportOptionSet
=== PAUSE TestAccVPC_classicLinkDNSSupportOptionSet
=== RUN   TestAccVPC_assignGeneratedIPv6CIDRBlock
=== PAUSE TestAccVPC_assignGeneratedIPv6CIDRBlock
=== RUN   TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
=== PAUSE TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
=== RUN   TestAccVPC_IpamIpv4BasicNetmask
    vpc_test.go:877: skipping long-running test in short mode
--- SKIP: TestAccVPC_IpamIpv4BasicNetmask (0.00s)
=== RUN   TestAccVPC_IpamIpv4BasicExplicitCidr
    vpc_test.go:903: skipping long-running test in short mode
--- SKIP: TestAccVPC_IpamIpv4BasicExplicitCidr (0.00s)
=== CONT  TestAccEC2VPCDataSource_basic
=== CONT  TestAccVPC_DynamicResourceTags_ignoreChanges
=== CONT  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
=== CONT  TestAccVPC_DefaultTags_updateToProviderOnly
--- PASS: TestAccEC2VPCDataSource_basic (45.30s)
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_overlappingTag
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (55.52s)
=== CONT  TestAccVPC_assignGeneratedIPv6CIDRBlock
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (56.17s)
=== CONT  TestAccVPC_classicLinkDNSSupportOptionSet
--- PASS: TestAccVPC_classicLinkDNSSupportOptionSet (34.50s)
=== CONT  TestAccVPC_classicLinkOptionSet
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (102.11s)
=== CONT  TestAccVPC_disabledDNSSupport
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (77.22s)
=== CONT  TestAccVPC_bothDNSOptionsSet
--- PASS: TestAccVPC_classicLinkOptionSet (35.05s)
=== CONT  TestAccVPC_updateDNSHostnames
--- PASS: TestAccVPC_disabledDNSSupport (44.08s)
=== CONT  TestAccVPC_tenancy
--- PASS: TestAccVPC_bothDNSOptionsSet (42.02s)
=== CONT  TestAccVPC_ignoreTags
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (113.87s)
=== CONT  TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges
--- PASS: TestAccVPC_updateDNSHostnames (58.24s)
=== CONT  TestAccVPC_defaultAndIgnoreTags
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (42.37s)
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_duplicateTag
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (1.39s)
=== CONT  TestAccVPC_disappears
--- PASS: TestAccVPC_ignoreTags (48.74s)
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag
--- PASS: TestAccVPC_tenancy (69.05s)
=== CONT  TestAccVPC_DefaultTags_providerOnly
--- PASS: TestAccVPC_disappears (15.33s)
=== CONT  TestAccVPC_tags
--- PASS: TestAccVPC_defaultAndIgnoreTags (50.85s)
=== CONT  TestAccVPC_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (57.91s)
=== CONT  TestAccVPC_basic
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (40.48s)
=== CONT  TestAccEC2VPCDataSource_CIDRBlockAssociations_multiple
--- PASS: TestAccVPC_DefaultTags_providerOnly (60.41s)
--- PASS: TestAccVPC_basic (24.51s)
--- PASS: TestAccVPC_tags (69.22s)
--- PASS: TestAccEC2VPCDataSource_CIDRBlockAssociations_multiple (48.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        331.983s
```