### PR TITLE
Amend remaining references to separate 'waiter' package

### DIFF
--- a/docs/contributing/error-handling.md
+++ b/docs/contributing/error-handling.md
@@ -225,7 +225,7 @@ if err != nil {
 Code that also uses waiters or other operations that return errors should follow a similar pattern, including the resource identifier since it has typically been set before this execution:
 
 ```go
-if _, err := waiter.VpcAvailable(conn, d.Id()); err != nil {
+if _, err := VpcAvailable(conn, d.Id()); err != nil {
     return fmt.Errorf("error waiting for EC2 VPC (%s) availability: %w", d.Id(), err)
 }
 ```
@@ -281,7 +281,7 @@ if err != nil {
 Code that also uses [waiters](retries-and-waiters.md) or other operations that return errors should follow a similar pattern:
 
 ```go
-if _, err := waiter.VpcDeleted(conn, d.Id()); err != nil {
+if _, err := VpcDeleted(conn, d.Id()); err != nil {
     return fmt.Errorf("error waiting for EC2 VPC (%s) deletion: %w", d.Id(), err)
 }
 ```
@@ -364,7 +364,7 @@ if err != nil {
 Code that also uses waiters or other operations that return errors should follow a similar pattern:
 
 ```go
-if _, err := waiter.VpcAvailable(conn, d.Id()); err != nil {
+if _, err := VpcAvailable(conn, d.Id()); err != nil {
     return fmt.Errorf("error waiting for EC2 VPC (%s) update: %w", d.Id(), err)
 }
 ```

--- a/docs/contributing/retries-and-waiters.md
+++ b/docs/contributing/retries-and-waiters.md
@@ -229,7 +229,7 @@ import (
 	iamwaiterStopTime := time.Now().Add(tfiam.PropagationTimeout)
 
 	// Ensure to add IAM eventual consistency timeout in case of retries
-	err = resource.Retry(tfiam.PropagationTimeout+waiter.ThingOperationTimeout, func() *resource.RetryError {
+	err = resource.Retry(tfiam.PropagationTimeout+ThingOperationTimeout, func() *resource.RetryError {
 		// Only retry IAM eventual consistency errors up to that timeout
 		iamwaiterRetry := time.Now().Before(iamwaiterStopTime)
 
@@ -522,7 +522,7 @@ func ThingDeleted(conn *example.Example, id string) (*example.Thing, error) {
 function ExampleThingCreate(d *schema.ResourceData, meta interface{}) error {
 	// ... AWS Go SDK logic to create resource ...
 
-	if _, err := waiter.ThingCreated(conn, d.Id()); err != nil {
+	if _, err := ThingCreated(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for Example Thing (%s) creation: %w", d.Id(), err)
 	}
 
@@ -532,7 +532,7 @@ function ExampleThingCreate(d *schema.ResourceData, meta interface{}) error {
 function ExampleThingDelete(d *schema.ResourceData, meta interface{}) error {
 	// ... AWS Go SDK logic to delete resource ...
 
-	if _, err := waiter.ThingDeleted(conn, d.Id()); err != nil {
+	if _, err := ThingDeleted(conn, d.Id()); err != nil {
 		return fmt.Errorf("error waiting for Example Thing (%s) deletion: %w", d.Id(), err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Removes remaining references to `waiter` package in docs, e.g. `waiter.ThingCreated'.

No further references to `waiter` package remain, aside from the service packages refactor guide instructing folks to adapt them:

```bash
❯ grep -rnw 'waiter\.\S*'
grep: .git/objects/pack/pack-8bd2e66db795e65187bf2be768561fa514040173.pack: binary file matches
docs/contributing/service-package-pullrequest-guide.md:119:     func waiter.{FunctionName}Status() =>
docs/contributing/service-package-pullrequest-guide.md:126:     func waiter.{FunctionName}() =>
```