### PR TITLE
d/apigatewayv2_export - new data source

### DIFF
--- a/.changelog/22732.txt
+++ b/.changelog/22732.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_pigateway_v2_export
+```

--- a/.changelog/22732.txt
+++ b/.changelog/22732.txt
@@ -1,3 +1,3 @@
 ```release-note:new-data-source
-aws_pigateway_v2_export
+aws_apigatewayv2_export
 ```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -354,8 +354,9 @@ func Provider() *schema.Provider {
 			"aws_api_gateway_rest_api":    apigateway.DataSourceRestAPI(),
 			"aws_api_gateway_vpc_link":    apigateway.DataSourceVPCLink(),
 
-			"aws_apigatewayv2_api":  apigatewayv2.DataSourceAPI(),
-			"aws_apigatewayv2_apis": apigatewayv2.DataSourceAPIs(),
+			"aws_apigatewayv2_api":    apigatewayv2.DataSourceAPI(),
+			"aws_apigatewayv2_apis":   apigatewayv2.DataSourceAPIs(),
+			"aws_apigatewayv2_export": apigatewayv2.DataSourceExport(),
 
 			"aws_appmesh_mesh":            appmesh.DataSourceMesh(),
 			"aws_appmesh_virtual_service": appmesh.DataSourceVirtualService(),

--- a/internal/service/apigatewayv2/export_data_source.go
+++ b/internal/service/apigatewayv2/export_data_source.go
@@ -1,0 +1,84 @@
+package apigatewayv2
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceExport() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceExportRead,
+
+		Schema: map[string]*schema.Schema{
+			"api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"body": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"export_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"1.0"}, false),
+			},
+			"include_extensions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"specification": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"OAS30"}, false),
+			},
+			"stage_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"output_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"JSON", "YAML"}, false),
+			},
+		},
+	}
+}
+
+func dataSourceExportRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).APIGatewayV2Conn
+
+	apiId := d.Get("api_id").(string)
+
+	input := &apigatewayv2.ExportApiInput{
+		ApiId:             aws.String(apiId),
+		Specification:     aws.String(d.Get("specification").(string)),
+		OutputType:        aws.String(d.Get("output_type").(string)),
+		IncludeExtensions: aws.Bool(d.Get("include_extensions").(bool)),
+	}
+
+	if v, ok := d.GetOk("stage_name"); ok {
+		input.StageName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("export_version"); ok {
+		input.ExportVersion = aws.String(v.(string))
+	}
+
+	export, err := conn.ExportApi(input)
+	if err != nil {
+		return fmt.Errorf("error exporting Gateway v2 API (%s): %w", apiId, err)
+	}
+
+	d.SetId(apiId)
+
+	d.Set("body", string(export.Body))
+
+	return nil
+}

--- a/internal/service/apigatewayv2/export_data_source_test.go
+++ b/internal/service/apigatewayv2/export_data_source_test.go
@@ -77,28 +77,33 @@ resource "aws_apigatewayv2_route" "test" {
 }
 
 func testAccExportHTTPDataSourceBasicConfig(rName string) string {
-	return testAccExportHTTPDataSourceConfigBase(rName) + `
+	return acctest.ConfigCompose(testAccExportHTTPDataSourceConfigBase(rName), `
 data "aws_apigatewayv2_export" "test" {
   api_id        = aws_apigatewayv2_route.test.api_id
   specification = "OAS30"
   output_type   = "JSON"
 }
-`
+`)
 }
 
 func testAccExportHTTPDataSourceStageConfig(rName string) string {
-	return testAccExportHTTPDataSourceConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExportHTTPDataSourceConfigBase(rName), fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
+  api_id        = aws_apigatewayv2_deployment.test.api_id
+  name          = %[1]q
+  deployment_id = aws_apigatewayv2_deployment.test.id
+}
+
+resource "aws_apigatewayv2_deployment" "test" {
   api_id      = aws_apigatewayv2_route.test.api_id
-  name        = %[1]q
-  auto_deploy = true
+  description = %[1]q
 }
 
 data "aws_apigatewayv2_export" "test" {
-  api_id        = aws_apigatewayv2_route.test.api_id
+  api_id        = aws_apigatewayv2_api.test.id
   specification = "OAS30"
   output_type   = "JSON"
   stage_name    = aws_apigatewayv2_stage.test.name
 }
-`, rName)
+`, rName))
 }

--- a/internal/service/apigatewayv2/export_data_source_test.go
+++ b/internal/service/apigatewayv2/export_data_source_test.go
@@ -1,0 +1,104 @@
+package apigatewayv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccExportGatewayV2ExportDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_apigatewayv2_export.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apigatewayv2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportHTTPDataSourceBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "api_id", "aws_apigatewayv2_route.test", "api_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "body"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccExportGatewayV2ExportDataSource_stage(t *testing.T) {
+	dataSourceName := "data.aws_apigatewayv2_export.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apigatewayv2.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExportHTTPDataSourceStageConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "api_id", "aws_apigatewayv2_route.test", "api_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "stage_name", "aws_apigatewayv2_stage.test", "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "body"),
+				),
+			},
+		},
+	})
+}
+
+func testAccExportHTTPDataSourceConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "test" {
+  api_id           = aws_apigatewayv2_api.test.id
+  integration_type = "HTTP_PROXY"
+
+  integration_method = "GET"
+  integration_uri    = "https://example.com"
+}
+
+resource "aws_apigatewayv2_route" "test" {
+  api_id    = aws_apigatewayv2_api.test.id
+  route_key = "GET /test"
+  target    = "integrations/${aws_apigatewayv2_integration.test.id}"
+}
+`, rName)
+}
+
+func testAccExportHTTPDataSourceBasicConfig(rName string) string {
+	return testAccExportHTTPDataSourceConfigBase(rName) + `
+data "aws_apigatewayv2_export" "test" {
+  api_id        = aws_apigatewayv2_route.test.api_id
+  specification = "OAS30"
+  output_type   = "JSON"
+}
+`
+}
+
+func testAccExportHTTPDataSourceStageConfig(rName string) string {
+	return testAccExportHTTPDataSourceConfigBase(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id      = aws_apigatewayv2_route.test.api_id
+  name        = %[1]q
+  auto_deploy = true
+}
+
+data "aws_apigatewayv2_export" "test" {
+  api_id        = aws_apigatewayv2_route.test.api_id
+  specification = "OAS30"
+  output_type   = "JSON"
+  stage_name    = aws_apigatewayv2_stage.test.name
+}
+`, rName)
+}

--- a/website/docs/d/apigatewayv2_export.html.markdown
+++ b/website/docs/d/apigatewayv2_export.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "API Gateway v2 (WebSocket and HTTP APIs)"
 layout: "aws"
-page_title: "AWS: aws_apigatewayv2_api"
+page_title: "AWS: aws_apigatewayv2_export"
 description: |-
   Exports a definition of an API in a particular output format and specification.
 ---
 
-# Data Source: aws_apigatewayv2_api
+# Data Source: aws_apigatewayv2_export
 
 Exports a definition of an API in a particular output format and specification.
 

--- a/website/docs/d/apigatewayv2_export.html.markdown
+++ b/website/docs/d/apigatewayv2_export.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "API Gateway v2 (WebSocket and HTTP APIs)"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_api"
+description: |-
+  Exports a definition of an API in a particular output format and specification.
+---
+
+# Data Source: aws_apigatewayv2_api
+
+Exports a definition of an API in a particular output format and specification.
+
+## Example Usage
+
+```terraform
+data "aws_apigatewayv2_export" "test" {
+  api_id        = aws_apigatewayv2_route.test.api_id
+  specification = "OAS30"
+  output_type   = "JSON"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_id` - (Required) The API identifier.
+* `specification` - (Required) The version of the API specification to use. `OAS30`, for OpenAPI 3.0, is the only supported value.
+* `output_type` - (Required) The output type of the exported definition file. Valid values are `JSON` and `YAML`.
+* `export_version` - (Optional) The version of the API Gateway export algorithm. API Gateway uses the latest version by default. Currently, the only supported version is `1.0`.
+* `include_extensions` - (Optional) Specifies whether to include API Gateway extensions in the exported API definition. API Gateway extensions are included by default.
+* `stage_name` - (Optional) The name of the API stage to export. If you don't specify this property, a representation of the latest API configuration is exported.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The API identifier.
+* `body` - The id of the API.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12942.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccExportGatewayV2ExportDataSource_ PKG=apigatewayv2

--- PASS: TestAccExportGatewayV2ExportDataSource_basic (40.71s)
--- PASS: TestAccExportGatewayV2ExportDataSource_stage (49.20s)
```
