### PR TITLE
d/aws_imagebuilder_distribution_configurations - new data source

### DIFF
--- a/.changelog/22733.txt
+++ b/.changelog/22733.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_imagebuilder_distribution_configurations
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -567,6 +567,7 @@ func Provider() *schema.Provider {
 			"aws_imagebuilder_component":                     imagebuilder.DataSourceComponent(),
 			"aws_imagebuilder_components":                    imagebuilder.DataSourceComponents(),
 			"aws_imagebuilder_distribution_configuration":    imagebuilder.DataSourceDistributionConfiguration(),
+			"aws_imagebuilder_distribution_configurations":   imagebuilder.DataSourceDistributionConfigurations(),
 			"aws_imagebuilder_image":                         imagebuilder.DataSourceImage(),
 			"aws_imagebuilder_image_pipeline":                imagebuilder.DataSourceImagePipeline(),
 			"aws_imagebuilder_image_recipe":                  imagebuilder.DataSourceImageRecipe(),

--- a/internal/service/imagebuilder/distribution_configurations_data_source.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source.go
@@ -11,7 +11,7 @@ import (
 
 func DataSourceDistributionConfigurations() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDistributionConfigurations,
+		Read: dataSourceDistributionConfigurationsRead,
 		Schema: map[string]*schema.Schema{
 			"arns": {
 				Type:     schema.TypeSet,
@@ -28,7 +28,7 @@ func DataSourceDistributionConfigurations() *schema.Resource {
 	}
 }
 
-func dataSourceDistributionConfigurations(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDistributionConfigurationsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ImageBuilderConn
 
 	input := &imagebuilder.ListDistributionConfigurationsInput{}

--- a/internal/service/imagebuilder/distribution_configurations_data_source.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source.go
@@ -1,0 +1,74 @@
+package imagebuilder
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceDistributionConfigurations() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDistributionConfigurations,
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": dataSourceFiltersSchema(),
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceDistributionConfigurations(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ImageBuilderConn
+
+	input := &imagebuilder.ListDistributionConfigurationsInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = buildFiltersDataSource(v.(*schema.Set))
+	}
+
+	var results []*imagebuilder.DistributionConfigurationSummary
+
+	err := conn.ListDistributionConfigurationsPages(input, func(page *imagebuilder.ListDistributionConfigurationsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, distributionConfigurationSummary := range page.DistributionConfigurationSummaryList {
+			if distributionConfigurationSummary == nil {
+				continue
+			}
+
+			results = append(results, distributionConfigurationSummary)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Image Builder Distribution Configurations: %w", err)
+	}
+
+	var arns, names []string
+
+	for _, r := range results {
+		arns = append(arns, aws.StringValue(r.Arn))
+		names = append(names, aws.StringValue(r.Name))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/imagebuilder/distribution_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source_test.go
@@ -46,7 +46,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "test-{{ imagebuilder:buildDate }}"
     }
 
-    region = aws_region.current.name
+    region = data.aws_region.current.name
   }
 }
 

--- a/internal/service/imagebuilder/distribution_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source_test.go
@@ -36,6 +36,8 @@ func TestAccImageBuilderDistributionConfigurationsDataSource_filter(t *testing.T
 
 func testAccConfigDistributionConfigurations_filter(rName string) string {
 	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
 resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
 
@@ -44,7 +46,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "test-{{ imagebuilder:buildDate }}"
     }
 
-    region = "us-west-2"
+    region = aws_region.current.name
   }
 }
 

--- a/internal/service/imagebuilder/distribution_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source_test.go
@@ -41,7 +41,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
 
   distribution {
     ami_distribution_configuration {
-        name = "test-{{ imagebuilder:buildDate }}"
+      name = "test-{{ imagebuilder:buildDate }}"
     }
 
     region = "us-west-2"

--- a/internal/service/imagebuilder/distribution_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source_test.go
@@ -37,12 +37,12 @@ func TestAccImageBuilderDistributionConfigurationsDataSource_filter(t *testing.T
 func testAccConfigDistributionConfigurations_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_imagebuilder_distribution_configuration" "test" {
-  name                  = %[1]q
+  name = %[1]q
 
   distribution {
     ami_distribution_configuration {
-	    name = "test-{{ imagebuilder:buildDate }}"
-	}
+        name = "test-{{ imagebuilder:buildDate }}"
+    }
 
     region = "us-west-2"
   }

--- a/internal/service/imagebuilder/distribution_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source_test.go
@@ -1,0 +1,58 @@
+package imagebuilder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccImageBuilderDistributionConfigurationsDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_imagebuilder_distribution_configurations.test"
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigDistributionConfigurations_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arns.0", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigDistributionConfigurations_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name                  = %[1]q
+
+  distribution {
+    ami_distribution_configuration {
+	    name = "test-{{ imagebuilder:buildDate }}"
+	}
+
+    region = "us-west-2"
+  }
+}
+
+data "aws_imagebuilder_distribution_configurations" "test" {
+  filter {
+    name   = "name"
+    values = [aws_imagebuilder_distribution_configuration.test.name]
+  }
+}
+`, rName)
+}

--- a/website/docs/d/imagebuilder_distribution_configurations.html.markdown
+++ b/website/docs/d/imagebuilder_distribution_configurations.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Image Builder"
+layout: "aws"
+page_title: "AWS: aws_imagebuilder_distribution_configurations"
+description: |-
+    Get information on Image Builder Distribution Configurations.
+---
+
+# Data Source: aws_imagebuilder_distribution_configurations
+
+Use this data source to get the ARNs and names of Image Builder Distribution Configurations matching the specified criteria.
+
+## Example Usage
+
+```terraform
+data "aws_imagebuilder_distribution_configurations" "example" {
+  filter {
+    name   = "name"
+    values = ["example"]
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+## filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListDistributionConfigurations API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListDistributionConfigurations.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `arns` - Set of ARNs of the matched Image Builder Distribution Configurations.
+* `names` - Set of names of the matched Image Builder Distribution Configurations.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #17035.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderDistributionConfigurationsDataSource_" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderDistributionConfigurationsDataSource_ -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfigurationsDataSource_filter
=== PAUSE TestAccImageBuilderDistributionConfigurationsDataSource_filter
=== CONT  TestAccImageBuilderDistributionConfigurationsDataSource_filter
--- PASS: TestAccImageBuilderDistributionConfigurationsDataSource_filter (31.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       39.472s
```
