### PR TITLE
d/aws_subnet_ids: Deprecate

### DIFF
--- a/.changelog/22743.txt
+++ b/.changelog/22743.txt
@@ -1,0 +1,3 @@
+```release-note:note
+data-source/aws_subnet_ids: The `aws_subnet_ids` data source has been deprecated and will be removed removed in a future version. Use the `aws_subnets` data source instead
+```

--- a/.changelog/22743.txt
+++ b/.changelog/22743.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-data-source/aws_subnet_ids: The `aws_subnet_ids` data source has been deprecated and will be removed removed in a future version. Use the `aws_subnets` data source instead
+data-source/aws_subnet_ids: The `aws_subnet_ids` data source has been deprecated and will be removed in a future version. Use the `aws_subnets` data source instead
 ```

--- a/internal/service/ec2/subnet_ids_data_source.go
+++ b/internal/service/ec2/subnet_ids_data_source.go
@@ -27,6 +27,8 @@ func DataSourceSubnetIDs() *schema.Resource {
 				Required: true,
 			},
 		},
+		DeprecationMessage: `The aws_subnet_ids data source has been deprecated and will be removed removed in a future version. ` +
+			`Use the aws_subnets data source instead.`,
 	}
 }
 

--- a/internal/service/ec2/subnet_ids_data_source.go
+++ b/internal/service/ec2/subnet_ids_data_source.go
@@ -27,7 +27,7 @@ func DataSourceSubnetIDs() *schema.Resource {
 				Required: true,
 			},
 		},
-		DeprecationMessage: `The aws_subnet_ids data source has been deprecated and will be removed removed in a future version. ` +
+		DeprecationMessage: `The aws_subnet_ids data source has been deprecated and will be removed in a future version. ` +
 			`Use the aws_subnets data source instead.`,
 	}
 }

--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 This resource can be useful for getting back a set of subnet ids for a vpc.
 
-~> **NOTE:** The `aws_subnet_ids` data source has been deprecated and will be removed removed in a future version. Use the [`aws_subnets`](subnets.html) data source instead.
+~> **NOTE:** The `aws_subnet_ids` data source has been deprecated and will be removed in a future version. Use the [`aws_subnets`](subnets.html) data source instead.
 
 ## Example Usage
 

--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -12,6 +12,8 @@ description: |-
 
 This resource can be useful for getting back a set of subnet ids for a vpc.
 
+~> **NOTE:** The `aws_subnet_ids` data source has been deprecated and will be removed removed in a future version. Use the [`aws_subnets`](subnets.html) data source instead.
+
 ## Example Usage
 
 The following shows outputing all cidr blocks for every subnet id in a vpc.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20592.
Relates #20433.
Relates #22818.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEC2SubnetIDsDataSource_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2SubnetIDsDataSource_'  -timeout 180m
=== RUN   TestAccEC2SubnetIDsDataSource_basic
=== PAUSE TestAccEC2SubnetIDsDataSource_basic
=== RUN   TestAccEC2SubnetIDsDataSource_filter
=== PAUSE TestAccEC2SubnetIDsDataSource_filter
=== CONT  TestAccEC2SubnetIDsDataSource_basic
=== CONT  TestAccEC2SubnetIDsDataSource_filter
--- PASS: TestAccEC2SubnetIDsDataSource_filter (27.38s)
--- PASS: TestAccEC2SubnetIDsDataSource_basic (40.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	44.562s
```
