### PR TITLE
vpc/peering_connection Update auto_accept description to suggest the usage of the accepter when creating inter-region peering

### DIFF
--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -150,7 +150,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Notes
 
-If both VPCs are not in the same AWS account do not enable the `auto_accept` attribute.
+If both VPCs are not in the same AWS account and region do not enable the `auto_accept` attribute.
 The accepter can manage its side of the connection using the `aws_vpc_peering_connection_accepter` resource
 or accept the connection manually using the AWS Management Console, AWS CLI, through SDKs, etc.
 

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
    Defaults to the account ID the [AWS provider][1] is currently connected to.
 * `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.
-* `auto_accept` - (Optional) Accept the peering (both VPCs need to be in the same AWS account).
+* `auto_accept` - (Optional) Accept the peering (both VPCs need to be in the same AWS account and region).
 * `peer_region` - (Optional) The region of the accepter VPC of the VPC Peering Connection. `auto_accept` must be `false`,
 and use the `aws_vpc_peering_connection_accepter` to manage the accepter side.
 * `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options to be set for the VPC that accepts


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

This PR does not update any functionality of the provider, however aims to fix some incomplete information by the documentation.
The `auto_accept` option can be used only for VPC peering between VPC in the same region and environment. According to the note at the top of the page it is suggested to use a combination of `aws_vpc_peering_connection` and `aws_vpc_peering_connection_accepter` for every inter-region or cross-account peering. This needs to be reflected also in the description of the `auto_accept` parameter, which would not work in case the two VPCs are not in the same region.

I believe there will be no need to run acceptance testing considering there is no change on the code.