### PR TITLE
Issue #22755: Updated IoT Role Alias to take a credential_duration maximum value of 43200…

### DIFF
--- a/.changelog/22757.txt
+++ b/.changelog/22757.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_role_alias: Increase the maximum allowed value of the `credential_duration` argument to `43200` (12 hours)
+```

--- a/internal/service/iot/role_alias.go
+++ b/internal/service/iot/role_alias.go
@@ -38,7 +38,7 @@ func ResourceRoleAlias() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      3600,
-				ValidateFunc: validation.IntBetween(900, 3600),
+				ValidateFunc: validation.IntBetween(900, 43200),
 			},
 		},
 	}

--- a/internal/service/iot/role_alias_test.go
+++ b/internal/service/iot/role_alias_test.go
@@ -42,7 +42,7 @@ func TestAccIoTRoleAlias_basic(t *testing.T) {
 					testAccCheckRoleAliasExists(resourceName),
 					testAccCheckRoleAliasExists(resourceName2),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
-					resource.TestCheckResourceAttr(resourceName, "credential_duration", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "credential_duration", "43200"),
 				),
 			},
 			{
@@ -175,7 +175,7 @@ EOF
 resource "aws_iot_role_alias" "ra" {
   alias               = "%s"
   role_arn            = aws_iam_role.role.arn
-  credential_duration = 1800
+  credential_duration = 43200
 }
 
 resource "aws_iot_role_alias" "ra2" {

--- a/website/docs/r/iot_role_alias.html.markdown
+++ b/website/docs/r/iot_role_alias.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `alias` - (Required) The name of the role alias.
 * `role_arn` - (Required) The identity of the role to which the alias refers.
-* `credential_duration` - (Optional) The duration of the credential, in seconds. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 900 seconds (15 minutes) to 3600 seconds (60 minutes).
+* `credential_duration` - (Optional) The duration of the credential, in seconds. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 900 seconds (15 minutes) to 43200 seconds (12 hours).
 
 ## Attributes Reference
 


### PR DESCRIPTION
… seconds.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22755 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
