### PR TITLE
r/aws_imagebuilder_distribution_configuration - add container_distribution_configuration attribute

### DIFF
--- a/.changelog/22758.txt
+++ b/.changelog/22758.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_imagebuilder_distribution_configuration: Add `container_distribution_configuration` attribute
+resource/aws_imagebuilder_distribution_configuration: Add `container_distribution_configuration` argument
 ```

--- a/.changelog/22758.txt
+++ b/.changelog/22758.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_distribution_configuration: Add `container_distribution_configuration` attribute
+```

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -396,6 +396,124 @@ func TestAccImageBuilderDistributionConfiguration_DistributionAMIDistribution_ta
 	})
 }
 
+func TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationDistributionContainerDistributionConfigurationContainerTagsConfig(rName, "tag1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "distribution.0.container_distribution_configuration.0.container_tags.*", "tag1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationDistributionContainerDistributionConfigurationContainerTagsConfig(rName, "tag2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "distribution.0.container_distribution_configuration.0.container_tags.*", "tag2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationDistributionContainerDistributionConfigurationDescriptionConfig(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationDistributionContainerDistributionConfigurationDescriptionConfig(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationDistributionContainerDistributionConfigurationTargetRepositoryConfig(rName, "repository1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.target_repository.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name", "repository1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service", "ECR"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationDistributionContainerDistributionConfigurationTargetRepositoryConfig(rName, "repository2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.target_repository.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name", "repository2"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service", "ECR"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	licenseConfigurationResourceName := "aws_licensemanager_license_configuration.test"
@@ -738,6 +856,73 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   }
 }
 `, rName, targetAccountId)
+}
+
+func testAccDistributionConfigurationDistributionContainerDistributionConfigurationTargetRepositoryConfig(rName string, repositoryName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+    name = %[1]q
+
+    distribution {
+      container_distribution_configuration {
+        target_repository {
+          repository_name = %[2]q
+          service         = "ECR"
+		} 
+	  }
+	  
+      region = data.aws_region.current.name
+    }
+}
+`, rName, repositoryName)
+}
+
+func testAccDistributionConfigurationDistributionContainerDistributionConfigurationDescriptionConfig(rName string, description string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+    name = %[1]q
+
+    distribution {
+      container_distribution_configuration {
+        target_repository {
+          repository_name = "repository-name"
+          service         = "ECR"
+		} 
+
+        description = %[2]q
+	  }
+
+      region = data.aws_region.current.name
+    }
+}
+`, rName, description)
+}
+
+func testAccDistributionConfigurationDistributionContainerDistributionConfigurationContainerTagsConfig(rName string, containerTag string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+    name = %[1]q
+
+    distribution {
+      container_distribution_configuration {
+        target_repository {
+          repository_name = "repository-name"
+          service         = "ECR"
+		} 
+
+        container_tags = [%[2]q]
+	  }
+
+      region = data.aws_region.current.name
+    }
+}
+`, rName, containerTag)
 }
 
 func testAccDistributionConfigurationDistributionLicenseConfigurationARNs1Config(rName string) string {

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -863,18 +863,18 @@ func testAccDistributionConfigurationDistributionContainerDistributionConfigurat
 data "aws_region" "current" {}
 
 resource "aws_imagebuilder_distribution_configuration" "test" {
-    name = %[1]q
+  name = %[1]q
 
-    distribution {
-      container_distribution_configuration {
-        target_repository {
-          repository_name = %[2]q
-          service         = "ECR"
-		} 
-	  }
-	  
-      region = data.aws_region.current.name
+  distribution {
+    container_distribution_configuration {
+      target_repository {
+        repository_name = %[2]q
+        service         = "ECR"
+      }
     }
+
+    region = data.aws_region.current.name
+  }
 }
 `, rName, repositoryName)
 }
@@ -884,20 +884,20 @@ func testAccDistributionConfigurationDistributionContainerDistributionConfigurat
 data "aws_region" "current" {}
 
 resource "aws_imagebuilder_distribution_configuration" "test" {
-    name = %[1]q
+  name = %[1]q
 
-    distribution {
-      container_distribution_configuration {
-        target_repository {
-          repository_name = "repository-name"
-          service         = "ECR"
-		} 
+  distribution {
+    container_distribution_configuration {
+      target_repository {
+        repository_name = "repository-name"
+        service         = "ECR"
+      }
 
-        description = %[2]q
-	  }
-
-      region = data.aws_region.current.name
+      description = %[2]q
     }
+
+    region = data.aws_region.current.name
+  }
 }
 `, rName, description)
 }
@@ -907,20 +907,20 @@ func testAccDistributionConfigurationDistributionContainerDistributionConfigurat
 data "aws_region" "current" {}
 
 resource "aws_imagebuilder_distribution_configuration" "test" {
-    name = %[1]q
+  name = %[1]q
 
-    distribution {
-      container_distribution_configuration {
-        target_repository {
-          repository_name = "repository-name"
-          service         = "ECR"
-		} 
+  distribution {
+    container_distribution_configuration {
+      target_repository {
+        repository_name = "repository-name"
+        service         = "ECR"
+      }
 
-        container_tags = [%[2]q]
-	  }
-
-      region = data.aws_region.current.name
+      container_tags = [%[2]q]
     }
+
+    region = data.aws_region.current.name
+  }
 }
 `, rName, containerTag)
 }

--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -56,6 +56,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `ami_distribution_configuration` - (Optional) Configuration block with Amazon Machine Image (AMI) distribution settings. Detailed below.
+* `container_distribution_configuration` - (Optional) Configuration block with container distribution settings. Detailed below.
 * `license_configuration_arns` - (Optional) Set of Amazon Resource Names (ARNs) of License Manager License Configurations.
 
 ### ami_distribution_configuration
@@ -75,6 +76,17 @@ The following arguments are optional:
 
 * `user_groups` - (Optional) Set of EC2 launch permission user groups to assign. Use `all` to distribute a public AMI.
 * `user_ids` - (Optional) Set of AWS Account identifiers to assign.
+
+### container_distribution_configuration
+
+* `container_tags` - (Optional) Set of tags that are attached to the container distribution configuration.
+* `description` - (Optional) Description of the container distribution configuration.
+* `target_repository` (Required) Configuration block with the destination repository for the container distribution configuration.
+
+### target_repository
+
+* `repository_name` - (Required) The name of the container repository where the output container image is stored. This name is prefixed by the repository location.
+* `service` - (Required) The service in which this image is registered. Valid values: `ECR`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/16839.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_ -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description
=== RUN   TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository
=== PAUSE TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository
=== CONT  TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_containerTags (50.26s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_targetRepository (50.31s)
--- PASS: TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribution_description (50.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       58.265s
```
