### PR TITLE
r/aws_connect_security_profile-read new attribute

### DIFF
--- a/internal/service/connect/enum.go
+++ b/internal/service/connect/enum.go
@@ -27,6 +27,9 @@ const (
 	// ListQuickConnectsMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
 	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListQuickConnects.html
 	ListQuickConnectsMaxResults = 60
+	// ListSecurityProfilePermissionsMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
+	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListSecurityProfilePermissions.html
+	ListSecurityProfilePermissionsMaxResults = 60
 )
 
 func InstanceAttributeMapping() map[string]string {

--- a/internal/service/connect/enum.go
+++ b/internal/service/connect/enum.go
@@ -24,7 +24,7 @@ const (
 	// MaxResults Valid Range: Minimum value of 1. Maximum value of 1000
 	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListPrompts.html
 	ListPromptsMaxResults = 60
-	// ListLambdaFunctionsMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
+	// ListQuickConnectsMaxResults Valid Range: Minimum value of 1. Maximum value of 1000.
 	// https://docs.aws.amazon.com/connect/latest/APIReference/API_ListQuickConnects.html
 	ListQuickConnectsMaxResults = 60
 )

--- a/internal/service/connect/security_profile.go
+++ b/internal/service/connect/security_profile.go
@@ -146,7 +146,17 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("organization_resource_id", resp.SecurityProfile.OrganizationResourceId)
 	d.Set("security_profile_id", resp.SecurityProfile.Id)
 	d.Set("name", resp.SecurityProfile.SecurityProfileName)
-	// NOTE: The response does not return information about the permissions
+
+	// reading permissions requires a separate API call
+	permissions, err := getConnectSecurityProfilePermissions(ctx, conn, instanceID, securityProfileID)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error finding Connect Security Profile Permissions for Security Profile (%s): %w", securityProfileID, err))
+	}
+
+	if permissions != nil {
+		d.Set("permissions", flex.FlattenStringSet(permissions))
+	}
 
 	tags := KeyValueTags(resp.SecurityProfile.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
@@ -229,4 +239,30 @@ func SecurityProfileParseID(id string) (string, string, error) {
 	}
 
 	return parts[0], parts[1], nil
+}
+
+func getConnectSecurityProfilePermissions(ctx context.Context, conn *connect.Connect, instanceID, securityProfileID string) ([]*string, error) {
+	var result []*string
+
+	input := &connect.ListSecurityProfilePermissionsInput{
+		InstanceId:        aws.String(instanceID),
+		MaxResults:        aws.Int64(ListSecurityProfilePermissionsMaxResults),
+		SecurityProfileId: aws.String(securityProfileID),
+	}
+
+	err := conn.ListSecurityProfilePermissionsPagesWithContext(ctx, input, func(page *connect.ListSecurityProfilePermissionsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		result = append(result, page.Permissions...)
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/internal/service/connect/security_profile_test.go
+++ b/internal/service/connect/security_profile_test.go
@@ -18,8 +18,9 @@ import (
 //Serialized acceptance tests due to Connect account limits (max 2 parallel tests)
 func TestAccConnectSecurityProfile_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"basic":      testAccSecurityProfile_basic,
-		"disappears": testAccSecurityProfile_disappears,
+		"basic":              testAccSecurityProfile_basic,
+		"disappears":         testAccSecurityProfile_disappears,
+		"update_permissions": testAccSecurityProfile_updatePermissions,
 	}
 
 	for name, tc := range testCases {
@@ -73,6 +74,57 @@ func testAccSecurityProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSecurityProfile_updatePermissions(t *testing.T) {
+	var v connect.DescribeSecurityProfileOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_security_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, connect.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSecurityProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityProfileBasicConfig(rName, rName2, "TestPermissionsUpdate"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityProfileExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "security_profile_id"),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "description", "TestPermissionsUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"permissions"},
+			},
+			{
+				// Test updating permissions
+				Config: testAccSecurityProfilePermissionsConfig(rName, rName2, "TestPermissionsUpdate"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSecurityProfileExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "security_profile_id"),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "description", "TestPermissionsUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
@@ -188,6 +240,27 @@ resource "aws_connect_security_profile" "test" {
   instance_id = aws_connect_instance.test.id
   name        = %[1]q
   description = %[2]q
+
+  tags = {
+    "Name" = "Test Security Profile"
+  }
+}
+`, rName2, label))
+}
+
+func testAccSecurityProfilePermissionsConfig(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccSecurityProfileBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_connect_security_profile" "test" {
+  instance_id = aws_connect_instance.test.id
+  name        = %[1]q
+  description = %[2]q
+
+  permissions = [
+    "BasicAgentAccess",
+    "OutboundCallAccess",
+  ]
 
   tags = {
     "Name" = "Test Security Profile"

--- a/internal/service/connect/security_profile_test.go
+++ b/internal/service/connect/security_profile_test.go
@@ -52,7 +52,7 @@ func testAccSecurityProfile_basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
@@ -72,7 +72,7 @@ func testAccSecurityProfile_basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
@@ -188,11 +188,6 @@ resource "aws_connect_security_profile" "test" {
   instance_id = aws_connect_instance.test.id
   name        = %[1]q
   description = %[2]q
-
-  permissions = [
-    "BasicAgentAccess",
-    "OutboundCallAccess",
-  ]
 
   tags = {
     "Name" = "Test Security Profile"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccConnectSecurityProfile_serial PKG=connect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnectSecurityProfile_serial'  -timeout 180m
=== RUN   TestAccConnectSecurityProfile_serial
=== RUN   TestAccConnectSecurityProfile_serial/basic
=== RUN   TestAccConnectSecurityProfile_serial/disappears
=== RUN   TestAccConnectSecurityProfile_serial/update_permissions
--- PASS: TestAccConnectSecurityProfile_serial (477.90s)
    --- PASS: TestAccConnectSecurityProfile_serial/basic (212.92s)
    --- PASS: TestAccConnectSecurityProfile_serial/disappears (108.76s)
    --- PASS: TestAccConnectSecurityProfile_serial/update_permissions (156.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    485.724s

...
```

### Notes

- There is support to retrieve the `permissions` associated to a Security Profile via another API call that is documented at [Amazon Connect API Reference: ListSecurityProfilePermissions](https://docs.aws.amazon.com/connect/latest/APIReference/API_ListSecurityProfilePermissions.html)
