### PR TITLE
ISO tagging: Further refine error handling

### DIFF
--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 data-source/aws_ecr_repository: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_ecr_repository: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ecr_repository: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -9,3 +9,7 @@ resource/aws_ecr_repository: Further refine tag error handling in ISO partitions
 ```release-note:bug
 resource/aws_ecs_capacity_provider: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_ecs_cluster: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -17,3 +17,7 @@ resource/aws_ecs_cluster: Further refine tag error handling in ISO partitions
 ```release-note:bug
 resource/aws_ecs_service: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_ecs_task_definition: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -25,3 +25,7 @@ resource/aws_ecs_task_definition: Further refine tag error handling in ISO parti
 ```release-note:bug
 resource/aws_ecs_task_set: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_sns_topic: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -21,3 +21,7 @@ resource/aws_ecs_service: Further refine tag error handling in ISO partitions
 ```release-note:bug
 resource/aws_ecs_task_definition: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_ecs_task_set: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -5,3 +5,7 @@ data-source/aws_ecr_repository: Further refine tag error handling in ISO partiti
 ```release-note:bug
 resource/aws_ecr_repository: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_ecs_capacity_provider: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -13,3 +13,7 @@ resource/aws_ecs_capacity_provider: Further refine tag error handling in ISO par
 ```release-note:bug
 resource/aws_ecs_cluster: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_ecs_service: Further refine tag error handling in ISO partitions
+```

--- a/.changelog/22780.txt
+++ b/.changelog/22780.txt
@@ -29,3 +29,11 @@ resource/aws_ecs_task_set: Further refine tag error handling in ISO partitions
 ```release-note:bug
 resource/aws_sns_topic: Further refine tag error handling in ISO partitions
 ```
+
+```release-note:bug
+resource/aws_sqs_queue: Further refine tag error handling in ISO partitions
+```
+
+```release-note:bug
+data-source/aws_sqs_queue: Further refine tag error handling in ISO partitions
+```

--- a/internal/service/cloudwatch/composite_alarm.go
+++ b/internal/service/cloudwatch/composite_alarm.go
@@ -103,14 +103,14 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] CloudWatch Composite Alarm (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] failed creating CloudWatch Composite Alarm (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
 		_, err = conn.PutCompositeAlarmWithContext(ctx, &input)
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating CloudWatch Composite Alarm (%s): %s", name, err)
+		return diag.Errorf("failed creating CloudWatch Composite Alarm (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -130,12 +130,12 @@ func resourceCompositeAlarmCreate(ctx context.Context, d *schema.ResourceData, m
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] error adding tags after create for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 			return resourceCompositeAlarmRead(ctx, d, meta)
 		}
 
 		if err != nil {
-			return diag.Errorf("error creating CloudWatch Composite Alarm (%s) tags: %s", d.Id(), err)
+			return diag.Errorf("failed adding tags after create for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -192,12 +192,12 @@ func resourceCompositeAlarmRead(ctx context.Context, d *schema.ResourceData, met
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for CloudWatch Composite Alarm %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 		return nil
 	}
 
 	if err != nil {
-		return diag.Errorf("error listing tags of alarm: %s", err)
+		return diag.Errorf("failed listing tags for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -233,12 +233,12 @@ func resourceCompositeAlarmUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] Unable to update tags for CloudWatch Composite Alarm %s: %s", arn, err)
+			log.Printf("[WARN] failed updating tags for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 			return resourceCompositeAlarmRead(ctx, d, meta)
 		}
 
 		if err != nil {
-			return diag.Errorf("error updating CloudWatch Composite Alarm (%s) tags: %s", arn, err)
+			return diag.Errorf("failed updating tags for CloudWatch Composite Alarm (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -297,14 +297,14 @@ func resourceMetricAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] CloudWatch Metric Alarm (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] failed creating CloudWatch Metric Alarm (%s) with tags: %s. Trying create without tags.", d.Get("alarm_name").(string), err)
 		params.Tags = nil
 
 		_, err = conn.PutMetricAlarm(&params)
 	}
 
 	if err != nil {
-		return fmt.Errorf("Creating metric alarm failed: %w", err)
+		return fmt.Errorf("failed creating CloudWatch Metric Alarm (%s): %w", d.Get("alarm_name").(string), err)
 	}
 
 	d.SetId(d.Get("alarm_name").(string))
@@ -325,12 +325,12 @@ func resourceMetricAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] could not add tags after create for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 			return resourceMetricAlarmRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("creating CloudWatch Metric Alarm (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for CloudWatch Metric Alarm (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -408,7 +408,7 @@ func resourceMetricAlarmRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for CloudWatch Metric Alarm %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -443,12 +443,12 @@ func resourceMetricAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] Unable to update tags for CloudWatch Metric Alarm %s: %s", arn, err)
+			log.Printf("[WARN] failed updating tags for CloudWatch Metric Alarm (%s): %s", d.Id(), err)
 			return resourceMetricAlarmRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating CloudWatch Metric Alarm (%s) tags: %w", arn, err)
+			return fmt.Errorf("failed updating tags for CloudWatch Metric Alarm (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/cloudwatch/metric_stream.go
+++ b/internal/service/cloudwatch/metric_stream.go
@@ -150,14 +150,14 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if params.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] CloudWatch Metric Stream (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] failed creating CloudWatch Metric Stream (%s) with tags: %s. Trying create without tags.", name, err)
 		params.Tags = nil
 
 		output, err = conn.PutMetricStreamWithContext(ctx, &params)
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("putting metric_stream failed: %s", err))
+		return diag.Errorf("failed creating CloudWatch Metric Stream (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -169,12 +169,12 @@ func resourceMetricStreamCreate(ctx context.Context, d *schema.ResourceData, met
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] error adding tags after create for CloudWatch Metric Stream (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 			return resourceMetricStreamRead(ctx, d, meta)
 		}
 
 		if err != nil {
-			return diag.Errorf("error creating CloudWatch Metric Stream (%s) tags: %s", d.Id(), err)
+			return diag.Errorf("failed adding tags after create for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -228,12 +228,12 @@ func resourceMetricStreamRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for CloudWatch Metric Stream %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 		return nil
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing tags for CloudWatch Metric Stream (%s): %w", d.Id(), err))
+		return diag.Errorf("failed listing tags for CloudWatch Metric Stream (%s): %s", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/ecr/consts.go
+++ b/internal/service/ecr/consts.go
@@ -1,5 +1,0 @@
-package ecr
-
-const (
-	ErrCodeAccessDenied = "AccessDenied"
-)

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -138,14 +138,14 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECR Repository (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] failed creating ECR Repository (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
 		out, err = conn.CreateRepository(&input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating ECR repository: %s", err)
+		return fmt.Errorf("failed creating ECR Repository (%s): %w", d.Get("name").(string), err)
 	}
 
 	repository := *out.Repository // nosemgrep: prefer-aws-go-sdk-pointer-conversion-assignment // false positive
@@ -160,12 +160,12 @@ func resourceRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] error adding tags after create for ECR Repository (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error creating ECR Repository (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for ECR Repository (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -238,12 +238,12 @@ func resourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for ECR Repository %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for ECR Repository (%s): %w", arn, err)
+		return fmt.Errorf("failed listing tags for ECR Repository (%s): %w", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -328,12 +328,12 @@ func resourceRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions may not support tagging, giving error
 		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] Unable to update tags for ECR Repository %s: %s", d.Id(), err)
+			log.Printf("[WARN] failed updating tags for ECR Repository (%s): %s", d.Id(), err)
 			return resourceRepositoryRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating ECR Repository (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed updating tags for ECR Repository (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -117,13 +117,14 @@ func dataSourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for ECR Repository %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for ECR Repository (%s): %s", d.Id(), err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for ECR Repository (%s): %w", arn, err)
+		return fmt.Errorf("failed listing tags for ECR Repository (%s): %w", arn, err)
 	}
+
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags for ECR Repository (%s): %w", arn, err)
 	}

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceRepository() *schema.Resource {
@@ -115,7 +116,7 @@ func dataSourceRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := ListTags(conn, arn)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ecr.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecr.ErrCodeValidationException)) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ECR Repository %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -127,14 +127,14 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure creating Capacity Provider (%s) with tags: %s. Trying create without tags.", name, err)
+		log.Printf("[WARN] ECS tagging failed creating Capacity Provider (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
 		output, err = conn.CreateCapacityProvider(&input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating ECS Capacity Provider (%s): %w", name, err)
+		return fmt.Errorf("failed creating ECS Capacity Provider (%s): %w", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.CapacityProvider.CapacityProviderArn))
@@ -145,12 +145,12 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			// If default tags only, log and continue. Otherwise, error.
-			log.Printf("[WARN] ECS tagging failure adding tags after create for Capacity Provider (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed adding tags after create for Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure adding tags after create for Capacity Provider (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed adding tags after create for Capacity Provider (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -186,7 +186,7 @@ func resourceCapacityProviderRead(d *schema.ResourceData, meta interface{}) erro
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure listing tags for Capacity Provider (%s): %s", d.Id(), err)
+		log.Printf("[WARN] ECS tagging failed listing tags for Capacity Provider (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -246,12 +246,12 @@ func resourceCapacityProviderUpdate(d *schema.ResourceData, meta interface{}) er
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure updating tags for Capacity Provider (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed updating tags for Capacity Provider (%s): %s", d.Id(), err)
 			return resourceCapacityProviderRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure updating tags for Capacity Provider (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed updating tags for Capacity Provider (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -127,13 +127,7 @@ func resourceCapacityProviderCreate(d *schema.ResourceData, meta interface{}) er
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		resID := "Undefined"
-
-		if output != nil && output.CapacityProvider != nil && output.CapacityProvider.CapacityProviderArn != nil {
-			resID = aws.StringValue(output.CapacityProvider.CapacityProviderArn)
-		}
-
-		log.Printf("[WARN] ECS tagging failure creating Capacity Provider (%s) with tags: %s. Trying create without tags.", resID, err)
+		log.Printf("[WARN] ECS tagging failure creating Capacity Provider (%s) with tags: %s. Trying create without tags.", name, err)
 		input.Tags = nil
 
 		output, err = conn.CreateCapacityProvider(&input)

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -208,7 +208,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	out, err := retryClusterCreate(conn, input)
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] ECS Cluster (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
 		input.Tags = nil
 
@@ -231,7 +231,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			// If default tags only, log and continue. Otherwise, error.
 			log.Printf("[WARN] error adding tags after create for ECS Cluster (%s): %s", d.Id(), err)
 			return resourceClusterRead(d, meta)
@@ -309,7 +309,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	tags := KeyValueTags(cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for ECS Cluster %s: %s", d.Id(), err)
 		return nil
 	}
@@ -376,7 +376,7 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := UpdateTags(conn, d.Id(), o, n)
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if tfawserr.ErrCodeContains(err, ecs.ErrCodeAccessDeniedException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeInvalidParameterException) || tfawserr.ErrCodeContains(err, ecs.ErrCodeUnsupportedFeatureException) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			log.Printf("[WARN] Unable to update tags for ECS Cluster %s: %s", d.Id(), err)
 			return nil
 		}

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -209,14 +209,14 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure creating Cluster (%s) with tags: %s. Trying create without tags.", clusterName, err)
+		log.Printf("[WARN] ECS tagging failed creating Cluster (%s) with tags: %s. Trying create without tags.", clusterName, err)
 		input.Tags = nil
 
 		out, err = retryClusterCreate(conn, input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating ECS Cluster (%s): %w", clusterName, err)
+		return fmt.Errorf("failed creating ECS Cluster (%s): %w", clusterName, err)
 	}
 
 	log.Printf("[DEBUG] ECS cluster %s created", aws.StringValue(out.Cluster.ClusterArn))
@@ -233,12 +233,12 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			// If default tags only, log and continue. Otherwise, error.
-			log.Printf("[WARN] ECS tagging failure adding tags after create for Cluster (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed adding tags after create for Cluster (%s): %s", d.Id(), err)
 			return resourceClusterRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure adding tags after create for Cluster (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed adding tags after create for Cluster (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -310,7 +310,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure listing tags for Cluster (%s): %s", d.Id(), err)
+		log.Printf("[WARN] ECS tagging failed listing tags for Cluster (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -377,12 +377,12 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure updating tags for Cluster (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed updating tags for Cluster (%s): %s", d.Id(), err)
 			return nil
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure updating tags for Cluster (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed updating tags for Cluster (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -209,13 +209,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		resID := "Undefined"
-
-		if out != nil && out.Cluster != nil && out.Cluster.ClusterArn != nil {
-			resID = aws.StringValue(out.Cluster.ClusterArn)
-		}
-
-		log.Printf("[WARN] ECS tagging failure creating Cluster (%s) with tags: %s. Trying create without tags.", resID, err)
+		log.Printf("[WARN] ECS tagging failure creating Cluster (%s) with tags: %s. Trying create without tags.", clusterName, err)
 		input.Tags = nil
 
 		out, err = retryClusterCreate(conn, input)

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -566,14 +566,14 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure creating Service (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
+		log.Printf("[WARN] ECS tagging failed creating Service (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
 		output, err = retryServiceCreate(conn, input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating ECS service (%s): %w", d.Get("name").(string), err)
+		return fmt.Errorf("failed creating ECS service (%s): %w", d.Get("name").(string), err)
 	}
 
 	if output == nil || output.Service == nil {
@@ -600,12 +600,12 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure adding tags after create for Service (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed adding tags after create for Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure adding tags after create for Service (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed adding tags after create for Service (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -754,7 +754,7 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure listing tags for Service (%s): %s", d.Id(), err)
+		log.Printf("[WARN] ECS tagging failed listing tags for Service (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -1156,12 +1156,12 @@ func resourceServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure updating tags for Service (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed updating tags for Service (%s): %s", d.Id(), err)
 			return resourceServiceRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure updating tags for Service (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed updating tags for Service (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -566,13 +566,7 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		resID := "Undefined"
-
-		if output != nil && output.Service != nil && output.Service.ServiceArn != nil {
-			resID = aws.StringValue(output.Service.ServiceArn)
-		}
-
-		log.Printf("[WARN] ECS tagging failure creating Service (%s) with tags: %s. Trying create without tags.", resID, err)
+		log.Printf("[WARN] ECS tagging failure creating Service (%s) with tags: %s. Trying create without tags.", d.Get("name").(string), err)
 		input.Tags = nil
 
 		output, err = retryServiceCreate(conn, input)

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -519,14 +519,14 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure creating Task Definition (%s) with tags: %s. Trying create without tags.", d.Get("family").(string), err)
+		log.Printf("[WARN] ECS tagging failed creating Task Definition (%s) with tags: %s. Trying create without tags.", d.Get("family").(string), err)
 		input.Tags = nil
 
 		out, err = conn.RegisterTaskDefinition(&input)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating ECS Task Definition (%s): %w", d.Get("family").(string), err)
+		return fmt.Errorf("failed creating ECS Task Definition (%s): %w", d.Get("family").(string), err)
 	}
 
 	taskDefinition := *out.TaskDefinition // nosemgrep: prefer-aws-go-sdk-pointer-conversion-assignment // false positive
@@ -543,12 +543,12 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure adding tags after create for Task Definition (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed adding tags after create for Task Definition (%s): %s", d.Id(), err)
 			return resourceTaskDefinitionRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure adding tags after create for Task Definition (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed adding tags after create for Task Definition (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -638,7 +638,7 @@ func resourceTaskDefinitionRead(d *schema.ResourceData, meta interface{}) error 
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure listing tags for Task Definition (%s): %s", d.Id(), err)
+		log.Printf("[WARN] ECS tagging failed listing tags for Task Definition (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -726,12 +726,12 @@ func resourceTaskDefinitionUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure updating tags for Task Definition (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed updating tags for Task Definition (%s): %s", d.Id(), err)
 			return nil
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure updating tags for Task Definition (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed updating tags for Task Definition (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -519,13 +519,7 @@ func resourceTaskDefinitionCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		resID := "Undefined"
-
-		if out != nil && out.TaskDefinition != nil && out.TaskDefinition.Family != nil {
-			resID = aws.StringValue(out.TaskDefinition.Family)
-		}
-
-		log.Printf("[WARN] ECS tagging failure creating Task Definition (%s) with tags: %s. Trying create without tags.", resID, err)
+		log.Printf("[WARN] ECS tagging failure creating Task Definition (%s) with tags: %s. Trying create without tags.", d.Get("family").(string), err)
 		input.Tags = nil
 
 		out, err = conn.RegisterTaskDefinition(&input)

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -336,13 +336,7 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		resID := "Undefined"
-
-		if output != nil && output.TaskSet != nil && output.TaskSet.Id != nil {
-			resID = fmt.Sprintf("%s,%s,%s", aws.StringValue(output.TaskSet.Id), service, cluster)
-		}
-
-		log.Printf("[WARN] ECS tagging failure creating Task Set (%s) with tags: %s. Trying create without tags.", resID, err)
+		log.Printf("[WARN] ECS tagging failure creating Task Set with tags: %s. Trying create without tags.", err)
 		input.Tags = nil
 
 		output, err = retryTaskSetCreate(conn, input)

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -336,7 +336,7 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure creating Task Set with tags: %s. Trying create without tags.", err)
+		log.Printf("[WARN] ECS tagging failed creating Task Set with tags: %s. Trying create without tags.", err)
 		input.Tags = nil
 
 		output, err = retryTaskSetCreate(conn, input)
@@ -363,12 +363,12 @@ func resourceTaskSetCreate(d *schema.ResourceData, meta interface{}) error {
 
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			// If default tags only, log and continue. Otherwise, error.
-			log.Printf("[WARN] ECS tagging failure adding tags after create for Task Set (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed adding tags after create for Task Set (%s): %s", d.Id(), err)
 			return resourceTaskSetRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure adding tags after create for Task Set (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed adding tags after create for Task Set (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -451,7 +451,7 @@ func resourceTaskSetRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failure listing tags for Task Set (%s): %s", d.Id(), err)
+		log.Printf("[WARN] ECS tagging failed listing tags for Task Set (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -505,12 +505,12 @@ func resourceTaskSetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions (i.e., ISO) may not support tagging, giving error
 		if verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] ECS tagging failure updating tags for Task Set (%s): %s", d.Id(), err)
+			log.Printf("[WARN] ECS tagging failed updating tags for Task Set (%s): %s", d.Id(), err)
 			return resourceTaskSetRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("ECS tagging failure updating tags for Task Set (%s): %w", d.Id(), err)
+			return fmt.Errorf("ECS tagging failed updating tags for Task Set (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -72,7 +72,7 @@ func resourceBusCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] EventBridge Bus (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] EventBridge Bus (%s) create failed (%s) with tags. Trying create without tags.", eventBusName, err)
 		input.Tags = nil
 		output, err = conn.CreateEventBus(input)
 	}

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -125,7 +125,7 @@ func resourceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions may not support tag-on-create
 	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] EventBridge Rule (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] EventBridge Rule (%s) create failed (%s) with tags. Trying create without tags.", name, err)
 		input.Tags = nil
 		arn, err = retryPutRule(conn, input)
 	}

--- a/internal/service/iam/consts.go
+++ b/internal/service/iam/consts.go
@@ -1,9 +1,5 @@
 package iam
 
 const (
-	ErrCodeAccessDenied = "AccessDenied"
-)
-
-const (
 	policyModelMarshallJSONStartSliceSize = 2
 )

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -204,14 +204,14 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] IAM Role (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+		log.Printf("[WARN] failed creating IAM Role (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
 		output, err = retryCreateRole(conn, request)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating IAM Role (%s): %w", name, err)
+		return fmt.Errorf("failed creating IAM Role (%s): %w", name, err)
 	}
 
 	roleName := aws.StringValue(output.Role.RoleName)
@@ -238,12 +238,12 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] error adding tags after create for IAM Role (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for IAM Role (%s): %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error creating IAM Role (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM Role (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -324,7 +324,7 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for IAM Role %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for IAM Role (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -493,12 +493,12 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions may not support tagging, giving error
 		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] Unable to update tags for IAM Role %s: %s", d.Id(), err)
+			log.Printf("[WARN] failed updating tags for IAM Role %s: %s", d.Id(), err)
 			return resourceRoleRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating IAM Role (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed updating tags for IAM Role (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -9,10 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceRole() *schema.Resource {
@@ -101,7 +101,7 @@ func dataSourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 	tags := KeyValueTags(output.Role.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for IAM Role %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -102,14 +102,14 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tag-on-create
 	if request.Tags != nil && meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] IAM User (%s) create failed (%s) with tags. Trying create without tags.", d.Get("name").(string), err)
+		log.Printf("[WARN] failed creating IAM User (%s) with tags: %s. Trying create without tags.", name, err)
 		request.Tags = nil
 
 		createResp, err = conn.CreateUser(request)
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error creating IAM User %s: %s", name, err)
+		return fmt.Errorf("failed creating IAM User (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(createResp.User.UserName))
@@ -120,12 +120,12 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 		// If default tags only, log and continue. Otherwise, error.
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] error adding tags after create for IAM User (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for IAM User (%s): %s", d.Id(), err)
 			return resourceUserRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error creating IAM User (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for IAM User (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -189,7 +189,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
 	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] Unable to list tags for IAM User %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for IAM User (%s): %s", d.Id(), err)
 		return nil
 	}
 
@@ -261,12 +261,12 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Some partitions may not support tagging, giving error
 		if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
-			log.Printf("[WARN] Unable to update tags for IAM User %s: %s", d.Id(), err)
+			log.Printf("[WARN] failed updating tags for IAM User (%s): %s", d.Id(), err)
 			return resourceUserRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating IAM User (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed updating tags for IAM User (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/user_data_source.go
+++ b/internal/service/iam/user_data_source.go
@@ -7,10 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DataSourceUser() *schema.Resource {
@@ -71,7 +71,7 @@ func dataSourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	tags := KeyValueTags(user.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, iam.ErrCodeInvalidInputException) || tfawserr.ErrCodeContains(err, iam.ErrCodeServiceFailureException)) {
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID && verify.CheckISOErrorTagsUnsupported(err) {
 		log.Printf("[WARN] Unable to list tags for IAM User %s: %s", d.Id(), err)
 		return nil
 	}

--- a/internal/service/sns/consts.go
+++ b/internal/service/sns/consts.go
@@ -70,8 +70,3 @@ const (
 	TopicAttributeNameSQSSuccessFeedbackSampleRate         = "SQSSuccessFeedbackSampleRate"
 	TopicAttributeNameTopicArn                             = "TopicArn"
 )
-
-const (
-	ErrCodeAccessDenied  = "AccessDenied"
-	ErrCodeInvalidAction = "InvalidAction"
-)

--- a/internal/service/sns/topic_test.go
+++ b/internal/service/sns/topic_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func init() {
-	acctest.RegisterServiceErrorCheckFunc(sns.EndpointsID, testAccErrorCheckSkipSNS)
+	acctest.RegisterServiceErrorCheckFunc(sns.EndpointsID, testAccErrorCheckSkip)
 }
 
-func testAccErrorCheckSkipSNS(t *testing.T) resource.ErrorCheckFunc {
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"Invalid protocol type: firehose",
 		"Unknown attribute FifoTopic",

--- a/internal/service/sqs/consts.go
+++ b/internal/service/sqs/consts.go
@@ -1,12 +1,6 @@
 package sqs
 
 const (
-	ErrCodeAccessDenied       = "AccessDenied"
-	ErrCodeAuthorizationError = "AuthorizationError"
-	ErrCodeInvalidAction      = "InvalidAction"
-)
-
-const (
 	FIFOQueueNameSuffix = ".fifo"
 )
 

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -219,8 +219,9 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}, sqs.ErrCodeQueueDeletedRecently)
 
 	// Some partitions may not support tag-on-create
-	if input.Tags != nil && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation)) {
-		log.Printf("[WARN] SQS Queue (%s) create failed (%s) with tags. Trying create without tags.", d.Id(), err)
+	if input.Tags != nil && verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] failed creating SQS Queue (%s) with tags: %s. Trying create without tags.", name, err)
+
 		input.Tags = nil
 		outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(queueCreatedTimeout, func() (interface{}, error) {
 			return conn.CreateQueue(input)
@@ -228,7 +229,7 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating SQS Queue (%s): %w", name, err)
+		return fmt.Errorf("failed creating SQS Queue (%s): %w", name, err)
 	}
 
 	d.SetId(aws.StringValue(outputRaw.(*sqs.CreateQueueOutput).QueueUrl))
@@ -243,14 +244,14 @@ func resourceQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	if input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(conn, d.Id(), nil, tags)
 
-		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && (tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation)) {
+		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.CheckISOErrorTagsUnsupported(err) {
 			// if default tags only, log and continue (i.e., should error if explicitly setting tags and they can't be)
-			log.Printf("[WARN] error adding tags after create for SQS Queue (%s): %s", d.Id(), err)
+			log.Printf("[WARN] failed adding tags after create for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating SQS Queue (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed adding tags after create for SQS Queue (%s): %w", d.Id(), err)
 		}
 	}
 
@@ -307,14 +308,14 @@ func resourceQueueRead(d *schema.ResourceData, meta interface{}) error {
 		return ListTags(conn, d.Id())
 	}, sqs.ErrCodeQueueDoesNotExist)
 
-	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) {
+	if verify.CheckISOErrorTagsUnsupported(err) {
 		// Some partitions may not support tagging, giving error
-		log.Printf("[WARN] Unable to list tags for SQS Queue %s: %s", d.Id(), err)
+		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for SQS Queue (%s): %w", d.Id(), err)
+		return fmt.Errorf("failed listing tags for SQS Queue (%s): %w", d.Id(), err)
 	}
 
 	tags := outputRaw.(tftags.KeyValueTags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -364,14 +365,14 @@ func resourceQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 		err := UpdateTags(conn, d.Id(), o, n)
 
-		if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) || tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) || tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) || tfawserr.ErrCodeContains(err, sqs.ErrCodeUnsupportedOperation) {
+		if verify.CheckISOErrorTagsUnsupported(err) {
 			// Some partitions may not support tagging, giving error
-			log.Printf("[WARN] Unable to update tags for SQS Queue %s: %s", d.Id(), err)
+			log.Printf("[WARN] failed updating tags for SQS Queue (%s): %s", d.Id(), err)
 			return resourceQueueRead(d, meta)
 		}
 
 		if err != nil {
-			return fmt.Errorf("error updating SQS Queue (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("failed updating tags for SQS Queue (%s): %w", d.Id(), err)
 		}
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -35,21 +35,27 @@ func checkYAMLString(yamlString interface{}) (string, error) {
 }
 
 const (
-	ErrCodeAccessDenied                   = "AccessDenied"
-	ErrCodeInternalException              = "InternalException"
-	ErrCodeInternalServiceError           = "InternalServiceError"
-	ErrCodeInvalidParameterException      = "InvalidParameterException"
-	ErrCodeInvalidRequest                 = "InvalidRequest"
-	ErrCodeOperationDisabledException     = "OperationDisabledException"
-	ErrCodeOperationNotPermittedException = "OperationNotPermitted"
-	ErrCodeUnknownOperationException      = "UnknownOperationException"
-	ErrCodeUnsupportedFeatureException    = "UnsupportedFeatureException"
-	ErrCodeValidationError                = "ValidationError"
-	ErrCodeValidationException            = "ValidationException"
+	ErrCodeAccessDenied                = "AccessDenied"
+	ErrCodeAuthorizationError          = "AuthorizationError"
+	ErrCodeInternalException           = "InternalException"
+	ErrCodeInternalServiceError        = "InternalServiceError"
+	ErrCodeInvalidAction               = "InvalidAction"
+	ErrCodeInvalidParameterException   = "InvalidParameterException"
+	ErrCodeInvalidRequest              = "InvalidRequest"
+	ErrCodeOperationDisabledException  = "OperationDisabledException"
+	ErrCodeOperationNotPermitted       = "OperationNotPermitted"
+	ErrCodeUnknownOperationException   = "UnknownOperationException"
+	ErrCodeUnsupportedFeatureException = "UnsupportedFeatureException"
+	ErrCodeValidationError             = "ValidationError"
+	ErrCodeValidationException         = "ValidationException"
 )
 
 func CheckISOErrorTagsUnsupported(err error) bool {
 	if tfawserr.ErrCodeContains(err, ErrCodeAccessDenied) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeAuthorizationError) {
 		return true
 	}
 
@@ -58,6 +64,10 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrCodeContains(err, ErrCodeInternalServiceError) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeInvalidAction) {
 		return true
 	}
 
@@ -73,7 +83,7 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 		return true
 	}
 
-	if tfawserr.ErrCodeContains(err, ErrCodeOperationNotPermittedException) {
+	if tfawserr.ErrCodeContains(err, ErrCodeOperationNotPermitted) {
 		return true
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -46,6 +46,7 @@ const (
 	ErrCodeOperationNotPermitted       = "OperationNotPermitted"
 	ErrCodeUnknownOperationException   = "UnknownOperationException"
 	ErrCodeUnsupportedFeatureException = "UnsupportedFeatureException"
+	ErrCodeUnsupportedOperation        = "UnsupportedOperation"
 	ErrCodeValidationError             = "ValidationError"
 	ErrCodeValidationException         = "ValidationException"
 )
@@ -92,6 +93,10 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrCodeContains(err, ErrCodeUnsupportedFeatureException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeUnsupportedOperation) {
 		return true
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -43,6 +43,7 @@ const (
 	ErrCodeOperationDisabledException     = "OperationDisabledException"
 	ErrCodeOperationNotPermittedException = "OperationNotPermitted"
 	ErrCodeUnknownOperationException      = "UnknownOperationException"
+	ErrCodeUnsupportedFeatureException    = "UnsupportedFeatureException"
 	ErrCodeValidationError                = "ValidationError"
 	ErrCodeValidationException            = "ValidationException"
 )
@@ -77,6 +78,10 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 	}
 
 	if tfawserr.ErrCodeContains(err, ErrCodeUnknownOperationException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeUnsupportedFeatureException) {
 		return true
 	}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -36,12 +36,15 @@ func checkYAMLString(yamlString interface{}) (string, error) {
 
 const (
 	ErrCodeAccessDenied                   = "AccessDenied"
-	ErrCodeUnknownOperation               = "UnknownOperationException"
-	ErrCodeValidationError                = "ValidationError"
-	ErrCodeOperationDisabledException     = "OperationDisabledException"
 	ErrCodeInternalException              = "InternalException"
-	ErrCodeInternalServiceFault           = "InternalServiceError"
+	ErrCodeInternalServiceError           = "InternalServiceError"
+	ErrCodeInvalidParameterException      = "InvalidParameterException"
+	ErrCodeInvalidRequest                 = "InvalidRequest"
+	ErrCodeOperationDisabledException     = "OperationDisabledException"
 	ErrCodeOperationNotPermittedException = "OperationNotPermitted"
+	ErrCodeUnknownOperationException      = "UnknownOperationException"
+	ErrCodeValidationError                = "ValidationError"
+	ErrCodeValidationException            = "ValidationException"
 )
 
 func CheckISOErrorTagsUnsupported(err error) bool {
@@ -49,11 +52,19 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 		return true
 	}
 
-	if tfawserr.ErrCodeContains(err, ErrCodeUnknownOperation) {
+	if tfawserr.ErrCodeContains(err, ErrCodeInternalException) {
 		return true
 	}
 
-	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "not support tagging") {
+	if tfawserr.ErrCodeContains(err, ErrCodeInternalServiceError) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeInvalidParameterException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeInvalidRequest) {
 		return true
 	}
 
@@ -61,15 +72,19 @@ func CheckISOErrorTagsUnsupported(err error) bool {
 		return true
 	}
 
-	if tfawserr.ErrCodeContains(err, ErrCodeInternalException) {
-		return true
-	}
-
-	if tfawserr.ErrCodeContains(err, ErrCodeInternalServiceFault) {
-		return true
-	}
-
 	if tfawserr.ErrCodeContains(err, ErrCodeOperationNotPermittedException) {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeUnknownOperationException) {
+		return true
+	}
+
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationError, "not support tagging") {
+		return true
+	}
+
+	if tfawserr.ErrCodeContains(err, ErrCodeValidationException) {
 		return true
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22532

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS='TestAccCloudWatchCompositeAlarm_|TestAccCloudWatchMetricAlarm_|TestAccCloudWatchMetricStream_' PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchCompositeAlarm_|TestAccCloudWatchMetricAlarm_|TestAccCloudWatchMetricStream_'  -timeout 180m
--- PASS: TestAccCloudWatchMetricAlarm_missingStatistic (13.01s)
--- PASS: TestAccCloudWatchMetricAlarm_disappears (26.72s)
--- PASS: TestAccCloudWatchMetricAlarm_dataPointsToAlarm (33.42s)
--- PASS: TestAccCloudWatchMetricAlarm_extendedStatistic (33.52s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (42.16s)
--- PASS: TestAccCloudWatchMetricStream_includeFilters (42.32s)
--- PASS: TestAccCloudWatchMetricStream_noName (42.53s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (42.53s)
--- PASS: TestAccCloudWatchMetricStream_tags (42.72s)
--- PASS: TestAccCloudWatchCompositeAlarm_basic (43.08s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic (43.55s)
--- PASS: TestAccCloudWatchMetricAlarm_basic (34.45s)
--- PASS: TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (55.60s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_swfAction (32.65s)
--- PASS: TestAccCloudWatchCompositeAlarm_disappears (27.78s)
--- PASS: TestAccCloudWatchCompositeAlarm_updateAlarmRule (71.71s)
--- PASS: TestAccCloudWatchMetricAlarm_tags (80.98s)
--- PASS: TestAccCloudWatchMetricAlarm_treatMissingData (81.15s)
--- PASS: TestAccCloudWatchCompositeAlarm_description (57.67s)
--- PASS: TestAccCloudWatchCompositeAlarm_actionsEnabled (55.29s)
--- PASS: TestAccCloudWatchCompositeAlarm_allActions (58.41s)
--- PASS: TestAccCloudWatchCompositeAlarm_insufficientDataActions (83.96s)
--- PASS: TestAccCloudWatchCompositeAlarm_alarmActions (76.09s)
--- PASS: TestAccCloudWatchCompositeAlarm_okActions (76.05s)
--- PASS: TestAccCloudWatchMetricAlarm_expression (129.37s)
--- PASS: TestAccCloudWatchMetricStream_basic (142.02s)
--- PASS: TestAccCloudWatchMetricStream_update (148.51s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate (215.26s)
--- PASS: TestAccCloudWatchMetricStream_updateName (220.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	221.785s
% make testacc TESTS='TestAccECRRepository_|TestAccECRRepositoryDataSource_' PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_|TestAccECRRepositoryDataSource_'  -timeout 180m
--- PASS: TestAccECRRepositoryDataSource_nonExistent (3.94s)
--- PASS: TestAccECRRepositoryDataSource_basic (21.01s)
--- PASS: TestAccECRRepository_immutability (21.38s)
--- PASS: TestAccECRRepository_basic (21.44s)
--- PASS: TestAccECRRepositoryDataSource_encryption (24.15s)
--- PASS: TestAccECRRepository_tags (31.58s)
--- PASS: TestAccECRRepository_Encryption_aes256 (39.39s)
--- PASS: TestAccECRRepository_Encryption_kms (40.86s)
--- PASS: TestAccECRRepository_Image_scanning (47.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	49.566s
% make testacc TESTS=TestAccSNSTopic_ PKG=sns
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopic_'  -timeout 180m
--- PASS: TestAccSNSTopic_fifoExpectContentBasedDeduplicationError (7.09s)
--- PASS: TestAccSNSTopic_disappears (35.10s)
--- PASS: TestAccSNSTopic_NameGenerated_fifoTopic (46.06s)
--- PASS: TestAccSNSTopic_policy (46.37s)
--- PASS: TestAccSNSTopic_Name_fifoTopic (46.61s)
--- PASS: TestAccSNSTopic_namePrefix (46.62s)
--- PASS: TestAccSNSTopic_name (46.73s)
--- PASS: TestAccSNSTopic_withDeliveryPolicy (46.82s)
--- PASS: TestAccSNSTopic_basic (46.83s)
--- PASS: TestAccSNSTopic_NamePrefix_fifoTopic (46.90s)
--- PASS: TestAccSNSTopic_withIAMRole (54.01s)
--- PASS: TestAccSNSTopic_deliveryStatus (57.76s)
--- PASS: TestAccSNSTopic_fifoWithContentBasedDeduplication (65.13s)
--- PASS: TestAccSNSTopic_encryption (65.19s)
--- PASS: TestAccSNSTopic_tags (79.63s)
--- PASS: TestAccSNSTopic_withFakeIAMRole (138.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	140.953s
% make testacc TESTS=TestAccSQSQueue PKG=sqs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue'  -timeout 180m
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (5.57s)
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (5.74s)
--- PASS: TestAccSQSQueueDataSource_basic (72.77s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (77.75s)
--- PASS: TestAccSQSQueue_fifoQueue (77.75s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (77.79s)
--- PASS: TestAccSQSQueue_namePrefix (77.93s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (77.93s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (77.96s)
--- PASS: TestAccSQSQueue_basic (72.24s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (78.03s)
--- PASS: TestAccSQSQueue_disappears (86.67s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (98.05s)
--- PASS: TestAccSQSQueue_redriveAllowPolicy (106.47s)
--- PASS: TestAccSQSQueue_redrivePolicy (108.07s)
--- PASS: TestAccSQSQueue_Policy_basic (108.73s)
--- PASS: TestAccSQSQueue_tags (116.71s)
--- PASS: TestAccSQSQueue_update (122.72s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (123.73s)
--- PASS: TestAccSQSQueuePolicy_disappears (131.10s)
--- PASS: TestAccSQSQueue_Name_generated (58.80s)
--- PASS: TestAccSQSQueueDataSource_tags (60.49s)
--- PASS: TestAccSQSQueue_recentlyDeleted (146.98s)
--- PASS: TestAccSQSQueue_encryption (162.85s)
--- PASS: TestAccSQSQueuePolicy_Disappears_queue (118.68s)
--- PASS: TestAccSQSQueuePolicy_basic (118.83s)
--- PASS: TestAccSQSQueuePolicy_update (146.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	220.440s
% make testacc TESTS='TestAccECSCapacityProvider_|TestAccECSCluster_|TestAccECSClusterDataSource_|TestAccECSService_|TestAccECSTaskDefinition_|TestAccECSTaskSet_' PKG=ecs TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSCapacityProvider_|TestAccECSCluster_|TestAccECSClusterDataSource_|TestAccECSService_|TestAccECSTaskDefinition_|TestAccECSTaskSet_' -short -timeout 180m
--- SKIP: TestAccECSService_healthCheckGracePeriodSeconds (0.00s)
--- SKIP: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (0.00s)
--- SKIP: TestAccECSService_ServiceRegistries_changes (0.00s)
--- SKIP: TestAccECSTaskDefinition_fsxWinFileSystem (0.00s)
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (23.53s)
--- PASS: TestAccECSTaskDefinition_disappears (38.20s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (39.01s)
--- PASS: TestAccECSTaskDefinition_proxy (40.83s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (45.58s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (26.56s)
--- PASS: TestAccECSTaskDefinition_executionRole (29.29s)
--- PASS: TestAccECSTaskSet_basic (68.02s)
--- PASS: TestAccECSTaskSet_withExternalId (71.83s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargate (75.50s)
--- PASS: TestAccECSTaskDefinition_tags (75.51s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (35.66s)
--- PASS: TestAccECSCapacityProvider_basic (77.48s)
--- PASS: TestAccECSTaskDefinition_basic (39.50s)
--- PASS: TestAccECSTaskSet_withScale (89.27s)
--- PASS: TestAccECSTaskSet_withMultipleCapacityProviderStrategies (90.06s)
--- PASS: TestAccECSTaskSet_disappears (98.97s)
--- PASS: TestAccECSTaskSet_Tags (104.05s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (39.78s)
--- PASS: TestAccECSTaskDefinition_arrays (31.61s)
--- PASS: TestAccECSTaskDefinition_constraint (34.18s)
--- PASS: TestAccECSService_executeCommand (112.75s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (44.31s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (37.37s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (122.55s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (39.62s)
--- PASS: TestAccECSTaskDefinition_runtimePlatform (40.03s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (61.63s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (38.23s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargateAndPlatformVersion (137.75s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (38.10s)
--- PASS: TestAccECSTaskSet_withServiceRegistries (144.73s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (39.45s)
--- PASS: TestAccECSTaskDefinition_pidMode (39.36s)
--- PASS: TestAccECSTaskDefinition_ipcMode (37.79s)
--- PASS: TestAccECSTaskSet_withCapacityProviderStrategy (153.31s)
--- PASS: TestAccECSService_Tags_managed (86.60s)
--- PASS: TestAccECSService_PlacementStrategy_missing (1.96s)
--- PASS: TestAccECSTaskDefinition_networkMode (35.18s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (31.97s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (59.90s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (48.21s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (86.77s)
--- PASS: TestAccECSService_PlacementConstraints_basic (58.21s)
--- PASS: TestAccECSTaskSet_withAlb (209.03s)
--- PASS: TestAccECSService_Tags_basic (142.67s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (13.67s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (78.95s)
--- PASS: TestAccECSTaskDefinition_service (105.60s)
--- PASS: TestAccECSService_forceNewDeployment (86.07s)
--- PASS: TestAccECSService_Tags_propagate (223.44s)
--- PASS: TestAccECSService_ServiceRegistries_container (177.85s)
--- PASS: TestAccECSService_clusterName (89.50s)
--- PASS: TestAccECSService_PlacementStrategy_basic (107.94s)
--- PASS: TestAccECSService_basicImport (75.22s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (25.77s)
--- PASS: TestAccECSCluster_containerInsights (63.77s)
--- PASS: TestAccECSCluster_configuration (53.89s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (154.52s)
--- PASS: TestAccECSService_ServiceRegistries_basic (174.34s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (87.28s)
--- PASS: TestAccECSService_basic (81.73s)
--- PASS: TestAccECSCluster_disappears (21.87s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (71.72s)
--- PASS: TestAccECSService_loadBalancerChanges (135.27s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (178.80s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (188.10s)
--- PASS: TestAccECSService_DeploymentValues_basic (72.72s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (87.60s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (195.95s)
--- PASS: TestAccECSCluster_basic (35.01s)
--- PASS: TestAccECSService_DeploymentControllerType_external (47.98s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (138.72s)
--- PASS: TestAccECSService_disappears (70.48s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (39.72s)
--- PASS: TestAccECSCluster_tags (68.52s)
--- PASS: TestAccECSService_iamRole (66.08s)
--- PASS: TestAccECSCluster_singleCapacityProvider (89.53s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (190.41s)
--- PASS: TestAccECSService_alb (243.57s)
--- PASS: TestAccECSCapacityProvider_disappears (61.22s)
--- PASS: TestAccECSCluster_capacityProviders (64.77s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (66.60s)
--- PASS: TestAccECSCapacityProvider_managedScaling (119.68s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (95.73s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (297.65s)
--- PASS: TestAccECSService_renamedCluster (122.01s)
--- PASS: TestAccECSCapacityProvider_managedScalingPartial (119.45s)
--- PASS: TestAccECSService_familyAndRevision (118.90s)
--- PASS: TestAccECSCapacityProvider_tags (135.24s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (139.52s)
--- PASS: TestAccECSService_multipleTargetGroups (329.27s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (239.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	550.733s
% make testacc TESTS='TestAccEventsBus_|TestAccEventsRule_' PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBus_|TestAccEventsRule_'  -timeout 180m
--- SKIP: TestAccEventsBus_partnerEventSource (0.00s)
--- SKIP: TestAccEventsRule_partnerEventBus (0.00s)
--- PASS: TestAccEventsBus_default (2.79s)
--- PASS: TestAccEventsBus_disappears (16.55s)
--- PASS: TestAccEventsRule_namePrefix (23.30s)
--- PASS: TestAccEventsRule_Name_generated (23.37s)
--- PASS: TestAccEventsRule_scheduleAndPattern (23.38s)
--- PASS: TestAccEventsRule_eventBusARN (24.05s)
--- PASS: TestAccEventsRule_role (31.35s)
--- PASS: TestAccEventsRule_pattern (34.31s)
--- PASS: TestAccEventsRule_description (34.49s)
--- PASS: TestAccEventsBus_basic (45.64s)
--- PASS: TestAccEventsRule_basic (46.64s)
--- PASS: TestAccEventsRule_isEnabled (46.71s)
--- PASS: TestAccEventsRule_eventBusName (51.31s)
--- PASS: TestAccEventsBus_tags (53.54s)
--- PASS: TestAccEventsRule_tags (56.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	57.958s
```
