### PR TITLE
r/aws_ecs_cluster: deprecate capacity provider attributes

### DIFF
--- a/.changelog/22783.txt
+++ b/.changelog/22783.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_ecs_cluster: The `capacity_providers` and `default_capacity_provider_strategy` arguments have been deprecated. Use the `aws_ecs_cluster_capacity_providers` resource instead.
+ ```

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -50,9 +50,10 @@ func ResourceCluster() *schema.Resource {
 				Computed: true,
 			},
 			"capacity_providers": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Use the aws_ecs_cluster_capacity_providers resource instead",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -114,9 +115,10 @@ func ResourceCluster() *schema.Resource {
 				},
 			},
 			"default_capacity_provider_strategy": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Use the aws_ecs_cluster_capacity_providers resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"base": {

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -25,7 +25,7 @@ resource "aws_ecs_cluster" "foo" {
 }
 ```
 
-## Example W/Log Configuration
+### Example with Log Configuration
 
 ```terraform
 resource "aws_kms_key" "example" {
@@ -54,13 +54,41 @@ resource "aws_ecs_cluster" "test" {
 }
 ```
 
+### Example with Capacity Providers
+
+```terraform
+resource "aws_ecs_cluster" "example" {
+  name = "example"
+}
+
+resource "aws_ecs_cluster_capacity_providers" "example" {
+  cluster_name = aws_ecs_cluster.example.name
+
+  capacity_providers = [aws_ecs_capacity_provider.example.name]
+
+  default_capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = aws_ecs_capacity_provider.example.name
+  }
+}
+
+resource "aws_ecs_capacity_provider" "example" {
+  name = "example"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.example.arn
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `capacity_providers` - (Optional) List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
+* `capacity_providers` - (Optional, **Deprecated** use the `aws_ecs_cluster_capacity_providers` resource instead) List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
 * `configuration` - (Optional) The execute command configuration for the cluster. Detailed below.
-* `default_capacity_provider_strategy` - (Optional) Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
+* `default_capacity_provider_strategy` - (Optional, **Deprecated** use the `aws_ecs_cluster_capacity_providers` resource instead) Configuration block for capacity provider strategy to use by default for the cluster. Can be one or more. Detailed below.
 * `name` - (Required) Name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
 * `setting` - (Optional) Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22754
Relates #22672
Relates #22776 


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
