### PR TITLE
r/vpc_endpoint_subnet_association: Fix resource import

### DIFF
--- a/.changelog/22796.txt
+++ b/.changelog/22796.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_endpoint_subnet_association: Fix resource importing
+```

--- a/internal/service/ec2/vpc_endpoint_subnet_association.go
+++ b/internal/service/ec2/vpc_endpoint_subnet_association.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,7 +21,7 @@ func ResourceVPCEndpointSubnetAssociation() *schema.Resource {
 		Read:   resourceVPCEndpointSubnetAssociationRead,
 		Delete: resourceVPCEndpointSubnetAssociationDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceVPCEndpointSubnetAssociationImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -145,4 +146,21 @@ func resourceVPCEndpointSubnetAssociationDelete(d *schema.ResourceData, meta int
 	}
 
 	return nil
+}
+
+func resourceVPCEndpointSubnetAssociationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Wrong format of resource: %s. Please follow 'vpc-endpoint-id/subnet-id'", d.Id())
+	}
+
+	endpointID := parts[0]
+	subnetID := parts[1]
+	log.Printf("[DEBUG] Importing VPC Endpoint (%s) Subnet (%s) Association", endpointID, subnetID)
+
+	d.SetId(VPCEndpointSubnetAssociationCreateID(endpointID, subnetID))
+	d.Set("vpc_endpoint_id", endpointID)
+	d.Set("subnet_id", subnetID)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/ec2/vpc_endpoint_subnet_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_subnet_association_test.go
@@ -31,6 +31,12 @@ func TestAccEC2VPCEndpointSubnetAssociation_basic(t *testing.T) {
 					testAccCheckVpcEndpointSubnetAssociationExists(resourceName, &vpce),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccVPCEndpointSubnetAssociationImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -205,4 +211,16 @@ resource "aws_vpc_endpoint_subnet_association" "test" {
   subnet_id       = aws_subnet.test[count.index].id
 }
 `)
+}
+
+func testAccVPCEndpointSubnetAssociationImportStateIdFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		id := fmt.Sprintf("%s/%s", rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["subnet_id"])
+		return id, nil
+	}
 }

--- a/website/docs/r/vpc_endpoint_subnet_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_subnet_association.html.markdown
@@ -47,3 +47,12 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the association.
+
+## Import
+
+VPC Endpoint Subnet Associations can be imported using `vpc_endpoint_id` together with `subnet_id`,
+e.g.,
+
+```
+$ terraform import aws_vpc_endpoint_subnet_association.example vpce-aaaaaaaa/subnet-bbbbbbbbbbbbbbbbb
+```


### PR DESCRIPTION
This is essentially the same as #10454, with subnet ID replacing route table ID.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

```
% make testacc TESTS=TestAccEC2VPCEndpointRouteTableAssociation_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2VPCEndpointRouteTableAssociation_'  -timeout 180m
=== RUN   TestAccEC2VPCEndpointRouteTableAssociation_basic
=== PAUSE TestAccEC2VPCEndpointRouteTableAssociation_basic
=== RUN   TestAccEC2VPCEndpointRouteTableAssociation_disappears
=== PAUSE TestAccEC2VPCEndpointRouteTableAssociation_disappears
=== CONT  TestAccEC2VPCEndpointRouteTableAssociation_basic
=== CONT  TestAccEC2VPCEndpointRouteTableAssociation_disappears
--- PASS: TestAccEC2VPCEndpointRouteTableAssociation_disappears (92.64s)
--- PASS: TestAccEC2VPCEndpointRouteTableAssociation_basic (104.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	107.893s
```