### PR TITLE
certificate name and SANS should always be lower case

### DIFF
--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -177,7 +177,7 @@ func ResourceCertificate() *schema.Resource {
 						// AWS Provider 3.0 -- plan-time validation prevents "domain_name"
 						// argument to accept a string with trailing period; thus, trim of trailing period
 						// no longer required here
-						"domain_name": diff.Get("domain_name").(string),
+						"domain_name": strings.ToLower(diff.Get("domain_name").(string)),
 					}}
 
 					if sanSet, ok := diff.Get("subject_alternative_names").(*schema.Set); ok {
@@ -192,7 +192,7 @@ func ResourceCertificate() *schema.Resource {
 								// AWS Provider 3.0 -- plan-time validation prevents "subject_alternative_names"
 								// argument to accept strings with trailing period; thus, trim of trailing period
 								// no longer required here
-								"domain_name": san,
+								"domain_name": strings.ToLower(san),
 							}
 
 							domainValidationOptionsList = append(domainValidationOptionsList, m)


### PR DESCRIPTION
* BUG => convert sans and acm certificate name to lower case. This is a bug as currently if we use upper case in aws_acm_certificate domain_name or subject_alternative_names with validation method as "DNS" then aws_route53_record will always fail.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
