### PR TITLE
r/cloudwatch_event_target: remove launch_type default

### DIFF
--- a/.changelog/22803.txt
+++ b/.changelog/22803.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_cloudwatch_event_target: The `ecs_target` `launch_type` argument no longer has a default value (previously was `EC2`)
+```

--- a/.changelog/22803.txt
+++ b/.changelog/22803.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_cloudwatch_event_target: The `ecs_target` `launch_type` argument no longer has a default value (previously was `EC2`)
 ```

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -157,7 +157,6 @@ func ResourceTarget() *schema.Resource {
 						"launch_type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  eventbridge.LaunchTypeEc2,
 							ValidateFunc: validation.Any(
 								validation.StringIsEmpty,
 								validation.StringInSlice(eventbridge.LaunchType_Values(), false),

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -437,6 +437,65 @@ func TestAccEventsTarget_redshift(t *testing.T) {
 	})
 }
 
+// TestAccEventsTarget_ecsWithoutLaunchType verifies Event Target resources
+// can be created without a specified LaunchType
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16078
+func TestAccEventsTarget_ecsWithoutLaunchType(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
+	iamRoleResourceName := "aws_iam_role.test"
+	ecsTaskDefinitionResourceName := "aws_ecs_task_definition.task"
+	var v eventbridge.Target
+	rName := sdkacctest.RandomWithPrefix("tf_ecs_target")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, eventbridge.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetECSWithoutLaunchTypeConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.task_count", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "ecs_target.0.task_definition_arn", ecsTaskDefinitionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.network_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.network_configuration.0.subnets.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTargetECSConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", "FARGATE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTargetECSWithoutLaunchTypeConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.launch_type", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEventsTarget_ecsWithBlankLaunchType(t *testing.T) {
 	resourceName := "aws_cloudwatch_event_target.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -1419,6 +1478,25 @@ resource "aws_redshift_cluster" "test" {
   skip_final_snapshot                 = true
 }
 `, 123))
+}
+
+func testAccTargetECSWithoutLaunchTypeConfig(rName string) string {
+	return testAccTargetECSBaseConfig(rName) + `
+resource "aws_cloudwatch_event_target" "test" {
+  arn      = aws_ecs_cluster.test.id
+  rule     = aws_cloudwatch_event_rule.test.id
+  role_arn = aws_iam_role.test.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.task.arn
+
+    network_configuration {
+      subnets = [aws_subnet.subnet.id]
+    }
+  }
+}
+`
 }
 
 func testAccTargetECSWithBlankLaunchTypeConfig(rName string) string {

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -28,6 +28,7 @@ Upgrade topics:
 - [Data Source: aws_cloudwatch_log_group](#data-source-aws_cloudwatch_log_group)
 - [Data Source: aws_subnet_ids](#data-source-aws_subnet_ids)
 - [Resource: aws_batch_compute_environment](#resource-aws_batch_compute_environment)
+- [Resource: aws_cloudwatch_event_target](#resource-aws_cloudwatch_event_target)
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
@@ -349,6 +350,47 @@ resource "aws_batch_compute_environment" "test" {
 
   service_role = aws_iam_role.batch_service.arn
   type         = "UNMANAGED"
+}
+```
+
+## Resource: aws_cloudwatch_event_target
+
+### Removal of `ecs_target` `launch_type` default value
+
+Previously, the `ecs_target` `launch_type` argument defaulted to `EC2` if no value was configured in Terraform.
+
+Workarounds, such as using the empty string `""` as shown below, should be removed:
+
+```terraform
+resource "aws_cloudwatch_event_target" "test" {
+  arn      = aws_ecs_cluster.test.id
+  rule     = aws_cloudwatch_event_rule.test.id
+  role_arn = aws_iam_role.test.arn
+  ecs_target {
+    launch_type         = ""
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.task.arn
+    network_configuration {
+      subnets = [aws_subnet.subnet.id]
+    }
+  }
+}
+```
+
+An updated configuration:
+
+```terraform
+resource "aws_cloudwatch_event_target" "test" {
+  arn      = aws_ecs_cluster.test.id
+  rule     = aws_cloudwatch_event_rule.test.id
+  role_arn = aws_iam_role.test.arn
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.task.arn
+    network_configuration {
+      subnets = [aws_subnet.subnet.id]
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/16078
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22776
Relates #20433 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccEventsTarget_Input_transformer (104.27s)
--- PASS: TestAccEventsTarget_RetryPolicy_deadLetter (109.71s)
--- PASS: TestAccEventsTarget_basic (118.85s)
--- PASS: TestAccEventsTarget_batch (131.47s)
--- PASS: TestAccEventsTarget_disappears (60.23s)
--- PASS: TestAccEventsTarget_ecs (317.22s)
--- PASS: TestAccEventsTarget_ecsFull (96.61s)
--- PASS: TestAccEventsTarget_ecsWithBlankLaunchType (134.21s)
--- PASS: TestAccEventsTarget_ecsWithBlankTaskCount (316.90s)
--- PASS: TestAccEventsTarget_ecsWithoutLaunchType (133.32s)
--- PASS: TestAccEventsTarget_eventBusARN (80.01s)
--- PASS: TestAccEventsTarget_eventBusName (108.13s)
--- PASS: TestAccEventsTarget_full (112.59s)
--- PASS: TestAccEventsTarget_generatedTargetID (68.02s)
--- PASS: TestAccEventsTarget_http (78.19s)
--- PASS: TestAccEventsTarget_inputTransformerJSONString (98.11s)
--- PASS: TestAccEventsTarget_kinesis (112.95s)
--- PASS: TestAccEventsTarget_redshift (293.13s)
--- PASS: TestAccEventsTarget_sqs (105.17s)
--- PASS: TestAccEventsTarget_ssmDocument (80.44s)
--- SKIP: TestAccEventsTarget_partnerEventBus (0.00s)
```
