### PR TITLE
Enhance FIPS, DualStack, Unique STS Region Support

### DIFF
--- a/.changelog/22804.txt
+++ b/.changelog/22804.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Add `sts_region`, `use_dualstack_endpoint`, `use_fips_endpoint` arguments
+```

--- a/.changelog/22804.txt
+++ b/.changelog/22804.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-provider: Add `sts_region`, `use_dualstack_endpoint`, `use_fips_endpoint` arguments
+provider: Add `ec2_metadata_service_endpoint`, `ec2_metadata_service_endpoint_mode`, `use_dualstack_endpoint`, `use_fips_endpoint` arguments
 ```

--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -499,32 +499,6 @@ func TestAccAcctestProvider_AssumeRole_empty(t *testing.T) {
 	})
 }
 
-func TestAccAcctestProvider_assumeRoleFIPS(t *testing.T) {
-	var providers []*schema.Provider
-	region := "us-west-2"
-	rName := sdkacctest.RandomWithPrefix(ResourcePrefix)
-	role := fmt.Sprintf("arn:aws:iam::%s:role/%s", "067819342479", rName)
-	stsEndpoint := "https://sts-fips.us-west-2.amazonaws.com"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { PreCheck(t) },
-		ErrorCheck:        ErrorCheck(t),
-		ProviderFactories: FactoriesInternal(&providers),
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccXYZ1Config(rName),
-			},
-			{
-				Config: testAccXYZ2Config(rName, region, role, stsEndpoint),
-				Check: resource.ComposeTestCheckFunc(
-					CheckCallerIdentityAccountID("data.aws_caller_identity.current"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckPartition(providers *[]*schema.Provider, expectedPartition string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if providers == nil {
@@ -1120,66 +1094,4 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 `, region))
-}
-
-func testAccXYZ1Config(rName string) string {
-	return ConfigCompose(
-		fmt.Sprintf(`
-data "aws_partition" "current" {}
-
-resource "aws_iam_role" "test" {
-  name = %[1]q
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Principal = {
-        "AWS" = "arn:aws:iam::067819342479:user/yakdriver",
-      }
-      Effect = "Allow"
-      Sid    = ""
-    }]
-  })
-}
-`, rName))
-}
-
-func testAccXYZ2Config(rName, region, role, stsEndpoint string) string {
-	//lintignore:AT004
-	return ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
-provider "aws" {
-  region = %[2]q
-
-  assume_role {
-    role_arn = %[3]q
-  }
-
-  #endpoints {
-  #  sts = %[4]q
-  #}
-}
-
-data "aws_caller_identity" "current" {}
-
-data "aws_partition" "current" {}
-
-resource "aws_iam_role" "test" {
-  name = %[1]q
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole",
-      Principal = {
-        "AWS" = "arn:aws:iam::067819342479:user/yakdriver",
-      }
-      Effect = "Allow"
-      Sid    = ""
-    }]
-  })
-}
-`, rName, region, role, stsEndpoint))
 }

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1611,8 +1611,6 @@ func (c *Config) Client() (interface{}, error) {
 		Region:   aws.String(stsRegion),
 	}
 
-	fmt.Printf("setting sts region to: %s\n", stsRegion)
-
 	client.STSConn = sts.New(sess.Copy(stsConfig))
 
 	// Services that require multiple client configurations

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -1226,8 +1226,9 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	}
 
-	awsbaseConfig := awsbase.Config{
+	awsbaseConfig := &awsbase.Config{
 		AccessKey:               c.AccessKey,
+		APNInfo:                 StdUserAgentProducts(c.TerraformVersion),
 		CallerDocumentationURL:  "https://registry.terraform.io/providers/hashicorp/aws",
 		CallerName:              "Terraform AWS Provider",
 		DebugLogging:            logging.IsDebugOrHigher(),
@@ -1243,7 +1244,6 @@ func (c *Config) Client() (interface{}, error) {
 		SkipRequestingAccountId: c.SkipRequestingAccountId,
 		StsEndpoint:             c.Endpoints[STS],
 		Token:                   c.Token,
-		APNInfo:                 StdUserAgentProducts(c.TerraformVersion),
 		//UseDualStackEndpoint:        c.UseDualStackEndpoint,
 		//UseFIPSEndpoint:             c.UseFIPSEndpoint,
 	}
@@ -1610,6 +1610,8 @@ func (c *Config) Client() (interface{}, error) {
 		Endpoint: aws.String(c.Endpoints[STS]),
 		Region:   aws.String(stsRegion),
 	}
+
+	fmt.Printf("setting sts region to: %s\n", stsRegion)
 
 	client.STSConn = sts.New(sess.Copy(stsConfig))
 

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -888,8 +888,12 @@ type Config struct {
 	SkipRequestingAccountId bool
 	SkipMetadataApiCheck    bool
 	S3ForcePathStyle        bool
+	STSRegion               string
 
 	TerraformVersion string
+
+	UseDualStackEndpoint bool
+	UseFIPSEndpoint      bool
 }
 
 type AWSClient struct {
@@ -1240,6 +1244,8 @@ func (c *Config) Client() (interface{}, error) {
 		StsEndpoint:             c.Endpoints[STS],
 		Token:                   c.Token,
 		APNInfo:                 StdUserAgentProducts(c.TerraformVersion),
+		//UseDualStackEndpoint:        c.UseDualStackEndpoint,
+		//UseFIPSEndpoint:             c.UseFIPSEndpoint,
 	}
 
 	if c.AssumeRoleARN != "" {
@@ -1553,7 +1559,6 @@ func (c *Config) Client() (interface{}, error) {
 		SSOConn:                           sso.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSO])})),
 		SSOOIDCConn:                       ssooidc.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSOOIDC])})),
 		StorageGatewayConn:                storagegateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[StorageGateway])})),
-		STSConn:                           sts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[STS])})),
 		SupportConn:                       support.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Support])})),
 		SWFConn:                           swf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SWF])})),
 		SyntheticsConn:                    synthetics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Synthetics])})),
@@ -1593,6 +1598,20 @@ func (c *Config) Client() (interface{}, error) {
 	shieldConfig := &aws.Config{
 		Endpoint: aws.String(c.Endpoints[Shield]),
 	}
+
+	// Services that require different region handling
+	stsRegion := c.STSRegion
+
+	if stsRegion == "" {
+		stsRegion = c.Region
+	}
+
+	stsConfig := &aws.Config{
+		Endpoint: aws.String(c.Endpoints[STS]),
+		Region:   aws.String(stsRegion),
+	}
+
+	client.STSConn = sts.New(sess.Copy(stsConfig))
 
 	// Services that require multiple client configurations
 	s3Config := &aws.Config{

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -855,45 +854,34 @@ func init() {
 }
 
 type Config struct {
-	AccessKey             string
-	SecretKey             string
-	SharedConfigFile      string
-	SharedCredentialsFile string
-	Profile               string
-	Token                 string
-	Region                string
-	MaxRetries            int
-
-	AssumeRoleARN               string
-	AssumeRoleDurationSeconds   int
-	AssumeRoleExternalID        string
-	AssumeRolePolicy            string
-	AssumeRolePolicyARNs        []string
-	AssumeRoleSessionName       string
-	AssumeRoleTags              map[string]string
-	AssumeRoleTransitiveTagKeys []string
-
-	AllowedAccountIds   []string
-	ForbiddenAccountIds []string
-
-	DefaultTagsConfig *tftags.DefaultConfig
-	Endpoints         map[string]string
-	IgnoreTagsConfig  *tftags.IgnoreConfig
-	Insecure          bool
-	HTTPProxy         string
-
-	SkipCredsValidation     bool
-	SkipGetEC2Platforms     bool
-	SkipRegionValidation    bool
-	SkipRequestingAccountId bool
-	SkipMetadataApiCheck    bool
-	S3ForcePathStyle        bool
-	STSRegion               string
-
-	TerraformVersion string
-
-	UseDualStackEndpoint bool
-	UseFIPSEndpoint      bool
+	AccessKey                      string
+	AllowedAccountIds              []string
+	AssumeRole                     *awsbase.AssumeRole
+	DefaultTagsConfig              *tftags.DefaultConfig
+	EC2MetadataServiceEndpoint     string
+	EC2MetadataServiceEndpointMode string
+	Endpoints                      map[string]string
+	ForbiddenAccountIds            []string
+	HTTPProxy                      string
+	IgnoreTagsConfig               *tftags.IgnoreConfig
+	Insecure                       bool
+	MaxRetries                     int
+	Profile                        string
+	Region                         string
+	S3ForcePathStyle               bool
+	SecretKey                      string
+	SharedConfigFile               string
+	SharedCredentialsFile          string
+	SkipCredsValidation            bool
+	SkipGetEC2Platforms            bool
+	SkipMetadataApiCheck           bool
+	SkipRegionValidation           bool
+	SkipRequestingAccountId        bool
+	STSRegion                      string
+	TerraformVersion               string
+	Token                          string
+	UseDualStackEndpoint           bool
+	UseFIPSEndpoint                bool
 }
 
 type AWSClient struct {
@@ -1195,27 +1183,6 @@ func (client *AWSClient) RegionalHostname(prefix string) string {
 	return fmt.Sprintf("%s.%s.%s", prefix, client.Region, client.DNSSuffix)
 }
 
-func (c *Config) assumeRole() *awsbase.AssumeRole {
-	if c.AssumeRoleARN == "" {
-		return nil
-	}
-
-	assumeRole := &awsbase.AssumeRole{
-		RoleARN:           c.AssumeRoleARN,
-		ExternalID:        c.AssumeRoleExternalID,
-		Policy:            c.AssumeRolePolicy,
-		PolicyARNs:        c.AssumeRolePolicyARNs,
-		SessionName:       c.AssumeRoleSessionName,
-		Tags:              c.AssumeRoleTags,
-		TransitiveTagKeys: c.AssumeRoleTransitiveTagKeys,
-	}
-
-	if c.AssumeRoleDurationSeconds != 0 {
-		assumeRole.Duration = time.Duration(c.AssumeRoleDurationSeconds) * time.Second
-	}
-	return assumeRole
-}
-
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
 	// Get the auth and region. This can fail if keys/regions were not
@@ -1226,7 +1193,7 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	}
 
-	awsbaseConfig := &awsbase.Config{
+	awsbaseConfig := awsbase.Config{
 		AccessKey:               c.AccessKey,
 		APNInfo:                 StdUserAgentProducts(c.TerraformVersion),
 		CallerDocumentationURL:  "https://registry.terraform.io/providers/hashicorp/aws",
@@ -1244,12 +1211,17 @@ func (c *Config) Client() (interface{}, error) {
 		SkipRequestingAccountId: c.SkipRequestingAccountId,
 		StsEndpoint:             c.Endpoints[STS],
 		Token:                   c.Token,
-		//UseDualStackEndpoint:        c.UseDualStackEndpoint,
-		//UseFIPSEndpoint:             c.UseFIPSEndpoint,
+		UseDualStackEndpoint:    c.UseDualStackEndpoint,
+		UseFIPSEndpoint:         c.UseFIPSEndpoint,
 	}
 
-	if c.AssumeRoleARN != "" {
-		awsbaseConfig.AssumeRole = c.assumeRole()
+	if c.AssumeRole != nil && c.AssumeRole.RoleARN != "" {
+		awsbaseConfig.AssumeRole = c.AssumeRole
+	}
+
+	if c.EC2MetadataServiceEndpoint != "" {
+		awsbaseConfig.EC2MetadataServiceEndpoint = c.EC2MetadataServiceEndpoint
+		awsbaseConfig.EC2MetadataServiceEndpointMode = c.EC2MetadataServiceEndpointMode
 	}
 
 	if c.SharedConfigFile != "" {
@@ -1559,6 +1531,7 @@ func (c *Config) Client() (interface{}, error) {
 		SSOConn:                           sso.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSO])})),
 		SSOOIDCConn:                       ssooidc.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SSOOIDC])})),
 		StorageGatewayConn:                storagegateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[StorageGateway])})),
+		STSConn:                           sts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[STS])})),
 		SupportConn:                       support.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Support])})),
 		SWFConn:                           swf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[SWF])})),
 		SyntheticsConn:                    synthetics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[Synthetics])})),
@@ -1598,20 +1571,6 @@ func (c *Config) Client() (interface{}, error) {
 	shieldConfig := &aws.Config{
 		Endpoint: aws.String(c.Endpoints[Shield]),
 	}
-
-	// Services that require different region handling
-	stsRegion := c.STSRegion
-
-	if stsRegion == "" {
-		stsRegion = c.Region
-	}
-
-	stsConfig := &aws.Config{
-		Endpoint: aws.String(c.Endpoints[STS]),
-		Region:   aws.String(stsRegion),
-	}
-
-	client.STSConn = sts.New(sess.Copy(stsConfig))
 
 	// Services that require multiple client configurations
 	s3Config := &aws.Config{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -173,24 +173,27 @@ func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"access_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["access_key"],
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The access key for API operations. You can retrieve this\n" +
+					"from the 'Security & Credentials' section of the AWS console.",
 			},
 
 			"secret_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["secret_key"],
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The secret key for API operations. You can retrieve this\n" +
+					"from the 'Security & Credentials' section of the AWS console.",
 			},
 
 			"profile": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["profile"],
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The profile for API operations. If not set, the default profile\n" +
+					"created with `aws configure` will be used.",
 			},
 
 			"assume_role": assumeRoleSchema(),
@@ -203,17 +206,19 @@ func Provider() *schema.Provider {
 			},
 
 			"shared_credentials_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["shared_credentials_file"],
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The path to the shared credentials file. If not set\n" +
+					"this defaults to ~/.aws/credentials.",
 			},
 
 			"token": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: descriptions["token"],
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "session token. A session token is only required if you are\n" +
+					"using temporary security credentials.",
 			},
 
 			"region": {
@@ -223,15 +228,18 @@ func Provider() *schema.Provider {
 					"AWS_REGION",
 					"AWS_DEFAULT_REGION",
 				}, nil),
-				Description:  descriptions["region"],
+				Description: "The region where AWS operations will take place. Examples\n" +
+					"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003,
 				InputDefault: "us-east-1", // lintignore:AWSAT003
 			},
 
 			"max_retries": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     25,
-				Description: descriptions["max_retries"],
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  25,
+				Description: "The maximum number of times an AWS API request is\n" +
+					"being executed. If the API request still fails, an error is\n" +
+					"thrown.",
 			},
 
 			"allowed_account_ids": {
@@ -268,9 +276,10 @@ func Provider() *schema.Provider {
 			},
 
 			"http_proxy": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: descriptions["http_proxy"],
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The address of an HTTP proxy to use when accessing the AWS API. " +
+					"Can also be configured using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.",
 			},
 
 			"endpoints": endpointsSchema(),
@@ -301,52 +310,61 @@ func Provider() *schema.Provider {
 			},
 
 			"insecure": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["insecure"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, " +
+					"default value is `false`",
 			},
 
 			"skip_credentials_validation": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["skip_credentials_validation"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip the credentials validation via STS API. " +
+					"Used for AWS API implementations that do not have STS available/implemented.",
 			},
 
 			"skip_get_ec2_platforms": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["skip_get_ec2_platforms"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip getting the supported EC2 platforms. " +
+					"Used by users that don't have ec2:DescribeAccountAttributes permissions.",
 			},
 
 			"skip_region_validation": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["skip_region_validation"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip static validation of region name. " +
+					"Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
 			},
 
 			"skip_requesting_account_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["skip_requesting_account_id"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip requesting the account ID. " +
+					"Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
 			},
 
 			"skip_metadata_api_check": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["skip_metadata_api_check"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip the AWS Metadata API check. " +
+					"Used for AWS API implementations that do not have a metadata api endpoint.",
 			},
 
 			"s3_force_path_style": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: descriptions["s3_force_path_style"],
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Set this to true to force the request to use path-style addressing,\n" +
+					"i.e., http://s3.amazonaws.com/BUCKET/KEY. By default, the S3 client will\n" +
+					"use virtual hosted bucket addressing when possible\n" +
+					"(http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.",
 			},
 		},
 
@@ -1827,62 +1845,6 @@ func Provider() *schema.Provider {
 	return provider
 }
 
-var descriptions map[string]string
-
-func init() {
-	descriptions = map[string]string{
-		"region": "The region where AWS operations will take place. Examples\n" +
-			"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003
-
-		"access_key": "The access key for API operations. You can retrieve this\n" +
-			"from the 'Security & Credentials' section of the AWS console.",
-
-		"secret_key": "The secret key for API operations. You can retrieve this\n" +
-			"from the 'Security & Credentials' section of the AWS console.",
-
-		"profile": "The profile for API operations. If not set, the default profile\n" +
-			"created with `aws configure` will be used.",
-
-		"shared_credentials_file": "The path to the shared credentials file. If not set\n" +
-			"this defaults to ~/.aws/credentials.",
-
-		"token": "session token. A session token is only required if you are\n" +
-			"using temporary security credentials.",
-
-		"max_retries": "The maximum number of times an AWS API request is\n" +
-			"being executed. If the API request still fails, an error is\n" +
-			"thrown.",
-
-		"http_proxy": "The address of an HTTP proxy to use when accessing the AWS API. " +
-			"Can also be configured using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.",
-
-		"endpoint": "Use this to override the default service endpoint URL",
-
-		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, " +
-			"default value is `false`",
-
-		"skip_credentials_validation": "Skip the credentials validation via STS API. " +
-			"Used for AWS API implementations that do not have STS available/implemented.",
-
-		"skip_get_ec2_platforms": "Skip getting the supported EC2 platforms. " +
-			"Used by users that don't have ec2:DescribeAccountAttributes permissions.",
-
-		"skip_region_validation": "Skip static validation of region name. " +
-			"Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
-
-		"skip_requesting_account_id": "Skip requesting the account ID. " +
-			"Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
-
-		"skip_medatadata_api_check": "Skip the AWS Metadata API check. " +
-			"Used for AWS API implementations that do not have a metadata api endpoint.",
-
-		"s3_force_path_style": "Set this to true to force the request to use path-style addressing,\n" +
-			"i.e., http://s3.amazonaws.com/BUCKET/KEY. By default, the S3 client will\n" +
-			"use virtual hosted bucket addressing when possible\n" +
-			"(http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.",
-	}
-}
-
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
 	config := conns.Config{
 		AccessKey:               d.Get("access_key").(string),
@@ -2081,7 +2043,7 @@ func endpointsSchema() *schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "",
-			Description: descriptions["endpoint"],
+			Description: "Use this to override the default service endpoint URL",
 		}
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -179,69 +179,6 @@ func Provider() *schema.Provider {
 				Description: "The access key for API operations. You can retrieve this\n" +
 					"from the 'Security & Credentials' section of the AWS console.",
 			},
-
-			"secret_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
-				Description: "The secret key for API operations. You can retrieve this\n" +
-					"from the 'Security & Credentials' section of the AWS console.",
-			},
-
-			"profile": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
-				Description: "The profile for API operations. If not set, the default profile\n" +
-					"created with `aws configure` will be used.",
-			},
-
-			"assume_role": assumeRoleSchema(),
-
-			"shared_config_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				Description: "The path to the shared config file. If not set, defaults to ~/.aws/config.",
-			},
-
-			"shared_credentials_file": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
-				Description: "The path to the shared credentials file. If not set\n" +
-					"this defaults to ~/.aws/credentials.",
-			},
-
-			"token": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
-				Description: "session token. A session token is only required if you are\n" +
-					"using temporary security credentials.",
-			},
-
-			"region": {
-				Type:     schema.TypeString,
-				Required: true,
-				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-					"AWS_REGION",
-					"AWS_DEFAULT_REGION",
-				}, nil),
-				Description: "The region where AWS operations will take place. Examples\n" +
-					"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003,
-				InputDefault: "us-east-1", // lintignore:AWSAT003
-			},
-
-			"max_retries": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  25,
-				Description: "The maximum number of times an AWS API request is\n" +
-					"being executed. If the API request still fails, an error is\n" +
-					"thrown.",
-			},
-
 			"allowed_account_ids": {
 				Type:          schema.TypeSet,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -249,15 +186,7 @@ func Provider() *schema.Provider {
 				ConflictsWith: []string{"forbidden_account_ids"},
 				Set:           schema.HashString,
 			},
-
-			"forbidden_account_ids": {
-				Type:          schema.TypeSet,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Optional:      true,
-				ConflictsWith: []string{"allowed_account_ids"},
-				Set:           schema.HashString,
-			},
-
+			"assume_role": assumeRoleSchema(),
 			"default_tags": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -274,16 +203,20 @@ func Provider() *schema.Provider {
 					},
 				},
 			},
-
+			"endpoints": endpointsSchema(),
+			"forbidden_account_ids": {
+				Type:          schema.TypeSet,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				ConflictsWith: []string{"allowed_account_ids"},
+				Set:           schema.HashString,
+			},
 			"http_proxy": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: "The address of an HTTP proxy to use when accessing the AWS API. " +
 					"Can also be configured using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.",
 			},
-
-			"endpoints": endpointsSchema(),
-
 			"ignore_tags": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -308,7 +241,6 @@ func Provider() *schema.Provider {
 					},
 				},
 			},
-
 			"insecure": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -316,47 +248,32 @@ func Provider() *schema.Provider {
 				Description: "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted, " +
 					"default value is `false`",
 			},
-
-			"skip_credentials_validation": {
-				Type:     schema.TypeBool,
+			"max_retries": {
+				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  false,
-				Description: "Skip the credentials validation via STS API. " +
-					"Used for AWS API implementations that do not have STS available/implemented.",
+				Default:  25,
+				Description: "The maximum number of times an AWS API request is\n" +
+					"being executed. If the API request still fails, an error is\n" +
+					"thrown.",
 			},
-
-			"skip_get_ec2_platforms": {
-				Type:     schema.TypeBool,
+			"profile": {
+				Type:     schema.TypeString,
 				Optional: true,
-				Default:  false,
-				Description: "Skip getting the supported EC2 platforms. " +
-					"Used by users that don't have ec2:DescribeAccountAttributes permissions.",
+				Default:  "",
+				Description: "The profile for API operations. If not set, the default profile\n" +
+					"created with `aws configure` will be used.",
 			},
-
-			"skip_region_validation": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				Description: "Skip static validation of region name. " +
-					"Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"AWS_REGION",
+					"AWS_DEFAULT_REGION",
+				}, nil),
+				Description: "The region where AWS operations will take place. Examples\n" +
+					"are us-east-1, us-west-2, etc.", // lintignore:AWSAT003,
+				InputDefault: "us-east-1", // lintignore:AWSAT003
 			},
-
-			"skip_requesting_account_id": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				Description: "Skip requesting the account ID. " +
-					"Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
-			},
-
-			"skip_metadata_api_check": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				Description: "Skip the AWS Metadata API check. " +
-					"Used for AWS API implementations that do not have a metadata api endpoint.",
-			},
-
 			"s3_force_path_style": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -365,6 +282,85 @@ func Provider() *schema.Provider {
 					"i.e., http://s3.amazonaws.com/BUCKET/KEY. By default, the S3 client will\n" +
 					"use virtual hosted bucket addressing when possible\n" +
 					"(http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.",
+			},
+			"secret_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The secret key for API operations. You can retrieve this\n" +
+					"from the 'Security & Credentials' section of the AWS console.",
+			},
+			"shared_config_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The path to the shared config file. If not set, defaults to ~/.aws/config.",
+			},
+			"shared_credentials_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The path to the shared credentials file. If not set\n" +
+					"this defaults to ~/.aws/credentials.",
+			},
+			"skip_credentials_validation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip the credentials validation via STS API. " +
+					"Used for AWS API implementations that do not have STS available/implemented.",
+			},
+			"skip_get_ec2_platforms": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip getting the supported EC2 platforms. " +
+					"Used by users that don't have ec2:DescribeAccountAttributes permissions.",
+			},
+			"skip_metadata_api_check": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip the AWS Metadata API check. " +
+					"Used for AWS API implementations that do not have a metadata api endpoint.",
+			},
+			"skip_region_validation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip static validation of region name. " +
+					"Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
+			},
+			"skip_requesting_account_id": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Skip requesting the account ID. " +
+					"Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
+			},
+			"sts_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Region where the STS endpoint resides",
+			},
+			"token": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "session token. A session token is only required if you are\n" +
+					"using temporary security credentials.",
+			},
+			"use_dualstack_endpoint": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Resolve an endpoint with DualStack capability",
+			},
+			"use_fips_endpoint": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Resolve an endpoint with FIPS capability",
 			},
 		},
 
@@ -1848,25 +1844,28 @@ func Provider() *schema.Provider {
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
 	config := conns.Config{
 		AccessKey:               d.Get("access_key").(string),
-		SecretKey:               d.Get("secret_key").(string),
-		Profile:                 d.Get("profile").(string),
-		Token:                   d.Get("token").(string),
-		Region:                  d.Get("region").(string),
-		SharedConfigFile:        d.Get("shared_config_file").(string),
-		SharedCredentialsFile:   d.Get("shared_credentials_file").(string),
 		DefaultTagsConfig:       expandProviderDefaultTags(d.Get("default_tags").([]interface{})),
 		Endpoints:               make(map[string]string),
-		MaxRetries:              d.Get("max_retries").(int),
+		HTTPProxy:               d.Get("http_proxy").(string),
 		IgnoreTagsConfig:        expandProviderIgnoreTags(d.Get("ignore_tags").([]interface{})),
 		Insecure:                d.Get("insecure").(bool),
-		HTTPProxy:               d.Get("http_proxy").(string),
+		MaxRetries:              d.Get("max_retries").(int),
+		Profile:                 d.Get("profile").(string),
+		Region:                  d.Get("region").(string),
+		S3ForcePathStyle:        d.Get("s3_force_path_style").(bool),
+		SecretKey:               d.Get("secret_key").(string),
+		SharedConfigFile:        d.Get("shared_config_file").(string),
+		SharedCredentialsFile:   d.Get("shared_credentials_file").(string),
 		SkipCredsValidation:     d.Get("skip_credentials_validation").(bool),
 		SkipGetEC2Platforms:     d.Get("skip_get_ec2_platforms").(bool),
+		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),
 		SkipRegionValidation:    d.Get("skip_region_validation").(bool),
 		SkipRequestingAccountId: d.Get("skip_requesting_account_id").(bool),
-		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),
-		S3ForcePathStyle:        d.Get("s3_force_path_style").(bool),
+		STSRegion:               d.Get("sts_region").(string),
 		TerraformVersion:        terraformVersion,
+		Token:                   d.Get("token").(string),
+		UseDualStackEndpoint:    d.Get("use_dualstack_endpoint").(bool),
+		UseFIPSEndpoint:         d.Get("use_fips_endpoint").(bool),
 	}
 
 	if l, ok := d.Get("assume_role").([]interface{}); ok && len(l) > 0 && l[0] != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -217,6 +217,11 @@ func Provider() *schema.Provider {
 				Description: "The address of an HTTP proxy to use when accessing the AWS API. " +
 					"Can also be configured using the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.",
 			},
+			"iam_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IAM endpoint to use that can have a distinct region",
+			},
 			"ignore_tags": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -338,10 +343,10 @@ func Provider() *schema.Provider {
 				Description: "Skip requesting the account ID. " +
 					"Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
 			},
-			"sts_region": {
+			"sts_endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Region where the STS endpoint resides",
+				Description: "STS endpoint to use that can have a distinct region",
 			},
 			"token": {
 				Type:     schema.TypeString,

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -59,23 +59,23 @@ func SharedRegionalSweepClient(region string) (interface{}, error) {
 	}
 
 	if role := os.Getenv(conns.EnvVarAssumeRoleARN); role != "" {
-		conf.AssumeRoleARN = role
+		conf.AssumeRole.RoleARN = role
 
-		conf.AssumeRoleDurationSeconds = defaultSweeperAssumeRoleDurationSeconds
+		conf.AssumeRole.Duration = time.Duration(defaultSweeperAssumeRoleDurationSeconds) * time.Second
 		if v := os.Getenv(conns.EnvVarAssumeRoleDuration); v != "" {
 			d, err := strconv.Atoi(v)
 			if err != nil {
 				return nil, fmt.Errorf("environment variable %s: %w", conns.EnvVarAssumeRoleDuration, err)
 			}
-			conf.AssumeRoleDurationSeconds = d
+			conf.AssumeRole.Duration = time.Duration(d) * time.Second
 		}
 
 		if v := os.Getenv(conns.EnvVarAssumeRoleExternalID); v != "" {
-			conf.AssumeRoleExternalID = v
+			conf.AssumeRole.ExternalID = v
 		}
 
 		if v := os.Getenv(conns.EnvVarAssumeRoleSessionName); v != "" {
-			conf.AssumeRoleSessionName = v
+			conf.AssumeRole.SessionName = v
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20824
Requires hashicorp/aws-sdk-go-base#88
Relates aws/aws-sdk-go#3938

Running a similar config to #20824:

```terraform
provider "aws" {
  region = "us-west-2"

  assume_role {
    role_arn = "arn:aws:iam::012345678901:role/Litnupras"
  }

  endpoints {
    sts = "https://sts-fips.us-west-2.amazonaws.com"
  }
}

data "aws_caller_identity" "this" {}
```

The current provider throws the error shown in #20824. However, with a provider built from this branch, this is the result (the correct result since it creates no resources):

```console
% terraform apply

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Output from acceptance testing (randomly chosen to make sure things work as normal):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccS3Object_ PKG=s3     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Object_'  -timeout 180m
--- SKIP: TestAccS3Object_nonVersioned (1.43s)
--- PASS: TestAccS3Object_noNameNoKey (4.72s)
--- PASS: TestAccS3Object_withContentCharacteristics (37.20s)
--- PASS: TestAccS3Object_objectBucketKeyEnabled (42.14s)
--- PASS: TestAccS3Object_defaultBucketSSE (44.44s)
--- PASS: TestAccS3Object_etagEncryption (43.17s)
--- PASS: TestAccS3Object_bucketBucketKeyEnabled (44.73s)
--- PASS: TestAccS3Object_sse (44.75s)
--- PASS: TestAccS3Object_kms (45.31s)
--- PASS: TestAccS3Object_updates (71.94s)
--- PASS: TestAccS3Object_updateSameFile (72.64s)
--- PASS: TestAccS3Object_contentBase64 (30.58s)
--- PASS: TestAccS3Object_ignoreTags (74.07s)
--- PASS: TestAccS3Object_updatesWithVersioningViaAccessPoint (74.38s)
--- PASS: TestAccS3Object_updatesWithVersioning (76.49s)
--- PASS: TestAccS3Object_content (33.55s)
--- PASS: TestAccS3Object_source (33.57s)
--- PASS: TestAccS3Object_metadata (100.18s)
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithNone (102.18s)
--- PASS: TestAccS3Object_sourceHashTrigger (60.50s)
--- PASS: TestAccS3Object_empty (30.88s)
--- PASS: TestAccS3Object_acl (103.58s)
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithOn (61.97s)
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (125.72s)
--- PASS: TestAccS3Object_tagsMultipleSlashes (125.82s)
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (128.17s)
--- PASS: TestAccS3Object_tags (128.34s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithNone (87.50s)
--- PASS: TestAccS3Object_storageClass (150.26s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithSet (110.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	156.292s
```
