### PR TITLE
r/aws_batch_compute_environment: Enforce no `compute_resources` block for `UNMANAGED` compute environments

### DIFF
--- a/.changelog/22805.txt
+++ b/.changelog/22805.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_batch_compute_environment: No `compute_resources` configuration block can be specified when `type` is `UNMANAGED`
+```

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -1324,10 +1324,7 @@ func TestAccBatchComputeEnvironment_tags(t *testing.T) {
 }
 
 func TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testing.T) {
-	var ce batch.ComputeEnvironmentDetail
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_batch_compute_environment.test"
-	serviceRoleResourceName := "aws_iam_role.batch_service"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
@@ -1336,23 +1333,9 @@ func TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testi
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeEnvironmentUnmanagedWithComputeResourcesConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeEnvironmentExists(resourceName, &ce),
-					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("compute-environment/%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "compute_environment_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "compute_environment_name_prefix", ""),
-					resource.TestCheckResourceAttr(resourceName, "compute_resources.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "ecs_cluster_arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "service_role", serviceRoleResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "status_reason"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "type", "UNMANAGED"),
-				),
+				Config:      testAccComputeEnvironmentUnmanagedWithComputeResourcesConfig(rName),
+				ExpectError: regexp.MustCompile("no `compute_resources` can be specified when `type` is \"UNMANAGED\""),
 			},
-			// Can't import in this scenario.
 		},
 	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19087.
Relates #20433.
Relates #22776.
Relates #22818.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBatchComputeEnvironment_ PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchComputeEnvironment_'  -timeout 180m
=== RUN   TestAccBatchComputeEnvironment_basic
=== PAUSE TestAccBatchComputeEnvironment_basic
=== RUN   TestAccBatchComputeEnvironment_disappears
=== PAUSE TestAccBatchComputeEnvironment_disappears
=== RUN   TestAccBatchComputeEnvironment_nameGenerated
=== PAUSE TestAccBatchComputeEnvironment_nameGenerated
=== RUN   TestAccBatchComputeEnvironment_namePrefix
=== PAUSE TestAccBatchComputeEnvironment_namePrefix
=== RUN   TestAccBatchComputeEnvironment_createEC2
=== PAUSE TestAccBatchComputeEnvironment_createEC2
=== RUN   TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags
=== PAUSE TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags
=== RUN   TestAccBatchComputeEnvironment_createSpot
=== PAUSE TestAccBatchComputeEnvironment_createSpot
=== RUN   TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage
=== PAUSE TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage
=== RUN   TestAccBatchComputeEnvironment_createFargate
=== PAUSE TestAccBatchComputeEnvironment_createFargate
=== RUN   TestAccBatchComputeEnvironment_createFargateSpot
=== PAUSE TestAccBatchComputeEnvironment_createFargateSpot
=== RUN   TestAccBatchComputeEnvironment_updateState
=== PAUSE TestAccBatchComputeEnvironment_updateState
=== RUN   TestAccBatchComputeEnvironment_updateServiceRole
=== PAUSE TestAccBatchComputeEnvironment_updateServiceRole
=== RUN   TestAccBatchComputeEnvironment_defaultServiceRole
=== PAUSE TestAccBatchComputeEnvironment_defaultServiceRole
=== RUN   TestAccBatchComputeEnvironment_ComputeResources_minVCPUs
=== PAUSE TestAccBatchComputeEnvironment_ComputeResources_minVCPUs
=== RUN   TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs
=== PAUSE TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs
=== RUN   TestAccBatchComputeEnvironment_ec2Configuration
=== PAUSE TestAccBatchComputeEnvironment_ec2Configuration
=== RUN   TestAccBatchComputeEnvironment_launchTemplate
=== PAUSE TestAccBatchComputeEnvironment_launchTemplate
=== RUN   TestAccBatchComputeEnvironment_updateLaunchTemplate
=== PAUSE TestAccBatchComputeEnvironment_updateLaunchTemplate
=== RUN   TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate
=== PAUSE TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate
=== RUN   TestAccBatchComputeEnvironment_tags
=== PAUSE TestAccBatchComputeEnvironment_tags
=== RUN   TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources
=== PAUSE TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources
=== RUN   TestAccBatchComputeEnvironment_createEC2WithoutComputeResources
=== PAUSE TestAccBatchComputeEnvironment_createEC2WithoutComputeResources
=== RUN   TestAccBatchComputeEnvironment_createSpotWithoutIAMFleetRole
=== PAUSE TestAccBatchComputeEnvironment_createSpotWithoutIAMFleetRole
=== CONT  TestAccBatchComputeEnvironment_basic
=== CONT  TestAccBatchComputeEnvironment_defaultServiceRole
=== CONT  TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage
=== CONT  TestAccBatchComputeEnvironment_createEC2
=== CONT  TestAccBatchComputeEnvironment_createSpot
=== CONT  TestAccBatchComputeEnvironment_updateServiceRole
=== CONT  TestAccBatchComputeEnvironment_updateState
=== CONT  TestAccBatchComputeEnvironment_createFargate
=== CONT  TestAccBatchComputeEnvironment_createFargateSpot
=== CONT  TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate
=== CONT  TestAccBatchComputeEnvironment_createSpotWithoutIAMFleetRole
=== CONT  TestAccBatchComputeEnvironment_createEC2WithoutComputeResources
=== CONT  TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources
=== CONT  TestAccBatchComputeEnvironment_tags
=== CONT  TestAccBatchComputeEnvironment_namePrefix
=== CONT  TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags
=== CONT  TestAccBatchComputeEnvironment_updateLaunchTemplate
=== CONT  TestAccBatchComputeEnvironment_launchTemplate
=== CONT  TestAccBatchComputeEnvironment_ec2Configuration
=== CONT  TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs
=== CONT  TestAccBatchComputeEnvironment_defaultServiceRole
    acctest.go:750: skipping tests; missing IAM service-linked role /aws-service-role/batch. Please create the role and retry
--- SKIP: TestAccBatchComputeEnvironment_defaultServiceRole (1.62s)
=== CONT  TestAccBatchComputeEnvironment_ComputeResources_minVCPUs
--- PASS: TestAccBatchComputeEnvironment_createUnmanagedWithComputeResources (8.99s)
=== CONT  TestAccBatchComputeEnvironment_nameGenerated
--- PASS: TestAccBatchComputeEnvironment_createEC2WithoutComputeResources (32.19s)
=== CONT  TestAccBatchComputeEnvironment_disappears
--- PASS: TestAccBatchComputeEnvironment_basic (61.76s)
--- PASS: TestAccBatchComputeEnvironment_createSpotWithoutIAMFleetRole (62.93s)
--- PASS: TestAccBatchComputeEnvironment_createFargate (65.98s)
--- PASS: TestAccBatchComputeEnvironment_createFargateSpot (72.69s)
--- PASS: TestAccBatchComputeEnvironment_createEC2 (74.99s)
--- PASS: TestAccBatchComputeEnvironment_ec2Configuration (82.29s)
--- PASS: TestAccBatchComputeEnvironment_namePrefix (88.21s)
--- PASS: TestAccBatchComputeEnvironment_CreateSpotAllocationStrategy_bidPercentage (108.95s)
--- PASS: TestAccBatchComputeEnvironment_tags (118.70s)
--- PASS: TestAccBatchComputeEnvironment_nameGenerated (115.06s)
--- PASS: TestAccBatchComputeEnvironment_updateState (124.74s)
--- PASS: TestAccBatchComputeEnvironment_UpdateSecurityGroupsAndSubnets_fargate (133.55s)
--- PASS: TestAccBatchComputeEnvironment_updateLaunchTemplate (137.06s)
--- PASS: TestAccBatchComputeEnvironment_updateServiceRole (139.45s)
--- PASS: TestAccBatchComputeEnvironment_launchTemplate (146.68s)
--- PASS: TestAccBatchComputeEnvironment_ComputeResources_maxVCPUs (152.44s)
--- PASS: TestAccBatchComputeEnvironment_CreateEC2DesiredVCPUsEC2KeyPairImageID_computeResourcesTags (171.63s)
--- PASS: TestAccBatchComputeEnvironment_disappears (286.38s)
--- PASS: TestAccBatchComputeEnvironment_ComputeResources_minVCPUs (400.16s)
--- PASS: TestAccBatchComputeEnvironment_createSpot (488.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      491.500s
```
