### PR TITLE
Add nil checks for route table association state

### DIFF
--- a/.changelog/22806.txt
+++ b/.changelog/22806.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route_table_association: Handle nil 'AssociationState' in ISO regions
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -437,8 +437,10 @@ func FindMainRouteTableAssociationByVPCID(conn *ec2.EC2, vpcID string) (*ec2.Rou
 
 	for _, association := range routeTable.Associations {
 		if aws.BoolValue(association.Main) {
-			if state := aws.StringValue(association.AssociationState.State); state == ec2.RouteTableAssociationStateCodeDisassociated {
-				continue
+			if association.AssociationState != nil {
+				if state := aws.StringValue(association.AssociationState.State); state == ec2.RouteTableAssociationStateCodeDisassociated {
+					continue
+				}
 			}
 
 			return association, nil
@@ -465,8 +467,10 @@ func FindRouteTableAssociationByID(conn *ec2.EC2, associationID string) (*ec2.Ro
 
 	for _, association := range routeTable.Associations {
 		if aws.StringValue(association.RouteTableAssociationId) == associationID {
-			if state := aws.StringValue(association.AssociationState.State); state == ec2.RouteTableAssociationStateCodeDisassociated {
-				return nil, &resource.NotFoundError{Message: state}
+			if association.AssociationState != nil {
+				if state := aws.StringValue(association.AssociationState.State); state == ec2.RouteTableAssociationStateCodeDisassociated {
+					return nil, &resource.NotFoundError{Message: state}
+				}
 			}
 
 			return association, nil

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -313,7 +313,11 @@ func StatusRouteTableAssociationState(conn *ec2.EC2, id string) resource.StateRe
 		}
 
 		if output.AssociationState == nil {
-			return nil, "", nil
+			// In ISO partitions AssociationState can be nil.
+			// If the association has been found then we assume it's associated.
+			state := ec2.RouteTableAssociationStateCodeAssociated
+
+			return &ec2.RouteTableAssociationState{State: aws.String(state)}, state, nil
 		}
 
 		return output.AssociationState, aws.StringValue(output.AssociationState.State), nil

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -312,6 +312,10 @@ func StatusRouteTableAssociationState(conn *ec2.EC2, id string) resource.StateRe
 			return nil, "", err
 		}
 
+		if output.AssociationState == nil {
+			return nil, "", nil
+		}
+
 		return output.AssociationState, aws.StringValue(output.AssociationState.State), nil
 	}
 }


### PR DESCRIPTION
In aws-iso region the AssociationState isn't set in the Associations for route tables. This caused a nil pointer dereference and an RPC error when refreshing state on an `aws_route_table_association` resource.

For reference the output from the AWS CLI command `aws ec2 describe-route-tables` looks like this in AWS us-west-2:
```
{
    "RouteTables": [
        {
            "Associations": [
                {
                    "AssociationState": {
                        "State": "associated"
                    },
                    "Main": false,
                    "RouteTableAssociationId": "rtbassoc-000000000000000000",
                    "RouteTableId": "rtb-000000000000000000",
                    "SubnetId": "subnet-000000000000000000"
                }
...
```
And looks like this in an AWS ISO region:
```
{
    "RouteTables": [
        {
            "Associations": [
                {
                    "Main": false,
                    "RouteTableAssociationId": "rtbassoc-000000000000000000",
                    "RouteTableId": "rtb-000000000000000000",
                    "SubnetId": "subnet-000000000000000000"
                }
...
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing (chosen because of this PR [#21710](https://github.com/hashicorp/terraform-provider-aws/pull/21710)):
```
% make testacc PKG_NAME=internal/service/ec2 TESTARGS='-run=TestAccEC2RouteTable_basic\|TestAccEC2RouteTableAssociation_Subnet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2RouteTable_basic\|TestAccEC2RouteTableAssociation_Subnet_basic -timeout 180m
=== RUN   TestAccEC2RouteTableAssociation_Subnet_basic
=== PAUSE TestAccEC2RouteTableAssociation_Subnet_basic
=== RUN   TestAccEC2RouteTable_basic
=== PAUSE TestAccEC2RouteTable_basic
=== CONT  TestAccEC2RouteTableAssociation_Subnet_basic
=== CONT  TestAccEC2RouteTable_basic
--- PASS: TestAccEC2RouteTable_basic (65.35s)
--- PASS: TestAccEC2RouteTableAssociation_Subnet_basic (78.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	82.046s
```

This is my first PR for this project, let me know if there's anything else I should add/update/change. Thank you!

cc: @YakDriver @ewbankkit because of other recent ISO region related changes and context.
