### PR TITLE
lambda/provisioned_concurrency_config: Really support ARNs in function_name

### DIFF
--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -56,6 +56,8 @@ func resourceProvisionedConcurrencyConfigCreate(d *schema.ResourceData, meta int
 	functionName := d.Get("function_name").(string)
 	qualifier := d.Get("qualifier").(string)
 
+	functionName = ProvisionedConcurrencyConfigCanonicalizeFunctionName(functionName)
+
 	input := &lambda.PutProvisionedConcurrencyConfigInput{
 		FunctionName:                    aws.String(functionName),
 		ProvisionedConcurrentExecutions: aws.Int64(int64(d.Get("provisioned_concurrent_executions").(int))),
@@ -173,6 +175,15 @@ func ProvisionedConcurrencyConfigParseID(id string) (string, string, error) {
 	}
 
 	return parts[0], parts[1], nil
+}
+
+func ProvisionedConcurrencyConfigCanonicalizeFunctionName(f string) string {
+	parsed, err := GetFunctionNameFromARN(f)
+	// It is already a function name
+	if err != nil {
+		return f
+	}
+	return parsed
 }
 
 func refreshProvisionedConcurrencyConfigStatus(conn *lambda.Lambda, functionName, qualifier string) resource.StateRefreshFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes #22392

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2
TBD
...
```
