### PR TITLE
Add Route 53 Recovery Control sweepers

### DIFF
--- a/internal/service/route53recoverycontrolconfig/cluster.go
+++ b/internal/service/route53recoverycontrolconfig/cluster.go
@@ -121,18 +121,17 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 func resourceClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).Route53RecoveryControlConfigConn
 
-	input := &r53rcc.DeleteClusterInput{
+	log.Printf("[INFO] Deleting Route53 Recovery Control Config Cluster: %s", d.Id())
+	_, err := conn.DeleteCluster(&r53rcc.DeleteClusterInput{
 		ClusterArn: aws.String(d.Id()),
-	}
-
-	_, err := conn.DeleteCluster(input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, r53rcc.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Route53 Recovery Control Config Cluster: %s", err)
+		return fmt.Errorf("error deleting Route53 Recovery Control Config Cluster: %w", err)
 	}
 
 	_, err = waitRoute53RecoveryControlConfigClusterDeleted(conn, d.Id())

--- a/internal/service/route53recoverycontrolconfig/control_panel.go
+++ b/internal/service/route53recoverycontrolconfig/control_panel.go
@@ -134,18 +134,17 @@ func resourceControlPanelUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceControlPanelDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).Route53RecoveryControlConfigConn
 
-	input := &r53rcc.DeleteControlPanelInput{
+	log.Printf("[INFO] Deleting Route53 Recovery Control Config Control Panel: %s", d.Id())
+	_, err := conn.DeleteControlPanel(&r53rcc.DeleteControlPanelInput{
 		ControlPanelArn: aws.String(d.Id()),
-	}
-
-	_, err := conn.DeleteControlPanel(input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, r53rcc.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Route53 Recovery Control Config Control Panel: %s", err)
+		return fmt.Errorf("error deleting Route53 Recovery Control Config Control Panel: %w", err)
 	}
 
 	_, err = waitRoute53RecoveryControlConfigControlPanelDeleted(conn, d.Id())

--- a/internal/service/route53recoverycontrolconfig/routing_control.go
+++ b/internal/service/route53recoverycontrolconfig/routing_control.go
@@ -133,11 +133,10 @@ func resourceRoutingControlUpdate(d *schema.ResourceData, meta interface{}) erro
 func resourceRoutingControlDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).Route53RecoveryControlConfigConn
 
-	input := &r53rcc.DeleteRoutingControlInput{
+	log.Printf("[INFO] Deleting Route53 Recovery Control Config Routing Control: %s", d.Id())
+	_, err := conn.DeleteRoutingControl(&r53rcc.DeleteRoutingControlInput{
 		RoutingControlArn: aws.String(d.Id()),
-	}
-
-	_, err := conn.DeleteRoutingControl(input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, r53rcc.ErrCodeResourceNotFoundException) {
 		return nil

--- a/internal/service/route53recoverycontrolconfig/safety_rule.go
+++ b/internal/service/route53recoverycontrolconfig/safety_rule.go
@@ -205,18 +205,17 @@ func resourceSafetyRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceSafetyRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).Route53RecoveryControlConfigConn
 
-	input := &r53rcc.DeleteSafetyRuleInput{
+	log.Printf("[INFO] Deleting Route53 Recovery Control Config Safety Rule: %s", d.Id())
+	_, err := conn.DeleteSafetyRule(&r53rcc.DeleteSafetyRuleInput{
 		SafetyRuleArn: aws.String(d.Id()),
-	}
-
-	_, err := conn.DeleteSafetyRule(input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, r53rcc.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error deleting Route53 Recovery Control Config Safety Rule: %s", err)
+		return fmt.Errorf("Error deleting Route53 Recovery Control Config Safety Rule: %w", err)
 	}
 
 	_, err = waitRoute53RecoveryControlConfigSafetyRuleDeleted(conn, d.Id())

--- a/internal/service/route53recoverycontrolconfig/sweep.go
+++ b/internal/service/route53recoverycontrolconfig/sweep.go
@@ -1,0 +1,340 @@
+//go:build sweep
+// +build sweep
+
+package route53recoverycontrolconfig
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	r53rcc "github.com/aws/aws-sdk-go/service/route53recoverycontrolconfig"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_route53recoverycontrolconfig_cluster", &resource.Sweeper{
+		Name: "aws_route53recoverycontrolconfig_cluster",
+		F:    sweepClusters,
+		Dependencies: []string{
+			"aws_route53recoverycontrolconfig_control_panel",
+		},
+	})
+
+	resource.AddTestSweepers("aws_route53recoverycontrolconfig_control_panel", &resource.Sweeper{
+		Name: "aws_route53recoverycontrolconfig_control_panel",
+		F:    sweepControlPanels,
+		Dependencies: []string{
+			"aws_route53recoverycontrolconfig_routing_control",
+			"aws_route53recoverycontrolconfig_safety_rule",
+		},
+	})
+
+	resource.AddTestSweepers("aws_route53recoverycontrolconfig_routing_control", &resource.Sweeper{
+		Name: "aws_route53recoverycontrolconfig_routing_control",
+		F:    sweepRoutingControls,
+	})
+
+	resource.AddTestSweepers("aws_route53recoverycontrolconfig_safety_rule", &resource.Sweeper{
+		Name: "aws_route53recoverycontrolconfig_safety_rule",
+		F:    sweepSafetyRules,
+	})
+}
+
+func sweepClusters(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
+	input := &r53rcc.ListClustersInput{}
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Clusters {
+			r := ResourceCluster()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.ClusterArn))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Recovery Control Config Cluster sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Route53 Recovery Control Config Clusters (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Route53 Recovery Control Config Clusters (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepControlPanels(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
+	input := &r53rcc.ListClustersInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Clusters {
+			input := &r53rcc.ListControlPanelsInput{
+				ClusterArn: v.ClusterArn,
+			}
+
+			err := conn.ListControlPanelsPages(input, func(page *r53rcc.ListControlPanelsOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, v := range page.ControlPanels {
+					if aws.BoolValue(v.DefaultControlPanel) {
+						continue
+					}
+
+					r := ResourceControlPanel()
+					d := r.Data(nil)
+					d.SetId(aws.StringValue(v.ControlPanelArn))
+
+					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
+
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Control Panels (%s): %w", region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Recovery Control Config Control Panel sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Clusters (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Route53 Recovery Control Config Control Panels (%s): %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func sweepRoutingControls(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
+	input := &r53rcc.ListClustersInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Clusters {
+			input := &r53rcc.ListControlPanelsInput{
+				ClusterArn: v.ClusterArn,
+			}
+
+			err := conn.ListControlPanelsPages(input, func(page *r53rcc.ListControlPanelsOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, v := range page.ControlPanels {
+					input := &r53rcc.ListRoutingControlsInput{
+						ControlPanelArn: v.ControlPanelArn,
+					}
+
+					err := conn.ListRoutingControlsPages(input, func(page *r53rcc.ListRoutingControlsOutput, lastPage bool) bool {
+						if page == nil {
+							return !lastPage
+						}
+
+						for _, v := range page.RoutingControls {
+							r := ResourceRoutingControl()
+							d := r.Data(nil)
+							d.SetId(aws.StringValue(v.RoutingControlArn))
+
+							sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+						}
+
+						return !lastPage
+					})
+
+					if sweep.SkipSweepError(err) {
+						continue
+					}
+
+					if err != nil {
+						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Routing Controls (%s): %w", region, err))
+					}
+				}
+
+				return !lastPage
+			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
+
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Control Panels (%s): %w", region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Recovery Control Config Routing Control sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Clusters (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Route53 Recovery Control Config Routing Controls (%s): %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func sweepSafetyRules(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*conns.AWSClient).Route53RecoveryControlConfigConn
+	input := &r53rcc.ListClustersInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]*sweep.SweepResource, 0)
+
+	err = conn.ListClustersPages(input, func(page *r53rcc.ListClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Clusters {
+			input := &r53rcc.ListControlPanelsInput{
+				ClusterArn: v.ClusterArn,
+			}
+
+			err := conn.ListControlPanelsPages(input, func(page *r53rcc.ListControlPanelsOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, v := range page.ControlPanels {
+					input := &r53rcc.ListSafetyRulesInput{
+						ControlPanelArn: v.ControlPanelArn,
+					}
+
+					err := conn.ListSafetyRulesPages(input, func(page *r53rcc.ListSafetyRulesOutput, lastPage bool) bool {
+						if page == nil {
+							return !lastPage
+						}
+
+						for _, v := range page.SafetyRules {
+							r := ResourceSafetyRule()
+							d := r.Data(nil)
+							if v.ASSERTION != nil {
+								d.SetId(aws.StringValue(v.ASSERTION.SafetyRuleArn))
+							} else if v.GATING != nil {
+								d.SetId(aws.StringValue(v.GATING.SafetyRuleArn))
+							} else {
+								continue
+							}
+
+							sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+						}
+
+						return !lastPage
+					})
+
+					if sweep.SkipSweepError(err) {
+						continue
+					}
+
+					if err != nil {
+						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Safety Rules (%s): %w", region, err))
+					}
+				}
+
+				return !lastPage
+			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
+
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Control Panels (%s): %w", region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Route53 Recovery Control Config Safety Rule sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Route53 Recovery Control Config Clusters (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Route53 Recovery Control Config Safety Rules (%s): %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -88,6 +88,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/rds"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/route53"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/s3control"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21967.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make sweep SWEEPARGS=-sweep-run=aws_route53recoverycontrolconfig_cluster SWEEP=us-east-1
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-1 -sweep-run=aws_route53recoverycontrolconfig_cluster -timeout 60m
2022/01/28 09:58:50 [DEBUG] Running Sweepers for region (us-east-1):
2022/01/28 09:58:50 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_control_panel) has dependency (aws_route53recoverycontrolconfig_routing_control), running..
2022/01/28 09:58:50 [DEBUG] Running Sweeper (aws_route53recoverycontrolconfig_routing_control) in region (us-east-1)
2022/01/28 09:58:50 [INFO] AWS Auth provider used: "EnvProvider"
2022/01/28 09:58:50 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/01/28 09:58:51 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/01/28 09:58:52 [DEBUG] Completed Sweeper (aws_route53recoverycontrolconfig_routing_control) in region (us-east-1) in 1.880863328s
2022/01/28 09:58:52 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_control_panel) has dependency (aws_route53recoverycontrolconfig_safety_rule), running..
2022/01/28 09:58:52 [DEBUG] Running Sweeper (aws_route53recoverycontrolconfig_safety_rule) in region (us-east-1)
2022/01/28 09:58:55 [DEBUG] Completed Sweeper (aws_route53recoverycontrolconfig_safety_rule) in region (us-east-1) in 2.356758603s
2022/01/28 09:58:55 [DEBUG] Running Sweeper (aws_route53recoverycontrolconfig_control_panel) in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Completed Sweeper (aws_route53recoverycontrolconfig_control_panel) in region (us-east-1) in 913.752711ms
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_routing_control) already ran in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_safety_rule) already ran in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_cluster) has dependency (aws_route53recoverycontrolconfig_control_panel), running..
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_control_panel) has dependency (aws_route53recoverycontrolconfig_routing_control), running..
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_routing_control) already ran in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_control_panel) has dependency (aws_route53recoverycontrolconfig_safety_rule), running..
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_safety_rule) already ran in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Sweeper (aws_route53recoverycontrolconfig_control_panel) already ran in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Running Sweeper (aws_route53recoverycontrolconfig_cluster) in region (us-east-1)
2022/01/28 09:58:56 [DEBUG] Waiting for state to become: [success]
2022/01/28 09:58:56 [DEBUG] Waiting for state to become: [success]
2022/01/28 09:58:56 [INFO] Deleting Route53 Recovery Control Config Cluster: arn:aws:route53-recovery-control::187416307283:cluster/8f14196f-63f4-4485-8740-b673e290fd37
2022/01/28 09:58:56 [INFO] Deleting Route53 Recovery Control Config Cluster: arn:aws:route53-recovery-control::187416307283:cluster/9add6e14-b2a1-48e8-9475-004848574334
2022/01/28 09:58:56 [DEBUG] Waiting for state to become: []
2022/01/28 09:58:56 [DEBUG] Waiting for state to become: []
2022/01/28 09:59:02 [DEBUG] Completed Sweeper (aws_route53recoverycontrolconfig_cluster) in region (us-east-1) in 5.98981828s
2022/01/28 09:59:02 Completed Sweepers for region (us-east-1) in 11.141516482s
2022/01/28 09:59:02 Sweeper Tests for region (us-east-1) ran successfully:
        - aws_route53recoverycontrolconfig_routing_control
        - aws_route53recoverycontrolconfig_safety_rule
        - aws_route53recoverycontrolconfig_control_panel
        - aws_route53recoverycontrolconfig_cluster
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      15.140s
```
