### PR TITLE
Add maintainer editability check

### DIFF
--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -7,7 +7,7 @@ jobs:
   PermissionsCheck:
     env:
       MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
-      ALLOW_LISTED: ${{ contains(fromJSON('["anGie44", "bflad", "breathingdust", "ewbankkit", "gdavison", "johnsonaj", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding"]'), github.actor) }}
+      ALLOW_LISTED: ${{ contains(fromJSON('["anGie44", "breathingdust", "ewbankkit", "gdavison", "johnsonaj", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -7,7 +7,7 @@ jobs:
   PermissionsCheck:
     env:
       MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
-      ALLOW_LISTED: ${{ contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding"]'), github.actor) }}
+      ALLOW_LISTED: ${{ contains(fromJSON('["anGie44", "bflad", "breathingdust", "ewbankkit", "gdavison", "johnsonaj", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -7,7 +7,7 @@ jobs:
   PermissionsCheck:
     env:
       MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
-      ALLOW_LISTED: ${{ contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.pull_request.author_association) }}
+      ALLOW_LISTED: ${{ contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "justinretzolk", "maryelizbeth", "YakDriver", "zhelding"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Hey @${{ github.actor }} :wave: Thank you very much for your contribution! At times, our maintainers need to make direct edits to pull requests in order to help get it ready to be merged. Your current settings do not allow maintainers to make such edits. To help facilitate this, can you update your pull request to allow such edits as described in GitHub's [Allowing changes to a pull request branch created from a fork][1] documentation?
+            Hey @${{ github.actor }} :wave: Thank you very much for your contribution! At times, our maintainers need to make direct edits to pull requests in order to help get it ready to be merged. Your current settings do not allow maintainers to make such edits. To help facilitate this, update your pull request to allow such edits as described in GitHub's [Allowing changes to a pull request branch created from a fork][1] documentation. (If you're using a fork owned by an organization, your organization may not allow you to change this setting. If that is the case, let us know.)
 
             [1]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -1,0 +1,22 @@
+name: "Check Maintainer Edit Permissions"
+on:
+  pull_request_target:
+    types:
+      - opened
+jobs:
+  PermissionsCheck:
+    env:
+      MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
+      ALLOW_LISTED: ${{ contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.pull_request.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment if maintainers cannot edit
+        if: ${{ ( env.ALLOW_LISTED == false ) && ( env.MAINTAINER_CAN_MODIFY == false ) }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Hey @${{ github.actor }} :wave: Thank you very much for your contribution! At times, our maintainers need to make direct edits to pull requests in order to help get it ready to be merged. Your current settings do not allow maintainers to make such edits. To help facilitate this, can you update your pull request to allow such edits as described in GitHub's [Allowing changes to a pull request branch created from a fork][1] documentation?
+
+            [1]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
+

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit
-        if: ${{ ( env.ALLOW_LISTED == false ) && ( env.MAINTAINER_CAN_MODIFY == false ) }}
+        if: ${{ ( env.ALLOW_LISTED == 'false' ) && ( env.MAINTAINER_CAN_MODIFY == 'false' ) }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Output from acceptance testing:

- n/a - adding an action.

### Information

This PR proposes a new GitHub Action for checking whether or not a PR submitter has enabled the setting that [allows changes to a PR branch created from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork). Enabling this setting allows maintainers to more quickly address PRs when a minor change is needed, rather than needing to ask the submitter to go back and complete the work when they have time.

### Notes and Considerations

Currently, I've structured the Action to conditionally run based on two things:

- If the user is not part of the "allow list" (based on [author_association](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation)); e.g. the user is not a `COLLABORATOR`, `MEMBER`, or `OWNER` of the repository.
- If the `maintainer_can_modify` setting is set to `false`

I've considered the approach of replacing the `author_association` test with whether or not the PR is from a fork, and part of me feels that would be a better path. I would be interested in additional feedback as to whether that is a better approach.