### PR TITLE
Appstream elastic fleet

### DIFF
--- a/.changelog/22830.txt
+++ b/.changelog/22830.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appstream_fleet: Add support for elastic fleet
+```

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -38,22 +38,26 @@ func ResourceFleet() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"available": {
 							Type:     schema.TypeInt,
+							Optional: true,
 							Computed: true,
 						},
 						"desired_instances": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
 						},
 						"in_use": {
 							Type:     schema.TypeInt,
+							Optional: true,
 							Computed: true,
 						},
 						"running": {
 							Type:     schema.TypeInt,
+							Optional: true,
 							Computed: true,
 						},
 					},

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -482,7 +482,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("max_concurrent_sessions") {
-		input.MaxUserDurationInSeconds = aws.Int64(int64(d.Get("max_concurrent_sessions").(int)))
+		input.MaxConcurrentSessions = aws.Int64(int64(d.Get("max_concurrent_sessions").(int)))
 	}
 
 	if d.HasChange("vpc_config") {

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -37,7 +37,7 @@ func ResourceFleet() *schema.Resource {
 			"compute_capacity": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
-				Required: false,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"available": {
@@ -194,15 +194,15 @@ func ResourceFleet() *schema.Resource {
 func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppStreamConn
 	input := &appstream.CreateFleetInput{
-		Name:            aws.String(d.Get("name").(string)),
-		InstanceType:    aws.String(d.Get("instance_type").(string)),
+		Name:         aws.String(d.Get("name").(string)),
+		InstanceType: aws.String(d.Get("instance_type").(string)),
 	}
 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	if v, ok := d.GetOk("compute_capacity"); ok {
-		input.Description = expandComputeCapacity(d.Get("compute_capacity").([]interface{}))
+		input.ComputeCapacity = expandComputeCapacity(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -246,7 +246,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("platform"); ok {
-		input.IamRoleArn = aws.String(v.(string))
+		input.Platform = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("max_user_duration_in_seconds"); ok {
@@ -397,7 +397,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	shouldStop := false
 
-	if d.HasChanges("description", "domain_join_info", "enable_default_internet_access", "iam_role_arn", "instance_type","platform", "max_user_duration_in_seconds", "stream_view", "vpc_config") {
+	if d.HasChanges("description", "domain_join_info", "enable_default_internet_access", "iam_role_arn", "instance_type", "platform", "max_user_duration_in_seconds", "stream_view", "vpc_config") {
 		shouldStop = true
 	}
 

--- a/website/docs/r/appstream_fleet.html.markdown
+++ b/website/docs/r/appstream_fleet.html.markdown
@@ -43,19 +43,20 @@ resource "aws_appstream_fleet" "test_fleet" {
 
 The following arguments are required:
 
-* `compute_capacity` - (Required) Configuration block for the desired capacity of the fleet. See below.
 * `instance_type` - (Required) Instance type to use when launching fleet instances.
 * `name` - (Required) Unique name for the fleet.
 
 The following arguments are optional:
 
+* `compute_capacity` - (Required) Configuration block for the desired capacity of the fleet. See below.
 * `description` - (Optional) Description to display.
 * `disconnect_timeout_in_seconds` - (Optional) Amount of time that a streaming session remains active after users disconnect.
 * `display_name` - (Optional) Human-readable friendly name for the AppStream fleet.
 * `domain_join_info` - (Optional) Configuration block for the name of the directory and organizational unit (OU) to use to join the fleet to a Microsoft Active Directory domain. See below.
 * `enable_default_internet_access` - (Optional) Enables or disables default internet access for the fleet.
-* `fleet_type` - (Optional) Fleet type. Valid values are: `ON_DEMAND`, `ALWAYS_ON`
+* `fleet_type` - (Optional) Fleet type. Valid values are: `ON_DEMAND`, `ALWAYS_ON`, `ELASTIC`
 * `iam_role_arn` - (Optional) ARN of the IAM role to apply to the fleet.
+* `platform` - (Optional) ARN of the IAM role to apply to the fleet.
 * `idle_disconnect_timeout_in_seconds` - (Optional) Amount of time that users can be idle (inactive) before they are disconnected from their streaming session and the `disconnect_timeout_in_seconds` time interval begins.
 * `image_name` - (Optional) Name of the image used to create the fleet.
 * `image_arn` - (Optional) ARN of the public, private, or shared image to use.

--- a/website/docs/r/appstream_fleet.html.markdown
+++ b/website/docs/r/appstream_fleet.html.markdown
@@ -56,7 +56,8 @@ The following arguments are optional:
 * `enable_default_internet_access` - (Optional) Enables or disables default internet access for the fleet.
 * `fleet_type` - (Optional) Fleet type. Valid values are: `ON_DEMAND`, `ALWAYS_ON`, `ELASTIC`
 * `iam_role_arn` - (Optional) ARN of the IAM role to apply to the fleet.
-* `platform` - (Optional) ARN of the IAM role to apply to the fleet.
+* `platform` - (Optional) Platform of ELASTIC fleet.  Either WINDOWS o AMAZON_LINUX
+* `max_concurrent_sessions` - (Optional) The maximum concurrent sessions of an Elastic Fleet.
 * `idle_disconnect_timeout_in_seconds` - (Optional) Amount of time that users can be idle (inactive) before they are disconnected from their streaming session and the `disconnect_timeout_in_seconds` time interval begins.
 * `image_name` - (Optional) Name of the image used to create the fleet.
 * `image_arn` - (Optional) ARN of the public, private, or shared image to use.


### PR DESCRIPTION
This change adds support for the Appstream Elastic fleet type.    

It added two new variables:
-   platform
-   max_concurrent_sessions

These variables are both required to support elastic fleets.  The variable compute_capacity is no longer required, as this is not valid for elastic fleets.

Further support for applications and blocks can be added by using the awscc provider as suggested by Shkarlatov in #22587

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22587

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAppStreamFleet_ PKG=appstream
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamFleet_'  -timeout 180m
=== RUN   TestAccAppStreamFleet_basic
=== PAUSE TestAccAppStreamFleet_basic
=== RUN   TestAccAppStreamFleet_disappears
=== PAUSE TestAccAppStreamFleet_disappears
=== RUN   TestAccAppStreamFleet_completeWithStop
=== PAUSE TestAccAppStreamFleet_completeWithStop
=== RUN   TestAccAppStreamFleet_completeWithoutStop
=== PAUSE TestAccAppStreamFleet_completeWithoutStop
=== RUN   TestAccAppStreamFleet_elasticWithTags
=== PAUSE TestAccAppStreamFleet_elasticWithTags
=== CONT  TestAccAppStreamFleet_basic
=== CONT  TestAccAppStreamFleet_completeWithoutStop
=== CONT  TestAccAppStreamFleet_elasticWithTags
=== CONT  TestAccAppStreamFleet_disappears
=== CONT  TestAccAppStreamFleet_completeWithStop
--- PASS: TestAccAppStreamFleet_elasticWithTags (310.91s)
--- PASS: TestAccAppStreamFleet_basic (833.88s)
--- PASS: TestAccAppStreamFleet_disappears (943.69s)
--- PASS: TestAccAppStreamFleet_completeWithoutStop (1060.04s)
--- PASS: TestAccAppStreamFleet_completeWithStop (2252.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  2252.076s

...
```


I modified the TestAccAppStreamFleet_withTags to TestAccAppStreamFleet_elasticWithTags, this now creates an Elastic fleet instead of an ondemand stack.   Most AWS accounts can only support 5 Appstream fleets at the same time so this streamlines things a little.   We still get to test the creation of a stack with tags but now also the Elastic stack type.

