### PR TITLE
r/aws_imagebuilder_image_recipe - add support for component parameters

### DIFF
--- a/.changelog/22837.txt
+++ b/.changelog/22837.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_imagebuilder_image_recipe: Add support for component parameters
+resource/aws_imagebuilder_image_recipe: Add `parameter` argument to the `component` configuration block
 ```

--- a/.changelog/22837.txt
+++ b/.changelog/22837.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image_recipe: Add support for component parameters
+```

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -604,7 +604,7 @@ func flattenComponentParameter(apiObject *imagebuilder.ComponentParameter) map[s
 
 	if v := apiObject.Value; v != nil {
 		// ImageBuilder API quirk
-		// Even though Value is a slice, only first element is used.
+		// Even though Value is a slice, only one element is accepted.
 		tfMap["value"] = aws.StringValueSlice(v)[0]
 	}
 

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -134,6 +134,23 @@ func ResourceImageRecipe() *schema.Resource {
 							Required:     true,
 							ValidateFunc: verify.ValidARN,
 						},
+						"parameter": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -367,6 +384,56 @@ func expandComponentConfiguration(tfMap map[string]interface{}) *imagebuilder.Co
 		apiObject.ComponentArn = aws.String(v)
 	}
 
+	if v, ok := tfMap["parameter"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.Parameters = expandComponentParameters(v.List())
+	}
+
+	return apiObject
+}
+
+func expandComponentParameters(tfList []interface{}) []*imagebuilder.ComponentParameter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*imagebuilder.ComponentParameter
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandComponentParameter(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandComponentParameter(tfMap map[string]interface{}) *imagebuilder.ComponentParameter {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.ComponentParameter{}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		apiObject.Name = aws.String(v)
+	}
+
+	if v, ok := tfMap["value"].(string); ok {
+		// ImageBuilder API quirk
+		// Even though Value is a slice, only one element is accepted.
+		apiObject.Value = aws.StringSlice([]string{v})
+	}
+
 	return apiObject
 }
 
@@ -497,6 +564,48 @@ func flattenComponentConfiguration(apiObject *imagebuilder.ComponentConfiguratio
 
 	if v := apiObject.ComponentArn; v != nil {
 		tfMap["component_arn"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Parameters; v != nil {
+		tfMap["parameter"] = flattenComponentParameters(v)
+	}
+
+	return tfMap
+}
+
+func flattenComponentParameters(apiObjects []*imagebuilder.ComponentParameter) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenComponentParameter(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenComponentParameter(apiObject *imagebuilder.ComponentParameter) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Name; v != nil {
+		tfMap["name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Value; v != nil {
+		// ImageBuilder API quirk
+		// Even though Value is a slice, only first element is used.
+		tfMap["value"] = aws.StringValueSlice(v)[0]
 	}
 
 	return tfMap

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -428,7 +428,7 @@ func expandComponentParameter(tfMap map[string]interface{}) *imagebuilder.Compon
 		apiObject.Name = aws.String(v)
 	}
 
-	if v, ok := tfMap["value"].(string); ok {
+	if v, ok := tfMap["value"].(string); ok && v != "" {
 		// ImageBuilder API quirk
 		// Even though Value is a slice, only one element is accepted.
 		apiObject.Value = aws.StringSlice([]string{v})

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -421,6 +421,32 @@ func TestAccImageBuilderImageRecipe_component(t *testing.T) {
 	})
 }
 
+func TestAccImageBuilderImageRecipe_componentParameter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_image_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageRecipeComponentParameterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImageRecipeExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "component.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "component.0.parameter.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "component.0.parameter.0.name", "Parameter1"),
+					resource.TestCheckResourceAttr(resourceName, "component.0.parameter.0.value", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "component.0.parameter.1.name", "Parameter2"),
+					resource.TestCheckResourceAttr(resourceName, "component.0.parameter.1.value", "Value2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderImageRecipe_description(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_image_recipe.test"
@@ -908,6 +934,58 @@ resource "aws_imagebuilder_image_recipe" "test" {
   version      = "1.0.0"
 }
 `, rName))
+}
+
+func testAccImageRecipeComponentParameterConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_imagebuilder_component" "test" {
+  data = <<EOF
+phases:
+  - name: build
+    steps:
+      - name: example
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo {{ Parameter1 }}
+            - echo {{ Parameter2 }}
+parameters:
+  - Parameter1:
+      type: string
+  - Parameter2:
+      type: string  
+schemaVersion: 1.0
+EOF
+
+  name     = %[1]q
+  platform = "Linux"
+  version  = "1.0.0"
+}
+
+resource "aws_imagebuilder_image_recipe" "test" {
+  component {
+    component_arn = aws_imagebuilder_component.test.arn
+
+    parameter {
+      name  = "Parameter1"
+      value = "Value1"
+    }
+
+    parameter {
+      name  = "Parameter2"
+      value = "Value2"
+    }
+  }
+
+  name         = %[1]q
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
+}
+`, rName)
 }
 
 func testAccImageRecipeDescriptionConfig(rName string, description string) string {

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -33,7 +33,7 @@ resource "aws_imagebuilder_image_recipe" "example" {
     }
 
     parameter {
-      name  = "Parameter2
+      name  = "Parameter2"
       value = "Value2"
     }
   }

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -26,6 +26,16 @@ resource "aws_imagebuilder_image_recipe" "example" {
 
   component {
     component_arn = aws_imagebuilder_component.example.arn
+
+    parameter {
+      name  = "Parameter1"
+      value = "Value1"
+    }
+
+    parameter {
+      name  = "Parameter2
+      value = "Value2"
+    }
   }
 
   name         = "example"
@@ -74,9 +84,17 @@ The following arguments are optional:
 
 ### component
 
-The following arguments are required:
+The `component` block supports the following arguments:
 
 * `component_arn` - (Required) Amazon Resource Name (ARN) of the Image Builder Component to associate.
+* `parameter` - (Optional) Configuration block(s) for parameters to configure the component. Detailed below.
+
+### parameter
+
+The following arguments are required:
+
+* `name` - (Required) The name of the component parameter.
+* `value` - (Required) The value for the named component parameter.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20855.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderImageRecipe_componentParameter" PKG_NAME=internal/service/imagebuilder

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderImageRecipe_componentParameter -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (32.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       40.026s
```
