### PR TITLE
d/aws_imagebuilder_distribution_configuration - add container_distribution_configuration attribute

### DIFF
--- a/.changelog/22838.txt
+++ b/.changelog/22838.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_imagebuilder_distribution_configuration: Add `container_distribution_configuration` attribute
+data-source/aws_imagebuilder_distribution_configuration: Add `container_distribution_configuration` attribute to the `distribution` configuration block
 ```

--- a/.changelog/22838.txt
+++ b/.changelog/22838.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_imagebuilder_distribution_configuration: Add `container_distribution_configuration` attribute
+```

--- a/internal/service/imagebuilder/distribution_configuration_data_source.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source.go
@@ -88,6 +88,41 @@ func DataSourceDistributionConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"container_distribution_configuration": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"container_tags": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_repository": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"service": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"license_configuration_arns": {
 							Type:     schema.TypeSet,
 							Computed: true,

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -55,12 +55,12 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-	container_distribution_configuration {
-		target_repository {
-			repository_name = "repository-name"
-			service = "ECR"
-		}
-	}
+    container_distribution_configuration {
+      target_repository {
+        repository_name = "repository-name"
+        service         = "ECR"
+      }
+    }
 
     region = data.aws_region.current.name
   }

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -29,6 +29,12 @@ func TestAccImageBuilderDistributionConfigurationDataSource_arn(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "date_updated", resourceName, "date_updated"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.#", resourceName, "distribution.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.#", resourceName, "distribution.0.container_distribution_configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.container_tags.#", resourceName, "distribution.0.container_distribution_configuration.0.container_tags.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.description", resourceName, "distribution.0.container_distribution_configuration.0.description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.#", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),
@@ -48,6 +54,13 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
     ami_distribution_configuration {
       name = "{{ imagebuilder:buildDate }}"
     }
+
+	container_distribution_configuration {
+		target_repository {
+			repository_name = "repository-name"
+			service = "ECR"
+		}
+	}
 
     region = data.aws_region.current.name
   }

--- a/website/docs/d/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/d/imagebuilder_distribution_configuration.html.markdown
@@ -38,6 +38,12 @@ In addition to all arguments above, the following attributes are exported:
             * `user_groups` - Set of EC2 launch permission user groups.
             * `user_ids` - Set of AWS Account identifiers.
         * `target_account_ids` - Set of target AWS Account identifiers.
+    * `container_distribution_configuration` - Nested list of container distribution configurations.
+        * `container_tags` - Set of tags that are attached to the container distribution configuration.
+        * `description` - Description of the container distribution configuration.
+        * `target_repository` - Set of destination repositories for the container distribution configuration.
+            * `repository_name` - Name of the container repository where the output container image is stored.
+            * `service` - Service in which the image is registered.
     * `license_configuration_arns` - Set of Amazon Resource Names (ARNs) of License Manager License Configurations.
     * `region` - AWS Region of distribution.
 * `name` - Name of the distribution configuration.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16839.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderDistributionConfigurationDataSource_arn" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderDistributionConfigurationDataSource_arn -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfigurationDataSource_arn
=== PAUSE TestAccImageBuilderDistributionConfigurationDataSource_arn
=== CONT  TestAccImageBuilderDistributionConfigurationDataSource_arn
--- PASS: TestAccImageBuilderDistributionConfigurationDataSource_arn (29.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       36.750s
```
