### PR TITLE
aws_cloudformation_stack: use retry logic on IAM role error

### DIFF
--- a/.changelog/22840.txt
+++ b/.changelog/22840.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack: Add retry logic to create and update function on IAM Role failure
+```

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -444,27 +444,6 @@ func TestAccCloudFormationStack_onFailure(t *testing.T) {
 	})
 }
 
-func TestAccCloudFormationStack_withIAM(t *testing.T) {
-	var stack cloudformation.Stack
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudformation_stack.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, cloudformation.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccStackConfig_withIAM(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists(resourceName, &stack),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckCloudFormationStackExists(n string, stack *cloudformation.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1020,65 +999,6 @@ resource "aws_s3_bucket" "test" {
 resource "aws_cloudformation_stack" "test" {
   name       = %[1]q
   on_failure = "DO_NOTHING"
-
-  template_body = jsonencode({
-    AWSTemplateFormatVersion = "2010-09-09"
-    Resources = {
-      S3Bucket = {
-        Type = "AWS::S3::Bucket"
-      }
-    }
-  })
-}
-`, rName)
-}
-
-func testAccStackConfig_withIAM(rName string) string {
-	return fmt.Sprintf(`
-data "aws_iam_policy_document" "test" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["cloudformation.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "test" {
-  assume_role_policy = data.aws_iam_policy_document.test.json
-}
-
-resource "aws_iam_policy" "test" {
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["s3:*"]
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = aws_iam_policy.test.arn
-  role       = aws_iam_role.test.name
-}
-
-data "aws_iam_role" "test" {
-  # This is introduced so the aws_cloudformation_stack has a dependency on the role_attachment
-  # instead of the role directly. Without it, the policy may not exist before cloudformation
-  # has a chance to delete it's resources
-  name = aws_iam_role_policy_attachment.test.role
-}
-
-resource "aws_cloudformation_stack" "test" {
-  name = %[1]q
-
-  on_failure   = "DO_NOTHING"
-  iam_role_arn = aws_iam_role.test.arn
 
   template_body = jsonencode({
     AWSTemplateFormatVersion = "2010-09-09"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22834

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-aws git:(master) ✗ make testacc TESTS=TestAccCloudFormationStack_withIAM PKG=cloudformation
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStack_withIAM'  -timeout 180m
=== RUN   TestAccCloudFormationStack_withIAM
=== PAUSE TestAccCloudFormationStack_withIAM
=== CONT  TestAccCloudFormationStack_withIAM
--- PASS: TestAccCloudFormationStack_withIAM (67.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	67.927s
➜  terraform-provider-aws git:(master) ✗
```
