### PR TITLE
r/aws_imagebuilder_distribution_configuration - add support for launch template configurations

### DIFF
--- a/.changelog/22842.txt
+++ b/.changelog/22842.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_distribution_configuration: Add `launch_template_configuration` argument
+```

--- a/.changelog/22842.txt
+++ b/.changelog/22842.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_imagebuilder_distribution_configuration: Add `launch_template_configuration` argument
+resource/aws_imagebuilder_distribution_configuration: Add `launch_template_configuration` argument to the `distribution` configuration block
 ```

--- a/internal/service/imagebuilder/distribution_configuration.go
+++ b/internal/service/imagebuilder/distribution_configuration.go
@@ -152,6 +152,25 @@ func ResourceDistributionConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"launch_template_configuration": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 100,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  true,
+									},
+									"launch_template_id": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: verify.ValidLaunchTemplateID,
+									},
+								},
+							},
+						},
 						"license_configuration_arns": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -380,6 +399,32 @@ func expandContainerDistributionConfiguration(tfMap map[string]interface{}) *ima
 	return apiObject
 }
 
+func expandLaunchTemplateConfigurations(tfList []interface{}) []*imagebuilder.LaunchTemplateConfiguration {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*imagebuilder.LaunchTemplateConfiguration
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandLaunchTemplateConfiguration(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
 func expandDistribution(tfMap map[string]interface{}) *imagebuilder.Distribution {
 	if tfMap == nil {
 		return nil
@@ -393,6 +438,10 @@ func expandDistribution(tfMap map[string]interface{}) *imagebuilder.Distribution
 
 	if v, ok := tfMap["container_distribution_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.ContainerDistributionConfiguration = expandContainerDistributionConfiguration(v[0].(map[string]interface{}))
+	}
+
+	if v, ok := tfMap["launch_template_configuration"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.LaunchTemplateConfigurations = expandLaunchTemplateConfigurations(v.List())
 	}
 
 	if v, ok := tfMap["license_configuration_arns"].(*schema.Set); ok && v.Len() > 0 {
@@ -475,6 +524,24 @@ func expandTargetContainerRepository(tfMap map[string]interface{}) *imagebuilder
 	return apiObject
 }
 
+func expandLaunchTemplateConfiguration(tfMap map[string]interface{}) *imagebuilder.LaunchTemplateConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &imagebuilder.LaunchTemplateConfiguration{}
+
+	if v, ok := tfMap["launch_template_id"].(string); ok && v != "" {
+		apiObject.LaunchTemplateId = aws.String(v)
+	}
+
+	if v, ok := tfMap["default"].(bool); ok {
+		apiObject.SetDefaultVersion = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
 func flattenAMIDistributionConfiguration(apiObject *imagebuilder.AmiDistributionConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
@@ -531,6 +598,24 @@ func flattenContainerDistributionConfiguration(apiObject *imagebuilder.Container
 	return tfMap
 }
 
+func flattenLaunchTemplateConfigurations(apiObjects []*imagebuilder.LaunchTemplateConfiguration) []interface{} {
+	if apiObjects == nil {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenLaunchTemplateConfiguration(apiObject))
+	}
+
+	return tfList
+}
+
 func flattenDistribution(apiObject *imagebuilder.Distribution) map[string]interface{} {
 	if apiObject == nil {
 		return nil
@@ -544,6 +629,10 @@ func flattenDistribution(apiObject *imagebuilder.Distribution) map[string]interf
 
 	if v := apiObject.ContainerDistributionConfiguration; v != nil {
 		tfMap["container_distribution_configuration"] = []interface{}{flattenContainerDistributionConfiguration(v)}
+	}
+
+	if v := apiObject.LaunchTemplateConfigurations; v != nil {
+		tfMap["launch_template_configuration"] = flattenLaunchTemplateConfigurations(v)
 	}
 
 	if v := apiObject.LicenseConfigurationArns; v != nil {
@@ -606,6 +695,24 @@ func flattenTargetContainerRepository(apiObject *imagebuilder.TargetContainerRep
 
 	if v := apiObject.Service; v != nil {
 		tfMap["service"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenLaunchTemplateConfiguration(apiObject *imagebuilder.LaunchTemplateConfiguration) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.LaunchTemplateId; v != nil {
+		tfMap["launch_template_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.SetDefaultVersion; v != nil {
+		tfMap["default"] = aws.BoolValue(v)
 	}
 
 	return tfMap

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -514,6 +514,47 @@ func TestAccImageBuilderDistributionConfiguration_DistributionContainerDistribut
 	})
 }
 
+func TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	launchTemplateResourceName := "aws_launch_template.test"
+	resourceName := "aws_imagebuilder_distribution_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckDistributionConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDDefaultConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.0.default", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "distribution.0.launch_template_configuration.0.launch_template_id", launchTemplateResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDNonDefaultConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionConfigurationExists(resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "distribution.0.launch_template_configuration.0.default", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "distribution.0.launch_template_configuration.0.launch_template_id", launchTemplateResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderDistributionConfiguration_Distribution_licenseARNs(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	licenseConfigurationResourceName := "aws_licensemanager_license_configuration.test"
@@ -923,6 +964,54 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
   }
 }
 `, rName, containerTag)
+}
+
+func testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDDefaultConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_launch_template" "test" {
+  instance_type = "t2.micro"
+  name          = %[1]q
+}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    launch_template_configuration {
+      default            = true
+      launch_template_id = aws_launch_template.test.id
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName)
+}
+
+func testAccDistributionConfigurationDistributionLaunchTemplateConfigurationLaunchTemplateIDNonDefaultConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_launch_template" "test" {
+  instance_type = "t2.micro"
+  name          = %[1]q
+}
+
+resource "aws_imagebuilder_distribution_configuration" "test" {
+  name = %[1]q
+
+  distribution {
+    launch_template_configuration {
+      default            = false
+      launch_template_id = aws_launch_template.test.id
+    }
+
+    region = data.aws_region.current.name
+  }
+}
+`, rName)
 }
 
 func testAccDistributionConfigurationDistributionLicenseConfigurationARNs1Config(rName string) string {

--- a/website/docs/r/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_distribution_configuration.html.markdown
@@ -24,6 +24,10 @@ resource "aws_imagebuilder_distribution_configuration" "example" {
 
       name = "example-{{ imagebuilder:buildDate }}"
 
+      launch_template_configuration {
+        launch_template_id = "lt-0aaa1bcde2ff3456"
+      }
+
       launch_permission {
         user_ids = ["123456789012"]
       }
@@ -57,6 +61,7 @@ The following arguments are optional:
 
 * `ami_distribution_configuration` - (Optional) Configuration block with Amazon Machine Image (AMI) distribution settings. Detailed below.
 * `container_distribution_configuration` - (Optional) Configuration block with container distribution settings. Detailed below.
+* `launch_template_configuration` - (Optional) Set of launch template configuration settings that apply to image distribution. Detailed below.
 * `license_configuration_arns` - (Optional) Set of Amazon Resource Names (ARNs) of License Manager License Configurations.
 
 ### ami_distribution_configuration
@@ -87,6 +92,11 @@ The following arguments are optional:
 
 * `repository_name` - (Required) The name of the container repository where the output container image is stored. This name is prefixed by the repository location.
 * `service` - (Required) The service in which this image is registered. Valid values: `ECR`.
+
+### launch_template_configuration
+
+* `default` - (Optional) Indicates whether to set the specified Amazon EC2 launch template as the default launch template. Defaults to `true`.
+* `launch_template_id` - (Required) The ID of the Amazon EC2 launch template to use.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19046.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== PAUSE TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
=== CONT  TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration
--- PASS: TestAccImageBuilderDistributionConfiguration_Distribution_launchTemplateConfiguration (58.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       66.795s
```
