### PR TITLE
r/s3_bucket_acl: new resource

### DIFF
--- a/.changelog/22853.txt
+++ b/.changelog/22853.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_s3_bucket_acl
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1622,6 +1622,7 @@ func Provider() *schema.Provider {
 
 			"aws_s3_bucket":                                      s3.ResourceBucket(),
 			"aws_s3_bucket_accelerate_configuration":             s3.ResourceBucketAccelerateConfiguration(),
+			"aws_s3_bucket_acl":                                  s3.ResourceBucketAcl(),
 			"aws_s3_bucket_analytics_configuration":              s3.ResourceBucketAnalyticsConfiguration(),
 			"aws_s3_bucket_cors_configuration":                   s3.ResourceBucketCorsConfiguration(),
 			"aws_s3_bucket_intelligent_tiering_configuration":    s3.ResourceBucketIntelligentTieringConfiguration(),

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -1,0 +1,487 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+const (
+	BucketAclSeparator                    = "/"
+	BucketAndExpectedBucketOwnerSeparator = ","
+)
+
+func ResourceBucketAcl() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBucketAclCreate,
+		ReadContext:   resourceBucketAclRead,
+		UpdateContext: resourceBucketAclUpdate,
+		DeleteContext: schema.NoopContext,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"access_control_policy": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"acl"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"grant": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"grantee": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"email_address": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"display_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"type": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringInSlice(s3.Type_Values(), false),
+												},
+												"uri": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"permission": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(s3.Permission_Values(), false),
+									},
+								},
+							},
+						},
+						"owner": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"display_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"acl": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"access_control_policy"},
+				ValidateFunc:  validation.StringInSlice(BucketCannedACL_Values(), false),
+			},
+			"bucket": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 63),
+			},
+			"expected_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+		},
+	}
+}
+
+func resourceBucketAclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket := d.Get("bucket").(string)
+	expectedBucketOwner := d.Get("expected_bucket_owner").(string)
+	acl := d.Get("acl").(string)
+
+	input := &s3.PutBucketAclInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if acl != "" {
+		input.ACL = aws.String(acl)
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	if v, ok := d.GetOk("access_control_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.AccessControlPolicy = expandBucketAclAccessControlPolicy(v.([]interface{}))
+	}
+
+	_, err := verify.RetryOnAWSCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.PutBucketAclWithContext(ctx, input)
+	})
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error creating S3 bucket ACL for %s: %w", bucket, err))
+	}
+
+	d.SetId(BucketACLCreateResourceID(bucket, expectedBucketOwner, acl))
+
+	return resourceBucketAclRead(ctx, d, meta)
+}
+
+func resourceBucketAclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, acl, err := BucketACLParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.GetBucketAclInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	output, err := conn.GetBucketAclWithContext(ctx, input)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchBucket) {
+		log.Printf("[WARN] S3 Bucket ACL (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error getting S3 bucket ACL (%s): %w", d.Id(), err))
+	}
+
+	if output == nil {
+		return diag.FromErr(fmt.Errorf("error getting S3 bucket ACL (%s): empty output", d.Id()))
+	}
+
+	d.Set("acl", acl)
+	d.Set("bucket", bucket)
+	d.Set("expected_bucket_owner", expectedBucketOwner)
+	if err := d.Set("access_control_policy", flattenBucketAclAccessControlPolicy(output)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting access_control_policy: %w", err))
+	}
+
+	return nil
+}
+
+func resourceBucketAclUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).S3Conn
+
+	bucket, expectedBucketOwner, acl, err := BucketACLParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &s3.PutBucketAclInput{
+		Bucket: aws.String(bucket),
+	}
+
+	if expectedBucketOwner != "" {
+		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+	}
+
+	if d.HasChange("access_control_policy") {
+		input.AccessControlPolicy = expandBucketAclAccessControlPolicy(d.Get("access_control_policy").([]interface{}))
+	}
+
+	if d.HasChange("acl") {
+		acl = d.Get("acl").(string)
+		input.ACL = aws.String(acl)
+	}
+
+	_, err = conn.PutBucketAclWithContext(ctx, input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error updating S3 bucket ACL (%s): %w", d.Id(), err))
+	}
+
+	if d.HasChange("acl") {
+		// Set new ACL value back in resource ID
+		d.SetId(BucketACLCreateResourceID(bucket, expectedBucketOwner, acl))
+	}
+
+	return resourceBucketAclRead(ctx, d, meta)
+}
+
+func expandBucketAclAccessControlPolicy(l []interface{}) *s3.AccessControlPolicy {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.AccessControlPolicy{}
+
+	if v, ok := tfMap["grant"].(*schema.Set); ok && v.Len() > 0 {
+		result.Grants = expandBucketAclAccessControlPolicyGrants(v.List())
+	}
+
+	if v, ok := tfMap["owner"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		result.Owner = expandBucketAclAccessControlPolicyOwner(v)
+	}
+
+	return result
+}
+
+func expandBucketAclAccessControlPolicyGrants(l []interface{}) []*s3.Grant {
+	var grants []*s3.Grant
+
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		grant := &s3.Grant{}
+
+		if v, ok := tfMap["grantee"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			grant.Grantee = expandBucketAclAccessControlPolicyGrantsGrantee(v)
+		}
+
+		if v, ok := tfMap["permission"].(string); ok && v != "" {
+			grant.Permission = aws.String(v)
+		}
+
+		grants = append(grants, grant)
+	}
+
+	return grants
+}
+
+func expandBucketAclAccessControlPolicyGrantsGrantee(l []interface{}) *s3.Grantee {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := &s3.Grantee{}
+
+	if v, ok := tfMap["email_address"].(string); ok && v != "" {
+		result.EmailAddress = aws.String(v)
+	}
+
+	if v, ok := tfMap["id"].(string); ok && v != "" {
+		result.ID = aws.String(v)
+	}
+
+	if v, ok := tfMap["type"].(string); ok && v != "" {
+		result.Type = aws.String(v)
+	}
+
+	if v, ok := tfMap["uri"].(string); ok && v != "" {
+		result.URI = aws.String(v)
+	}
+
+	return result
+}
+
+func expandBucketAclAccessControlPolicyOwner(l []interface{}) *s3.Owner {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	owner := &s3.Owner{}
+
+	if v, ok := tfMap["display_name"].(string); ok && v != "" {
+		owner.DisplayName = aws.String(v)
+	}
+
+	if v, ok := tfMap["id"].(string); ok && v != "" {
+		owner.ID = aws.String(v)
+	}
+
+	return owner
+}
+
+func flattenBucketAclAccessControlPolicy(output *s3.GetBucketAclOutput) []interface{} {
+	if output == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if len(output.Grants) > 0 {
+		m["grant"] = flattenBucketAclAccessControlPolicyGrants(output.Grants)
+	}
+
+	if output.Owner != nil {
+		m["owner"] = flattenBucketAclAccessControlPolicyOwner(output.Owner)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenBucketAclAccessControlPolicyGrants(grants []*s3.Grant) []interface{} {
+	var results []interface{}
+
+	for _, grant := range grants {
+		if grant == nil {
+			continue
+		}
+
+		m := make(map[string]interface{})
+
+		if grant.Grantee != nil {
+			m["grantee"] = flattenBucketAclAccessControlPolicyGrantsGrantee(grant.Grantee)
+		}
+
+		if grant.Permission != nil {
+			m["permission"] = aws.StringValue(grant.Permission)
+		}
+
+		results = append(results, m)
+	}
+
+	return results
+}
+
+func flattenBucketAclAccessControlPolicyGrantsGrantee(grantee *s3.Grantee) []interface{} {
+	if grantee == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if grantee.DisplayName != nil {
+		m["display_name"] = aws.StringValue(grantee.DisplayName)
+	}
+
+	if grantee.EmailAddress != nil {
+		m["email_address"] = aws.StringValue(grantee.EmailAddress)
+	}
+
+	if grantee.ID != nil {
+		m["id"] = aws.StringValue(grantee.ID)
+	}
+
+	if grantee.Type != nil {
+		m["type"] = aws.StringValue(grantee.Type)
+	}
+
+	if grantee.URI != nil {
+		m["uri"] = aws.StringValue(grantee.URI)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenBucketAclAccessControlPolicyOwner(owner *s3.Owner) []interface{} {
+	if owner == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if owner.DisplayName != nil {
+		m["display_name"] = aws.StringValue(owner.DisplayName)
+	}
+
+	if owner.ID != nil {
+		m["id"] = aws.StringValue(owner.ID)
+	}
+
+	return []interface{}{m}
+}
+
+// BucketACLCreateResourceID is a method for creating an ID string
+// with the bucket name and optional accountID and/or ACL.
+func BucketACLCreateResourceID(bucket, expectedBucketOwner, acl string) string {
+	if expectedBucketOwner == "" {
+		if acl == "" {
+			return bucket
+		}
+		return strings.Join([]string{bucket, acl}, BucketAclSeparator)
+	}
+
+	if acl == "" {
+		return strings.Join([]string{bucket, expectedBucketOwner}, BucketAndExpectedBucketOwnerSeparator)
+	}
+
+	parts := []string{bucket, expectedBucketOwner}
+	id := strings.Join([]string{strings.Join(parts, BucketAndExpectedBucketOwnerSeparator), acl}, BucketAclSeparator)
+
+	return id
+}
+
+// BucketACLParseResourceID is a method for parsing the ID string
+// for the bucket name, accountID, and ACL if provided.
+func BucketACLParseResourceID(id string) (string, string, string, error) {
+	idParts := strings.Split(id, BucketAndExpectedBucketOwnerSeparator)
+
+	// Bucket name and optional ACL
+	if len(idParts) == 1 && idParts[0] != "" {
+		parts := strings.Split(idParts[0], BucketAclSeparator)
+
+		if len(parts) == 1 { // no ACL in ID
+			return parts[0], "", "", nil
+		} else if len(parts) == 2 && parts[0] != "" && parts[1] != "" { // ACL in ID
+			return parts[0], "", parts[1], nil
+		}
+	}
+
+	// Bucket name, expected bucket owner (i.e. account ID) and optional ACL
+	if len(idParts) == 2 && idParts[0] != "" && idParts[1] != "" {
+		parts := strings.Split(idParts[1], BucketAclSeparator)
+
+		if len(parts) == 1 { // no ACL in ID
+			return idParts[0], parts[0], "", nil
+		} else if len(parts) == 2 && parts[0] != "" && parts[1] != "" { // ACL in ID
+			return idParts[0], parts[0], parts[1], nil
+		}
+	}
+
+	return "", "", "", fmt.Errorf("unexpected format for ID (%s), expected BUCKET or BUCKET%[2]sEXPECTED_BUCKET_OWNER or BUCKET%[3]sACL "+
+		"or BUCKET%[2]sEXPECTED_BUCKET_OWNER%[3]sACL", id, BucketAndExpectedBucketOwnerSeparator, BucketAclSeparator)
+}

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -26,7 +26,7 @@ func ResourceBucketAcl() *schema.Resource {
 		CreateContext: resourceBucketAclCreate,
 		ReadContext:   resourceBucketAclRead,
 		UpdateContext: resourceBucketAclUpdate,
-		DeleteContext: schema.NoopContext,
+		DeleteContext: resourceBucketAclDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -241,6 +241,11 @@ func resourceBucketAclUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	return resourceBucketAclRead(ctx, d, meta)
+}
+
+func resourceBucketAclDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[WARN] Cannot destroy S3 Bucket ACL. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
 }
 
 func expandBucketAclAccessControlPolicy(l []interface{}) *s3.AccessControlPolicy {

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -1,0 +1,477 @@
+package s3_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+func TestBucketACLParseResourceID(t *testing.T) {
+	testCases := []struct {
+		TestName            string
+		InputID             string
+		ExpectError         bool
+		ExpectedACL         string
+		ExpectedBucket      string
+		ExpectedBucketOwner string
+	}{
+		{
+			TestName:    "empty ID",
+			InputID:     "",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect format with comma separators",
+			InputID:     "test,example,123456789012",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect format with slash separators",
+			InputID:     "test/example/123456789012",
+			ExpectError: true,
+		},
+		{
+			TestName:            "valid ID with bucket",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and acl",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "", s3.BucketCannedACLPrivate),
+			ExpectedACL:         s3.BucketCannedACLPrivate,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and bucket owner",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket, bucket owner, and 'private' acl",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPrivate),
+			ExpectedACL:         s3.BucketCannedACLPrivate,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket, bucket owner, and 'public-read' acl",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPublicRead),
+			ExpectedACL:         s3.BucketCannedACLPublicRead,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			gotBucket, gotExpectedBucketOwner, gotAcl, err := tfs3.BucketACLParseResourceID(testCase.InputID)
+
+			if err == nil && testCase.ExpectError {
+				t.Fatalf("expected error")
+			}
+
+			if err != nil && !testCase.ExpectError {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if gotAcl != testCase.ExpectedACL {
+				t.Errorf("got bucket %s, expected %s", gotAcl, testCase.ExpectedACL)
+			}
+
+			if gotBucket != testCase.ExpectedBucket {
+				t.Errorf("got bucket %s, expected %s", gotBucket, testCase.ExpectedBucket)
+			}
+
+			if gotExpectedBucketOwner != testCase.ExpectedBucketOwner {
+				t.Errorf("got ExpectedBucketOwner %s, expected %s", gotExpectedBucketOwner, testCase.ExpectedBucketOwner)
+			}
+		})
+	}
+}
+
+func TestAccS3BucketAcl_basic(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionFullControl,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_disappears(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					// Bucket ACL cannot be destroyed, but we can verify Bucket deletion
+					// will result in a missing Bucket ACL resource
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucket(), "aws_s3_bucket.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_updateACL(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPublicRead),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
+				),
+			},
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl"},
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_updateGrant(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAcl_GrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionFullControl,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionWrite,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketAcl_GrantsUpdateConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeCanonicalUser,
+						"permission":     s3.PermissionRead,
+					}),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
+						"grantee.#":      "1",
+						"grantee.0.type": s3.TypeGroup,
+						"permission":     s3.PermissionReadAcp,
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]*regexp.Regexp{
+						"grantee.0.uri": regexp.MustCompile(`http://acs.*/groups/s3/LogDelivery`),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_ACLToGrant(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+				),
+			},
+			{
+				Config: testAccBucketAcl_GrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccS3BucketAcl_grantToACL(t *testing.T) {
+	bucketName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	resourceName := "aws_s3_bucket_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, s3.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketAcl_GrantsConfig(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
+				),
+			},
+			{
+				Config: testAccBucketAclBasicConfig(bucketName, s3.BucketCannedACLPrivate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketAclExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckBucketAclExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Conn
+
+		bucket, expectedBucketOwner, _, err := tfs3.BucketACLParseResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketAclInput{
+			Bucket: aws.String(bucket),
+		}
+
+		if expectedBucketOwner != "" {
+			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
+		}
+
+		output, err := conn.GetBucketAcl(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.Grants) == 0 || output.Owner == nil {
+			return fmt.Errorf("S3 bucket ACL %s not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccBucketAclBasicConfig(rName, acl string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = %[2]q
+}
+`, rName, acl)
+}
+
+func testAccBucketAcl_GrantsConfig(bucketName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "WRITE"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+`, bucketName)
+}
+
+func testAccBucketAcl_GrantsUpdateConfig(bucketName string) string {
+	return fmt.Sprintf(`
+data "aws_canonical_user_id" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.${data.aws_partition.current.dns_suffix}/groups/s3/LogDelivery"
+      }
+      permission = "READ_ACP"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+`, bucketName)
+}

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -244,10 +244,9 @@ func TestAccS3BucketAcl_updateACL(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"acl"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -30,13 +30,23 @@ func TestBucketACLParseResourceID(t *testing.T) {
 			ExpectError: true,
 		},
 		{
-			TestName:    "incorrect format with comma separators",
-			InputID:     "test,example,123456789012",
+			TestName:    "incorrect bucket and account ID format with slash separator",
+			InputID:     "test/123456789012",
 			ExpectError: true,
 		},
 		{
-			TestName:    "incorrect format with slash separators",
-			InputID:     "test/example/123456789012",
+			TestName:    "incorrect bucket, account ID, and ACL format with slash separators",
+			InputID:     "test/123456789012/private",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect bucket, account ID, and ACL format with mixed separators",
+			InputID:     "test/123456789012,private",
+			ExpectError: true,
+		},
+		{
+			TestName:    "incorrect bucket, ACL, and account ID format",
+			InputID:     "test,private,123456789012",
 			ExpectError: true,
 		},
 		{
@@ -47,10 +57,45 @@ func TestBucketACLParseResourceID(t *testing.T) {
 			ExpectedBucketOwner: "",
 		},
 		{
+			TestName:            "valid ID with bucket that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example-bucket", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example-bucket",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot and hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example.bucket",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has dots, hyphen, and numbers",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example.bucket.4000",
+			ExpectedBucketOwner: "",
+		},
+		{
 			TestName:            "valid ID with bucket and acl",
 			InputID:             tfs3.BucketACLCreateResourceID("example", "", s3.BucketCannedACLPrivate),
 			ExpectedACL:         s3.BucketCannedACLPrivate,
 			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot, hyphen, and number and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "my-example.bucket.4000",
 			ExpectedBucketOwner: "",
 		},
 		{
@@ -61,17 +106,31 @@ func TestBucketACLParseResourceID(t *testing.T) {
 			ExpectedBucketOwner: "123456789012",
 		},
 		{
-			TestName:            "valid ID with bucket, bucket owner, and 'private' acl",
+			TestName:            "valid ID with bucket that has dot, hyphen, and number and bucket owner",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "123456789012", ""),
+			ExpectedACL:         "",
+			ExpectedBucket:      "my-example.bucket.4000",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket, bucket owner, and acl",
 			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPrivate),
 			ExpectedACL:         s3.BucketCannedACLPrivate,
 			ExpectedBucket:      "example",
 			ExpectedBucketOwner: "123456789012",
 		},
 		{
-			TestName:            "valid ID with bucket, bucket owner, and 'public-read' acl",
-			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPublicRead),
-			ExpectedACL:         s3.BucketCannedACLPublicRead,
+			TestName:            "valid ID with bucket, bucket owner, and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("example", "123456789012", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
 			ExpectedBucket:      "example",
+			ExpectedBucketOwner: "123456789012",
+		},
+		{
+			TestName:            "valid ID with bucket that has dot, hyphen, and numbers, bucket owner, and acl that has hyphens",
+			InputID:             tfs3.BucketACLCreateResourceID("my-example.bucket.4000", "123456789012", s3.BucketCannedACLPublicReadWrite),
+			ExpectedACL:         s3.BucketCannedACLPublicReadWrite,
+			ExpectedBucket:      "my-example.bucket.4000",
 			ExpectedBucketOwner: "123456789012",
 		},
 	}
@@ -89,7 +148,7 @@ func TestBucketACLParseResourceID(t *testing.T) {
 			}
 
 			if gotAcl != testCase.ExpectedACL {
-				t.Errorf("got bucket %s, expected %s", gotAcl, testCase.ExpectedACL)
+				t.Errorf("got ACL %s, expected %s", gotAcl, testCase.ExpectedACL)
 			}
 
 			if gotBucket != testCase.ExpectedBucket {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3175,7 +3175,7 @@ resource "aws_s3_bucket" "bucket1" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket1" {
+resource "aws_s3_bucket_acl" "test1" {
   bucket = aws_s3_bucket.bucket1.id
   acl    = "private"
 }
@@ -3196,7 +3196,7 @@ resource "aws_s3_bucket" "bucket2" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket2" {
+resource "aws_s3_bucket_acl" "test2" {
   bucket = aws_s3_bucket.bucket2.id
   acl    = "private"
 }
@@ -3217,7 +3217,7 @@ resource "aws_s3_bucket" "bucket3" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket3" {
+resource "aws_s3_bucket_acl" "test3" {
   bucket = aws_s3_bucket.bucket3.id
   acl    = "private"
 }
@@ -3238,7 +3238,7 @@ resource "aws_s3_bucket" "bucket4" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket4" {
+resource "aws_s3_bucket_acl" "test4" {
   bucket = aws_s3_bucket.bucket4.id
   acl    = "private"
 }
@@ -3259,7 +3259,7 @@ resource "aws_s3_bucket" "bucket5" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket5" {
+resource "aws_s3_bucket_acl" "test5" {
   bucket = aws_s3_bucket.bucket5.id
   acl    = "private"
 }
@@ -3280,7 +3280,7 @@ resource "aws_s3_bucket" "bucket6" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket6" {
+resource "aws_s3_bucket_acl" "test6" {
   bucket = aws_s3_bucket.bucket6.id
   acl    = "private"
 }

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3089,6 +3089,12 @@ func testAccBucketConfig_withNoTags(bucketName string) string {
 resource "aws_s3_bucket" "bucket" {
   bucket        = %[1]q
   force_destroy = false
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3108,6 +3114,12 @@ resource "aws_s3_bucket" "bucket" {
     Key1 = "AAA"
     Key2 = "BBB"
     Key3 = "CCC"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -3130,6 +3142,12 @@ resource "aws_s3_bucket" "bucket" {
     Key4 = "DDD"
     Key5 = "EEE"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3149,9 +3167,15 @@ resource "aws_s3_bucket" "bucket1" {
     Name        = "tf-test-bucket-1-%[1]d"
     Environment = "%[1]d"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_acl" "bucket1" {
   bucket = aws_s3_bucket.bucket1.id
   acl    = "private"
 }
@@ -3164,9 +3188,15 @@ resource "aws_s3_bucket" "bucket2" {
     Name        = "tf-test-bucket-2-%[1]d"
     Environment = "%[1]d"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_acl" "bucket2" {
   bucket = aws_s3_bucket.bucket2.id
   acl    = "private"
 }
@@ -3179,9 +3209,15 @@ resource "aws_s3_bucket" "bucket3" {
     Name        = "tf-test-bucket-3-%[1]d"
     Environment = "%[1]d"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_acl" "bucket3" {
   bucket = aws_s3_bucket.bucket3.id
   acl    = "private"
 }
@@ -3194,9 +3230,15 @@ resource "aws_s3_bucket" "bucket4" {
     Name        = "tf-test-bucket-4-%[1]d"
     Environment = "%[1]d"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_acl" "bucket4" {
   bucket = aws_s3_bucket.bucket4.id
   acl    = "private"
 }
@@ -3209,9 +3251,15 @@ resource "aws_s3_bucket" "bucket5" {
     Name        = "tf-test-bucket-5-%[1]d"
     Environment = "%[1]d"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_acl" "bucket5" {
   bucket = aws_s3_bucket.bucket5.id
   acl    = "private"
 }
@@ -3224,9 +3272,15 @@ resource "aws_s3_bucket" "bucket6" {
     Name        = "tf-test-bucket-6-%[1]d"
     Environment = "%[1]d"
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_acl" "bucket6" {
   bucket = aws_s3_bucket.bucket6.id
   acl    = "private"
 }
@@ -3274,6 +3328,12 @@ func testAccBucketWithPolicyConfig(bucketName, partition string) string {
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
   policy = %[2]s
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3287,6 +3347,12 @@ func testAccBucketDestroyedConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3386,6 +3452,12 @@ func testAccBucketWithEmptyPolicyConfig(bucketName string) string {
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
   policy = ""
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3468,6 +3540,12 @@ func testAccBucketWithLoggingConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "log_bucket" {
@@ -3481,6 +3559,12 @@ resource "aws_s3_bucket" "bucket" {
   logging {
     target_bucket = aws_s3_bucket.log_bucket.id
     target_prefix = "log/"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -3595,6 +3679,12 @@ resource "aws_s3_bucket" "bucket" {
       storage_class = "GLACIER"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3617,6 +3707,12 @@ resource "aws_s3_bucket" "bucket" {
     expiration {
       expired_object_delete_marker = "true"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -3675,6 +3771,12 @@ resource "aws_s3_bucket" "bucket" {
       days          = 0
       storage_class = "GLACIER"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -3757,6 +3859,12 @@ resource "aws_s3_bucket" "bucket" {
   versioning {
     enabled = true
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3788,6 +3896,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "%[2]s"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -3829,6 +3943,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3864,6 +3984,12 @@ resource "aws_s3_bucket" "bucket" {
         }
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -3901,6 +4027,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -3934,6 +4066,12 @@ resource "aws_s3_bucket" "bucket" {
         replication_time {}
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4014,6 +4152,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "ONEZONE_IA"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4107,6 +4251,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4171,6 +4321,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4216,6 +4372,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4255,6 +4417,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4289,6 +4457,12 @@ resource "aws_s3_bucket" "bucket" {
 
   versioning {
     enabled = true
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4342,6 +4516,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4372,6 +4552,12 @@ resource "aws_s3_bucket" "bucket" {
         bucket = aws_s3_bucket.destination.arn
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4404,6 +4590,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4431,6 +4623,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "STANDARD"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4468,6 +4666,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "STANDARD"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4512,6 +4716,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4548,6 +4758,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "STANDARD"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4587,6 +4803,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "STANDARD"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4630,6 +4852,12 @@ resource "aws_s3_bucket" "bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
@@ -4668,6 +4896,12 @@ resource "aws_s3_bucket" "bucket" {
         storage_class = "STANDARD"
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 
@@ -4714,11 +4948,17 @@ func testAccBucketConfig_forceDestroy(bucketName string) string {
 resource "aws_s3_bucket" "bucket" {
   bucket        = "%s"
   force_destroy = true
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_acl" "test" {
   bucket = aws_s3_bucket.bucket.id
-  acl    = "publi-read"
+  acl    = "public-read"
 }
 `, bucketName)
 }
@@ -4735,6 +4975,12 @@ resource "aws_s3_bucket" "bucket" {
 
   object_lock_configuration {
     object_lock_enabled = "Enabled"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      grant,
+    ]
   }
 }
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -19,12 +19,16 @@ Provides a S3 bucket resource.
 ```terraform
 resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
-  acl    = "private"
 
   tags = {
     Name        = "My bucket"
     Environment = "Dev"
   }
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.b.id
+  acl    = "private"
 }
 ```
 
@@ -38,7 +42,6 @@ See the [`aws_s3_bucket_website_configuration` resource](s3_bucket_website_confi
 ```terraform
 resource "aws_s3_bucket" "b" {
   bucket = "s3-website-test.hashicorp.com"
-  acl    = "public-read"
 
   cors_rule {
     allowed_headers = ["*"]
@@ -48,6 +51,11 @@ resource "aws_s3_bucket" "b" {
     max_age_seconds = 3000
   }
 }
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.b.id
+  acl    = "public-read"
+}
 ```
 
 ### Using versioning
@@ -55,11 +63,15 @@ resource "aws_s3_bucket" "b" {
 ```terraform
 resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
-  acl    = "private"
 
   versioning {
     enabled = true
   }
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.b.id
+  acl    = "private"
 }
 ```
 
@@ -68,17 +80,26 @@ resource "aws_s3_bucket" "b" {
 ```terraform
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "my-tf-log-bucket"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
-  acl    = "private"
 
   logging {
-    target_bucket = aws_s3_bucket.log_bucket.id
+    # The log bucket must have its ACL configured first
+    target_bucket = aws_s3_bucket_acl.log_bucket_acl.bucket
     target_prefix = "log/"
   }
+}
+
+resource "aws_s3_bucket_acl" "b_bucket_acl" {
+  bucket = aws_s3_bucket.b.id
+  acl    = "private"
 }
 ```
 
@@ -87,7 +108,6 @@ resource "aws_s3_bucket" "b" {
 ```terraform
 resource "aws_s3_bucket" "bucket" {
   bucket = "my-bucket"
-  acl    = "private"
 
   lifecycle_rule {
     id      = "log"
@@ -126,9 +146,13 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
+}
+
 resource "aws_s3_bucket" "versioning_bucket" {
   bucket = "my-versioning-bucket"
-  acl    = "private"
 
   versioning {
     enabled = true
@@ -152,6 +176,11 @@ resource "aws_s3_bucket" "versioning_bucket" {
       days = 90
     }
   }
+}
+
+resource "aws_s3_bucket_acl" "versioning_bucket_acl" {
+  bucket = aws_s3_bucket.versioning_bucket.id
+  acl    = "private"
 }
 ```
 
@@ -247,7 +276,6 @@ resource "aws_s3_bucket" "destination" {
 resource "aws_s3_bucket" "source" {
   provider = aws.central
   bucket   = "tf-test-bucket-source-12345"
-  acl      = "private"
 
   versioning {
     enabled = true
@@ -279,6 +307,11 @@ resource "aws_s3_bucket" "source" {
       }
     }
   }
+}
+
+resource "aws_s3_bucket_acl" "source_bucket_acl" {
+  bucket = aws_s3_bucket.source.id
+  acl    = "private"
 }
 ```
 

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -1,0 +1,132 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_acl"
+description: |-
+  Provides an S3 bucket ACL resource.
+---
+
+# Resource: aws_s3_bucket_acl
+
+Provides an S3 bucket ACL resource.
+
+## Example Usage
+
+### With ACL
+
+```terraform
+resource "aws_s3_bucket" "example" {
+  bucket = "my-tf-example-bucket"
+}
+
+resource "aws_s3_bucket_acl" "example_bucket_acl" {
+  bucket = aws_s3_bucket.example.id
+  acl    = "private"
+}
+```
+
+### With Grants
+
+```terraform
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "my-tf-example-bucket"
+}
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.example.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "READ"
+    }
+
+    grant {
+      grantee {
+        type = "Group"
+        uri  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+      }
+      permission = "READ_ACP"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `acl` - (Optional, Conflicts with `access_control_policy`) The canned ACL to apply to the bucket.
+* `access_control_policy` - (Optional, Conflicts with `acl`) A configuration block that sets the ACL permissions for an object per grantee [documented below](#access_control_policy).
+* `bucket` - (Required, Forces new resource) The name of the bucket.
+* `expected_bucket_owner` - (Optional, Forces new resource) The account ID of the expected bucket owner.
+
+### access_control_policy
+
+The `access_control_policy` configuration block supports the following arguments:
+
+* `grant` - (Required) Set of `grant` configuration blocks [documented below](#grant).
+* `owner` - (Required) Configuration block of the bucket owner's display name and ID [documented below](#owner).
+
+### grant
+
+The `grant` configuration block supports the following arguments:
+
+* `grantee` - (Required) Configuration block for the person being granted permissions [documented below](#grantee).
+* `permission` - (Required) Logging permissions assigned to the grantee for the bucket.
+
+### owner
+
+The `owner` configuration block supports the following arguments:
+
+* `id` - (Required) The ID of the owner.
+* `display_name` - (Optional) The display name of the owner.
+
+### grantee
+
+The `grantee` configuration block supports the following arguments:
+
+* `email_address` - (Optional) Email address of the grantee. See [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for supported AWS regions where this argument can be specified.
+* `id` - (Optional) The canonical user ID of the grantee.
+* `type` - (Required) Type of grantee. Valid values: `CanonicalUser`, `AmazonCustomerByEmail`, `Group`.
+* `uri` - (Optional) URI of the grantee group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The `bucket` and `expected_bucket_owner` separated by a comma (`,`) if the latter is provided, and the `acl` prefixed with a slash (`/`) if configured.
+
+## Import
+
+S3 bucket ACL can be imported using the `bucket` e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name
+```
+
+S3 bucket ACL can also be imported using the `bucket` and `acl` separated by a slash (`/`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name/private
+```
+
+S3 bucket ACL can also be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name,123456789012
+```
+
+S3 bucket ACL can also be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) and `acl` prefixed with a slash (`/`) e.g.,
+
+```
+$ terraform import aws_s3_bucket_acl.example bucket-name,123456789012/private
+```

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an S3 bucket ACL resource.
 
+~> **Note:** `terraform destroy` does not delete the S3 Bucket ACL but does remove the resource from Terraform state.
+
 ## Example Usage
 
 ### With ACL

--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -105,7 +105,7 @@ The `grantee` configuration block supports the following arguments:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The `bucket` and `expected_bucket_owner` separated by a comma (`,`) if the latter is provided, and the `acl` prefixed with a slash (`/`) if configured.
+* `id` - The `bucket`, `expected_bucket_owner` (if configured), and `acl` (if configured) separated by commas (`,`).
 
 ## Import
 
@@ -115,20 +115,20 @@ S3 bucket ACL can be imported using the `bucket` e.g.,
 $ terraform import aws_s3_bucket_acl.example bucket-name
 ```
 
-S3 bucket ACL can also be imported using the `bucket` and `acl` separated by a slash (`/`) e.g.,
+S3 bucket ACL can also be imported using the `bucket` and `acl` separated by a comma (`,`), e.g.
 
 ```
-$ terraform import aws_s3_bucket_acl.example bucket-name/private
+$ terraform import aws_s3_bucket_acl.example bucket-name,private
 ```
 
-S3 bucket ACL can also be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) e.g.,
+S3 bucket ACL can also be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`), e.g.
 
 ```
 $ terraform import aws_s3_bucket_acl.example bucket-name,123456789012
 ```
 
-S3 bucket ACL can also be imported using the `bucket` and `expected_bucket_owner` separated by a comma (`,`) and `acl` prefixed with a slash (`/`) e.g.,
+S3 bucket ACL can also be imported using the `bucket`, `expected_bucket_owner`, and `acl` separated by commas (`,`), e.g.
 
 ```
-$ terraform import aws_s3_bucket_acl.example bucket-name,123456789012/private
+$ terraform import aws_s3_bucket_acl.example bucket-name,123456789012,private
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4418
Relates #20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestBucketACLParseResourceID (0.00s)
    --- PASS: TestBucketACLParseResourceID/empty_ID (0.00s)
    --- PASS: TestBucketACLParseResourceID/incorrect_format_with_comma_separators (0.00s)
    --- PASS: TestBucketACLParseResourceID/incorrect_format_with_slash_separators (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_and_acl (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket_and_bucket_owner (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket,_bucket_owner,_and_'private'_acl (0.00s)
    --- PASS: TestBucketACLParseResourceID/valid_ID_with_bucket,_bucket_owner,_and_'public-read'_acl (0.00s)

--- PASS: TestAccS3BucketAcl_ACLToGrant (176.79s)
--- PASS: TestAccS3BucketAcl_basic (102.26s)
--- PASS: TestAccS3BucketAcl_disappears (75.54s)
--- PASS: TestAccS3BucketAcl_grantToACL (177.39s)
--- PASS: TestAccS3BucketAcl_updateACL (177.84s)
--- PASS: TestAccS3BucketAcl_updateGrant (188.08s)

--- PASS: TestAccS3Bucket_Basic_acceleration (166.19s)
--- PASS: TestAccS3Bucket_Basic_basic (95.26s)
--- PASS: TestAccS3Bucket_Basic_emptyString (97.84s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (81.47s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (80.88s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (73.21s)
--- PASS: TestAccS3Bucket_Basic_generatedName (95.04s)
--- PASS: TestAccS3Bucket_Basic_keyEnabled (99.97s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (95.36s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (167.22s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (74.23s)
--- PASS: TestAccS3Bucket_Manage_MfaDeleteDisabled (98.79s)
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (216.92s)
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (174.43s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (104.56s)
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (88.45s)
--- PASS: TestAccS3Bucket_Manage_objectLock (119.02s)
--- PASS: TestAccS3Bucket_Manage_versioning (188.42s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMfaDeleteDisabled (100.65s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (96.94s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (211.09s)
--- PASS: TestAccS3Bucket_Replication_basic (279.67s)
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (76.05s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (167.08s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (45.52s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (190.70s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (185.22s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (249.94s)
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (101.76s)
--- PASS: TestAccS3Bucket_Replication_twoDestination (150.03s)
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (131.06s)
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (138.93s)
--- PASS: TestAccS3Bucket_Security_corsDelete (88.02s)
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (102.19s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (172.85s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (173.41s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (100.32s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (99.19s)
--- PASS: TestAccS3Bucket_Security_logging (105.85s)
--- PASS: TestAccS3Bucket_Security_policy (240.21s)
--- PASS: TestAccS3Bucket_Tags_basic (100.57s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (154.12s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (312.28s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (363.75s)
--- PASS: TestAccS3Bucket_Web_redirect (238.31s)
--- PASS: TestAccS3Bucket_Web_routingRules (168.56s)
--- PASS: TestAccS3Bucket_Web_simple (237.33s)
```
