### PR TITLE
d/aws_imagebuilder_image_recipe - add component parameter attribute

### DIFF
--- a/.changelog/22856.txt
+++ b/.changelog/22856.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_imagebuilder_image_recipe: Add `parameter` attribute to the `component` configuration block
+```

--- a/internal/service/imagebuilder/image_recipe_data_source.go
+++ b/internal/service/imagebuilder/image_recipe_data_source.go
@@ -86,6 +86,22 @@ func DataSourceImageRecipe() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"parameter": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/imagebuilder/image_recipe_data_source_test.go
+++ b/internal/service/imagebuilder/image_recipe_data_source_test.go
@@ -27,6 +27,10 @@ func TestAccImageBuilderImageRecipeDataSource_arn(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "block_device_mapping.#", resourceName, "block_device_mapping.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "component.#", resourceName, "component.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "component.0.component_arn", resourceName, "component.0.component_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "component.0.parameter.#", resourceName, "component.0.parameter.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "component.0.parameter.0.name", resourceName, "component.0.parameter.0.name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "component.0.parameter.0.value", resourceName, "component.0.parameter.0.value"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "date_created", resourceName, "date_created"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
@@ -62,6 +66,11 @@ resource "aws_imagebuilder_component" "test" {
         onFailure = "Continue"
       }]
     }]
+    parameters = [{
+      Parameter1 = {
+        type = "string"
+      }
+    }]
     schemaVersion = 1.0
   })
   name     = %[1]q
@@ -72,6 +81,11 @@ resource "aws_imagebuilder_component" "test" {
 resource "aws_imagebuilder_image_recipe" "test" {
   component {
     component_arn = aws_imagebuilder_component.test.arn
+
+    parameter {
+      name  = "Parameter1"
+      value = "Value1"
+    }
   }
 
   name             = %[1]q

--- a/website/docs/d/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/d/imagebuilder_image_recipe.html.markdown
@@ -42,6 +42,9 @@ In addition to all arguments above, the following attributes are exported:
     * `virtual_name` - Virtual device name. For example, `ephemeral0`. Instance store volumes are numbered starting from 0.
 * `component` - List of objects with components for the image recipe.
     * `component_arn` - Amazon Resource Name (ARN) of the Image Builder Component.
+    * `parameter` - Set of parameters that are used to configure the component.
+        * `name` - Name of the component parameter.
+        * `value` - Value of the component parameter.
 * `date_created` - Date the image recipe was created.
 * `description` - Description of the image recipe.
 * `name` - Name of the image recipe.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #20855.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderImageRecipeDataSource_arn" PKG_NAME=internal/service/imagebuilder 50s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderImageRecipeDataSource_arn -timeout 180m
=== RUN   TestAccImageBuilderImageRecipeDataSource_arn
=== PAUSE TestAccImageBuilderImageRecipeDataSource_arn
=== CONT  TestAccImageBuilderImageRecipeDataSource_arn
--- PASS: TestAccImageBuilderImageRecipeDataSource_arn (38.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       45.758s
```
