### PR TITLE
aws_vpc_ipam* docs and modifyIpam fixes

### DIFF
--- a/.changelog/22863.txt
+++ b/.changelog/22863.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_ipam: Correct update of `description`
+```

--- a/internal/service/ec2/vpc_ipam.go
+++ b/internal/service/ec2/vpc_ipam.go
@@ -187,10 +187,11 @@ func resourceVPCIpamUpdate(d *schema.ResourceData, meta interface{}) error {
 		if len(operatingRegionUpdateRemove) != 0 {
 			input.RemoveOperatingRegions = operatingRegionUpdateRemove
 		}
-		_, err := conn.ModifyIpam(input)
-		if err != nil {
-			return fmt.Errorf("Error modifying operating regions to ipam: %w", err)
-		}
+	}
+
+	_, err := conn.ModifyIpam(input)
+	if err != nil {
+		return fmt.Errorf("Error modifying operating regions to ipam: %w", err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_ipam_test.go
+++ b/internal/service/ec2/vpc_ipam_test.go
@@ -49,7 +49,7 @@ func TestAccVPCIpam_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCIpam_modifyRegion(t *testing.T) {
+func TestAccVPCIpam_modify(t *testing.T) {
 	var providers []*schema.Provider
 	resourceName := "aws_vpc_ipam.test"
 
@@ -77,13 +77,19 @@ func TestAccVPCIpam_modifyRegion(t *testing.T) {
 			{
 				Config: testAccVPCIpamOperatingRegion(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "description", "test ipam"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
 				),
 			},
 			{
 				Config: testAccVPCIpamBase,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+				),
+			},
+			{
+				Config: testAccVPCIpamBaseAlternateDescription,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "test ipam"),
 				),
 			},
 		},
@@ -162,6 +168,17 @@ resource "aws_vpc_ipam" "test" {
 }
 `
 
+const testAccVPCIpamBaseAlternateDescription = `
+data "aws_region" "current" {}
+
+resource "aws_vpc_ipam" "test" {
+  description = "test ipam"
+  operating_regions {
+    region_name = data.aws_region.current.name
+  }
+}
+`
+
 func testAccVPCIpamOperatingRegion() string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(2), `
@@ -173,7 +190,7 @@ data "aws_region" "alternate" {
 
 
 resource "aws_vpc_ipam" "test" {
-  description = "test ipam"
+  description = "test"
   operating_regions {
     region_name = data.aws_region.current.name
   }

--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -70,7 +70,7 @@ resource "aws_vpc_ipam_pool_cidr" "child_test" {
 The following arguments are supported:
 
 * `address_family` - (Optional) The IP protocol assigned to this pool. You must choose either IPv4 or IPv6 protocol for a pool.
-* `publicly_advertisable` - (Required) Defines whether or not IPv6 pool space is publicly advertisable over the internet. This option is not available for IPv4 pool space.
+* `publicly_advertisable` - (Optional) Defines whether or not IPv6 pool space is publicly advertisable over the internet. This option is not available for IPv4 pool space.
 * `allocation_default_netmask_length` - (Optional) A default netmask length for allocations added to this pool. If, for example, the CIDR assigned to this pool is 10.0.0.0/8 and you enter 16 here, new allocations will default to 10.0.0.0/16 (unless you provide a different netmask value when you create the new allocation).
 * `allocation_max_netmask_length` - (Optional) The maximum netmask length that will be required for CIDR allocations in this pool.
 * `allocation_min_netmask_length` - (Optional) The minimum netmask length that will be required for CIDR allocations in this pool.

--- a/website/docs/r/vpc_ipam_pool_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr.html.markdown
@@ -57,6 +57,7 @@ resource "aws_vpc_ipam_pool" "ipv6_test_public" {
   locale         = "us-east-1"
   description    = "public ipv6"
   advertisable   = false
+  aws_service    = "ec2"
 }
 
 resource "aws_vpc_ipam_pool_cidr" "ipv6_test_public" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes:
-  #22718
- #22862

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccVPCIpam_" PKG_NAME="./internal/service/ec2" ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ././internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCIpam_ -timeout 180m
=== RUN   TestAccVPCIpam_ByoipIPv6
    vpc_byoip_test.go:21: Environment variable IPAM_BYOIP_IPV6_MESSAGE, IPAM_BYOIP_IPV6_SIGNATURE, or IPAM_BYOIP_IPV6_PROVISIONED_CIDR is not set
--- SKIP: TestAccVPCIpam_ByoipIPv6 (0.00s)
=== RUN   TestAccVPCIpam_basic
=== PAUSE TestAccVPCIpam_basic
=== RUN   TestAccVPCIpam_modify
=== PAUSE TestAccVPCIpam_modify
=== RUN   TestAccVPCIpam_tags
=== PAUSE TestAccVPCIpam_tags
=== CONT  TestAccVPCIpam_basic
=== CONT  TestAccVPCIpam_tags
=== CONT  TestAccVPCIpam_modify
--- PASS: TestAccVPCIpam_basic (37.91s)
--- PASS: TestAccVPCIpam_tags (62.90s)
--- PASS: TestAccVPCIpam_modify (76.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        80.256s
```
