### PR TITLE
provider: Logging fixes

### DIFF
--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -285,7 +285,6 @@ import (
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	awsbasev1 "github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/version"
 )
@@ -1226,7 +1225,7 @@ func (c *Config) Client() (interface{}, error) {
 		AccessKey:               c.AccessKey,
 		CallerDocumentationURL:  "https://registry.terraform.io/providers/hashicorp/aws",
 		CallerName:              "Terraform AWS Provider",
-		DebugLogging:            logging.IsDebugOrHigher(),
+		DebugLogging:            true, // Until https://github.com/hashicorp/aws-sdk-go-base/issues/96 is implemented
 		IamEndpoint:             c.Endpoints[IAM],
 		Insecure:                c.Insecure,
 		HTTPProxy:               c.HTTPProxy,

--- a/main.go
+++ b/main.go
@@ -27,5 +27,8 @@ func main() {
 		return
 	}
 
+	logFlags := log.Flags()
+	logFlags = logFlags &^ (log.Ldate | log.Ltime)
+	log.SetFlags(logFlags)
 	plugin.Serve(opts)
 }


### PR DESCRIPTION
Fixes two logging issues

1. Since the Terraform CLI handles logging levels, providers should emit all logs and let Terraform handle it. Always log AWS API requests and responses.

2. Log entries from the provider had doubled timestamps and severity, with the severity assigned by Terraform always set to `INFO`.

Before:

> 2022-02-01T11:43:22.681-0800 [INFO]  provider.terraform-provider-aws: 2022/02/01 11:43:22 [DEBUG] Reading Caller Identity: timestamp=2022-02-01T11:43:22.681-0800

After:

> 2022-02-01T11:50:30.236-0800 [DEBUG] provider.terraform-provider-aws: Reading Caller Identity: timestamp=2022-02-01T11:50:30.236-0800
