### PR TITLE
r/aws_backup_selection: Prevent continual recreation due to `condition` and `not_resources` diffs

### DIFF
--- a/.changelog/22882.txt
+++ b/.changelog/22882.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_backup_selection: Fix permanent diffs for `condition` and `not_resources` arguments causing resource recreation
+```

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -48,6 +48,7 @@ func ResourceSelection() *schema.Resource {
 			"condition": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -166,6 +167,7 @@ func ResourceSelection() *schema.Resource {
 			"not_resources": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -48,27 +48,23 @@ func ResourceSelection() *schema.Resource {
 			"condition": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"string_equals": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -77,20 +73,17 @@ func ResourceSelection() *schema.Resource {
 						"string_like": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -99,20 +92,17 @@ func ResourceSelection() *schema.Resource {
 						"string_not_equals": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -121,20 +111,17 @@ func ResourceSelection() *schema.Resource {
 						"string_not_like": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
-										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -179,7 +166,6 @@ func ResourceSelection() *schema.Resource {
 			"not_resources": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -48,23 +48,27 @@ func ResourceSelection() *schema.Resource {
 			"condition": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"string_equals": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -73,17 +77,20 @@ func ResourceSelection() *schema.Resource {
 						"string_like": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -92,17 +99,20 @@ func ResourceSelection() *schema.Resource {
 						"string_not_equals": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -111,17 +121,20 @@ func ResourceSelection() *schema.Resource {
 						"string_not_like": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Required: true,
+										Computed: true,
 										ForceNew: true,
 									},
 								},
@@ -166,6 +179,7 @@ func ResourceSelection() *schema.Resource {
 			"not_resources": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/internal/service/backup/selection_test.go
+++ b/internal/service/backup/selection_test.go
@@ -316,11 +316,14 @@ func testAccSelectionImportStateIDFunc(resourceName string) resource.ImportState
 
 func testAccBackupSelectionConfigBase(rName string) string {
 	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 resource "aws_backup_vault" "test" {
   name = %[1]q
@@ -353,7 +356,9 @@ resource "aws_backup_selection" "test" {
     key   = "foo"
     value = "bar"
   }
+  condition {}
 
+  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
@@ -382,6 +387,9 @@ resource "aws_backup_selection" "test" {
     key   = "boo"
     value = "far"
   }
+
+  condition {}
+  not_resources = []
 
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
@@ -428,6 +436,7 @@ resource "aws_backup_selection" "test" {
     }
   }
 
+  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:rds:*:*:cluster:*",
     "arn:${data.aws_partition.current.partition}:rds:*:*:db:*"
@@ -472,6 +481,9 @@ resource "aws_backup_selection" "test" {
     value = "bar"
   }
 
+  condition {}
+  not_resources = []
+
   resources = aws_ebs_volume.test[*].arn
 }
 `, rName))
@@ -492,6 +504,7 @@ resource "aws_backup_selection" "test" {
     key   = "foo"
     value = "bar"
   }
+  condition {}
 
   not_resources = ["arn:${data.aws_partition.current.partition}:fsx:*"]
   resources     = ["*"]
@@ -515,6 +528,8 @@ resource "aws_backup_selection" "test" {
     value = "bar2"
   }
 
+  condition {}
+  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]

--- a/internal/service/backup/selection_test.go
+++ b/internal/service/backup/selection_test.go
@@ -117,7 +117,7 @@ func TestAccBackupSelection_withTags(t *testing.T) {
 	})
 }
 
-func TestAccBackupSelection_ConditionsWithTags(t *testing.T) {
+func TestAccBackupSelection_conditionsWithTags(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	resourceName := "aws_backup_selection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/backup/selection_test.go
+++ b/internal/service/backup/selection_test.go
@@ -316,14 +316,11 @@ func testAccSelectionImportStateIDFunc(resourceName string) resource.ImportState
 
 func testAccBackupSelectionConfigBase(rName string) string {
 	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {
-}
+data "aws_caller_identity" "current" {}
 
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
-data "aws_region" "current" {
-}
+data "aws_region" "current" {}
 
 resource "aws_backup_vault" "test" {
   name = %[1]q
@@ -356,9 +353,7 @@ resource "aws_backup_selection" "test" {
     key   = "foo"
     value = "bar"
   }
-  condition {}
 
-  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
@@ -387,9 +382,6 @@ resource "aws_backup_selection" "test" {
     key   = "boo"
     value = "far"
   }
-
-  condition {}
-  not_resources = []
 
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
@@ -436,7 +428,6 @@ resource "aws_backup_selection" "test" {
     }
   }
 
-  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:rds:*:*:cluster:*",
     "arn:${data.aws_partition.current.partition}:rds:*:*:db:*"
@@ -481,9 +472,6 @@ resource "aws_backup_selection" "test" {
     value = "bar"
   }
 
-  condition {}
-  not_resources = []
-
   resources = aws_ebs_volume.test[*].arn
 }
 `, rName))
@@ -504,7 +492,6 @@ resource "aws_backup_selection" "test" {
     key   = "foo"
     value = "bar"
   }
-  condition {}
 
   not_resources = ["arn:${data.aws_partition.current.partition}:fsx:*"]
   resources     = ["*"]
@@ -528,8 +515,6 @@ resource "aws_backup_selection" "test" {
     value = "bar2"
   }
 
-  condition {}
-  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22595.
Relates #22074.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTARGS='-run=TestAccBackupSelection_' PKG=backup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 20  -run=TestAccBackupSelection_ -timeout 180m
=== RUN   TestAccBackupSelection_basic
=== PAUSE TestAccBackupSelection_basic
=== RUN   TestAccBackupSelection_disappears
=== PAUSE TestAccBackupSelection_disappears
=== RUN   TestAccBackupSelection_Disappears_backupPlan
=== PAUSE TestAccBackupSelection_Disappears_backupPlan
=== RUN   TestAccBackupSelection_withTags
=== PAUSE TestAccBackupSelection_withTags
=== RUN   TestAccBackupSelection_conditionsWithTags
=== PAUSE TestAccBackupSelection_conditionsWithTags
=== RUN   TestAccBackupSelection_withResources
=== PAUSE TestAccBackupSelection_withResources
=== RUN   TestAccBackupSelection_withNotResources
=== PAUSE TestAccBackupSelection_withNotResources
=== RUN   TestAccBackupSelection_updateTag
=== PAUSE TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_basic
=== CONT  TestAccBackupSelection_conditionsWithTags
=== CONT  TestAccBackupSelection_Disappears_backupPlan
=== CONT  TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_withNotResources
=== CONT  TestAccBackupSelection_withResources
=== CONT  TestAccBackupSelection_withTags
=== CONT  TestAccBackupSelection_disappears
--- PASS: TestAccBackupSelection_Disappears_backupPlan (23.43s)
--- PASS: TestAccBackupSelection_disappears (24.05s)
--- PASS: TestAccBackupSelection_withTags (26.95s)
--- PASS: TestAccBackupSelection_withNotResources (27.29s)
--- PASS: TestAccBackupSelection_conditionsWithTags (27.32s)
--- PASS: TestAccBackupSelection_basic (27.33s)
--- PASS: TestAccBackupSelection_withResources (34.06s)
--- PASS: TestAccBackupSelection_updateTag (39.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	42.686s
```

Without the additional `Computed: true,` lines:

```console
% make testacc TESTARGS='-run=TestAccBackupSelection_' PKG=backup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 20  -run=TestAccBackupSelection_ -timeout 180m
=== RUN   TestAccBackupSelection_basic
=== PAUSE TestAccBackupSelection_basic
=== RUN   TestAccBackupSelection_disappears
=== PAUSE TestAccBackupSelection_disappears
=== RUN   TestAccBackupSelection_Disappears_backupPlan
=== PAUSE TestAccBackupSelection_Disappears_backupPlan
=== RUN   TestAccBackupSelection_withTags
=== PAUSE TestAccBackupSelection_withTags
=== RUN   TestAccBackupSelection_conditionsWithTags
=== PAUSE TestAccBackupSelection_conditionsWithTags
=== RUN   TestAccBackupSelection_withResources
=== PAUSE TestAccBackupSelection_withResources
=== RUN   TestAccBackupSelection_withNotResources
=== PAUSE TestAccBackupSelection_withNotResources
=== RUN   TestAccBackupSelection_updateTag
=== PAUSE TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_basic
=== CONT  TestAccBackupSelection_conditionsWithTags
=== CONT  TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_withResources
=== CONT  TestAccBackupSelection_Disappears_backupPlan
=== CONT  TestAccBackupSelection_withTags
=== CONT  TestAccBackupSelection_withNotResources
=== CONT  TestAccBackupSelection_disappears
=== CONT  TestAccBackupSelection_withNotResources
    selection_test.go:185: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_backup_selection.test must be replaced
        -/+ resource "aws_backup_selection" "test" {
              ~ id            = "945ad2e9-d08d-4c78-bacd-0c8bf0d9f557" -> (known after apply)
                name          = "tf-acc-test-5623171520545612140"
                # (4 unchanged attributes hidden)
        
              - condition { # forces replacement
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
=== CONT  TestAccBackupSelection_updateTag
    selection_test.go:213: Step 1/3 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_backup_selection.test must be replaced
        -/+ resource "aws_backup_selection" "test" {
              ~ id            = "e4b4bdcc-457f-4582-9224-7f84c62c3b43" -> (known after apply)
                name          = "tf-acc-test-1384450328350657658"
              - not_resources = [] -> null
                # (3 unchanged attributes hidden)
        
              - condition { # forces replacement
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
=== CONT  TestAccBackupSelection_withTags
    selection_test.go:97: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_backup_selection.test must be replaced
        -/+ resource "aws_backup_selection" "test" {
              ~ id            = "2e2f1734-7c9e-4487-8c3d-b25e7a42f4b8" -> (known after apply)
                name          = "tf-acc-test-3073452506905329527"
              - not_resources = [] -> null
                # (3 unchanged attributes hidden)
        
              - condition { # forces replacement
                }
        
                # (2 unchanged blocks hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
=== CONT  TestAccBackupSelection_basic
    selection_test.go:22: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_backup_selection.test must be replaced
        -/+ resource "aws_backup_selection" "test" {
              ~ id            = "9b7600e5-f6f4-402c-ac02-08015a407d60" -> (known after apply)
                name          = "tf-acc-test-3567899883468099802"
              - not_resources = [] -> null
                # (3 unchanged attributes hidden)
        
              - condition { # forces replacement
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccBackupSelection_withNotResources (22.66s)
--- PASS: TestAccBackupSelection_Disappears_backupPlan (24.72s)
--- PASS: TestAccBackupSelection_disappears (25.16s)
--- FAIL: TestAccBackupSelection_updateTag (25.71s)
--- PASS: TestAccBackupSelection_conditionsWithTags (25.76s)
--- FAIL: TestAccBackupSelection_basic (25.91s)
--- FAIL: TestAccBackupSelection_withTags (26.02s)
=== CONT  TestAccBackupSelection_withResources
    selection_test.go:157: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_backup_selection.test must be replaced
        -/+ resource "aws_backup_selection" "test" {
              ~ id            = "2a31ecbb-d7e8-4140-820c-13e6e88bbac7" -> (known after apply)
                name          = "tf-acc-test-2908317212325495939"
              - not_resources = [] -> null
                # (3 unchanged attributes hidden)
        
              - condition { # forces replacement
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccBackupSelection_withResources (32.65s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/backup	36.080s
FAIL
make: *** [testacc] Error 1
```