### PR TITLE
d/aws_imagebuilder_distribution_configuration - add launch_template_configuration attribute

### DIFF
--- a/.changelog/22884.txt
+++ b/.changelog/22884.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_imagebuilder_distribution_configuration: Add `launch_template_configuration` attribute to the `distribution` configuration block
+```

--- a/internal/service/imagebuilder/distribution_configuration_data_source.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source.go
@@ -123,6 +123,22 @@ func DataSourceDistributionConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"launch_template_configuration": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"launch_template_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"license_configuration_arns": {
 							Type:     schema.TypeSet,
 							Computed: true,

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -51,8 +51,8 @@ func testAccDistributionConfigurationARNDataSourceConfig(rName string) string {
 data "aws_region" "current" {}
 
 resource "aws_launch_template" "test" {
-	instance_type = "t2.micro"
-	name = %[1]q
+  instance_type = "t2.micro"
+  name          = %[1]q
 }
 
 resource "aws_imagebuilder_distribution_configuration" "test" {
@@ -70,10 +70,10 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-	launch_template_configuration {
-		default = false
-		launch_template_id = aws_launch_template.test.id
-	}
+    launch_template_configuration {
+      default            = false
+      launch_template_id = aws_launch_template.test.id
+    }
 
     region = data.aws_region.current.name
   }

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -35,6 +35,9 @@ func TestAccImageBuilderDistributionConfigurationDataSource_arn(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.#", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.repository_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service", resourceName, "distribution.0.container_distribution_configuration.0.target_repository.0.service"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.#", resourceName, "distribution.0.launch_template_configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.default", resourceName, "distribution.0.launch_template_configuration.0.default"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "distribution.0.launch_template_configuration.0.launch_template_id", resourceName, "distribution.0.launch_template_configuration.0.launch_template_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),
@@ -46,6 +49,11 @@ func TestAccImageBuilderDistributionConfigurationDataSource_arn(t *testing.T) {
 func testAccDistributionConfigurationARNDataSourceConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
+
+resource "aws_launch_template" "test" {
+	instance_type = "t2.micro"
+	name = %[1]q
+}
 
 resource "aws_imagebuilder_distribution_configuration" "test" {
   name = %[1]q
@@ -61,6 +69,11 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
         service         = "ECR"
       }
     }
+
+	launch_template_configuration {
+		default = false
+		launch_template_id = aws_launch_template.test.id
+	}
 
     region = data.aws_region.current.name
   }

--- a/website/docs/d/imagebuilder_distribution_configuration.html.markdown
+++ b/website/docs/d/imagebuilder_distribution_configuration.html.markdown
@@ -44,6 +44,9 @@ In addition to all arguments above, the following attributes are exported:
         * `target_repository` - Set of destination repositories for the container distribution configuration.
             * `repository_name` - Name of the container repository where the output container image is stored.
             * `service` - Service in which the image is registered.
+    * `launch_template_configuration` - Nested list of launch template configurations.
+        * `default` - Indicates whether the specified Amazon EC2 launch template is set as the default launch template.
+        * `launch_template_id` - ID of the Amazon EC2 launch template.
     * `license_configuration_arns` - Set of Amazon Resource Names (ARNs) of License Manager License Configurations.
     * `region` - AWS Region of distribution.
 * `name` - Name of the distribution configuration.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #19046.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccImageBuilderDistributionConfigurationDataSource_arn" PKG_NAME=internal/service/imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderDistributionConfigurationDataSource_arn -timeout 180m
=== RUN   TestAccImageBuilderDistributionConfigurationDataSource_arn
=== PAUSE TestAccImageBuilderDistributionConfigurationDataSource_arn
=== CONT  TestAccImageBuilderDistributionConfigurationDataSource_arn
--- PASS: TestAccImageBuilderDistributionConfigurationDataSource_arn (36.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       44.340s
```
