### PR TITLE
r/aws_ec2_client_vpn_endpoint & r/aws_ec2_client_vpn_network_association: Deprecate `status` attribute

### DIFF
--- a/.changelog/22887.txt
+++ b/.changelog/22887.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/aws_ec2_client_vpn_endpoint: The `status` attribute has been deprecated
+```
+
+```release-note:note
+resource/aws_ec2_client_vpn_network_association: The `status` attribute has been deprecated
+```

--- a/internal/service/ec2/client_vpn_endpoint.go
+++ b/internal/service/ec2/client_vpn_endpoint.go
@@ -178,8 +178,9 @@ func ResourceClientVPNEndpoint() *schema.Resource {
 				Default:  false,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: `This attribute has been deprecated.`,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/ec2/client_vpn_network_association.go
+++ b/internal/service/ec2/client_vpn_network_association.go
@@ -50,8 +50,9 @@ func ResourceClientVPNNetworkAssociation() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: `This attribute has been deprecated.`,
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -86,7 +86,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the Client VPN endpoint.
 * `dns_name` - The DNS name to be used by clients when establishing their VPN session.
 * `id` - The ID of the Client VPN endpoint.
-* `status` - The current state of the Client VPN endpoint.
+* `status` - **Deprecated** The current state of the Client VPN endpoint.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://www.terraform.io/docs/providers/aws/index.html#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The unique ID of the target network association.
 * `association_id` - The unique ID of the target network association.
 * `security_groups` - The IDs of the security groups applied to the target network association.
-* `status` - The current state of the target network association.
+* `status` - **Deprecated** The current state of the target network association.
 * `vpc_id` - The ID of the VPC in which the target subnet is located.
 
 ## Timeouts


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13904.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
