### PR TITLE
r/aws_ec2_client_vpn_endpoint: Change `dns_servers` argument from `TypeSet` to `TypeList`

### DIFF
--- a/internal/service/ec2/client_vpn_endpoint.go
+++ b/internal/service/ec2/client_vpn_endpoint.go
@@ -151,7 +151,7 @@ func ResourceClientVPNEndpoint() *schema.Resource {
 				Computed: true,
 			},
 			"dns_servers": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -237,8 +237,8 @@ func resourceClientVPNEndpointCreate(d *schema.ResourceData, meta interface{}) e
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("dns_servers"); ok {
-		input.DnsServers = flex.ExpandStringSet(v.(*schema.Set))
+	if v, ok := d.GetOk("dns_servers"); ok && len(v.([]interface{})) > 0 {
+		input.DnsServers = flex.ExpandStringList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("self_service_portal"); ok {
@@ -374,14 +374,14 @@ func resourceClientVPNEndpointUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if d.HasChange("dns_servers") {
-			dnsServers := d.Get("dns_servers").(*schema.Set)
-			enabled := dnsServers.Len() > 0
+			dnsServers := d.Get("dns_servers").([]interface{})
+			enabled := len(dnsServers) > 0
 
 			input.DnsServers = &ec2.DnsServersOptionsModifyStructure{
 				Enabled: aws.Bool(enabled),
 			}
 			if enabled {
-				input.DnsServers.CustomDnsServers = flex.ExpandStringSet(dnsServers)
+				input.DnsServers.CustomDnsServers = flex.ExpandStringList(dnsServers)
 			}
 		}
 

--- a/internal/service/ec2/client_vpn_endpoint_test.go
+++ b/internal/service/ec2/client_vpn_endpoint_test.go
@@ -505,8 +505,8 @@ func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "dns_servers.*", "8.8.8.8"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "dns_servers.*", "8.8.4.4"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "8.8.4.4"),
 				),
 			},
 			{
@@ -519,7 +519,7 @@ func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "dns_servers.*", "4.4.4.4"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "4.4.4.4"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #20690.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTARGS='-run=TestAccEC2ClientVPNEndpoint_serial/Endpoint -short' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2ClientVPNEndpoint_serial/Endpoint -short -timeout 180m
=== RUN   TestAccEC2ClientVPNEndpoint_serial
=== PAUSE TestAccEC2ClientVPNEndpoint_serial
=== CONT  TestAccEC2ClientVPNEndpoint_serial
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientConnect
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientConnect
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
    client_vpn_endpoint_test.go:250: skipping long-running test in short mode
2022/02/01 16:56:02 [WARN] Notifying semaphore without Wait
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuth
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuth
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_msADAuth
    client_vpn_endpoint_test.go:214: skipping long-running test in short mode
2022/02/01 16:56:03 [WARN] Notifying semaphore without Wait
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_tags
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_tags
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_basicDataSource
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_basicDataSource
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_basic
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_basic
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_withDNSServers
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_withDNSServers
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_disappears
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_disappears
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== RUN   TestAccEC2ClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientConnect
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_tags
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_basic
=== CONT  TestAccEC2ClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_disappears
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_withDNSServers
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuth
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_basicDataSource
--- PASS: TestAccEC2ClientVPNEndpoint_serial (3.72s)
    --- SKIP: TestAccEC2ClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth (0.00s)
    --- SKIP: TestAccEC2ClientVPNEndpoint_serial/Endpoint_msADAuth (0.00s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_basic (29.73s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate (37.05s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_tags (50.90s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientLoginBanner (52.45s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_disappears (66.68s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/AuthorizationRule_disappearsEndpoint (84.39s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup (84.78s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_withDNSServers (99.33s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_selfServicePortal (100.79s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService (104.11s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_basicDataSource (104.54s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_withClientConnect (113.54s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_federatedAuth (116.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        124.032s
```
