### PR TITLE
r/aws_ec2_client_vpn_endpoint: `connection_log_options.cloudwatch_log_stream` is Computed

### DIFF
--- a/.changelog/22891.txt
+++ b/.changelog/22891.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_client_vpn_endpoint: `connection_log_options.cloudwatch_log_stream` argument is Computed, preventing spurious resource diffs
+```

--- a/internal/service/ec2/client_vpn_endpoint.go
+++ b/internal/service/ec2/client_vpn_endpoint.go
@@ -134,6 +134,7 @@ func ResourceClientVPNEndpoint() *schema.Resource {
 						"cloudwatch_log_stream": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"enabled": {
 							Type:     schema.TypeBool,

--- a/internal/service/ec2/client_vpn_endpoint_test.go
+++ b/internal/service/ec2/client_vpn_endpoint_test.go
@@ -867,7 +867,7 @@ resource "aws_cloudwatch_log_stream" "test2" {
 
 locals {
   log_stream_index = %[2]d
-  log_stream       = local.log_stream_index == 0 ? null : ( local.log_stream_index == 1 ? aws_cloudwatch_log_stream.test1.name : aws_cloudwatch_log_stream.test2.name)
+  log_stream       = local.log_stream_index == 0 ? null : (local.log_stream_index == 1 ? aws_cloudwatch_log_stream.test1.name : aws_cloudwatch_log_stream.test2.name)
 }
 
 resource "aws_ec2_client_vpn_endpoint" "test" {

--- a/internal/service/ec2/client_vpn_endpoint_test.go
+++ b/internal/service/ec2/client_vpn_endpoint_test.go
@@ -451,6 +451,16 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 		CheckDestroy: testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccEc2ClientVpnEndpointConfigWithConnectionLogOptions(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClientVPNEndpointExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_log_options.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "connection_log_options.0.cloudwatch_log_group", logGroupResourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_log_options.0.cloudwatch_log_stream"),
+					resource.TestCheckResourceAttr(resourceName, "connection_log_options.0.enabled", "true"),
+				),
+			},
+			{
 				Config: testAccEc2ClientVpnEndpointConfigWithConnectionLogOptions(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
@@ -856,7 +866,8 @@ resource "aws_cloudwatch_log_stream" "test2" {
 }
 
 locals {
-  index = %[2]d
+  log_stream_index = %[2]d
+  log_stream       = local.log_stream_index == 0 ? null : ( local.log_stream_index == 1 ? aws_cloudwatch_log_stream.test1.name : aws_cloudwatch_log_stream.test2.name)
 }
 
 resource "aws_ec2_client_vpn_endpoint" "test" {
@@ -871,7 +882,7 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
   connection_log_options {
     enabled               = true
     cloudwatch_log_group  = aws_cloudwatch_log_group.test.name
-    cloudwatch_log_stream = local.index == 1 ? aws_cloudwatch_log_stream.test1.name : aws_cloudwatch_log_stream.test2.name
+    cloudwatch_log_stream = local.log_stream
   }
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22231.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTARGS='-run=TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup -timeout 180m
=== RUN   TestAccEC2ClientVPNEndpoint_serial
=== PAUSE TestAccEC2ClientVPNEndpoint_serial
=== CONT  TestAccEC2ClientVPNEndpoint_serial
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
--- PASS: TestAccEC2ClientVPNEndpoint_serial (0.74s)
    --- PASS: TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup (62.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        66.573s
```

Without the additional `Computed: true,` line:

```console
% make testacc TESTARGS='-run=TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup -timeout 180m
=== RUN   TestAccEC2ClientVPNEndpoint_serial
=== PAUSE TestAccEC2ClientVPNEndpoint_serial
=== CONT  TestAccEC2ClientVPNEndpoint_serial
=== RUN   TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== PAUSE TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
=== CONT  TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup
    client_vpn_endpoint_test.go:447: Step 1/6 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_ec2_client_vpn_endpoint.test will be updated in-place
          ~ resource "aws_ec2_client_vpn_endpoint" "test" {
                id                     = "cvpn-endpoint-0856bbd7f709618c9"
                tags                   = {
                    "Name" = "tf-acc-test-1806600246361132977"
                }
                # (11 unchanged attributes hidden)
        
        
        
        
              ~ connection_log_options {
                  - cloudwatch_log_stream = "cvpn-endpoint-0856bbd7f709618c9-us-west-2-2022/02/01-MhQrnneLFv7R" -> null
                    # (2 unchanged attributes hidden)
                }
                # (3 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccEC2ClientVPNEndpoint_serial (0.56s)
    --- FAIL: TestAccEC2ClientVPNEndpoint_serial/Endpoint_withLogGroup (18.18s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        21.633s
FAIL
make: *** [testacc] Error 1
```