### PR TITLE
Reduce minimum file system throughput for aws_fsx_ontap_file_system

### DIFF
--- a/.changelog/22898.txt
+++ b/.changelog/22898.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_ontap_file_system: Reduce the minimum valid value of the `throughput_capacity` argument to `128` (128 MB/s)
+```

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -207,7 +207,7 @@ func ResourceOntapFileSystem() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{512, 1024, 2048}),
+				ValidateFunc: validation.IntInSlice([]int{128, 512, 1024, 2048}),
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -48,7 +48,7 @@ func TestAccFSxOntapFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_ip_address_range"),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_vpc.test", "default_route_table_id"),
-					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "512"),
+					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "128"),
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_subnet_id", "aws_subnet.test1", "id"),
 					resource.TestCheckResourceAttr(resourceName, "endpoints.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "endpoints.0.intercluster.#", "1"),
@@ -549,7 +549,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 }
 `)
@@ -561,7 +561,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
   fsx_admin_password  = %[2]q
 
@@ -578,7 +578,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity          = 1024
   subnet_ids                = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type           = "MULTI_AZ_1"
-  throughput_capacity       = 512
+  throughput_capacity       = 128
   preferred_subnet_id       = aws_subnet.test1.id
   endpoint_ip_address_range = "198.19.255.0/24"
 
@@ -595,7 +595,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 
   disk_iops_configuration {
@@ -637,7 +637,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
   route_table_ids     = [aws_route_table.test.id]
 
@@ -678,7 +678,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 
   tags = {
@@ -741,7 +741,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 
   tags = {
@@ -757,7 +757,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 
   tags = {
@@ -773,7 +773,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
 
   tags = {
@@ -790,7 +790,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity              = 1024
   subnet_ids                    = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type               = "MULTI_AZ_1"
-  throughput_capacity           = 512
+  throughput_capacity           = 128
   preferred_subnet_id           = aws_subnet.test1.id
   weekly_maintenance_start_time = %[2]q
 
@@ -807,7 +807,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity                  = 1024
   subnet_ids                        = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type                   = "MULTI_AZ_1"
-  throughput_capacity               = 512
+  throughput_capacity               = 128
   preferred_subnet_id               = aws_subnet.test1.id
   daily_automatic_backup_start_time = %[2]q
   automatic_backup_retention_days   = 1
@@ -825,7 +825,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity                = 1024
   subnet_ids                      = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type                 = "MULTI_AZ_1"
-  throughput_capacity             = 512
+  throughput_capacity             = 128
   preferred_subnet_id             = aws_subnet.test1.id
   automatic_backup_retention_days = %[2]d
 
@@ -847,7 +847,7 @@ resource "aws_fsx_ontap_file_system" "test" {
   storage_capacity    = 1024
   subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
   deployment_type     = "MULTI_AZ_1"
-  throughput_capacity = 512
+  throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
   kms_key_id          = aws_kms_key.test.arn
 

--- a/website/docs/r/fsx_ontap_file_system.html.markdown
+++ b/website/docs/r/fsx_ontap_file_system.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `fsx_admin_password` - (Optional) The ONTAP administrative password for the fsxadmin user that you can use to administer your file system using the ONTAP CLI and REST API.
 * `route_table_ids` - (Optional) Specifies the VPC route tables in which your file system's endpoints will be created. You should specify all VPC route tables associated with the subnets in which your clients are located. By default, Amazon FSx selects your VPC's default route table.
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `throughput_capacity` - (Required) Sets the throughput capacity (in MBps) for the file system that you're creating. Valid values are `128`, `256`, `512`, `1024`, and `2048`.
 
 ### Disk Iops Configuration
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/22896

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccFSxOntapFileSystem PKG=fsx      

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxOntapFileSystem'  -timeout 180m
=== RUN   TestAccFSxOntapFileSystem_basic
=== PAUSE TestAccFSxOntapFileSystem_basic
=== RUN   TestAccFSxOntapFileSystem_fsxAdminPassword
=== PAUSE TestAccFSxOntapFileSystem_fsxAdminPassword
=== RUN   TestAccFSxOntapFileSystem_endpointIPAddressRange
=== PAUSE TestAccFSxOntapFileSystem_endpointIPAddressRange
=== RUN   TestAccFSxOntapFileSystem_diskIops
=== PAUSE TestAccFSxOntapFileSystem_diskIops
=== RUN   TestAccFSxOntapFileSystem_disappears
=== PAUSE TestAccFSxOntapFileSystem_disappears
=== RUN   TestAccFSxOntapFileSystem_securityGroupIDs
=== PAUSE TestAccFSxOntapFileSystem_securityGroupIDs
=== RUN   TestAccFSxOntapFileSystem_routeTableIDs
=== PAUSE TestAccFSxOntapFileSystem_routeTableIDs
=== RUN   TestAccFSxOntapFileSystem_tags
=== PAUSE TestAccFSxOntapFileSystem_tags
=== RUN   TestAccFSxOntapFileSystem_weeklyMaintenanceStartTime
=== PAUSE TestAccFSxOntapFileSystem_weeklyMaintenanceStartTime
=== RUN   TestAccFSxOntapFileSystem_automaticBackupRetentionDays
=== PAUSE TestAccFSxOntapFileSystem_automaticBackupRetentionDays
=== RUN   TestAccFSxOntapFileSystem_kmsKeyID
=== PAUSE TestAccFSxOntapFileSystem_kmsKeyID
=== RUN   TestAccFSxOntapFileSystem_dailyAutomaticBackupStartTime
=== PAUSE TestAccFSxOntapFileSystem_dailyAutomaticBackupStartTime
=== CONT  TestAccFSxOntapFileSystem_basic
=== CONT  TestAccFSxOntapFileSystem_routeTableIDs
=== CONT  TestAccFSxOntapFileSystem_fsxAdminPassword
=== CONT  TestAccFSxOntapFileSystem_automaticBackupRetentionDays
=== CONT  TestAccFSxOntapFileSystem_dailyAutomaticBackupStartTime
=== CONT  TestAccFSxOntapFileSystem_kmsKeyID
=== CONT  TestAccFSxOntapFileSystem_diskIops
=== CONT  TestAccFSxOntapFileSystem_securityGroupIDs
=== CONT  TestAccFSxOntapFileSystem_disappears
=== CONT  TestAccFSxOntapFileSystem_endpointIPAddressRange
=== CONT  TestAccFSxOntapFileSystem_tags
=== CONT  TestAccFSxOntapFileSystem_weeklyMaintenanceStartTime
=== CONT  TestAccFSxOntapFileSystem_kmsKeyID
    ontap_file_system_test.go:389: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating EC2 VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
                status code: 400, request id: 95c011e1-1a38-4a04-8464-48bdc1a762ab
        
          with aws_vpc.test,
          on terraform_plugin_test.tf line 13, in resource "aws_vpc" "test":
          13: resource "aws_vpc" "test" {
        
--- FAIL: TestAccFSxOntapFileSystem_kmsKeyID (14.09s)
--- PASS: TestAccFSxOntapFileSystem_dailyAutomaticBackupStartTime (1963.30s)
--- PASS: TestAccFSxOntapFileSystem_basic (2044.43s)
--- PASS: TestAccFSxOntapFileSystem_disappears (2071.60s)
--- PASS: TestAccFSxOntapFileSystem_endpointIPAddressRange (2126.82s)
--- PASS: TestAccFSxOntapFileSystem_diskIops (2126.83s)
--- PASS: TestAccFSxOntapFileSystem_routeTableIDs (2148.23s)
--- PASS: TestAccFSxOntapFileSystem_weeklyMaintenanceStartTime (2170.81s)
--- PASS: TestAccFSxOntapFileSystem_tags (2276.13s)
--- PASS: TestAccFSxOntapFileSystem_fsxAdminPassword (2353.00s)
--- PASS: TestAccFSxOntapFileSystem_automaticBackupRetentionDays (2356.43s)
--- PASS: TestAccFSxOntapFileSystem_securityGroupIDs (4040.22s)

Rerun of KMS test (failed because of max number of VPCs was reached in my region/account):
$ make testacc TESTS=TestAccFSxOntapFileSystem_kmsKeyID PKG=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxOntapFileSystem_kmsKeyID'  -timeout 180m
=== RUN   TestAccFSxOntapFileSystem_kmsKeyID
=== PAUSE TestAccFSxOntapFileSystem_kmsKeyID
=== CONT  TestAccFSxOntapFileSystem_kmsKeyID
--- PASS: TestAccFSxOntapFileSystem_kmsKeyID (2409.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        2413.142s
```

Example usage:
```
resource "aws_fsx_ontap_file_system" "test" {
  storage_capacity    = 1024
  subnet_ids          = [aws_subnet.test1.id, aws_subnet.test2.id]
  deployment_type     = "MULTI_AZ_1"
  throughput_capacity = 128
  preferred_subnet_id = aws_subnet.test1.id
}
```