### PR TITLE
d/aws_vpc_ipam_pool: Align id and ipam_pool_id attributes

### DIFF
--- a/.changelog/22901.txt
+++ b/.changelog/22901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+datasource/aws_vpc_ipam_pool: `aws_vpc_ipam_pool.id` attribute is computed, preventing errors in plan operations
+```

--- a/internal/service/ec2/vpc_ipam_pool_data_source.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source.go
@@ -17,11 +17,15 @@ func DataSourceVPCIpamPool() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"filter": DataSourceFiltersSchema(),
-			"ipam_pool_id": {
+			"id": {
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
-			// computed
+			"ipam_pool_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -56,10 +60,6 @@ func DataSourceVPCIpamPool() *schema.Resource {
 				Computed: true,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -98,9 +98,8 @@ func dataSourceVPCIpamPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	input := &ec2.DescribeIpamPoolsInput{}
 
-	if v, ok := d.GetOk("ipam_pool_id"); ok {
+	if v, ok := d.GetOk("id"); ok {
 		input.IpamPoolIds = aws.StringSlice([]string{v.(string)})
-
 	}
 
 	filters, filtersOk := d.GetOk("filter")
@@ -142,6 +141,7 @@ func dataSourceVPCIpamPoolRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("locale", pool.Locale)
 	d.Set("pool_depth", pool.PoolDepth)
 	d.Set("publicly_advertisable", pool.PubliclyAdvertisable)
+	d.Set("ipam_pool_id", pool.IpamPoolId)
 	d.Set("source_ipam_pool_id", pool.SourceIpamPoolId)
 	d.Set("state", pool.State)
 

--- a/internal/service/ec2/vpc_ipam_pool_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceVPCIpamPool_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "locale", resourceName, "locale"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "pool_depth", resourceName, "pool_depth"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "publicly_advertisable", resourceName, "publicly_advertisable"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipam_pool_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "source_ipam_pool_id", resourceName, "source_ipam_pool_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "state", resourceName, "state"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
@@ -58,6 +59,6 @@ resource "aws_vpc_ipam_pool" "test" {
 }
 
 data "aws_vpc_ipam_pool" "test" {
-  ipam_pool_id = aws_vpc_ipam_pool.test.id
+  id = aws_vpc_ipam_pool.test.id
 }
 `)

--- a/website/docs/d/vpc_ipam_pool.html.markdown
+++ b/website/docs/d/vpc_ipam_pool.html.markdown
@@ -32,21 +32,29 @@ resource "aws_vpc" "test" {
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available
-VPCs in the current region. The given filters must match exactly one
-VPC whose data will be exported as attributes.
+IPAM pools in the current region. The given filters must match exactly one
+IPAM pool whose data will be exported as attributes.
 
-* `id` -
-* `filter` - Custom filter block as described below.
+* `id` - (Optional) The ID of the specific IPAM pool to retrieve.
+* `filter` - (Optional) Custom filter block as described below.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeIpamPools.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  An IPAM pool will be selected if any one of the given values matches.
 
 ## Attributes Reference
 
 All of the argument attributes except `filter` blocks are also exported as
 result attributes. This data source will complete the data by populating
 any fields that are not included in the configuration with the data for
-the selected VPC.
+the selected IPAM pool.
 
 The following attribute is additionally exported:
-
 
 * `address_family` - The IP protocol assigned to this pool.
 * `publicly_advertisable` - Defines whether or not IPv6 pool space is publicly ∂advertisable over the internet.
@@ -60,5 +68,6 @@ The following attribute is additionally exported:
 * `description` - A description for the IPAM pool.
 * `ipam_scope_id` - The ID of the scope the pool belongs to.
 * `locale` - Locale is the Region where your pool is available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region.
+* `ipam_pool_id` - The ID of the IPAM pool.
 * `source_ipam_pool_id` - The ID of the source IPAM pool.
 * `tags` - A map of tags to assigned to the resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description

- Replace `ipam_pool_id` with `id` for resource querying — seems to be the _standard_ way to do across provider's datasources
- `id` attribute is now flagged as _computed_, which would have caused errors when trying to reference it
```sh
│ Error: Missing required argument
│ 
│   with aws_vpc_ipam_pool_cidr_allocation.example,
│   on main.tf line 186, in resource "aws_vpc_ipam_pool_cidr_allocation" "example":
│  186:   ipam_pool_id   = data.aws_vpc_ipam_pool.workloads.id
│ 
│ The argument "ipam_pool_id" is required, but no definition was found.
``` 
- Fix typos in existing documentation

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDataSourceVPCIpamPool_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccDataSourceVPCIpamPool_basic'  -timeout 180m
=== RUN   TestAccDataSourceVPCIpamPool_basic
=== PAUSE TestAccDataSourceVPCIpamPool_basic
=== CONT  TestAccDataSourceVPCIpamPool_basic
--- PASS: TestAccDataSourceVPCIpamPool_basic (39.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	41.816s
```
