### PR TITLE
release/3.x: Backport of #22882 (r/aws_backup_selection continual diffs)

### DIFF
--- a/.changelog/22882.txt
+++ b/.changelog/22882.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_backup_selection: Fix permanent diffs for `condition` and `not_resources` arguments causing resource recreation
+```

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -48,6 +48,7 @@ func ResourceSelection() *schema.Resource {
 			"condition": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -166,6 +167,7 @@ func ResourceSelection() *schema.Resource {
 			"not_resources": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/internal/service/backup/selection_test.go
+++ b/internal/service/backup/selection_test.go
@@ -117,7 +117,7 @@ func TestAccBackupSelection_withTags(t *testing.T) {
 	})
 }
 
-func TestAccBackupSelection_ConditionsWithTags(t *testing.T) {
+func TestAccBackupSelection_conditionsWithTags(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	resourceName := "aws_backup_selection.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/backup/selection_test.go
+++ b/internal/service/backup/selection_test.go
@@ -316,14 +316,11 @@ func testAccSelectionImportStateIDFunc(resourceName string) resource.ImportState
 
 func testAccBackupSelectionConfigBase(rName string) string {
 	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {
-}
+data "aws_caller_identity" "current" {}
 
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
-data "aws_region" "current" {
-}
+data "aws_region" "current" {}
 
 resource "aws_backup_vault" "test" {
   name = %[1]q
@@ -356,9 +353,7 @@ resource "aws_backup_selection" "test" {
     key   = "foo"
     value = "bar"
   }
-  condition {}
 
-  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
@@ -387,9 +382,6 @@ resource "aws_backup_selection" "test" {
     key   = "boo"
     value = "far"
   }
-
-  condition {}
-  not_resources = []
 
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
@@ -436,7 +428,6 @@ resource "aws_backup_selection" "test" {
     }
   }
 
-  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:rds:*:*:cluster:*",
     "arn:${data.aws_partition.current.partition}:rds:*:*:db:*"
@@ -481,9 +472,6 @@ resource "aws_backup_selection" "test" {
     value = "bar"
   }
 
-  condition {}
-  not_resources = []
-
   resources = aws_ebs_volume.test[*].arn
 }
 `, rName))
@@ -504,7 +492,6 @@ resource "aws_backup_selection" "test" {
     key   = "foo"
     value = "bar"
   }
-  condition {}
 
   not_resources = ["arn:${data.aws_partition.current.partition}:fsx:*"]
   resources     = ["*"]
@@ -528,8 +515,6 @@ resource "aws_backup_selection" "test" {
     value = "bar2"
   }
 
-  condition {}
-  not_resources = []
   resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #22882.
Relates #22595.

### Acceptance Tests

```console
% make testacc TESTARGS='-run=TestAccBackupSelection_' PKG=backup
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 20  -run=TestAccBackupSelection_ -timeout 180m
=== RUN   TestAccBackupSelection_basic
=== PAUSE TestAccBackupSelection_basic
=== RUN   TestAccBackupSelection_disappears
=== PAUSE TestAccBackupSelection_disappears
=== RUN   TestAccBackupSelection_Disappears_backupPlan
=== PAUSE TestAccBackupSelection_Disappears_backupPlan
=== RUN   TestAccBackupSelection_withTags
=== PAUSE TestAccBackupSelection_withTags
=== RUN   TestAccBackupSelection_conditionsWithTags
=== PAUSE TestAccBackupSelection_conditionsWithTags
=== RUN   TestAccBackupSelection_withResources
=== PAUSE TestAccBackupSelection_withResources
=== RUN   TestAccBackupSelection_withNotResources
=== PAUSE TestAccBackupSelection_withNotResources
=== RUN   TestAccBackupSelection_updateTag
=== PAUSE TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_basic
=== CONT  TestAccBackupSelection_withNotResources
=== CONT  TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_conditionsWithTags
=== CONT  TestAccBackupSelection_Disappears_backupPlan
=== CONT  TestAccBackupSelection_withTags
=== CONT  TestAccBackupSelection_withResources
=== CONT  TestAccBackupSelection_disappears
--- PASS: TestAccBackupSelection_Disappears_backupPlan (23.68s)
--- PASS: TestAccBackupSelection_disappears (24.06s)
--- PASS: TestAccBackupSelection_withNotResources (25.27s)
--- PASS: TestAccBackupSelection_conditionsWithTags (26.78s)
--- PASS: TestAccBackupSelection_basic (26.80s)
--- PASS: TestAccBackupSelection_withTags (26.85s)
--- PASS: TestAccBackupSelection_withResources (34.35s)
--- PASS: TestAccBackupSelection_updateTag (38.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	41.691s
```