### PR TITLE
fsx/ontap_storeage_virtulal_mcahine: Remove deprecadted distinguidshed

### DIFF
--- a/.changelog/22915.txt
+++ b/.changelog/22915.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_fsx_ontap_storage_virtual_machine: Remove deprecated `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name`, migrating value to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name`
+```

--- a/.changelog/22915.txt
+++ b/.changelog/22915.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:breaking-change
 resource/aws_fsx_ontap_storage_virtual_machine: Remove deprecated `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name`, migrating value to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name`
 ```

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -237,6 +237,9 @@ jobs:
           if [[ "${pkg}" == */test-fixtures ]]; then
             continue
           fi
+          if [[ "${pkg}" == internal/generate/* ]]; then
+            continue
+          fi          
           while read file; do
             if [ "${file}" = "" ]; then
               continue

--- a/docs/contributing/contribution-checklists.md
+++ b/docs/contributing/contribution-checklists.md
@@ -583,7 +583,7 @@ More details about this code generation can be found in the [namevaluesfilters d
 
 ### Resource Filter Code Implementation
 
-- In the resource's equivalent data source Go file (e.g., `internal/service/ec2/internet_gateway_data_source.go`), add the following Go import: `"github.com/hashicorp/terraform-provider-aws/internal/namevaluesfilters"`
+- In the resource's equivalent data source Go file (e.g., `internal/service/ec2/internet_gateway_data_source.go`), add the following Go import: `"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"`
 - In the resource schema, add `"filter": namevaluesfilters.Schema(),`
 - Implement the logic to build the list of filters:
 

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -86,11 +86,10 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 										ValidateFunc: validation.StringLenBetween(1, 256),
 									},
 									"organizational_unit_distinguished_name": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ForceNew:      true,
-										ValidateFunc:  validation.StringLenBetween(1, 2000),
-										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"},
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 2000),
 									},
 									"password": {
 										Type:         schema.TypeString,
@@ -425,9 +424,7 @@ func expandFsxOntapSvmSelfManagedActiveDirectoryConfiguration(cfg []interface{})
 		out.FileSystemAdministratorsGroup = aws.String(v)
 	}
 
-	if v, ok := conf["organizational_unit_distinguidshed_name"].(string); ok && len(v) > 0 {
-		out.OrganizationalUnitDistinguishedName = aws.String(v)
-	} else if v, ok := conf["organizational_unit_distinguished_name"].(string); ok && len(v) > 0 {
+	if v, ok := conf["organizational_unit_distinguished_name"].(string); ok && len(v) > 0 {
 		out.OrganizationalUnitDistinguishedName = aws.String(v)
 	}
 
@@ -518,9 +515,7 @@ func flattenFsxOntapSelfManagedActiveDirectoryConfiguration(d *schema.ResourceDa
 	}
 
 	if rs.OrganizationalUnitDistinguishedName != nil {
-		if _, ok := d.GetOk("active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"); ok {
-			m["organizational_unit_distinguidshed_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
-		} else {
+		if _, ok := d.GetOk("active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"); ok {
 			m["organizational_unit_distinguished_name"] = aws.StringValue(rs.OrganizationalUnitDistinguishedName)
 		}
 	}

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -36,7 +36,13 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		MigrateState:  resourceOntapStorageVirtualMachineMigrateState,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    ResourceOntapStorageVirtualMachineV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: ResourceOntapStorageVirtualMachineStateUpgradeV0,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -35,6 +35,9 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceOntapStorageVirtualMachineMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -81,14 +84,6 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 										Optional:     true,
 										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 256),
-									},
-									"organizational_unit_distinguidshed_name": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ForceNew:      true,
-										ValidateFunc:  validation.StringLenBetween(1, 2000),
-										Deprecated:    "use 'organizational_unit_distinguished_name' instead",
-										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"},
 									},
 									"organizational_unit_distinguished_name": {
 										Type:          schema.TypeString,

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
@@ -1,0 +1,32 @@
+package fsx
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func resourceOntapStorageVirtualMachineMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found FSx Ontap Storage Virtual Machine state v0; migrating to v1")
+		return migrateOntapStorageVirtualMachineStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateOntapStorageVirtualMachineStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty FSx Ontap Storage Virtual Machine state; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+	is.Attributes["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"] = is.Attributes["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"]
+	delete(is.Attributes, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name")
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
@@ -1,32 +1,217 @@
 package fsx
 
 import (
-	"fmt"
+	"context"
 	"log"
+	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-func resourceOntapStorageVirtualMachineMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
-	switch v {
-	case 0:
-		log.Println("[INFO] Found FSx Ontap Storage Virtual Machine state v0; migrating to v1")
-		return migrateOntapStorageVirtualMachineStateV0toV1(is)
-	default:
-		return is, fmt.Errorf("Unexpected schema version: %d", v)
+func ResourceOntapStorageVirtualMachineV0() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"active_directory_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"netbios_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return strings.EqualFold(old, new)
+							},
+							ValidateFunc: validation.StringLenBetween(1, 15),
+						},
+						"self_managed_active_directory_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dns_ips": {
+										Type:     schema.TypeSet,
+										Required: true,
+										MinItems: 1,
+										MaxItems: 3,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.IsIPAddress,
+										},
+									},
+									"domain_name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 255),
+									},
+									"file_system_administrators_group": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+									"organizational_unit_distinguidshed_name": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										ForceNew:      true,
+										ValidateFunc:  validation.StringLenBetween(1, 2000),
+										Deprecated:    "use 'organizational_unit_distinguished_name' instead",
+										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"},
+									},
+									"organizational_unit_distinguished_name": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										ForceNew:      true,
+										ValidateFunc:  validation.StringLenBetween(1, 2000),
+										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"},
+									},
+									"password": {
+										Type:         schema.TypeString,
+										Sensitive:    true,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+									"username": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"iscsi": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dns_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ip_addresses": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"management": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dns_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ip_addresses": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"nfs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dns_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ip_addresses": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"smb": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dns_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ip_addresses": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"file_system_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(11, 21),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 47),
+			},
+			"root_volume_security_style": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(fsx.StorageVirtualMachineRootVolumeSecurityStyle_Values(), false),
+			},
+			"subtype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"svm_admin_password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringLenBetween(8, 50),
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
 	}
 }
 
-func migrateOntapStorageVirtualMachineStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
-	if is.Empty() || is.Attributes == nil {
-		log.Println("[DEBUG] Empty FSx Ontap Storage Virtual Machine state; nothing to migrate.")
-		return is, nil
-	}
+func ResourceOntapStorageVirtualMachineStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
 
-	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
-	is.Attributes["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"] = is.Attributes["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"]
-	delete(is.Attributes, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name")
+	rawState["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"] = rawState["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"]
+	delete(rawState, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name")
 
-	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
-	return is, nil
+	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+	return rawState, nil
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate_test.go
@@ -1,56 +1,35 @@
 package fsx_test
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	tffsx "github.com/hashicorp/terraform-provider-aws/internal/service/fsx"
 )
 
-func TestOntapStorageVirtualMachineMigrateState(t *testing.T) {
-	cases := map[string]struct {
-		StateVersion int
-		Attributes   map[string]string
-		Expected     map[string]string
-		Meta         interface{}
-	}{
-		"v0_1-notDistinguidshed": {
-			StateVersion: 0,
-			Attributes: map[string]string{
-				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name": "",
-			},
-			Expected: map[string]string{
-				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name": "",
-			},
-		},
-		"v0_1-bitDistinguidshed": {
-			StateVersion: 0,
-			Attributes: map[string]string{
-				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name": "MeArrugoDerrito",
-			},
-			Expected: map[string]string{
-				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name": "MeArrugoDerrito",
-			},
-		},
+func testOntapStorageVirtualMachineStateDataV0() map[string]interface{} {
+	return map[string]interface{}{
+		"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name": "MeArrugoDerrito",
+	}
+}
+
+func testOntapStorageVirtualMachineStateDataV1() map[string]interface{} {
+	v0 := testOntapStorageVirtualMachineStateDataV0()
+	return map[string]interface{}{
+		"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name": v0["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"],
+	}
+}
+
+func TestOntapStorageVirtualMachineStateUpgradeV0(t *testing.T) {
+	expected := testOntapStorageVirtualMachineStateDataV1()
+	actual, err := tffsx.ResourceOntapStorageVirtualMachineStateUpgradeV0(context.Background(), testOntapStorageVirtualMachineStateDataV0(), nil)
+
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
 	}
 
-	for tn, tc := range cases {
-		is := &terraform.InstanceState{
-			ID:         "some_id",
-			Attributes: tc.Attributes,
-		}
-
-		is, err := tffsx.ResourceOntapStorageVirtualMachine().MigrateState(tc.StateVersion, is, tc.Meta)
-		if err != nil {
-			t.Fatalf("bad: %s, err: %#v", tn, err)
-		}
-
-		for k, v := range tc.Expected {
-			if is.Attributes[k] != v {
-				t.Fatalf(
-					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
-					tn, k, v, k, is.Attributes[k], is.Attributes)
-			}
-		}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
 	}
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate_test.go
@@ -1,0 +1,56 @@
+package fsx_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tffsx "github.com/hashicorp/terraform-provider-aws/internal/service/fsx"
+)
+
+func TestOntapStorageVirtualMachineMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0_1-notDistinguidshed": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name": "",
+			},
+			Expected: map[string]string{
+				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name": "",
+			},
+		},
+		"v0_1-bitDistinguidshed": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name": "MeArrugoDerrito",
+			},
+			Expected: map[string]string{
+				"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name": "MeArrugoDerrito",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "some_id",
+			Attributes: tc.Attributes,
+		}
+
+		is, err := tffsx.ResourceOntapStorageVirtualMachine().MigrateState(tc.StateVersion, is, tc.Meta)
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -301,7 +301,7 @@ func TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationa
 					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.domain_name", domainName),
 					resource.TestCheckResourceAttr(resourceName, "endpoints.0.smb.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoints.0.smb.0.dns_name"),
-					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name", fmt.Sprintf("OU=computers,OU=%s", domainNetbiosName)),
+					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name", fmt.Sprintf("OU=computers,OU=%s", domainNetbiosName)),
 					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.password", domainPassword1),
 				),
 			},
@@ -531,11 +531,11 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
   active_directory_configuration {
     netbios_name = %[2]q
     self_managed_active_directory_configuration {
-      dns_ips                                 = aws_directory_service_directory.test.dns_ip_addresses
-      domain_name                             = %[3]q
-      password                                = %[4]q
-      username                                = "Admin"
-      organizational_unit_distinguidshed_name = "OU=computers,OU=%[5]s"
+      dns_ips                                = aws_directory_service_directory.test.dns_ip_addresses
+      domain_name                            = %[3]q
+      password                               = %[4]q
+      username                               = "Admin"
+      organizational_unit_distinguished_name = "OU=computers,OU=%[5]s"
     }
   }
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -277,46 +277,6 @@ func TestAccFSxOntapStorageVirtualMachine_activeDirectory(t *testing.T) {
 	})
 }
 
-func TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedMigrateDistinguidshed(t *testing.T) {
-	var storageVirtualMachine1 fsx.StorageVirtualMachine
-	resourceName := "aws_fsx_ontap_storage_virtual_machine.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	netBiosName := "tftest-" + sdkacctest.RandString(7)
-	domainNetbiosName := "tftestcorp"
-	domainName := "tftestcorp.local"
-	domainPassword1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
-		ErrorCheck:   acctest.ErrorCheck(t, fsx.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckFsxOntapStorageVirtualMachineDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedMigrateDistinguidshed(rName, netBiosName, domainNetbiosName, domainName, domainPassword1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFsxOntapStorageVirtualMachineExists(resourceName, &storageVirtualMachine1),
-					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.netbios_name", strings.ToUpper(netBiosName)),
-					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.domain_name", domainName),
-					resource.TestCheckResourceAttr(resourceName, "endpoints.0.smb.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "endpoints.0.smb.0.dns_name"),
-					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name", fmt.Sprintf("OU=computers,OU=%s", domainNetbiosName)),
-					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.0.self_managed_active_directory_configuration.0.password", domainPassword1),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"active_directory_configuration",
-				},
-			},
-		},
-	})
-}
-
 func testAccCheckFsxOntapStorageVirtualMachineExists(resourceName string, svm *fsx.StorageVirtualMachine) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -515,27 +475,6 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
       password                               = %[4]q
       username                               = "Admin"
       organizational_unit_distinguished_name = "OU=computers,OU=%[5]s"
-    }
-  }
-}
-`, rName, netBiosName, domainName, domainPassword, domainNetbiosName))
-}
-
-func testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedMigrateDistinguidshed(rName string, netBiosName string, domainNetbiosName string, domainName string, domainPassword string) string {
-	return acctest.ConfigCompose(testAccOntapStorageVirtualMachineADConfig(rName, domainName, domainPassword), fmt.Sprintf(`
-resource "aws_fsx_ontap_storage_virtual_machine" "test" {
-  file_system_id = aws_fsx_ontap_file_system.test.id
-  name           = %[1]q
-  depends_on     = [aws_directory_service_directory.test]
-
-  active_directory_configuration {
-    netbios_name = %[2]q
-    self_managed_active_directory_configuration {
-      dns_ips                                 = aws_directory_service_directory.test.dns_ip_addresses
-      domain_name                             = %[3]q
-      password                                = %[4]q
-      username                                = "Admin"
-      organizational_unit_distinguidshed_name = "OU=computers,OU=%[5]s"
     }
   }
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -277,7 +277,7 @@ func TestAccFSxOntapStorageVirtualMachine_activeDirectory(t *testing.T) {
 	})
 }
 
-func TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationalUnitDistinguishedName(t *testing.T) {
+func TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedMigrateDistinguidshed(t *testing.T) {
 	var storageVirtualMachine1 fsx.StorageVirtualMachine
 	resourceName := "aws_fsx_ontap_storage_virtual_machine.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -293,7 +293,7 @@ func TestAccFSxOntapStorageVirtualMachine_activeDirectoryDeprecatedOrganizationa
 		CheckDestroy: testAccCheckFsxOntapStorageVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedOrganizationalUnitDistinguishedName(rName, netBiosName, domainNetbiosName, domainName, domainPassword1),
+				Config: testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedMigrateDistinguidshed(rName, netBiosName, domainNetbiosName, domainName, domainPassword1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxOntapStorageVirtualMachineExists(resourceName, &storageVirtualMachine1),
 					resource.TestCheckResourceAttr(resourceName, "active_directory_configuration.#", "1"),
@@ -521,7 +521,7 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
 `, rName, netBiosName, domainName, domainPassword, domainNetbiosName))
 }
 
-func testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedOrganizationalUnitDistinguishedName(rName string, netBiosName string, domainNetbiosName string, domainName string, domainPassword string) string {
+func testAccFsxOntapStorageVirutalMachineSelfManagedActiveDirectoryConfigDeprecatedMigrateDistinguidshed(rName string, netBiosName string, domainNetbiosName string, domainName string, domainPassword string) string {
 	return acctest.ConfigCompose(testAccOntapStorageVirtualMachineADConfig(rName, domainName, domainPassword), fmt.Sprintf(`
 resource "aws_fsx_ontap_storage_virtual_machine" "test" {
   file_system_id = aws_fsx_ontap_file_system.test.id
@@ -531,11 +531,11 @@ resource "aws_fsx_ontap_storage_virtual_machine" "test" {
   active_directory_configuration {
     netbios_name = %[2]q
     self_managed_active_directory_configuration {
-      dns_ips                                = aws_directory_service_directory.test.dns_ip_addresses
-      domain_name                            = %[3]q
-      password                               = %[4]q
-      username                               = "Admin"
-      organizational_unit_distinguished_name = "OU=computers,OU=%[5]s"
+      dns_ips                                 = aws_directory_service_directory.test.dns_ip_addresses
+      domain_name                             = %[3]q
+      password                                = %[4]q
+      username                                = "Admin"
+      organizational_unit_distinguidshed_name = "OU=computers,OU=%[5]s"
     }
   }
 }

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -34,6 +34,7 @@ Upgrade topics:
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
+- [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine)
 - [Resource: aws_network_interface](#resource-aws_network_interface)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_s3_bucket_object](#resource-aws_s3_bucket_object)
@@ -432,6 +433,10 @@ output "elasticache_global_replication_group_version_result" {
 ## Resource: aws_elasticache_replication_group
 
 !> **WARNING:** This topic is placeholder documentation.
+
+## Resource: aws_fsx_ontap_storage_virtual_machine
+
+We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. This is available for state upgrade.
 
 ## Resource: aws_network_interface
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -436,7 +436,7 @@ output "elasticache_global_replication_group_version_result" {
 
 ## Resource: aws_fsx_ontap_storage_virtual_machine
 
-We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. This is available for state upgrade.
+We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning. 
 
 ## Resource: aws_network_interface
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -436,7 +436,7 @@ output "elasticache_global_replication_group_version_result" {
 
 ## Resource: aws_fsx_ontap_storage_virtual_machine
 
-We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning. 
+We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning.
 
 ## Resource: aws_network_interface
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22247
Relates #22246
Relates #22286

Output from acceptance testing:

```console
make testacc TESTS=TestOntapStorageVirtualMachineStateUpgradeV0 PKG=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestOntapStorageVirtualMachineStateUpgradeV0'  -timeout 180m
=== RUN   TestOntapStorageVirtualMachineStateUpgradeV0
2022/02/02 20:27:13 [DEBUG] Attributes before migration: map[string]interface {}{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name":"MeArrugoDerrito"}
2022/02/02 20:27:13 [DEBUG] Attributes after migration: map[string]interface {}{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name":"MeArrugoDerrito"}
--- PASS: TestOntapStorageVirtualMachineStateUpgradeV0 (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	1.390s
% make testacc TESTS=TestAccFSxOntapStorageVirtualMachine_ PKG=fsx               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxOntapStorageVirtualMachine_'  -timeout 180m
--- PASS: TestAccFSxOntapStorageVirtualMachine_rootVolumeSecurityStyle (2659.31s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_svmAdminPassword (2660.15s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_basic (2702.16s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_tags (2757.56s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_activeDirectory (2794.72s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_disappears (2865.29s)
--- PASS: TestAccFSxOntapStorageVirtualMachine_name (3167.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	3169.255s
```
