### PR TITLE
resource/aws_elasticache_replication_group: Migrate from availability_zones TypeSet attribute to preferred_cache_cluster_azs TypeList attribute

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -116,10 +116,10 @@ func ResourceReplicationGroup() *schema.Resource {
 				ForceNew: true,
 			},
 			"description": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"replication_group_description"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"description", "replication_group_description"},
 			},
 			"engine": {
 				Type:         schema.TypeString,
@@ -242,11 +242,11 @@ func ResourceReplicationGroup() *schema.Resource {
 				ConflictsWith: []string{"cluster_mode"},
 			},
 			"replication_group_description": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"description"},
-				Deprecated:    "Use description instead",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"description", "replication_group_description"},
+				Deprecated:   "Use description instead",
 			},
 			"replication_group_id": {
 				Type:         schema.TypeString,
@@ -378,13 +378,8 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("description"); ok {
 		params.ReplicationGroupDescription = aws.String(v.(string))
 	}
-
 	if v, ok := d.GetOk("replication_group_description"); ok {
 		params.ReplicationGroupDescription = aws.String(v.(string))
-	}
-
-	if params.ReplicationGroupDescription == nil {
-		return errors.New("one of replication_group_description or description must be configured")
 	}
 
 	if v, ok := d.GetOk("data_tiering_enabled"); ok {

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -421,8 +421,7 @@ func TestAccElastiCacheReplicationGroup_updateAuthToken(t *testing.T) {
 				Config: testAccReplicationGroup_EnableAuthTokenTransitEncryptionConfig(rName, sdkacctest.RandString(16)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(
-						resourceName, "transit_encryption_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", "true"),
 				),
 			},
 			{
@@ -1067,8 +1066,7 @@ func TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption(t *test
 				Config: testAccReplicationGroup_EnableAuthTokenTransitEncryptionConfig(sdkacctest.RandString(10), sdkacctest.RandString(16)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(
-						resourceName, "transit_encryption_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", "true"),
 				),
 			},
 			{
@@ -1120,6 +1118,7 @@ func TestAccElastiCacheReplicationGroup_useCMKKMSKeyID(t *testing.T) {
 
 	var rg elasticache.ReplicationGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_replication_group.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, elasticache.EndpointsID),
@@ -1129,8 +1128,8 @@ func TestAccElastiCacheReplicationGroup_useCMKKMSKeyID(t *testing.T) {
 			{
 				Config: testAccReplicationGroup_UseCMKKMSKeyID(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
-					resource.TestCheckResourceAttrSet("aws_elasticache_replication_group.bar", "kms_key_id"),
+					testAccCheckReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 				),
 			},
 		},
@@ -2608,27 +2607,27 @@ func testAccReplicationGroup_UseCMKKMSKeyID(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVpcWithSubnets(1),
 		fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "bar" { # TODO: rename
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = "1"
   port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.bar.name
-  security_group_ids            = [aws_security_group.bar.id]
+  subnet_group_name             = aws_elasticache_subnet_group.test.name
+  security_group_ids            = [aws_security_group.test.id]
   parameter_group_name          = "default.redis3.2"
   availability_zones            = [data.aws_availability_zones.available.names[0]]
   engine_version                = "3.2.6"
   at_rest_encryption_enabled    = true
-  kms_key_id                    = aws_kms_key.bar.arn
+  kms_key_id                    = aws_kms_key.test.arn
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
   name       = %[1]q
   subnet_ids = aws_subnet.test[*].id
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "tf-test-security-group-descr"
   vpc_id      = aws_vpc.test.id
@@ -2641,7 +2640,7 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_kms_key" "bar" {
+resource "aws_kms_key" "test" {
   description = "tf-test-cmk-kms-key-id"
 }
 `, rName),

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -2466,7 +2466,7 @@ func testAccReplicationGroupConfig_MultiAZNotInVPC_PreferredCacheClusterAZs_repe
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id        = %[1]q
   description                 = "test description"
-	  num_cache_clusters          = 4
+  num_cache_clusters          = 4
   node_type                   = "cache.t3.small"
   automatic_failover_enabled  = true
   multi_az_enabled            = true

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -37,14 +37,14 @@ To create a single shard primary with single read replica:
 
 ```terraform
 resource "aws_elasticache_replication_group" "example" {
-  automatic_failover_enabled    = true
-  preferred_cache_cluster_azs   = ["us-west-2a", "us-west-2b"]
-  replication_group_id          = "tf-rep-group-1"
-  replication_group_description = "test description"
-  node_type                     = "cache.m4.large"
-  number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
-  port                          = 6379
+  automatic_failover_enabled  = true
+  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
+  replication_group_id        = "tf-rep-group-1"
+  description                 = "example description"
+  node_type                   = "cache.m4.large"
+  number_cache_clusters       = 2
+  parameter_group_name        = "default.redis3.2"
+  port                        = 6379
 }
 ```
 
@@ -55,14 +55,14 @@ You have two options for adjusting the number of replicas:
 
 ```terraform
 resource "aws_elasticache_replication_group" "example" {
-  automatic_failover_enabled    = true
-  preferred_cache_cluster_azs   = ["us-west-2a", "us-west-2b"]
-  replication_group_id          = "tf-rep-group-1"
-  replication_group_description = "test description"
-  node_type                     = "cache.m4.large"
-  number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
-  port                          = 6379
+  automatic_failover_enabled  = true
+  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
+  replication_group_id        = "tf-rep-group-1"
+  description                 = "example description"
+  node_type                   = "cache.m4.large"
+  number_cache_clusters       = 2
+  parameter_group_name        = "default.redis3.2"
+  port                        = 6379
 
   lifecycle {
     ignore_changes = [number_cache_clusters]
@@ -83,12 +83,12 @@ To create two shards with a primary and a single read replica each:
 
 ```terraform
 resource "aws_elasticache_replication_group" "baz" {
-  replication_group_id          = "tf-redis-cluster"
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.small"
-  port                          = 6379
-  parameter_group_name          = "default.redis3.2.cluster.on"
-  automatic_failover_enabled    = true
+  replication_group_id       = "tf-redis-cluster"
+  description                = "example description"
+  node_type                  = "cache.t2.small"
+  port                       = 6379
+  parameter_group_name       = "default.redis3.2.cluster.on"
+  automatic_failover_enabled = true
 
   num_node_groups         = 2
   replicas_per_node_group = 1
@@ -107,9 +107,9 @@ A Global Replication Group can have one one two secondary Replication Groups in 
 
 ```terraform
 resource "aws_elasticache_replication_group" "secondary" {
-  replication_group_id          = "example-secondary"
-  replication_group_description = "secondary replication group"
-  global_replication_group_id   = aws_elasticache_global_replication_group.example.global_replication_group_id
+  replication_group_id        = "example-secondary"
+  description                 = "secondary replication group"
+  global_replication_group_id = aws_elasticache_global_replication_group.example.global_replication_group_id
 
   number_cache_clusters = 1
 }
@@ -124,8 +124,8 @@ resource "aws_elasticache_global_replication_group" "example" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = aws.other_region
 
-  replication_group_id          = "example-primary"
-  replication_group_description = "primary replication group"
+  replication_group_id = "example-primary"
+  description          = "primary replication group"
 
   engine         = "redis"
   engine_version = "5.0.6"
@@ -139,8 +139,9 @@ resource "aws_elasticache_replication_group" "primary" {
 
 The following arguments are required:
 
-* `replication_group_description` – (Required) User-created description for the replication group.
+* `description` – (Required) User-created description for the replication group.
 * `replication_group_id` – (Required) Replication group identifier. This parameter is stored as a lowercase string.
+* `replication_group_description` – (**Deprecated** use `description` instead) User-created description for the replication group.
 
 The following arguments are optional:
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -90,10 +90,8 @@ resource "aws_elasticache_replication_group" "baz" {
   parameter_group_name          = "default.redis3.2.cluster.on"
   automatic_failover_enabled    = true
 
-  cluster_mode {
-    replicas_per_node_group = 1
-    num_node_groups         = 2
-  }
+  num_node_groups         = 2
+  replicas_per_node_group = 1
 }
 ```
 
@@ -152,18 +150,19 @@ The following arguments are optional:
 * `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. This parameter is currently not supported by the AWS API. Defaults to `true`.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `number_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
 * `availability_zones` - (Optional, **Deprecated** use `preferred_cache_cluster_azs` instead) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not considered.
-* `cluster_mode` - (Optional) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
+* `cluster_mode` - (Optional, **Deprecated** use root-level `num_node_groups` and `replicas_per_node_group` instead) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
 * `data_tiering_enabled` - (Optional) Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to `true` when using r6gd nodes.
 * `engine` - (Optional) Name of the cache engine to be used for the clusters in this replication group. The only valid value is `redis`.
 * `engine_version` - (Optional) Version number of the cache engine to be used for the cache clusters in this replication group. If the version is 6 or higher, only the major version can be set, e.g., `6.x`, otherwise, specify the full version desired, e.g., `5.0.6`. The actual engine version used is returned in the attribute `engine_version_actual`, [defined below](#engine_version_actual).
 * `final_snapshot_identifier` - (Optional) The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made.
-* `global_replication_group_id` - (Optional) The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group. If `global_replication_group_id` is set, the `num_node_groups` parameter of the `cluster_mode` block cannot be set.
+* `global_replication_group_id` - (Optional) The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group. If `global_replication_group_id` is set, the `num_node_groups` parameter (or the `num_node_groups` parameter of the deprecated `cluster_mode` block) cannot be set.
 * `kms_key_id` - (Optional) The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true`.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
 * `multi_az_enabled` - (Optional) Specifies whether to enable Multi-AZ Support for the replication group. If `true`, `automatic_failover_enabled` must also be enabled. Defaults to `false`.
 * `node_type` - (Optional) Instance class to be used. See AWS documentation for information on [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html). Required unless `global_replication_group_id` is set. Cannot be set if `global_replication_group_id` is set.
 * `notification_topic_arn` – (Optional) ARN of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic`
-* `number_cache_clusters` - (Optional) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. One of `number_cache_clusters` or `cluster_mode` is required.
+* `number_cache_clusters` - (Optional, **Deprecated** use `num_cache_clusters` instead) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_cache_clusters`, `num_node_groups`, or the deprecated `cluster_mode`. Defaults to `1`.
+* `num_cache_clusters` - (Optional) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_node_groups`, the deprecated`number_cache_clusters`, or the deprecated `cluster_mode`. Defaults to `1`.
 * `parameter_group_name` - (Optional) Name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used. To enable "cluster mode", i.e., data sharding, use a parameter group that has the parameter `cluster-enabled` set to true.
 * `port` – (Optional) Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.
 * `preferred_cache_cluster_azs` - (Optional) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is considered. The first item in the list will be the primary node. Ignored when updating.

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -38,7 +38,7 @@ To create a single shard primary with single read replica:
 ```terraform
 resource "aws_elasticache_replication_group" "example" {
   automatic_failover_enabled    = true
-  availability_zones            = ["us-west-2a", "us-west-2b"]
+  preferred_cache_cluster_azs   = ["us-west-2a", "us-west-2b"]
   replication_group_id          = "tf-rep-group-1"
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
@@ -56,7 +56,7 @@ You have two options for adjusting the number of replicas:
 ```terraform
 resource "aws_elasticache_replication_group" "example" {
   automatic_failover_enabled    = true
-  availability_zones            = ["us-west-2a", "us-west-2b"]
+  preferred_cache_cluster_azs   = ["us-west-2a", "us-west-2b"]
   replication_group_id          = "tf-rep-group-1"
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
@@ -151,7 +151,7 @@ The following arguments are optional:
 * `auth_token` - (Optional) Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`.
 * `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. This parameter is currently not supported by the AWS API. Defaults to `true`.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `number_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
-* `availability_zones` - (Optional) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important.
+* `availability_zones` - (Optional, **Deprecated** use `preferred_cache_cluster_azs` instead) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not considered.
 * `cluster_mode` - (Optional) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
 * `data_tiering_enabled` - (Optional) Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to `true` when using r6gd nodes.
 * `engine` - (Optional) Name of the cache engine to be used for the clusters in this replication group. The only valid value is `redis`.
@@ -166,6 +166,7 @@ The following arguments are optional:
 * `number_cache_clusters` - (Optional) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. One of `number_cache_clusters` or `cluster_mode` is required.
 * `parameter_group_name` - (Optional) Name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used. To enable "cluster mode", i.e., data sharding, use a parameter group that has the parameter `cluster-enabled` set to true.
 * `port` – (Optional) Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.
+* `preferred_cache_cluster_azs` - (Optional) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is considered. The first item in the list will be the primary node. Ignored when updating.
 * `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud
 * `security_group_names` - (Optional) List of cache security group names to associate with this replication group.
 * `snapshot_arns` – (Optional) List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.


### PR DESCRIPTION
When creating a Redis cluster without sharding ("Cluster Mode Disabled" in AWS terminology), it is possible to specify a list of availability zones in which to place the cluster nodes. In the AWS API, the order of the list matters: the first AZ in the list is the primary AZ for the cluster, and the remainder of the nodes are assigned in order. The number of AZs in the list must match the number of nodes, and duplicates are allowed.

As currently implemented in the AWS Provider, the parameter `availability_zones` is of `TypeSet`, where order is not guaranteed and duplicates are not permitted. This means that the practitioner has no control over the location of the primary node and there can be at most one node in a given AZ.

Additionally, the current parameter name, `availability_zones`, does not match the AWS API parameter name `PreferredCacheClusterAZs`.

A new parameter `preferred_cache_cluster_azs` of `TypeList` should be added to `aws_elasticache_replication_group`. Changes to `aws_elasticache_replication_group` should not be marked `ForceNew`, as it is ignored on update.

Includes additional documentation updates related to deprecations in #22666

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #18438

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccElastiCacheReplicationGroup_ PKG=elasticache

--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (79.49s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (793.32s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (943.13s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (964.28s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (1146.95s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1265.41s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (1288.30s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1295.98s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (7.20s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1512.80s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (802.20s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (1605.67s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverDisabled (1720.36s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1828.89s)
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (4.42s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (1845.68s)
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (907.19s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1850.35s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailoverEnabled (1933.65s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1945.81s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (866.79s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (2478.08s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1232.51s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (1016.92s)
--- PASS: TestAccElastiCacheReplicationGroup_NEW_multiAzInVPC (943.27s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2602.62s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (922.65s)
--- PASS: TestAccElastiCacheReplicationGroup_NEW_multiAzNotInVPC_repeated (1090.35s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (893.47s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (3036.03s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (923.36s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (711.51s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzNotInVPC (2383.35s)
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1419.26s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (915.62s)
--- PASS: TestAccElastiCacheReplicationGroup_depecatedAvailabilityZones_vpc (843.89s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2318.88s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1785.06s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3581.17s)
--- PASS: TestAccElastiCacheReplicationGroup_NEW_vpc (1116.98s)
--- PASS: TestAccElastiCacheReplicationGroup_NEW_multiAzNotInVPC_notRepeated (881.76s)
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (1043.02s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2632.33s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (1151.43s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (4080.52s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (2330.81s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (3028.21s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (3068.74s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (3277.77s)
```
