### PR TITLE
ec2/customer_gateway: Remove empty validation

### DIFF
--- a/.changelog/22926.txt
+++ b/.changelog/22926.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_customer_gateway: `ip_address` can no longer be set to `""` 
+```

--- a/internal/service/ec2/customer_gateway.go
+++ b/internal/service/ec2/customer_gateway.go
@@ -52,13 +52,10 @@ func ResourceCustomerGateway() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"ip_address": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					validation.IsIPv4Address,
-				),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -31,6 +31,7 @@ Upgrade topics:
 - [Data Source: aws_s3_bucket_objects](#data-source-aws_s3_bucket_objects)
 - [Resource: aws_batch_compute_environment](#resource-aws_batch_compute_environment)
 - [Resource: aws_cloudwatch_event_target](#resource-aws_cloudwatch_event_target)
+- [Resource: aws_customer_gateway](#resource-aws_customer_gateway)
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
@@ -404,6 +405,10 @@ resource "aws_cloudwatch_event_target" "test" {
   }
 }
 ```
+
+## Resource: aws_customer_gateway
+
+Previously, `ip_address` could be set to `""`, which would result in an AWS error. However, this value is no longer accepted by the provider.
 
 ## Resource: aws_elasticache_cluster
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13943

Output from acceptance testing:

```
% make testacc TESTS=TestAccEC2CustomerGateway PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2CustomerGateway'  -timeout 180m
--- PASS: TestAccEC2CustomerGateway_disappears (27.07s)
--- PASS: TestAccEC2CustomerGatewayDataSource_id (31.32s)
--- PASS: TestAccEC2CustomerGatewayDataSource_filter (31.36s)
--- PASS: TestAccEC2CustomerGateway_basic (31.73s)
--- PASS: TestAccEC2CustomerGateway_deviceName (31.94s)
--- PASS: TestAccEC2CustomerGateway_4ByteASN (32.40s)
--- PASS: TestAccEC2CustomerGateway_tags (56.20s)
--- PASS: TestAccEC2CustomerGateway_certificate (121.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	122.712s
```
