### PR TITLE
aws_ec2_route_table_association: use retry logic on newly created resource

### DIFF
--- a/.changelog/22927.txt
+++ b/.changelog/22927.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_route_table_association: Retry resource Read for EC2 eventual consistency
+```

--- a/.changelog/22927.txt
+++ b/.changelog/22927.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ec2_route_table_association: Retry resource Read for EC2 eventual consistency
+resource/aws_route_table_association: Retry resource Read for EC2 eventual consistency
 ```

--- a/internal/service/ec2/route_table_association.go
+++ b/internal/service/ec2/route_table_association.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -88,7 +89,23 @@ func resourceRouteTableAssociationCreate(d *schema.ResourceData, meta interface{
 func resourceRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
 
-	association, err := FindRouteTableAssociationByID(conn, d.Id())
+	var association *ec2.RouteTableAssociation
+
+	err := resource.Retry(PropagationTimeout, func() *resource.RetryError {
+		var err error
+		association, err = FindRouteTableAssociationByID(conn, d.Id())
+		if d.IsNewResource() && tfawserr.ErrCodeEquals(err, tfresource.ErrEmptyResult.Error()) {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		association, err = FindRouteTableAssociationByID(conn, d.Id())
+	}
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route Table Association (%s) not found, removing from state", d.Id())


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22479
Closes #21629
Closes #21683 
Closes #21978 


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-aws git:(ec2-vpc-route-table-association-retry-logic) ✗ make testacc TESTS=TestAccEC2RouteTableAssociation PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2RouteTableAssociation'  -timeout 180m
=== RUN   TestAccEC2RouteTableAssociation_Subnet_basic
=== PAUSE TestAccEC2RouteTableAssociation_Subnet_basic
=== RUN   TestAccEC2RouteTableAssociation_Subnet_changeRouteTable
=== PAUSE TestAccEC2RouteTableAssociation_Subnet_changeRouteTable
=== RUN   TestAccEC2RouteTableAssociation_Gateway_basic
=== PAUSE TestAccEC2RouteTableAssociation_Gateway_basic
=== RUN   TestAccEC2RouteTableAssociation_Gateway_changeRouteTable
=== PAUSE TestAccEC2RouteTableAssociation_Gateway_changeRouteTable
=== RUN   TestAccEC2RouteTableAssociation_disappears
=== PAUSE TestAccEC2RouteTableAssociation_disappears
=== CONT  TestAccEC2RouteTableAssociation_Subnet_basic
=== CONT  TestAccEC2RouteTableAssociation_Gateway_changeRouteTable
=== CONT  TestAccEC2RouteTableAssociation_Gateway_basic
=== CONT  TestAccEC2RouteTableAssociation_disappears
=== CONT  TestAccEC2RouteTableAssociation_Subnet_changeRouteTable
--- PASS: TestAccEC2RouteTableAssociation_disappears (20.55s)
--- PASS: TestAccEC2RouteTableAssociation_Subnet_basic (21.85s)
--- PASS: TestAccEC2RouteTableAssociation_Gateway_basic (25.67s)
--- PASS: TestAccEC2RouteTableAssociation_Subnet_changeRouteTable (33.67s)
--- PASS: TestAccEC2RouteTableAssociation_Gateway_changeRouteTable (197.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	197.739s
➜  terraform-provider-aws git:(ec2-vpc-route-table-association-retry-logic) ✗
```
