### PR TITLE
ec2/network_acl: Remove empty validation

### DIFF
--- a/.changelog/22928.txt
+++ b/.changelog/22928.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_default_network_acl: These arguments can no longer be set to `""`: `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, or `ingress.*.ipv6_cidr_block`
+```

--- a/.changelog/22928.txt
+++ b/.changelog/22928.txt
@@ -1,3 +1,7 @@
 ```release-note:breaking-change
 resource/aws_default_network_acl: These arguments can no longer be set to `""`: `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, or `ingress.*.ipv6_cidr_block`
 ```
+
+```release-note:breaking-change
+resource/aws_network_acl: These arguments can no longer be set to `""`: `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, or `ingress.*.ipv6_cidr_block`
+```

--- a/internal/service/ec2/default_network_acl.go
+++ b/internal/service/ec2/default_network_acl.go
@@ -97,20 +97,14 @@ func ResourceDefaultNetworkACL() *schema.Resource {
 							Required: true,
 						},
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"icmp_type": {
 							Type:     schema.TypeInt,
@@ -157,20 +151,14 @@ func ResourceDefaultNetworkACL() *schema.Resource {
 							Required: true,
 						},
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"icmp_type": {
 							Type:     schema.TypeInt,

--- a/internal/service/ec2/network_acl.go
+++ b/internal/service/ec2/network_acl.go
@@ -88,20 +88,14 @@ func ResourceNetworkACL() *schema.Resource {
 							Required: true,
 						},
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"icmp_type": {
 							Type:     schema.TypeInt,
@@ -153,20 +147,14 @@ func ResourceNetworkACL() *schema.Resource {
 							Required: true,
 						},
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.IsCIDR,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"icmp_type": {
 							Type:     schema.TypeInt,

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -32,6 +32,7 @@ Upgrade topics:
 - [Resource: aws_batch_compute_environment](#resource-aws_batch_compute_environment)
 - [Resource: aws_cloudwatch_event_target](#resource-aws_cloudwatch_event_target)
 - [Resource: aws_customer_gateway](#resource-aws_customer_gateway)
+- [Resource: aws_default_network_acl](#resource-aws_default_network_acl)
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
@@ -410,6 +411,35 @@ resource "aws_cloudwatch_event_target" "test" {
 ## Resource: aws_customer_gateway
 
 Previously, `ip_address` could be set to `""`, which would result in an AWS error. However, this value is no longer accepted by the provider.
+
+## Resource: aws_default_network_acl
+
+Previously, `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, or `ingress.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid.
+
+For example, previously this type of configuration was valid:
+
+```terraform
+resource "aws_default_network_acl" "default" {
+  // ...
+  egress {
+    cidr_block      = "0.0.0.0/0"
+    ipv6_cidr_block = ""
+    // ...
+  }
+}
+```
+
+Now, simply remove the empty-value configuration:
+
+```terraform
+resource "aws_default_network_acl" "default" {
+  // ...
+  egress {
+    cidr_block      = "0.0.0.0/0"
+    // ...
+  }
+}
+```
 
 ## Resource: aws_elasticache_cluster
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -430,7 +430,7 @@ resource "aws_default_network_acl" "default" {
 }
 ```
 
-Now, simply remove the empty-value configuration:
+Now, set the argument to null (`ipv6_cidr_block = null`) or simply remove the empty-value configuration:
 
 ```terraform
 resource "aws_default_network_acl" "default" {

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -37,6 +37,7 @@ Upgrade topics:
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
 - [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine)
+- [Resource: aws_network_acl](#resource-aws_network_acl)
 - [Resource: aws_network_interface](#resource-aws_network_interface)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_s3_bucket_object](#resource-aws_s3_bucket_object)
@@ -498,6 +499,35 @@ output "elasticache_global_replication_group_version_result" {
 ## Resource: aws_fsx_ontap_storage_virtual_machine
 
 We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning.
+
+## Resource: aws_network_acl
+
+Previously, `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, or `ingress.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid.
+
+For example, previously this type of configuration was valid:
+
+```terraform
+resource "aws_network_acl" "default" {
+  // ...
+  egress {
+    cidr_block      = "0.0.0.0/0"
+    ipv6_cidr_block = ""
+    // ...
+  }
+}
+```
+
+Now, simply remove the empty-value configuration:
+
+```terraform
+resource "aws_network_acl" "default" {
+  // ...
+  egress {
+    cidr_block      = "0.0.0.0/0"
+    // ...
+  }
+}
+```
 
 ## Resource: aws_network_interface
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -508,16 +508,16 @@ For example, previously this type of configuration was valid:
 
 ```terraform
 resource "aws_network_acl" "default" {
-  // ...
+  # ...
   egress {
     cidr_block      = "0.0.0.0/0"
     ipv6_cidr_block = ""
-    // ...
+    # ...
   }
 }
 ```
 
-Now, simply remove the empty-value configuration:
+Now, set the argument to null (`ipv6_cidr_block = null`) or simply remove the empty-value configuration:
 
 ```terraform
 resource "aws_network_acl" "default" {

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -421,11 +421,11 @@ For example, previously this type of configuration was valid:
 
 ```terraform
 resource "aws_default_network_acl" "default" {
-  // ...
+  # ...
   egress {
     cidr_block      = "0.0.0.0/0"
     ipv6_cidr_block = ""
-    // ...
+    # ...
   }
 }
 ```
@@ -434,10 +434,10 @@ Now, set the argument to null (`ipv6_cidr_block = null`) or simply remove the em
 
 ```terraform
 resource "aws_default_network_acl" "default" {
-  // ...
+  # ...
   egress {
     cidr_block      = "0.0.0.0/0"
-    // ...
+    # ...
   }
 }
 ```
@@ -521,10 +521,10 @@ Now, set the argument to null (`ipv6_cidr_block = null`) or simply remove the em
 
 ```terraform
 resource "aws_network_acl" "default" {
-  // ...
+  # ...
   egress {
     cidr_block      = "0.0.0.0/0"
-    // ...
+    # ...
   }
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13943

Output from acceptance testing:

```console
% make testacc TESTS='TestAccEC2DefaultNetworkACL_|TestAccEC2NetworkACL_' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2DefaultNetworkACL_|TestAccEC2NetworkACL_'  -timeout 180m
--- PASS: TestAccEC2NetworkACL_ipv6ICMPRules (34.23s)
--- PASS: TestAccEC2DefaultNetworkACL_basic (38.00s)
--- PASS: TestAccEC2DefaultNetworkACL_withIPv6Ingress (38.08s)
--- PASS: TestAccEC2DefaultNetworkACL_Deny_ingress (38.19s)
--- PASS: TestAccEC2NetworkACL_espProtocol (38.56s)
--- PASS: TestAccEC2NetworkACL_ipv6VPCRules (47.89s)
--- PASS: TestAccEC2NetworkACL_onlyEgressRules (51.09s)
--- PASS: TestAccEC2NetworkACL_basic (51.19s)
--- PASS: TestAccEC2NetworkACL_egressAndIngressRules (51.20s)
--- PASS: TestAccEC2NetworkACL_caseSensitivityNoChanges (55.44s)
--- PASS: TestAccEC2NetworkACL_OnlyIngressRules_basic (55.87s)
--- PASS: TestAccEC2NetworkACL_ipv6Rules (56.58s)
--- PASS: TestAccEC2NetworkACL_subnetsDelete (68.50s)
--- PASS: TestAccEC2DefaultNetworkACL_subnetRemoval (70.52s)
--- PASS: TestAccEC2NetworkACL_subnets (74.45s)
--- PASS: TestAccEC2NetworkACL_disappears (39.38s)
--- PASS: TestAccEC2NetworkACL_OnlyIngressRules_update (77.91s)
--- PASS: TestAccEC2DefaultNetworkACL_basicIPv6VPC (40.06s)
--- PASS: TestAccEC2NetworkACL_subnetChange (79.97s)
--- PASS: TestAccEC2DefaultNetworkACL_subnetReassign (81.13s)
--- PASS: TestAccEC2NetworkACL_Egress_mode (83.34s)
--- PASS: TestAccEC2NetworkACL_Ingress_mode (84.24s)
--- PASS: TestAccEC2NetworkACL_tags (67.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	103.610s
```
