### PR TITLE
ec2/routes: Remove empty validation

### DIFF
--- a/internal/service/ec2/default_route_table.go
+++ b/internal/service/ec2/default_route_table.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -70,24 +69,18 @@ func ResourceDefaultRouteTable() *schema.Resource {
 						// Destinations.
 						///
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								verify.ValidIPv4CIDRNetworkAddress,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
 						},
 						"destination_prefix_list_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								verify.ValidIPv6CIDRNetworkAddress,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidIPv6CIDRNetworkAddress,
 						},
 
 						//

--- a/internal/service/ec2/route.go
+++ b/internal/service/ec2/route.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -62,28 +61,25 @@ func ResourceRoute() *schema.Resource {
 			// Destinations.
 			///
 			"destination_cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					verify.ValidIPv4CIDRNetworkAddress,
-				),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
+				ExactlyOneOf: []string{"destination_cidr_block", "destination_ipv6_cidr_block", "destination_prefix_list_id"},
 			},
 			"destination_ipv6_cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					verify.ValidIPv6CIDRNetworkAddress,
-				),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateFunc:     verify.ValidIPv6CIDRNetworkAddress,
 				DiffSuppressFunc: suppressEqualCIDRBlockDiffs,
+				ExactlyOneOf:     []string{"destination_cidr_block", "destination_ipv6_cidr_block", "destination_prefix_list_id"},
 			},
 			"destination_prefix_list_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"destination_cidr_block", "destination_ipv6_cidr_block", "destination_prefix_list_id"},
 			},
 
 			//

--- a/internal/service/ec2/route_table.go
+++ b/internal/service/ec2/route_table.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -85,24 +84,18 @@ func ResourceRouteTable() *schema.Resource {
 						// Destinations.
 						///
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								verify.ValidIPv4CIDRNetworkAddress,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidIPv4CIDRNetworkAddress,
 						},
 						"destination_prefix_list_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								verify.ValidIPv6CIDRNetworkAddress,
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidIPv6CIDRNetworkAddress,
 						},
 
 						//


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
