### PR TITLE
r/fsx_lustre_file_system - add `log_configuration` argument

### DIFF
--- a/.changelog/22935.txt
+++ b/.changelog/22935.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_lustre_file_system: Add `log_configuration` argument.
+```

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/fsx"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -213,6 +215,31 @@ func ResourceLustreFileSystem() *schema.Resource {
 					validation.StringMatch(regexp.MustCompile(`^[0-9].[0-9]+$`), "must be in format x.y"),
 				),
 			},
+			"log_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: verify.ValidARN,
+							StateFunc:    logStateFunc,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return strings.HasPrefix(old, fmt.Sprintf("%s:", new))
+							},
+						},
+						"level": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(fsx.LustreAccessAuditLogLevel_Values(), false),
+						},
+					},
+				},
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -337,6 +364,11 @@ func resourceLustreFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 		backupInput.FileSystemTypeVersion = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("log_configuration"); ok && len(v.([]interface{})) > 0 {
+		input.LustreConfiguration.LogConfiguration = expandFsxLustreLogCreateConfiguration(v.([]interface{}))
+		backupInput.LustreConfiguration.LogConfiguration = expandFsxLustreLogCreateConfiguration(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("backup_id"); ok {
 		backupInput.BackupId = aws.String(v.(string))
 
@@ -378,6 +410,7 @@ func resourceLustreFileSystemUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChangesExcept("tags_all", "tags") {
+		var waitAdminAction = false
 		input := &fsx.UpdateFileSystemInput{
 			ClientRequestToken:  aws.String(resource.UniqueId()),
 			FileSystemId:        aws.String(d.Id()),
@@ -408,6 +441,11 @@ func resourceLustreFileSystemUpdate(d *schema.ResourceData, meta interface{}) er
 			input.LustreConfiguration.DataCompressionType = aws.String(v.(string))
 		}
 
+		if d.HasChange("log_configuration") {
+			input.LustreConfiguration.LogConfiguration = expandFsxLustreLogCreateConfiguration(d.Get("log_configuration").([]interface{}))
+			waitAdminAction = true
+		}
+
 		_, err := conn.UpdateFileSystem(input)
 		if err != nil {
 			return fmt.Errorf("error updating FSX Lustre File System (%s): %w", d.Id(), err)
@@ -415,6 +453,12 @@ func resourceLustreFileSystemUpdate(d *schema.ResourceData, meta interface{}) er
 
 		if _, err := waitFileSystemUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("error waiting for FSx Lustre File System (%s) update: %w", d.Id(), err)
+		}
+
+		if waitAdminAction {
+			if _, err := waitAdministrativeActionCompleted(conn, d.Id(), fsx.AdministrativeActionTypeFileSystemUpdate, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf("error waiting for FSx Lustre File System (%s) Log Configuratio to be updated: %w", d.Id(), err)
+			}
 		}
 	}
 
@@ -483,6 +527,10 @@ func resourceLustreFileSystemRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("error setting subnet_ids: %w", err)
 	}
 
+	if err := d.Set("log_configuration", flattenFsxLustreLogConfiguration(lustreConfig.LogConfiguration)); err != nil {
+		return fmt.Errorf("error setting log_configuration: %w", err)
+	}
+
 	tags := KeyValueTags(filesystem.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
@@ -528,4 +576,52 @@ func resourceLustreFileSystemDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return nil
+}
+
+func expandFsxLustreLogCreateConfiguration(l []interface{}) *fsx.LustreLogCreateConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	data := l[0].(map[string]interface{})
+	req := &fsx.LustreLogCreateConfiguration{
+		Level: aws.String(data["level"].(string)),
+	}
+
+	if v, ok := data["destination"].(string); ok && v != "" {
+		req.Destination = aws.String(logStateFunc(v))
+	}
+
+	return req
+}
+
+func flattenFsxLustreLogConfiguration(adopts *fsx.LustreLogConfiguration) []map[string]interface{} {
+	if adopts == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"level": aws.StringValue(adopts.Level),
+	}
+
+	if adopts.Destination != nil {
+		m["destination"] = aws.StringValue(adopts.Destination)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func logStateFunc(v interface{}) string {
+	value := v.(string)
+	// API returns the specific log stream arn instead of provided log group
+	logArn, _ := arn.Parse(value)
+	if logArn.Service == "logs" {
+		parts := strings.SplitN(logArn.Resource, ":", 3)
+		if len(parts) == 3 {
+			return strings.TrimSuffix(value, fmt.Sprintf(":%s", parts[2]))
+		} else {
+			return value
+		}
+	}
+	return value
 }

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -55,6 +55,8 @@ func TestAccFSxLustreFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_type", fsx.StorageTypeSsd),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_backups", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data_compression_type", fsx.DataCompressionTypeNone),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration.0.level", "DISABLED"),
 				),
 			},
 			{
@@ -610,6 +612,45 @@ func TestAccFSxLustreFileSystem_deploymentTypePersistent2(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+		},
+	})
+}
+
+func TestAccFSxLustreFileSystem_logConfig(t *testing.T) {
+	var filesystem fsx.FileSystem
+	resourceName := "aws_fsx_lustre_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, fsx.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFsxLustreFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLustreFileSystemLogConfig(rName, "WARN_ONLY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxLustreFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration.0.level", "WARN_ONLY"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_configuration.0.destination"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+			{
+				Config: testAccLustreFileSystemLogConfig(rName, "ERROR_ONLY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxLustreFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration.0.level", "ERROR_ONLY"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_configuration.0.destination"),
+				),
 			},
 		},
 	})
@@ -1286,4 +1327,23 @@ resource "aws_fsx_lustre_file_system" "test" {
   data_compression_type = "LZ4"
 }
 `)
+}
+
+func testAccLustreFileSystemLogConfig(rName, status string) string {
+	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
+resource aws_cloudwatch_log_group "test" {
+  name = "/aws/fsx/%[1]s"
+}
+
+resource "aws_fsx_lustre_file_system" "test" {
+  storage_capacity = 1200
+  subnet_ids       = [aws_subnet.test1.id]
+  deployment_type  = data.aws_partition.current.partition == "aws-us-gov" ? "SCRATCH_2" : null # GovCloud does not support SCRATCH_1
+
+  log_configuration {
+    destination = aws_cloudwatch_log_group.test.arn
+    level       = %[2]q
+  }  
+}
+`, rName, status))
 }

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -1343,7 +1343,7 @@ resource "aws_fsx_lustre_file_system" "test" {
   log_configuration {
     destination = aws_cloudwatch_log_group.test.arn
     level       = %[2]q
-  }  
+  }
 }
 `, rName, status))
 }

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -48,6 +48,12 @@ The following arguments are supported:
 * `copy_tags_to_backups` - (Optional) A boolean flag indicating whether tags for the file system should be copied to backups. Applicable for `PERSISTENT_1` and `PERSISTENT_2` deployment_type. The default value is false.
 * `data_compression_type` - (Optional) Sets the data compression configuration for the file system. Valid values are `LZ4` and `NONE`. Default value is `NONE`. Unsetting this value reverts the compression type back to `NONE`.
 * `file_system_type_version` - (Optional) Sets the Lustre version for the file system that you're creating. Valid values are 2.10 for `SCRATCH_1`, `SCRATCH_2` and `PERSISTENT_1` deployment types. Valid values for 2.12 include all deployment types.
+* `log_configuration` - (Optional) The Lustre logging configuration used when creating an Amazon FSx for Lustre file system. When logging is enabled, Lustre logs error and warning events for data repositories associated with your file system to Amazon CloudWatch Logs.
+
+### log_configuration
+
+* `destination` - (Optional) The Amazon Resource Name (ARN) that specifies the destination of the logs. The name of the Amazon CloudWatch Logs log group must begin with the `/aws/fsx` prefix. If you do not provide a destination, Amazon FSx will create and use a log stream in the CloudWatch Logs `/aws/fsx/lustre` log group.
+* `level` - (Optional) Sets which data repository events are logged by Amazon FSx. Valid values are `WARN_ONLY`, `FAILURE_ONLY`, `ERROR_ONLY`, `WARN_ERROR` and `DISABLED`. Default value is `DISABLED`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22886

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccFSxLustreFileSystem_ PKG=fsx

--- PASS: TestAccFSxLustreFileSystem_logConfig (834.76s)
--- PASS: TestAccFSxLustreFileSystem_basic (628.66s)
```
