### PR TITLE
r/glue_partition_index - add timeouts

### DIFF
--- a/.changelog/22941.txt
+++ b/.changelog/22941.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_partition_index: Add support for custom timeouts.
+```

--- a/internal/service/glue/partition_index.go
+++ b/internal/service/glue/partition_index.go
@@ -3,6 +3,7 @@ package glue
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
@@ -68,6 +69,11 @@ func ResourcePartitionIndex() *schema.Resource {
 				},
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
@@ -92,7 +98,7 @@ func resourcePartitionIndexCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(createPartitionIndexID(catalogID, dbName, tableName, aws.StringValue(input.PartitionIndex.IndexName)))
 
-	if _, err := waitGluePartitionIndexCreated(conn, d.Id()); err != nil {
+	if _, err := waitGluePartitionIndexCreated(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error while waiting for Glue Partition Index (%s) to become available: %w", d.Id(), err)
 	}
 
@@ -152,7 +158,7 @@ func resourcePartitionIndexDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting Glue Partition Index: %w", err)
 	}
 
-	if _, err := waitGluePartitionIndexDeleted(conn, d.Id()); err != nil {
+	if _, err := waitGluePartitionIndexDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("error while waiting for Glue Partition Index (%s) to be deleted: %w", d.Id(), err)
 	}
 

--- a/internal/service/glue/wait.go
+++ b/internal/service/glue/wait.go
@@ -196,12 +196,12 @@ func waitGlueDevEndpointDeleted(conn *glue.Glue, name string) (*glue.DevEndpoint
 	return nil, err
 }
 
-func waitGluePartitionIndexCreated(conn *glue.Glue, id string) (*glue.PartitionIndexDescriptor, error) {
+func waitGluePartitionIndexCreated(conn *glue.Glue, id string, timeout time.Duration) (*glue.PartitionIndexDescriptor, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{glue.PartitionIndexStatusCreating},
 		Target:  []string{glue.PartitionIndexStatusActive},
 		Refresh: statusGluePartitionIndex(conn, id),
-		Timeout: 2 * time.Minute,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -213,12 +213,12 @@ func waitGluePartitionIndexCreated(conn *glue.Glue, id string) (*glue.PartitionI
 	return nil, err
 }
 
-func waitGluePartitionIndexDeleted(conn *glue.Glue, id string) (*glue.PartitionIndexDescriptor, error) {
+func waitGluePartitionIndexDeleted(conn *glue.Glue, id string, timeout time.Duration) (*glue.PartitionIndexDescriptor, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{glue.PartitionIndexStatusDeleting},
 		Target:  []string{},
 		Refresh: statusGluePartitionIndex(conn, id),
-		Timeout: 2 * time.Minute,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/website/docs/r/glue_partition_index.html.markdown
+++ b/website/docs/r/glue_partition_index.html.markdown
@@ -123,6 +123,13 @@ The following arguments are required:
 * `index_name` - (Required) Name of the partition index.
 * `keys` - (Required) Keys for the partition index.
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when creating the partition index.
+* `delete` - (Defaults to 10 mins) Used when deleting the partition index.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22908

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccGluePartitionIndex_ PKG=glue

--- PASS: TestAccGluePartitionIndex_Disappears_database (72.67s)
--- PASS: TestAccGluePartitionIndex_Disappears_table (78.67s)
--- PASS: TestAccGluePartitionIndex_basic (98.69s)
--- PASS: TestAccGluePartitionIndex_disappears (101.08s)
```
