### PR TITLE
Support modern extended statistics for CloudWatch metric alarm

### DIFF
--- a/.changelog/22942.txt
+++ b/.changelog/22942.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Additional allowed values for `extended_statistic` and `metric_query.metric.stat` arguments
+```

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -111,7 +111,11 @@ func ResourceMetricAlarm() *schema.Resource {
 										Required: true,
 										ValidateFunc: validation.Any(
 											validation.StringInSlice(cloudwatch.Statistic_Values(), false),
-											validation.StringMatch(regexp.MustCompile(`p(\d{1,2}(\.\d{0,2})?|100)`), "must specify a value between p0.0 and p100"),
+											validation.StringMatch(
+												// doesn't catch: PR with %-values provided, TM/WM/PR/TC/TS with no values provided
+												regexp.MustCompile(`^((p|(tm)|(wm)|(tc)|(ts))((\d{1,2}(\.\d{1,2})?)|(100))|(IQM)|(((TM)|(WM)|(PR)|(TC)|(TS)))\((\d+(\.\d+)?%?)?:(\d+(\.\d+)?%?)?\))$`),
+												"invalid statistic, see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html",
+											),
 										),
 									},
 									"unit": {
@@ -235,7 +239,11 @@ func ResourceMetricAlarm() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"statistic", "metric_query"},
-				ValidateFunc:  validation.StringMatch(regexp.MustCompile(`p(\d{1,2}(\.\d{0,2})?|100)`), "must specify a value between p0.0 and p100"),
+				ValidateFunc: validation.StringMatch(
+					// doesn't catch: PR with %-values provided, TM/WM/PR/TC/TS with no values provided
+					regexp.MustCompile(`^((p|(tm)|(wm)|(tc)|(ts))((\d{1,2}(\.\d{1,2})?)|(100))|(IQM)|(((TM)|(WM)|(PR)|(TC)|(TS)))\((\d+(\.\d+)?%?)?:(\d+(\.\d+)?%?)?\))$`),
+					"invalid statistic, see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html",
+				),
 			},
 			"treat_missing_data": {
 				Type:         schema.TypeString,

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -262,6 +262,38 @@ func TestAccCloudWatchMetricAlarm_extendedStatistic(t *testing.T) {
 		CheckDestroy: testAccCheckMetricAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "IQM(1:2)"), // IQM accepts no args
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "iqm10"), // IQM accepts no args
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			// {  TODO: more complex regex to reject this
+			// 	Config: testAccMetricAlarmExtendedStatisticConfig(rName, "PR(5%:10%)"),  // PR args must be absolute
+			// 	ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			// },
+			// {  TODO: more complex regex to reject this
+			// 	Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TC(:)"),  // at least one arg must be provided
+			// 	ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			// },
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "WM"), // missing syntax
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "p"), // missing arg
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "AB(1:2)"), // unknown stat 'AB'
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "cd42"), // unknown stat 'cd'
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
 				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "p88.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
@@ -365,38 +397,6 @@ func TestAccCloudWatchMetricAlarm_extendedStatistic(t *testing.T) {
 					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TC(:0.5)"),
 				),
-			},
-			{
-				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "IQM(1:2)"), // IQM accepts no args
-				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			},
-			{
-				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "iqm10"), // IQM accepts no args
-				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			},
-			// {  TODO: more complex regex to reject this
-			// 	Config: testAccMetricAlarmExtendedStatisticConfig(rName, "PR(5%:10%)"),  // PR args must be absolute
-			// 	ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			// },
-			// {  TODO: more complex regex to reject this
-			// 	Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TC(:)"),  // at least one arg must be provided
-			// 	ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			// },
-			{
-				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "WM"), // missing syntax
-				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			},
-			{
-				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "p"), // missing arg
-				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			},
-			{
-				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "AB(1:2)"), // unknown stat 'AB'
-				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
-			},
-			{
-				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "cd42"), // unknown stat 'cd'
-				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
 			},
 		},
 	})

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -262,11 +262,141 @@ func TestAccCloudWatchMetricAlarm_extendedStatistic(t *testing.T) {
 		CheckDestroy: testAccCheckMetricAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMetricAlarmExtendedStatisticConfig(rName),
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "p88.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p88.0"),
 				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "p0.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p0.0"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "p100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p100"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "p95"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p95"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "tm90"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "tm90"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TM(2%:98%)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TM(2%:98%)"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TM(150:1000)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TM(150:1000)"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "IQM"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "IQM"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "wm98"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "wm98"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "PR(:300)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "PR(:300)"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "PR(100:2000)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "PR(100:2000)"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "tc90"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "tc90"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TC(0.005:0.030)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TC(0.005:0.030)"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TS(80%:)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TS(80%:)"),
+				),
+			},
+			{
+				Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TC(:0.5)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TC(:0.5)"),
+				),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "IQM(1:2)"), // IQM accepts no args
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "iqm10"), // IQM accepts no args
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			// {  TODO: more complex regex to reject this
+			// 	Config: testAccMetricAlarmExtendedStatisticConfig(rName, "PR(5%:10%)"),  // PR args must be absolute
+			// 	ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			// },
+			// {  TODO: more complex regex to reject this
+			// 	Config: testAccMetricAlarmExtendedStatisticConfig(rName, "TC(:)"),  // at least one arg must be provided
+			// 	ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			// },
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "WM"), // missing syntax
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "p"), // missing arg
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "AB(1:2)"), // unknown stat 'AB'
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
+			},
+			{
+				Config:      testAccMetricAlarmExtendedStatisticConfig(rName, "cd42"), // unknown stat 'cd'
+				ExpectError: regexp.MustCompile(`invalid statistic, see: https:\/\/docs\.aws\.amazon\.com\/.*`),
 			},
 		},
 	})
@@ -614,7 +744,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
 `, rName)
 }
 
-func testAccMetricAlarmExtendedStatisticConfig(rName string) string {
+func testAccMetricAlarmExtendedStatisticConfig(rName string, stat string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
@@ -623,7 +753,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
   period                    = "120"
-  extended_statistic        = "p88.0"
+  extended_statistic        = "%s"
   threshold                 = "80"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
@@ -632,7 +762,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     InstanceId = "i-abc123"
   }
 }
-`, rName)
+`, rName, stat)
 }
 
 func testAccMetricAlarmMissingStatisticConfig(rName string) string {


### PR DESCRIPTION
### Community Note
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

### Details
Adds complexity to the extended-statistic reg-ex to support the current statistics defined [in the AWS docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html) during validation. Also parametrises tests for example statistics.

Closes #22078
Relates #13622

#### Test output
```
$ make test TEST=internal/service/cloudwatch/metric_alarm_test.go 
==> Checking that code complies with gofmt requirements...
go test internal/service/cloudwatch/metric_alarm_test.go  -timeout=5m
ok  	command-line-arguments	0.046s
```

### Output from acceptance testing
```
$ make testacc TESTS=TestAccCloudWatchMetricAlarm_extendedStatistic PKG=cloudwatch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_extendedStatistic'  -timeout 180m
=== RUN   TestAccCloudWatchMetricAlarm_extendedStatistic
=== PAUSE TestAccCloudWatchMetricAlarm_extendedStatistic
=== CONT  TestAccCloudWatchMetricAlarm_extendedStatistic
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: invalid value for extended_statistic (invalid statistic, see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html)
        
          with aws_cloudwatch_metric_alarm.test,
          on terraform_plugin_test.tf line 9, in resource "aws_cloudwatch_metric_alarm" "test":
           9:   extended_statistic        = "cd42"
        
--- FAIL: TestAccCloudWatchMetricAlarm_extendedStatistic (103.60s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	103.644s
FAIL
make: *** [GNUmakefile:36: testacc] Error 1
```

How do I test for invalid input? The test isn't catching the raised error, but running the test in non-acceptance mode passes