### PR TITLE
r/cloudwatch_event_target - `http_target.path_parameter_values` preserve order + validations

### DIFF
--- a/.changelog/22946.txt
+++ b/.changelog/22946.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Preserve order of `http_target.path_parameter_values`.
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_event_target: Add plan time validation for `input`, `input_path`, `run_command_targets.values`, `http_target.header_parameters`, `http_target.query_string_parameters`, `redshift_target.database`, `redshift_target.db_user`, `redshift_target.secrets_manager_arn`, `redshift_target.sql`, `redshift_target.statement_name`, `retry_policy.maximum_event_age_in_seconds`, `retry_policy.maximum_retry_attempts`.
+```

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -69,8 +71,12 @@ func ResourceTarget() *schema.Resource {
 			},
 
 			"input": {
-				Type:          schema.TypeString,
-				Optional:      true,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringIsJSON,
+					validation.StringLenBetween(0, 8192),
+				),
 				ConflictsWith: []string{"input_path", "input_transformer"},
 				// We could be normalizing the JSON here,
 				// but for built-in targets input may not be JSON
@@ -79,6 +85,7 @@ func ResourceTarget() *schema.Resource {
 			"input_path": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				ValidateFunc:  validation.StringLenBetween(0, 256),
 				ConflictsWith: []string{"input", "input_transformer"},
 			},
 
@@ -102,7 +109,11 @@ func ResourceTarget() *schema.Resource {
 						"values": {
 							Type:     schema.TypeList,
 							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							MaxItems: 50,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringLenBetween(1, 256),
+							},
 						},
 					},
 				},
@@ -117,15 +128,27 @@ func ResourceTarget() *schema.Resource {
 						"header_parameters": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							ValidateDiagFunc: allDiagFunc(
+								validation.MapKeyLenBetween(0, 512),
+								validation.MapKeyMatch(regexp.MustCompile(`^[!#$%&'*+-.^_|~0-9a-zA-Z]+$`), ""),
+								validation.MapValueLenBetween(0, 512),
+								validation.MapValueMatch(regexp.MustCompile(`^[ \t]*[\x20-\x7E]+([ \t]+[\x20-\x7E]+)*[ \t]*$`), ""),
+							),
+							Elem: &schema.Schema{Type: schema.TypeString},
 						},
 						"query_string_parameters": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							ValidateDiagFunc: allDiagFunc(
+								validation.MapKeyLenBetween(0, 512),
+								validation.MapKeyMatch(regexp.MustCompile(`[^\x00-\x1F\x7F]+`), ""),
+								validation.MapValueLenBetween(0, 512),
+								validation.MapValueMatch(regexp.MustCompile(`[^\x00-\x09\x0B\x0C\x0E-\x1F\x7F]+`), ""),
+							),
+							Elem: &schema.Schema{Type: schema.TypeString},
 						},
 						"path_parameter_values": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -281,24 +304,29 @@ func ResourceTarget() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"database": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 64),
 						},
 						"db_user": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 128),
 						},
 						"secrets_manager_arn": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidARN,
 						},
 						"sql": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 100000),
 						},
 						"statement_name": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 500),
 						},
 						"with_event": {
 							Type:     schema.TypeBool,
@@ -356,11 +384,12 @@ func ResourceTarget() *schema.Resource {
 						"maximum_event_age_in_seconds": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntAtLeast(60),
+							ValidateFunc: validation.IntBetween(0, 86400),
 						},
 						"maximum_retry_attempts": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 185),
 						},
 					},
 				},
@@ -1071,4 +1100,14 @@ func resourceTargetImport(d *schema.ResourceData, meta interface{}) ([]*schema.R
 	d.Set("event_bus_name", busName)
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func allDiagFunc(validators ...schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
+	return func(i interface{}, k cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		for _, validator := range validators {
+			diags = append(diags, validator(i, k)...)
+		}
+		return diags
+	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
 Closes #22929

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccEventsTarget_ PKG=events

--- PASS: TestAccEventsTarget_disappears (51.58s)
--- PASS: TestAccEventsTarget_ssmDocument (57.99s)
--- PASS: TestAccEventsTarget_generatedTargetID (58.12s)
--- PASS: TestAccEventsTarget_eventBusARN (58.92s)
--- PASS: TestAccEventsTarget_http (66.10s)
--- PASS: TestAccEventsTarget_inputTransformerJSONString (72.13s)
--- PASS: TestAccEventsTarget_ecsWithBlankTaskCount (73.99s)
--- PASS: TestAccEventsTarget_ecsFull (74.37s)
--- PASS: TestAccEventsTarget_kinesis (86.51s)
--- PASS: TestAccEventsTarget_full (87.84s)
--- PASS: TestAccEventsTarget_Input_transformer (88.13s)
--- PASS: TestAccEventsTarget_RetryPolicy_deadLetter (98.43s)
--- PASS: TestAccEventsTarget_sqs (100.55s)
--- PASS: TestAccEventsTarget_eventBusName (108.29s)
--- PASS: TestAccEventsTarget_basic (125.35s)
--- PASS: TestAccEventsTarget_batch (166.17s)
--- PASS: TestAccEventsTarget_ecsWithoutLaunchType (171.63s)
--- PASS: TestAccEventsTarget_ecsWithBlankLaunchType (172.59s)
--- PASS: TestAccEventsTarget_redshift (239.37s)
--- PASS: TestAccEventsTarget_ecs (309.72s)
```
