### PR TITLE
ec2: Remove remaining empty validation

### DIFF
--- a/.changelog/22948.txt
+++ b/.changelog/22948.txt
@@ -6,3 +6,6 @@ resource/aws_default_vpc: `ipv6_cidr_block` can no longer be set to `""`; remove
 resource/aws_instance: `private_ip` can no longer be set to `""`; remove or set to `null`
 ```
 
+```release-note:breaking-change
+resource/aws_vpc_ipv6_cidr_block_association: `ipv6_cidr_block` can no longer be set to `""`; remove or set to `null`
+```

--- a/.changelog/22948.txt
+++ b/.changelog/22948.txt
@@ -1,0 +1,8 @@
+```release-note:breaking-change
+resource/aws_default_vpc: `ipv6_cidr_block` can no longer be set to `""`; remove or set to `null`
+```
+
+```release-note:breaking-change
+resource/aws_instance: `private_ip` can no longer be set to `""`; remove or set to `null`
+```
+

--- a/.changelog/22948.txt
+++ b/.changelog/22948.txt
@@ -9,3 +9,7 @@ resource/aws_instance: `private_ip` can no longer be set to `""`; remove or set 
 ```release-note:breaking-change
 resource/aws_vpc_ipv6_cidr_block_association: `ipv6_cidr_block` can no longer be set to `""`; remove or set to `null`
 ```
+
+```release-note:breaking-change
+resource/aws_vpc: `ipv6_cidr_block` can no longer be set to `""`; remove or set to `null`
+```

--- a/internal/service/ec2/default_vpc.go
+++ b/internal/service/ec2/default_vpc.go
@@ -113,12 +113,9 @@ func ResourceDefaultVPC() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"ipv6_netmask_length", "assign_generated_ipv6_cidr_block"},
 				RequiredWith:  []string{"ipv6_ipam_pool_id"},
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					validation.All(
-						verify.ValidIPv6CIDRNetworkAddress,
-						validation.IsCIDRNetwork(VPCCIDRMaxIPv6, VPCCIDRMaxIPv6)),
-				),
+				ValidateFunc: validation.All(
+					verify.ValidIPv6CIDRNetworkAddress,
+					validation.IsCIDRNetwork(VPCCIDRMaxIPv6, VPCCIDRMaxIPv6)),
 			},
 			"ipv6_cidr_block_network_border_group": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/instance.go
+++ b/internal/service/ec2/instance.go
@@ -440,14 +440,11 @@ func ResourceInstance() *schema.Resource {
 				Computed: true,
 			},
 			"private_ip": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					validation.IsIPv4Address,
-				),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 			"public_dns": {
 				Type:     schema.TypeString,

--- a/internal/service/ec2/vpc.go
+++ b/internal/service/ec2/vpc.go
@@ -130,12 +130,9 @@ func ResourceVPC() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"ipv6_netmask_length", "assign_generated_ipv6_cidr_block"},
 				RequiredWith:  []string{"ipv6_ipam_pool_id"},
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					validation.All(
-						verify.ValidIPv6CIDRNetworkAddress,
-						validation.IsCIDRNetwork(VPCCIDRMaxIPv6, VPCCIDRMaxIPv6)),
-				),
+				ValidateFunc: validation.All(
+					verify.ValidIPv6CIDRNetworkAddress,
+					validation.IsCIDRNetwork(VPCCIDRMaxIPv6, VPCCIDRMaxIPv6)),
 			},
 			"ipv6_cidr_block_network_border_group": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/vpc_ipv6_cidr_block_association.go
+++ b/internal/service/ec2/vpc_ipv6_cidr_block_association.go
@@ -42,12 +42,9 @@ func ResourceVPCIPv6CIDRBlockAssociation() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					validation.All(
-						verify.ValidIPv6CIDRNetworkAddress,
-						validation.IsCIDRNetwork(VPCCIDRMaxIPv6, VPCCIDRMaxIPv6)),
-				),
+				ValidateFunc: validation.All(
+					verify.ValidIPv6CIDRNetworkAddress,
+					validation.IsCIDRNetwork(VPCCIDRMaxIPv6, VPCCIDRMaxIPv6)),
 			},
 			// ipam parameters are not required by the API but other usage mechanisms are not implemented yet. TODO ipv6 options:
 			// --amazon-provided-ipv6-cidr-block

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -25,28 +25,30 @@ Upgrade topics:
     - [Resource: aws_default_subnet](#resource-aws_default_subnet)
     - [Resource: aws_default_vpc](#resource-aws_default_vpc)
 - [Plural Data Source Behavior](#plural-data-source-behavior)
+- [Empty Strings Not Valid For Certain Resources](#empty-strings-not-valid-for-certain-resources)
+    - [Resource: aws_customer_gateway](#resource-aws_customer_gateway)
+    - [Resource: aws_default_network_acl](#resource-aws_default_network_acl)
+    - [Resource: aws_default_route_table](#resource-aws_default_route_table)
+    - [Resource: aws_default_vpc (Empty String)](#resource-aws_default_vpc-empty-string)
+    - [Resource: aws_instance](#resource-aws_instance)
+    - [Resource: aws_network_acl](#resource-aws_network_acl)
+    - [Resource: aws_route](#resource-aws_route)
+    - [Resource: aws_route_table](#resource-aws_route_table)
+    - [Resource: aws_vpc_ipv6_cidr_block_association](#resource-aws_vpc_ipv6_cidr_block_association)
 - [Data Source: aws_cloudwatch_log_group](#data-source-aws_cloudwatch_log_group)
 - [Data Source: aws_subnet_ids](#data-source-aws_subnet_ids)
 - [Data Source: aws_s3_bucket_object](#data-source-aws_s3_bucket_object)
 - [Data Source: aws_s3_bucket_objects](#data-source-aws_s3_bucket_objects)
 - [Resource: aws_batch_compute_environment](#resource-aws_batch_compute_environment)
 - [Resource: aws_cloudwatch_event_target](#resource-aws_cloudwatch_event_target)
-- [Resource: aws_customer_gateway](#resource-aws_customer_gateway)
-- [Resource: aws_default_network_acl](#resource-aws_default_network_acl)
-- [Resource: aws_default_route_table](#resource-aws_default_route_table)
-- [Resource: aws_default_vpc](#resource-aws_default_vpc)
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
 - [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine)
-- [Resource: aws_instance](#resource-aws_instance)
-- [Resource: aws_network_acl](#resource-aws_network_acl)
 - [Resource: aws_network_interface](#resource-aws_network_interface)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_s3_bucket_object](#resource-aws_s3_bucket_object)
 - [Resource: aws_spot_instance_request](#resource-aws_spot_instance_request)
-- [Resource: aws_route](#resource-aws_route)
-- [Resource: aws_route_table](#resource-aws_route_table)
 
 <!-- /TOC -->
 
@@ -86,30 +88,6 @@ provider "aws" {
   version = "~> 4.0"
 }
 ```
-
-## Plural Data Source Behavior
-
-The following plural data sources are now consistent with [Provider Design](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/provider-design.md#data-sources)
-such that they no longer return an error if zero results are found.
-
-* [aws_cognito_user_pools](/docs/providers/aws/d/cognito_user_pools.html)
-* [aws_db_event_categories](/docs/providers/aws/d/db_event_categories.html)
-* [aws_ebs_volumes](/docs/providers/aws/d/ebs_volumes.html)
-* [aws_ec2_coip_pools](/docs/providers/aws/d/ec2_coip_pools.html)
-* [aws_ec2_local_gateway_route_tables](/docs/providers/aws/d/ec2_local_gateway_route_tables.html)
-* [aws_ec2_local_gateway_virtual_interface_groups](/docs/providers/aws/d/ec2_local_gateway_virtual_interface_groups.html)
-* [aws_ec2_local_gateways](/docs/providers/aws/d/ec2_local_gateways.html)
-* [aws_ec2_transit_gateway_route_tables](/docs/providers/aws/d/ec2_transit_gateway_route_tables.html)
-* [aws_efs_access_points](/docs/providers/aws/d/efs_access_points.html)
-* [aws_emr_release_labels](/docs/providers/aws/d/emr_release_labels.markdown)
-* [aws_inspector_rules_packages](/docs/providers/aws/d/inspector_rules_packages.html)
-* [aws_ip_ranges](/docs/providers/aws/d/ip_ranges.html)
-* [aws_network_acls](/docs/providers/aws/d/network_acls.html)
-* [aws_route_tables](/docs/providers/aws/d/route_tables.html)
-* [aws_security_groups](/docs/providers/aws/d/security_groups.html)
-* [aws_ssoadmin_instances](/docs/providers/aws/d/ssoadmin_instances.html)
-* [aws_vpcs](/docs/providers/aws/d/vpcs.html)
-* [aws_vpc_peering_connections](/docs/providers/aws/d/vpc_peering_connections.html)
 
 ## Full Resource Lifecycle of Default Resources
 
@@ -221,6 +199,213 @@ resource "aws_default_vpc" "default" {
   force_destroy = true
 }
 ```
+
+## Plural Data Source Behavior
+
+The following plural data sources are now consistent with [Provider Design](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/provider-design.md#data-sources)
+such that they no longer return an error if zero results are found.
+
+* [aws_cognito_user_pools](/docs/providers/aws/d/cognito_user_pools.html)
+* [aws_db_event_categories](/docs/providers/aws/d/db_event_categories.html)
+* [aws_ebs_volumes](/docs/providers/aws/d/ebs_volumes.html)
+* [aws_ec2_coip_pools](/docs/providers/aws/d/ec2_coip_pools.html)
+* [aws_ec2_local_gateway_route_tables](/docs/providers/aws/d/ec2_local_gateway_route_tables.html)
+* [aws_ec2_local_gateway_virtual_interface_groups](/docs/providers/aws/d/ec2_local_gateway_virtual_interface_groups.html)
+* [aws_ec2_local_gateways](/docs/providers/aws/d/ec2_local_gateways.html)
+* [aws_ec2_transit_gateway_route_tables](/docs/providers/aws/d/ec2_transit_gateway_route_tables.html)
+* [aws_efs_access_points](/docs/providers/aws/d/efs_access_points.html)
+* [aws_emr_release_labels](/docs/providers/aws/d/emr_release_labels.markdown)
+* [aws_inspector_rules_packages](/docs/providers/aws/d/inspector_rules_packages.html)
+* [aws_ip_ranges](/docs/providers/aws/d/ip_ranges.html)
+* [aws_network_acls](/docs/providers/aws/d/network_acls.html)
+* [aws_route_tables](/docs/providers/aws/d/route_tables.html)
+* [aws_security_groups](/docs/providers/aws/d/security_groups.html)
+* [aws_ssoadmin_instances](/docs/providers/aws/d/ssoadmin_instances.html)
+* [aws_vpcs](/docs/providers/aws/d/vpcs.html)
+* [aws_vpc_peering_connections](/docs/providers/aws/d/vpc_peering_connections.html)
+
+## Empty Strings Not Valid For Certain Resources
+
+First, this breaking change but should affect very few configurations.
+
+Second, the motivation behind this change is that previously, you might set an argument to `""` to explicity convey it is empty. However, with the introduction of `null` in Terraform 0.12 and to prepare for continuing enhancements that distinguish between unset arguments and those that have a value, including an empty string (`""`), we are moving away from this use of zero values. We ask practitioners to either use `null` instead or remove the arguments that are set to `""`.
+
+### Resource: aws_customer_gateway
+
+Previously, `ip_address` could be set to `""`, which would result in an AWS error. However, this value is no longer accepted by the provider.
+
+### Resource: aws_default_network_acl
+
+Previously, `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, and `ingress.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_default_network_acl" "example" {
+  # ...
+  egress {
+    cidr_block      = "0.0.0.0/0"
+    ipv6_cidr_block = ""
+    # ...
+  }
+}
+```
+
+In this updated and valid configuration, we remove the empty-string configuration:
+
+```terraform
+resource "aws_default_network_acl" "example" {
+  # ...
+  egress {
+    cidr_block = "0.0.0.0/0"
+    # ...
+  }
+}
+```
+
+### Resource: aws_default_route_table
+
+Previously, `route.*.cidr_block` and `route.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_default_route_table" "example" {
+  # ...
+  route {
+    cidr_block      = local.ipv6 ? "" : local.destination
+    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
+  }
+}
+```
+
+In this updated and valid configuration, we use `null` instead of an empty string (`""`):
+
+```terraform
+resource "aws_default_route_table" "example" {
+  # ...
+  route {
+    cidr_block      = local.ipv6 ? null : local.destination
+    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
+  }
+}
+```
+
+### Resource: aws_default_vpc (Empty String)
+
+Previously, `ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+### Resource: aws_instance
+
+Previously, `private_ip` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `private_ip = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_instance" "test" {
+  instance_type = "t2.micro"
+  private_ip    = ""
+}
+```
+
+In this updated and valid configuration, we remove the empty-string configuration:
+
+```terraform
+resource "aws_instance" "test" {
+  instance_type = "t2.micro"
+}
+```
+
+### Resource: aws_network_acl
+
+Previously, `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, and `ingress.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_network_acl" "example" {
+  # ...
+  egress {
+    cidr_block      = "0.0.0.0/0"
+    ipv6_cidr_block = ""
+    # ...
+  }
+}
+```
+
+In this updated and valid configuration, we remove the empty-string configuration:
+
+```terraform
+resource "aws_network_acl" "example" {
+  # ...
+  egress {
+    cidr_block = "0.0.0.0/0"
+    # ...
+  }
+}
+```
+
+### Resource: aws_route
+
+Previously, `destination_cidr_block` and `destination_ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `destination_ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+In addition, now exactly one of `destination_cidr_block`, `destination_ipv6_cidr_block`, and `destination_prefix_list_id` can be set.
+
+For example, this type of configuration for `aws_route` is now not valid:
+
+```terraform
+resource "aws_route" "test" {
+  route_table_id = aws_route_table.test.id
+  gateway_id     = aws_internet_gateway.test.id
+
+  destination_cidr_block      = local.ipv6 ? "" : local.destination
+  destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
+}
+```
+
+In this updated and valid configuration, we use `null` instead of an empty-string (`""`):
+
+```terraform
+resource "aws_route" "test" {
+  route_table_id = aws_route_table.test.id
+  gateway_id     = aws_internet_gateway.test.id
+
+  destination_cidr_block      = local.ipv6 ? null : local.destination
+  destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
+}
+```
+
+### Resource: aws_route_table
+
+Previously, `route.*.cidr_block` and `route.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_route_table" "example" {
+  # ...
+  route {
+    cidr_block      = local.ipv6 ? "" : local.destination
+    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
+  }
+}
+```
+
+In this updated and valid configuration, we used `null` instead of an empty-string (`""`):
+
+```terraform
+resource "aws_route_table" "example" {
+  # ...
+  route {
+    cidr_block      = local.ipv6 ? null : local.destination
+    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
+  }
+}
+```
+
+### Resource: aws_vpc_ipv6_cidr_block_association
+
+Previously, `ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
 
 ## Data Source: aws_cloudwatch_log_group
 
@@ -414,71 +599,6 @@ resource "aws_cloudwatch_event_target" "test" {
 }
 ```
 
-## Resource: aws_customer_gateway
-
-Previously, `ip_address` could be set to `""`, which would result in an AWS error. However, this value is no longer accepted by the provider.
-
-## Resource: aws_default_network_acl
-
-Previously, `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, and `ingress.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
-
-For example, this type of configuration is now not valid:
-
-```terraform
-resource "aws_default_network_acl" "example" {
-  # ...
-  egress {
-    cidr_block      = "0.0.0.0/0"
-    ipv6_cidr_block = ""
-    # ...
-  }
-}
-```
-
-In this updated and valid configuration, we remove the empty-string configuration:
-
-```terraform
-resource "aws_default_network_acl" "example" {
-  # ...
-  egress {
-    cidr_block = "0.0.0.0/0"
-    # ...
-  }
-}
-```
-
-## Resource: aws_default_route_table
-
-Previously, `route.*.cidr_block` and `route.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
-
-For example, this type of configuration is now not valid:
-
-```terraform
-resource "aws_default_route_table" "example" {
-  # ...
-  route {
-    cidr_block      = local.ipv6 ? "" : local.destination
-    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
-  }
-}
-```
-
-In this updated and valid configuration, we use `null` instead of an empty string (`""`):
-
-```terraform
-resource "aws_default_route_table" "example" {
-  # ...
-  route {
-    cidr_block      = local.ipv6 ? null : local.destination
-    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
-  }
-}
-```
-
-## Resource: aws_default_vpc
-
-Previously, `ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
-
 ## Resource: aws_elasticache_cluster
 
 ### Error raised if neither `engine` nor `replication_group_id` is specified
@@ -537,56 +657,6 @@ output "elasticache_global_replication_group_version_result" {
 
 We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning.
 
-## Resource: aws_instance
-
-Previously, `private_ip` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `private_ip = null`) or remove the empty-string configuration.
-
-For example, this type of configuration is now not valid:
-
-```terraform
-resource "aws_instance" "test" {
-  instance_type = "t2.micro"
-  private_ip    = ""
-}
-```
-
-In this updated and valid configuration, we remove the empty-string configuration:
-
-```terraform
-resource "aws_instance" "test" {
-  instance_type = "t2.micro"
-}
-```
-
-## Resource: aws_network_acl
-
-Previously, `egress.*.cidr_block`, `egress.*.ipv6_cidr_block`, `ingress.*.cidr_block`, and `ingress.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
-
-For example, this type of configuration is now not valid:
-
-```terraform
-resource "aws_network_acl" "example" {
-  # ...
-  egress {
-    cidr_block      = "0.0.0.0/0"
-    ipv6_cidr_block = ""
-    # ...
-  }
-}
-```
-
-In this updated and valid configuration, we remove the empty-string configuration:
-
-```terraform
-resource "aws_network_acl" "example" {
-  # ...
-  egress {
-    cidr_block = "0.0.0.0/0"
-    # ...
-  }
-}
-```
-
 ## Resource: aws_network_interface
 
 !> **WARNING:** This topic is placeholder documentation.
@@ -635,11 +705,11 @@ resource "aws_s3_bucket" "example" {
 
 resource "aws_s3_bucket_website_configuration" "example" {
   bucket = aws_s3_bucket.example.id
-  
+
   index_document {
     suffix = "index.html"
   }
-  
+
   error_document {
     key = "error.html"
   }
@@ -702,7 +772,7 @@ resource "aws_s3_bucket" "website" {
 
 resource "aws_s3_bucket_website_configuration" "example" {
   bucket = aws_s3_bucket.website.id
-  
+
   index_document {
     suffix = "index.html"
   }
@@ -712,13 +782,25 @@ resource "aws_route53_record" "alias" {
   zone_id = aws_route53_zone.main.zone_id
   name    = "www"
   type    = "A"
-  
+
   alias {
     zone_id                = aws_s3_bucket.website.hosted_zone_id
     name                   = aws_s3_bucket_website_configuration.example.website_domain
     evaluate_target_health = true
   }
 }
+```
+
+## Resource: aws_s3_bucket_object
+
+The `aws_s3_bucket_object` resource is deprecated and will be removed in a future version. Use `aws_s3_object` instead, where new features and fixes will be added.
+
+When replacing `aws_s3_bucket_object` with `aws_s3_object` in your configuration, on the next apply, Terraform will recreate the object. If you prefer to not have Terraform recreate the object, import the object using `aws_s3_object`.
+
+For example, the following will import an S3 object into state, assuming the configuration exists, as `aws_s3_object.example`:
+
+```console
+% terraform import aws_s3_object.example s3://some-bucket-name/some/key.txt
 ```
 
 ## Resource: aws_spot_instance_request
@@ -743,76 +825,6 @@ resource "aws_spot_instance_request" "example" {
   # ... other configuration ...
   instance_interruption_behavior =  "hibernate"
 }
-```
-
-## Resource: aws_route
-
-Previously, `destination_cidr_block` and `destination_ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `destination_ipv6_cidr_block = null`) or remove the empty-string configuration.
-
-In addition, now exactly one of `destination_cidr_block`, `destination_ipv6_cidr_block`, and `destination_prefix_list_id` can be set.
-
-For example, this type of configuration for `aws_route` is now not valid:
-
-```terraform
-resource "aws_route" "test" {
-  route_table_id = aws_route_table.test.id
-  gateway_id     = aws_internet_gateway.test.id
-
-  destination_cidr_block      = local.ipv6 ? "" : local.destination
-  destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
-}
-```
-
-In this updated and valid configuration, we use `null` instead of an empty-string (`""`):
-
-```terraform
-resource "aws_route" "test" {
-  route_table_id = aws_route_table.test.id
-  gateway_id     = aws_internet_gateway.test.id
-
-  destination_cidr_block      = local.ipv6 ? null : local.destination
-  destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
-}
-```
-
-## Resource: aws_route_table
-
-Previously, `route.*.cidr_block` and `route.*.ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
-
-For example, this type of configuration is now not valid:
-
-```terraform
-resource "aws_route_table" "example" {
-  # ...
-  route {
-    cidr_block      = local.ipv6 ? "" : local.destination
-    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
-  }
-}
-```
-
-In this updated and valid configuration, we used `null` instead of an empty-string (`""`):
-
-```terraform
-resource "aws_route_table" "example" {
-  # ...
-  route {
-    cidr_block      = local.ipv6 ? null : local.destination
-    ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
-  }
-}
-```
-
-## Resource: aws_s3_bucket_object
-
-The `aws_s3_bucket_object` resource is deprecated and will be removed in a future version. Use `aws_s3_object` instead, where new features and fixes will be added.
-
-When replacing `aws_s3_bucket_object` with `aws_s3_object` in your configuration, on the next apply, Terraform will recreate the object. If you prefer to not have Terraform recreate the object, import the object using `aws_s3_object`.
-
-For example, the following will import an S3 object into state, assuming the configuration exists, as `aws_s3_object.example`:
-
-```console
-% terraform import aws_s3_object.example s3://some-bucket-name/some/key.txt
 ```
 
 ## EC2-Classic Resource and Data Source Support

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -229,7 +229,7 @@ such that they no longer return an error if zero results are found.
 
 First, this breaking change but should affect very few configurations.
 
-Second, the motivation behind this change is that previously, you might set an argument to `""` to explicity convey it is empty. However, with the introduction of `null` in Terraform 0.12 and to prepare for continuing enhancements that distinguish between unset arguments and those that have a value, including an empty string (`""`), we are moving away from this use of zero values. We ask practitioners to either use `null` instead or remove the arguments that are set to `""`.
+Second, the motivation behind this change is that previously, you might set an argument to `""` to explicitly convey it is empty. However, with the introduction of `null` in Terraform 0.12 and to prepare for continuing enhancements that distinguish between unset arguments and those that have a value, including an empty string (`""`), we are moving away from this use of zero values. We ask practitioners to either use `null` instead or remove the arguments that are set to `""`.
 
 ### Resource: aws_customer_gateway
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -227,7 +227,7 @@ such that they no longer return an error if zero results are found.
 
 ## Empty Strings Not Valid For Certain Resources
 
-First, this breaking change but should affect very few configurations.
+First, this is a breaking change but should affect very few configurations.
 
 Second, the motivation behind this change is that previously, you might set an argument to `""` to explicitly convey it is empty. However, with the introduction of `null` in Terraform 0.12 and to prepare for continuing enhancements that distinguish between unset arguments and those that have a value, including an empty string (`""`), we are moving away from this use of zero values. We ask practitioners to either use `null` instead or remove the arguments that are set to `""`.
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -34,10 +34,12 @@ Upgrade topics:
 - [Resource: aws_customer_gateway](#resource-aws_customer_gateway)
 - [Resource: aws_default_network_acl](#resource-aws_default_network_acl)
 - [Resource: aws_default_route_table](#resource-aws_default_route_table)
+- [Resource: aws_default_vpc](#resource-aws_default_vpc)
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
 - [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine)
+- [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_network_acl](#resource-aws_network_acl)
 - [Resource: aws_network_interface](#resource-aws_network_interface)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
@@ -473,6 +475,10 @@ resource "aws_default_route_table" "example" {
 }
 ```
 
+## Resource: aws_default_vpc
+
+Previously, `ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
 ## Resource: aws_elasticache_cluster
 
 ### Error raised if neither `engine` nor `replication_group_id` is specified
@@ -530,6 +536,27 @@ output "elasticache_global_replication_group_version_result" {
 ## Resource: aws_fsx_ontap_storage_virtual_machine
 
 We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning.
+
+## Resource: aws_instance
+
+Previously, `private_ip` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `private_ip = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_instance" "test" {
+  instance_type = "t2.micro"
+  private_ip    = ""
+}
+```
+
+In this updated and valid configuration, we remove the empty-string configuration:
+
+```terraform
+resource "aws_instance" "test" {
+  instance_type = "t2.micro"
+}
+```
 
 ## Resource: aws_network_acl
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -34,6 +34,7 @@ Upgrade topics:
     - [Resource: aws_network_acl](#resource-aws_network_acl)
     - [Resource: aws_route](#resource-aws_route)
     - [Resource: aws_route_table](#resource-aws_route_table)
+    - [Resource: aws_vpc](#resource-aws_vpc)
     - [Resource: aws_vpc_ipv6_cidr_block_association](#resource-aws_vpc_ipv6_cidr_block_association)
 - [Data Source: aws_cloudwatch_log_group](#data-source-aws_cloudwatch_log_group)
 - [Data Source: aws_subnet_ids](#data-source-aws_subnet_ids)
@@ -400,6 +401,27 @@ resource "aws_route_table" "example" {
     cidr_block      = local.ipv6 ? null : local.destination
     ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
   }
+}
+```
+
+### Resource: aws_vpc
+
+Previously, `ipv6_cidr_block` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ipv6_cidr_block = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_vpc" "test" {
+  cidr_block      = "10.1.0.0/16"
+  ipv6_cidr_block = ""
+}
+```
+
+In this updated and valid configuration, we remove `ipv6_cidr_block`:
+
+```terraform
+resource "aws_vpc" "test" {
+  cidr_block      = "10.1.0.0/16"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13943

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS='TestAccEC2VPC_|TestAccEC2VPCDataSource_' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run=TestAccEC2VPCDataSource_  -timeout 180m
--- PASS: TestAccEC2VPCDataSource_basic (39.49s)
--- PASS: TestAccEC2VPCDataSource_CIDRBlockAssociations_multiple (53.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	54.810s
% make testacc TESTS='TestAccVPC_|TestAccVPCDataSource_' PKG=ec2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPC_|TestAccVPCDataSource_'  -timeout 180m
--- SKIP: TestAccVPC_IpamIpv4BasicExplicitCidr (1.56s)
--- SKIP: TestAccVPC_IpamIpv4BasicNetmask (1.56s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (5.14s)
--- PASS: TestAccVPC_disappears (17.80s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (89.71s)
--- PASS: TestAccVPC_basic (45.77s)
--- PASS: TestAccVPC_classicLinkDNSSupportOptionSet (48.60s)
--- PASS: TestAccVPC_classicLinkOptionSet (48.80s)
--- PASS: TestAccVPC_disabledDNSSupport (63.37s)
--- PASS: TestAccVPC_bothDNSOptionsSet (63.63s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (62.20s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (67.52s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (69.11s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (70.33s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (76.37s)
--- PASS: TestAccVPC_updateDNSHostnames (76.57s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (78.07s)
--- PASS: TestAccVPC_DefaultTags_providerOnly (79.25s)
--- PASS: TestAccVPC_ignoreTags (83.37s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (83.38s)
--- PASS: TestAccVPC_tags (95.51s)
--- PASS: TestAccVPC_tenancy (100.31s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (131.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	132.855s
% make testacc TESTS=TestAccEC2DefaultVPCAndSubnet_serial PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2DefaultVPCAndSubnet_serial'  -timeout 180m
--- PASS: TestAccEC2DefaultVPCAndSubnet_serial (1.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	2.894s
% make testacc TESTS='TestAccEC2Instance_|TestAccEC2InstanceDataSource_' PKG=ec2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_|TestAccEC2InstanceDataSource_'  -timeout 180m
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs (81.19s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate (154.49s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs (107.95s)
--- PASS: TestAccEC2InstanceDataSource_basic (113.25s)
--- PASS: TestAccEC2Instance_LaunchTemplate_overrideTemplate (116.06s)
--- PASS: TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion (118.36s)
--- PASS: TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck (118.18s)
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (127.18s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePublic (127.18s)
--- PASS: TestAccEC2Instance_LaunchTemplate_setSpecificVersion (127.96s)
--- PASS: TestAccEC2Instance_Empty_privateIP (119.57s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPrivate (135.96s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPrivate (137.71s)
--- PASS: TestAccEC2Instance_AssociatePublic_overridePrivate (139.36s)
--- PASS: TestAccEC2Instance_primaryNetworkInterface (135.89s)
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPublic (146.97s)
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPublic (158.14s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs (207.99s)
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate (208.00s)
--- PASS: TestAccEC2Instance_LaunchTemplate_updateTemplateVersion (211.34s)
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (224.39s)
--- PASS: TestAccEC2Instance_associatePublicIPAndPrivateIP (108.79s)
--- PASS: TestAccEC2Instance_privateIP (120.78s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed (159.35s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination (148.69s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (122.53s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize (157.11s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyAll (157.36s)
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination (167.94s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3 (166.84s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2 (168.28s)
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1 (169.54s)
--- PASS: TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices (203.31s)
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (29.23s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (117.69s)
--- PASS: TestAccEC2Instance_keyPairCheck (211.99s)
--- PASS: TestAccEC2Instance_rootBlockDeviceMismatch (229.39s)
--- SKIP: TestAccEC2Instance_outpost (0.64s)
--- PASS: TestAccEC2Instance_tags (121.96s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (185.08s)
--- PASS: TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs (127.21s)
--- PASS: TestAccEC2Instance_addSecondaryInterface (401.01s)
--- PASS: TestAccEC2Instance_addSecurityGroupNetworkInterface (404.70s)
--- PASS: TestAccEC2Instance_networkInstanceSecurityGroups (128.71s)
--- PASS: TestAccEC2Instance_gp2WithIopsValue (10.88s)
--- PASS: TestAccEC2Instance_noAMIEphemeralDevices (102.49s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (9.72s)
--- PASS: TestAccEC2Instance_placementPartitionNumber (108.63s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (9.94s)
--- PASS: TestAccEC2Instance_rootInstanceStore (107.43s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (142.82s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (150.31s)
--- PASS: TestAccEC2Instance_placementGroup (107.71s)
--- SKIP: TestAccEC2Instance_inEC2Classic (0.44s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_withAttachedVolume (215.73s)
--- PASS: TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups (170.78s)
--- PASS: TestAccEC2Instance_instanceProfileChange (251.43s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyType (160.14s)
--- PASS: TestAccEC2Instance_dedicatedInstance (118.98s)
--- PASS: TestAccEC2Instance_EBSRootDevice_modifySize (168.73s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_kmsKeyARN (84.38s)
--- PASS: TestAccEC2Instance_blockDevices (112.37s)
--- PASS: TestAccEC2Instance_basic (78.88s)
--- PASS: TestAccEC2Instance_changeInstanceType (208.06s)
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (96.40s)
--- PASS: TestAccEC2Instance_gp2IopsDevice (112.42s)
--- PASS: TestAccEC2Instance_disableAPITermination (144.37s)
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (286.76s)
--- PASS: TestAccEC2InstanceDataSource_privateIP (111.71s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgName (104.07s)
--- PASS: TestAccEC2Instance_inDefaultVPCBySgID (115.89s)
--- PASS: TestAccEC2Instance_RootBlockDevice_kmsKeyARN (123.09s)
--- PASS: TestAccEC2InstanceDataSource_blockDeviceTags (105.33s)
--- PASS: TestAccEC2Instance_sourceDestCheck (191.03s)
--- PASS: TestAccEC2InstanceDataSource_vpcSecurityGroups (125.84s)
--- PASS: TestAccEC2InstanceDataSource_GetPasswordData_trueToFalse (203.65s)
--- PASS: TestAccEC2Instance_userDataBase64 (191.36s)
--- PASS: TestAccEC2Instance_atLeastOneOtherEBSVolume (182.49s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits (169.14s)
--- PASS: TestAccEC2InstanceDataSource_securityGroups (124.32s)
--- PASS: TestAccEC2Instance_gp3RootBlockDevice (164.50s)
--- PASS: TestAccEC2InstanceDataSource_placementGroup (120.95s)
--- PASS: TestAccEC2InstanceDataSource_vpc (124.36s)
--- PASS: TestAccEC2InstanceDataSource_secondaryPrivateIPs (123.77s)
--- PASS: TestAccEC2InstanceDataSource_enclaveOptions (101.78s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_none (121.97s)
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (124.75s)
--- PASS: TestAccEC2Instance_CapacityReservationPreference_open (120.21s)
--- PASS: TestAccEC2InstanceDataSource_metadataOptions (124.14s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyTarget (186.96s)
--- PASS: TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits (138.31s)
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (172.43s)
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (131.45s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits (155.47s)
--- PASS: TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable (108.22s)
--- PASS: TestAccEC2InstanceDataSource_creditSpecification (113.85s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits (130.12s)
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited (130.28s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3 (109.72s)
--- PASS: TestAccEC2InstanceDataSource_keyPair (117.87s)
--- PASS: TestAccEC2InstanceDataSource_ipv6Addresses (136.34s)
--- PASS: TestAccEC2InstanceDataSource_blockDevices (85.24s)
--- PASS: TestAccEC2Instance_metadataOptions (159.38s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2 (141.71s)
--- PASS: TestAccEC2Instance_CreditSpecification_updateCPUCredits (188.37s)
--- PASS: TestAccEC2InstanceDataSource_gp2IopsDevice (106.61s)
--- PASS: TestAccEC2Instance_enclaveOptions (205.85s)
--- PASS: TestAccEC2InstanceDataSource_gp3ThroughputDevice (107.90s)
--- PASS: TestAccEC2Instance_UserData_unspecifiedToEmptyString (154.69s)
--- PASS: TestAccEC2InstanceDataSource_GetUserData_noUserData (220.32s)
--- PASS: TestAccEC2InstanceDataSource_rootInstanceStore (114.50s)
--- PASS: TestAccEC2InstanceDataSource_RootBlockDevice_kmsKeyID (107.39s)
--- PASS: TestAccEC2InstanceDataSource_getUserData (197.39s)
--- PASS: TestAccEC2Instance_UserData_emptyStringToUnspecified (132.46s)
--- PASS: TestAccEC2InstanceDataSource_GetPasswordData_falseToTrue (198.94s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable (143.43s)
--- PASS: TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint (184.16s)
--- PASS: TestAccEC2Instance_hibernation (219.39s)
--- PASS: TestAccEC2InstanceDataSource_EBSBlockDevice_kmsKeyID (139.19s)
--- PASS: TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable (140.86s)
--- PASS: TestAccEC2InstanceDataSource_tags (128.49s)
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (159.61s)
--- PASS: TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard (134.78s)
--- PASS: TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint (232.38s)
--- PASS: TestAccEC2Instance_LaunchTemplate_swapIDAndName (127.08s)
--- PASS: TestAccEC2InstanceDataSource_azUserData (130.69s)
--- PASS: TestAccEC2Instance_CreditSpecification_standardCPUCredits (175.50s)
--- PASS: TestAccEC2Instance_disappears (318.85s)
--- PASS: TestAccEC2Instance_GetPasswordData_trueToFalse (202.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1045.837s
```
