### PR TITLE
Remove last empty string validation

### DIFF
--- a/.changelog/22954.txt
+++ b/.changelog/22954.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_efs_mount_target: `ip_address` can no longer be set to `""`; instead, remove or set to `null`
+```

--- a/.changelog/22954.txt
+++ b/.changelog/22954.txt
@@ -5,3 +5,7 @@ resource/aws_efs_mount_target: `ip_address` can no longer be set to `""`; instea
 ```release-note:breaking-change
 resource/aws_elasticsearch_domain: `ebs_options.0.volume_type` can no longer be set to `""`; instead, remove or set to `null`
 ```
+
+```release-note:breaking-change
+resource/aws_cloudwatch_event_target: `ecs_target.0.launch_type` can no longer be set to `""`; instead, remove or set to `null`
+```

--- a/.changelog/22954.txt
+++ b/.changelog/22954.txt
@@ -1,3 +1,7 @@
 ```release-note:breaking-change
 resource/aws_efs_mount_target: `ip_address` can no longer be set to `""`; instead, remove or set to `null`
 ```
+
+```release-note:breaking-change
+resource/aws_elasticsearch_domain: `ebs_options.0.volume_type` can no longer be set to `""`; instead, remove or set to `null`
+```

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -683,3 +683,13 @@ rules:
           metavariable: "$FUNC"
           regex: "^resource\\w*(Delete|Disable)$"
     severity: WARNING
+
+  - id: avoid-string-is-empty-validation
+    languages: [go]
+    message: Empty strings should not be included in validation
+    paths:
+      include:
+        - internal/
+    patterns:
+      - pattern: validation.Any(..., validation.StringIsEmpty, ...)
+    severity: ERROR

--- a/internal/service/efs/mount_target.go
+++ b/internal/service/efs/mount_target.go
@@ -44,14 +44,11 @@ func ResourceMountTarget() *schema.Resource {
 			},
 
 			"ip_address": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.Any(
-					validation.IsIPv4Address,
-					validation.StringIsEmpty,
-				),
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 
 			"security_groups": {

--- a/internal/service/efs/mount_target_test.go
+++ b/internal/service/efs/mount_target_test.go
@@ -359,10 +359,10 @@ resource "aws_efs_file_system" "test" {
 
 resource "aws_efs_mount_target" "test" {
   file_system_id = aws_efs_file_system.test.id
-  ip_address     = %[1]q
+  ip_address     = %[2]q
   subnet_id      = aws_subnet.test.id
 }
-`, ipAddress)
+`, rName, ipAddress)
 }
 
 func testAccMountTargetIPAddressConfigNullIP(rName string) string {

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -264,13 +264,10 @@ func ResourceDomain() *schema.Resource {
 							Optional: true,
 						},
 						"volume_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.StringInSlice(elasticsearch.VolumeType_Values(), false),
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(elasticsearch.VolumeType_Values(), false),
 						},
 					},
 				},

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rInt := sdkacctest.RandInt()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_elasticsearch_domain.test"

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -53,6 +53,10 @@ func TestAccElasticsearchDomainDataSource_Data_basic(t *testing.T) {
 }
 
 func TestAccElasticsearchDomainDataSource_Data_advanced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rInt := sdkacctest.RandInt()
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
 	datasourceName := "data.aws_elasticsearch_domain.test"

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func TestAccElasticsearchDomain_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -294,6 +298,10 @@ func TestAccElasticsearchDomain_withDedicatedMaster(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_duplicate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -343,6 +351,10 @@ func TestAccElasticsearchDomain_duplicate(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_v23(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -372,6 +384,10 @@ func TestAccElasticsearchDomain_v23(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_complex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -399,6 +415,10 @@ func TestAccElasticsearchDomain_complex(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_vpc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -494,6 +514,10 @@ func TestAccElasticsearchDomain_internetToVPCEndpoint(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_AutoTuneOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	autoTuneStartAtTime := testAccGetValidStartAtTime(t, "24h")
@@ -534,6 +558,10 @@ func TestAccElasticsearchDomain_AutoTuneOptions(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -567,6 +595,10 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -600,6 +632,10 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_iam(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -633,6 +669,10 @@ func TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -664,6 +704,10 @@ func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T)
 }
 
 func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -695,6 +739,10 @@ func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T
 }
 
 func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -726,6 +774,10 @@ func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testin
 }
 
 func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -759,6 +811,10 @@ func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -798,6 +854,10 @@ func TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_cognitoOptionsUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -837,6 +897,10 @@ func TestAccElasticsearchDomain_cognitoOptionsUpdate(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_policy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -864,6 +928,10 @@ func TestAccElasticsearchDomain_policy(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_policyIgnoreEquivalent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -889,6 +957,10 @@ func TestAccElasticsearchDomain_policyIgnoreEquivalent(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_EncryptAtRestDefault_key(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -917,6 +989,10 @@ func TestAccElasticsearchDomain_EncryptAtRestDefault_key(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_EncryptAtRestSpecify_key(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -945,6 +1021,10 @@ func TestAccElasticsearchDomain_EncryptAtRestSpecify_key(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_nodeToNodeEncryption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -973,6 +1053,10 @@ func TestAccElasticsearchDomain_nodeToNodeEncryption(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -1099,6 +1183,10 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13867
 func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1176,6 +1264,10 @@ func TestAccElasticsearchDomain_Update_version(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
 

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -1110,7 +1110,7 @@ func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
 		CheckDestroy: testAccCheckDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfigWithDisabledEBSAndVolumeType(rName, ""),
+				Config: testAccDomainConfigWithDisabledEBSNullVolumeType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.#", "1"),
@@ -1493,7 +1493,7 @@ resource "aws_elasticsearch_domain" "test" {
 `, rName, autoTuneStartAtTime)
 }
 
-func testAccDomainConfigWithDisabledEBSAndVolumeType(rName, volumeType string) string {
+func testAccDomainConfigWithDisabledEBSNullVolumeType(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
   domain_name           = substr(%[1]q, 0, 28)
@@ -1507,10 +1507,10 @@ resource "aws_elasticsearch_domain" "test" {
   ebs_options {
     ebs_enabled = false
     volume_size = 0
-    volume_type = %[2]q
+    volume_type = null
   }
 }
-`, rName, volumeType)
+`, rName)
 }
 
 func testAccDomainConfig_DomainEndpointOptions(rName string, enforceHttps bool, tlsSecurityPolicy string) string {

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -92,6 +92,10 @@ func TestAccElasticsearchDomain_requireHTTPS(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -481,6 +485,10 @@ func TestAccElasticsearchDomain_VPC_update(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_internetToVPCEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -1103,6 +1111,10 @@ func TestAccElasticsearchDomain_tags(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var input elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"
@@ -1139,6 +1151,10 @@ func TestAccElasticsearchDomain_update(t *testing.T) {
 }
 
 func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var input elasticsearch.ElasticsearchDomainStatus
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_elasticsearch_domain.test"

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -178,12 +178,9 @@ func ResourceTarget() *schema.Resource {
 							ValidateFunc: validation.StringLenBetween(1, 255),
 						},
 						"launch_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringIsEmpty,
-								validation.StringInSlice(eventbridge.LaunchType_Values(), false),
-							),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(eventbridge.LaunchType_Values(), false),
 						},
 						"network_configuration": {
 							Type:     schema.TypeList,

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -497,6 +497,10 @@ func TestAccEventsTarget_ecsWithoutLaunchType(t *testing.T) {
 }
 
 func TestAccEventsTarget_ecsWithBlankLaunchType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	resourceName := "aws_cloudwatch_event_target.test"
 	iamRoleResourceName := "aws_iam_role.test"
 	ecsTaskDefinitionResourceName := "aws_ecs_task_definition.task"

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -1509,7 +1509,7 @@ resource "aws_cloudwatch_event_target" "test" {
   ecs_target {
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.task.arn
-    launch_type         = ""
+    launch_type         = null
 
     network_configuration {
       subnets = [aws_subnet.subnet.id]

--- a/internal/service/s3/bucket_object_test.go
+++ b/internal/service/s3/bucket_object_test.go
@@ -1312,45 +1312,6 @@ func TestAccS3BucketObject_ignoreTags(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketObject_bucketObjectBucket(t *testing.T) {
-	var obj1 s3.GetObjectOutput
-	resourceName1 := "aws_s3_bucket_object.test"
-	resourceName2 := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t) },
-		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
-		Providers:    acctest.Providers,
-		CheckDestroy: testAccCheckBucketObjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBucketObjectConfig_objectBucketObject1(rName, "hink"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketObjectExists(resourceName1, &obj1),
-					testAccCheckBucketObjectBody(&obj1, "hink"),
-				),
-			},
-			{
-				Config: testAccBucketObjectConfig_objectBucketObject2(rName, "hink"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketObjectExists(resourceName2, &obj1),
-					testAccCheckBucketObjectBody(&obj1, "hink"),
-				),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
-			},
-			{
-				Config: testAccBucketObjectConfig_objectBucketObject2(rName, "hink"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObjectExists(resourceName2, &obj1),
-					testAccCheckObjectBody(&obj1, "hink"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckBucketObjectVersionIdDiffers(first, second *s3.GetObjectOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if first.VersionId == nil {
@@ -2184,34 +2145,6 @@ resource "aws_s3_bucket_object" "object" {
 
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
-  content = %[2]q
-}
-`, rName, content)
-}
-
-func testAccBucketObjectConfig_objectBucketObject1(rName string, content string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-}
-
-resource "aws_s3_bucket_object" "test" {
-  bucket  = aws_s3_bucket.test.bucket
-  key     = %[1]q
-  content = %[2]q
-}
-`, rName, content)
-}
-
-func testAccBucketObjectConfig_objectBucketObject2(rName string, content string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-}
-
-resource "aws_s3_object" "test" {
-  bucket  = aws_s3_bucket.test.bucket
-  key     = %[1]q
   content = %[2]q
 }
 `, rName, content)

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -320,7 +320,7 @@ resource "aws_instance" "test" {
 
 ### Resource: aws_efs_mount_target
 
-Previously, `ip_address` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `private_ip = null`) or remove the empty-string configuration.
+Previously, `ip_address` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ip_address = null`) or remove the empty-string configuration.
 
 For example, this type of configuration is now not valid:
 
@@ -338,6 +338,36 @@ In this updated and valid configuration, we remove the empty-string configuratio
 resource "aws_efs_mount_target" "test" {
   file_system_id = aws_efs_file_system.test.id
   subnet_id      = aws_subnet.test.id
+}
+```
+
+### Resource: aws_elasticsearch_domain
+
+Previously, `ebs_options.0.volume_type` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `volume_type = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_elasticsearch_domain" "example" {
+  # ...
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+    volume_type = var.volume_size > 0 ? local.volume_type : ""
+  }
+}
+```
+
+In this updated and valid configuration, we use `null` instead of `""`:
+
+```terraform
+resource "aws_elasticsearch_domain" "test" {
+  # ...
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+    volume_type = var.volume_size > 0 ? local.volume_type : null
+  }
 }
 ```
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -26,6 +26,7 @@ Upgrade topics:
     - [Resource: aws_default_vpc](#resource-aws_default_vpc)
 - [Plural Data Source Behavior](#plural-data-source-behavior)
 - [Empty Strings Not Valid For Certain Resources](#empty-strings-not-valid-for-certain-resources)
+    - [Resource: aws_cloudwatch_event_target (Empty String)](#resource-aws_cloudwatch_event_target-empty-string)
     - [Resource: aws_customer_gateway](#resource-aws_customer_gateway)
     - [Resource: aws_default_network_acl](#resource-aws_default_network_acl)
     - [Resource: aws_default_route_table](#resource-aws_default_route_table)
@@ -233,6 +234,38 @@ First, this is a breaking change but should affect very few configurations.
 
 Second, the motivation behind this change is that previously, you might set an argument to `""` to explicitly convey it is empty. However, with the introduction of `null` in Terraform 0.12 and to prepare for continuing enhancements that distinguish between unset arguments and those that have a value, including an empty string (`""`), we are moving away from this use of zero values. We ask practitioners to either use `null` instead or remove the arguments that are set to `""`.
 
+### Resource: aws_cloudwatch_event_target (Empty String)
+
+Previously, `ecs_target.0.launch_type` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `launch_type = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_cloudwatch_event_target" "example" {
+  # ...
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.task.arn
+    launch_type         = ""
+    # ...
+  }
+}
+```
+
+In this updated and valid configuration, we set `launch_type` to `null`:
+
+```terraform
+resource "aws_cloudwatch_event_target" "example" {
+  # ...
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.task.arn
+    launch_type         = null
+    # ...
+  }
+}
+```
+
 ### Resource: aws_customer_gateway
 
 Previously, `ip_address` could be set to `""`, which would result in an AWS error. However, this value is no longer accepted by the provider.
@@ -305,7 +338,7 @@ Previously, `private_ip` could be set to `""`. However, the value `""` is no lon
 For example, this type of configuration is now not valid:
 
 ```terraform
-resource "aws_instance" "test" {
+resource "aws_instance" "example" {
   instance_type = "t2.micro"
   private_ip    = ""
 }
@@ -314,7 +347,7 @@ resource "aws_instance" "test" {
 In this updated and valid configuration, we remove the empty-string configuration:
 
 ```terraform
-resource "aws_instance" "test" {
+resource "aws_instance" "example" {
   instance_type = "t2.micro"
 }
 ```
@@ -326,19 +359,19 @@ Previously, `ip_address` could be set to `""`. However, the value `""` is no lon
 For example, this type of configuration is now not valid:
 
 ```terraform
-resource "aws_efs_mount_target" "test" {
-  file_system_id = aws_efs_file_system.test.id
+resource "aws_efs_mount_target" "example" {
+  file_system_id = aws_efs_file_system.example.id
   ip_address     = ""
-  subnet_id      = aws_subnet.test.id
+  subnet_id      = aws_subnet.example.id
 }
 ```
 
 In this updated and valid configuration, we remove the empty-string configuration:
 
 ```terraform
-resource "aws_efs_mount_target" "test" {
-  file_system_id = aws_efs_file_system.test.id
-  subnet_id      = aws_subnet.test.id
+resource "aws_efs_mount_target" "example" {
+  file_system_id = aws_efs_file_system.example.id
+  subnet_id      = aws_subnet.example.id
 }
 ```
 
@@ -362,7 +395,7 @@ resource "aws_elasticsearch_domain" "example" {
 In this updated and valid configuration, we use `null` instead of `""`:
 
 ```terraform
-resource "aws_elasticsearch_domain" "test" {
+resource "aws_elasticsearch_domain" "example" {
   # ...
   ebs_options {
     ebs_enabled = true
@@ -410,9 +443,9 @@ In addition, now exactly one of `destination_cidr_block`, `destination_ipv6_cidr
 For example, this type of configuration for `aws_route` is now not valid:
 
 ```terraform
-resource "aws_route" "test" {
-  route_table_id = aws_route_table.test.id
-  gateway_id     = aws_internet_gateway.test.id
+resource "aws_route" "example" {
+  route_table_id = aws_route_table.example.id
+  gateway_id     = aws_internet_gateway.example.id
 
   destination_cidr_block      = local.ipv6 ? "" : local.destination
   destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
@@ -422,9 +455,9 @@ resource "aws_route" "test" {
 In this updated and valid configuration, we use `null` instead of an empty-string (`""`):
 
 ```terraform
-resource "aws_route" "test" {
-  route_table_id = aws_route_table.test.id
-  gateway_id     = aws_internet_gateway.test.id
+resource "aws_route" "example" {
+  route_table_id = aws_route_table.example.id
+  gateway_id     = aws_internet_gateway.example.id
 
   destination_cidr_block      = local.ipv6 ? null : local.destination
   destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : null
@@ -466,7 +499,7 @@ Previously, `ipv6_cidr_block` could be set to `""`. However, the value `""` is n
 For example, this type of configuration is now not valid:
 
 ```terraform
-resource "aws_vpc" "test" {
+resource "aws_vpc" "example" {
   cidr_block      = "10.1.0.0/16"
   ipv6_cidr_block = ""
 }
@@ -475,7 +508,7 @@ resource "aws_vpc" "test" {
 In this updated and valid configuration, we remove `ipv6_cidr_block`:
 
 ```terraform
-resource "aws_vpc" "test" {
+resource "aws_vpc" "example" {
   cidr_block      = "10.1.0.0/16"
 }
 ```

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -356,24 +356,7 @@ resource "aws_instance" "example" {
 
 Previously, `ip_address` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `ip_address = null`) or remove the empty-string configuration.
 
-For example, this type of configuration is now not valid:
-
-```terraform
-resource "aws_efs_mount_target" "example" {
-  file_system_id = aws_efs_file_system.example.id
-  ip_address     = ""
-  subnet_id      = aws_subnet.example.id
-}
-```
-
-In this updated and valid configuration, we remove the empty-string configuration:
-
-```terraform
-resource "aws_efs_mount_target" "example" {
-  file_system_id = aws_efs_file_system.example.id
-  subnet_id      = aws_subnet.example.id
-}
-```
+For example, this type of configuration is now not valid: `ip_address = ""`.
 
 ### Resource: aws_elasticsearch_domain
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -30,6 +30,7 @@ Upgrade topics:
     - [Resource: aws_default_network_acl](#resource-aws_default_network_acl)
     - [Resource: aws_default_route_table](#resource-aws_default_route_table)
     - [Resource: aws_default_vpc (Empty String)](#resource-aws_default_vpc-empty-string)
+    - [Resource: aws_efs_mount_target](#resource-aws_efs_mount_target)
     - [Resource: aws_instance](#resource-aws_instance)
     - [Resource: aws_network_acl](#resource-aws_network_acl)
     - [Resource: aws_route](#resource-aws_route)
@@ -314,6 +315,29 @@ In this updated and valid configuration, we remove the empty-string configuratio
 ```terraform
 resource "aws_instance" "test" {
   instance_type = "t2.micro"
+}
+```
+
+### Resource: aws_efs_mount_target
+
+Previously, `ip_address` could be set to `""`. However, the value `""` is no longer valid. Now, set the argument to `null` (_e.g._, `private_ip = null`) or remove the empty-string configuration.
+
+For example, this type of configuration is now not valid:
+
+```terraform
+resource "aws_efs_mount_target" "test" {
+  file_system_id = aws_efs_file_system.test.id
+  ip_address     = ""
+  subnet_id      = aws_subnet.test.id
+}
+```
+
+In this updated and valid configuration, we remove the empty-string configuration:
+
+```terraform
+resource "aws_efs_mount_target" "test" {
+  file_system_id = aws_efs_file_system.test.id
+  subnet_id      = aws_subnet.test.id
 }
 ```
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -31,6 +31,7 @@ Upgrade topics:
     - [Resource: aws_default_route_table](#resource-aws_default_route_table)
     - [Resource: aws_default_vpc (Empty String)](#resource-aws_default_vpc-empty-string)
     - [Resource: aws_efs_mount_target](#resource-aws_efs_mount_target)
+    - [Resource: aws_elasticsearch_domain](#resource-aws_elasticsearch_domain)
     - [Resource: aws_instance](#resource-aws_instance)
     - [Resource: aws_network_acl](#resource-aws_network_acl)
     - [Resource: aws_route](#resource-aws_route)
@@ -352,7 +353,7 @@ resource "aws_elasticsearch_domain" "example" {
   # ...
   ebs_options {
     ebs_enabled = true
-    volume_size = 10
+    volume_size = var.volume_size
     volume_type = var.volume_size > 0 ? local.volume_type : ""
   }
 }
@@ -365,7 +366,7 @@ resource "aws_elasticsearch_domain" "test" {
   # ...
   ebs_options {
     ebs_enabled = true
-    volume_size = 10
+    volume_size = var.volume_size
     volume_type = var.volume_size > 0 ? local.volume_type : null
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13943

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccEFSMountTarget PKG=efs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 20 -run='TestAccEFSMountTarget'  -timeout 180m
--- PASS: TestAccEFSMountTarget_IPAddress_emptyString (144.23s)
--- PASS: TestAccEFSMountTarget_disappears (133.90s)
--- PASS: TestAccEFSMountTarget_ipAddress (139.09s)
--- PASS: TestAccEFSMountTargetDataSource_byAccessPointID (143.58s)
--- PASS: TestAccEFSMountTargetDataSource_byFileSystemID (150.54s)
--- PASS: TestAccEFSMountTargetDataSource_basic (162.46s)
--- PASS: TestAccEFSMountTarget_basic (256.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	258.501s
% make testacc TESTS=TestAccEventsTarget_ PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsTarget_'  -timeout 180m
--- SKIP: TestAccEventsTarget_partnerEventBus (0.00s)
--- PASS: TestAccEventsTarget_disappears (26.87s)
--- PASS: TestAccEventsTarget_ssmDocument (28.90s)
--- PASS: TestAccEventsTarget_generatedTargetID (30.36s)
--- PASS: TestAccEventsTarget_eventBusARN (31.20s)
--- PASS: TestAccEventsTarget_http (33.82s)
--- PASS: TestAccEventsTarget_inputTransformerJSONString (43.12s)
--- PASS: TestAccEventsTarget_ecsFull (44.03s)
--- PASS: TestAccEventsTarget_ecsWithBlankTaskCount (44.10s)
--- PASS: TestAccEventsTarget_eventBusName (52.22s)
--- PASS: TestAccEventsTarget_Input_transformer (52.52s)
--- PASS: TestAccEventsTarget_kinesis (59.79s)
--- PASS: TestAccEventsTarget_full (60.44s)
--- PASS: TestAccEventsTarget_basic (61.35s)
--- PASS: TestAccEventsTarget_sqs (61.94s)
--- PASS: TestAccEventsTarget_RetryPolicy_deadLetter (63.36s)
--- PASS: TestAccEventsTarget_ecsWithoutLaunchType (86.61s)
--- PASS: TestAccEventsTarget_batch (135.60s)
--- PASS: TestAccEventsTarget_redshift (214.81s)
--- PASS: TestAccEventsTarget_ecs (283.56s)
--- PASS: TestAccEventsTarget_ecsWithBlankLaunchType (304.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	306.531s
% make testacc TESTS='TestAccElasticsearchDomain_|TestAccElasticsearchDomainDataSource' PKG=elasticsearch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 20 -run='TestAccElasticsearchDomain_|TestAccElasticsearchDomainDataSource'  -timeout 180m
--- PASS: TestAccElasticsearchDomain_WithVolumeType_missing (1286.91s)
--- PASS: TestAccElasticsearchDomain_EncryptAtRestDefault_key (951.47s)
--- PASS: TestAccElasticsearchDomain_policyIgnoreEquivalent (1040.32s)
--- PASS: TestAccElasticsearchDomain_nodeToNodeEncryption (1051.47s)
--- PASS: TestAccElasticsearchDomain_tags (1149.95s)
--- PASS: TestAccElasticsearchDomain_policy (1201.56s)
--- PASS: TestAccElasticsearchDomain_EncryptAtRestSpecify_key (1206.94s)
--- PASS: TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled (1269.89s)
--- PASS: TestAccElasticsearchDomainDataSource_Data_basic (1364.29s)
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs (1403.99s)
--- PASS: TestAccElasticsearchDomain_disappears (1448.70s)
--- PASS: TestAccElasticsearchDomain_AutoTuneOptions (1498.63s)
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs (1803.40s)
--- PASS: TestAccElasticsearchDomain_duplicate (636.67s)
--- PASS: TestAccElasticsearchDomain_v23 (2041.81s)
--- PASS: TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB (1370.97s)
--- PASS: TestAccElasticsearchDomain_AdvancedSecurityOptions_iam (2334.20s)
--- PASS: TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove (2464.70s)
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_auditLogs (1487.16s)
--- PASS: TestAccElasticsearchDomain_cognitoOptionsUpdate (2577.96s)
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs (2686.10s)
--- PASS: TestAccElasticsearchDomain_complex (1031.55s)
--- PASS: TestAccElasticsearchDomain_basic (839.65s)
--- PASS: TestAccElasticsearchDomain_vpc (1493.08s)
--- PASS: TestAccElasticsearchDomain_UpdateVolume_type (3376.26s)
--- PASS: TestAccElasticsearchDomain_update (3412.40s)
--- PASS: TestAccElasticsearchDomain_customEndpoint (1974.99s)
--- PASS: TestAccElasticsearchDomainDataSource_Data_advanced (1620.45s)
--- PASS: TestAccElasticsearchDomain_internetToVPCEndpoint (2601.80s)
... still running
```
