### PR TITLE
r/sagemaker_endpoint_configuration - emptiness check for arguments

### DIFF
--- a/.changelog/22960.txt
+++ b/.changelog/22960.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_endpoint_configuration: Emptiness check for arguments, Allow not passing `async_inference_config.kms_key_id`.
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -427,8 +427,8 @@ func expandSagemakerProductionVariants(configured []interface{}) []*sagemaker.Pr
 			l.InitialVariantWeight = aws.Float64(v.(float64))
 		}
 
-		if v, ok := data["accelerator_type"]; ok && v.(string) != "" {
-			l.AcceleratorType = aws.String(data["accelerator_type"].(string))
+		if v, ok := data["accelerator_type"].(string); ok && v != "" {
+			l.AcceleratorType = aws.String(v)
 		}
 
 		containers = append(containers, l)
@@ -472,12 +472,12 @@ func expandSagemakerDataCaptureConfig(configured []interface{}) *sagemaker.DataC
 		c.EnableCapture = aws.Bool(v.(bool))
 	}
 
-	if v, ok := m["kms_key_id"]; ok && v.(string) != "" {
-		c.KmsKeyId = aws.String(v.(string))
+	if v, ok := m["kms_key_id"].(string); ok && v != "" {
+		c.KmsKeyId = aws.String(v)
 	}
 
-	if v, ok := m["capture_content_type_header"]; ok && (len(v.([]interface{})) > 0) {
-		c.CaptureContentTypeHeader = expandSagemakerCaptureContentTypeHeader(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := m["capture_content_type_header"].([]interface{}); ok && (len(v) > 0) {
+		c.CaptureContentTypeHeader = expandSagemakerCaptureContentTypeHeader(v[0].(map[string]interface{}))
 	}
 
 	return c
@@ -577,12 +577,12 @@ func expandSagemakerEndpointConfigAsyncInferenceConfig(configured []interface{})
 
 	c := &sagemaker.AsyncInferenceConfig{}
 
-	if v, ok := m["client_config"]; ok && (len(v.([]interface{})) > 0) {
-		c.ClientConfig = expandSagemakerEndpointConfigClientConfig(v.([]interface{}))
+	if v, ok := m["client_config"].([]interface{}); ok && len(v) > 0 {
+		c.ClientConfig = expandSagemakerEndpointConfigClientConfig(v)
 	}
 
-	if v, ok := m["output_config"]; ok && (len(v.([]interface{})) > 0) {
-		c.OutputConfig = expandSagemakerEndpointConfigOutputConfig(v.([]interface{}))
+	if v, ok := m["output_config"].([]interface{}); ok && len(v) > 0 {
+		c.OutputConfig = expandSagemakerEndpointConfigOutputConfig(v)
 	}
 
 	return c
@@ -615,12 +615,12 @@ func expandSagemakerEndpointConfigOutputConfig(configured []interface{}) *sagema
 		S3OutputPath: aws.String(m["s3_output_path"].(string)),
 	}
 
-	if v, ok := m["kms_key_id"]; ok {
-		c.KmsKeyId = aws.String(v.(string))
+	if v, ok := m["kms_key_id"].(string); ok && v != "" {
+		c.KmsKeyId = aws.String(v)
 	}
 
-	if v, ok := m["notification_config"]; ok && (len(v.([]interface{})) > 0) {
-		c.NotificationConfig = expandSagemakerEndpointConfigNotificationConfig(v.([]interface{}))
+	if v, ok := m["notification_config"].([]interface{}); ok && len(v) > 0 {
+		c.NotificationConfig = expandSagemakerEndpointConfigNotificationConfig(v)
 	}
 
 	return c
@@ -635,12 +635,12 @@ func expandSagemakerEndpointConfigNotificationConfig(configured []interface{}) *
 
 	c := &sagemaker.AsyncInferenceNotificationConfig{}
 
-	if v, ok := m["error_topic"]; ok {
-		c.ErrorTopic = aws.String(v.(string))
+	if v, ok := m["error_topic"].(string); ok && v != "" {
+		c.ErrorTopic = aws.String(v)
 	}
 
-	if v, ok := m["success_topic"]; ok {
-		c.SuccessTopic = aws.String(v.(string))
+	if v, ok := m["success_topic"].(string); ok && v != "" {
+		c.SuccessTopic = aws.String(v)
 	}
 
 	return c

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -248,6 +248,38 @@ func TestAccSageMakerEndpointConfiguration_async(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "async_inference_config.0.output_config.0.s3_output_path"),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.0.notification_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.0.kms_key_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerEndpointConfiguration_async_kms(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigurationConfigAsyncKMSConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.client_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "async_inference_config.0.output_config.0.s3_output_path"),
+					resource.TestCheckResourceAttr(resourceName, "async_inference_config.0.output_config.0.notification_config.#", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "async_inference_config.0.output_config.0.kms_key_id", "aws_kms_key.test", "arn"),
 				),
 			},
@@ -563,7 +595,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 `, rName)
 }
 
-func testAccSagemakerEndpointConfigurationConfigAsyncConfig(rName string) string {
+func testAccSagemakerEndpointConfigurationConfigAsyncKMSConfig(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -591,6 +623,34 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     output_config {
       s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
       kms_key_id     = aws_kms_key.test.arn
+    }
+  }
+}
+`, rName)
+}
+
+func testAccSagemakerEndpointConfigurationConfigAsyncConfig(rName string) string {
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
+
+  async_inference_config {
+    output_config {
+      s3_output_path = "s3://${aws_s3_bucket.test.bucket}/"
     }
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22951

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccSageMakerEndpointConfiguration_ PKG=sagemaker

--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight (66.56s)
--- PASS: TestAccSageMakerEndpointConfiguration_disappears (76.99s)
--- PASS: TestAccSageMakerEndpointConfiguration_async_kms (78.75s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_notif (79.43s)
--- PASS: TestAccSageMakerEndpointConfiguration_kmsKeyID (79.92s)
--- PASS: TestAccSageMakerEndpointConfiguration_basic (84.00s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType (86.35s)
--- PASS: TestAccSageMakerEndpointConfiguration_async (87.44s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture (92.29s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client (97.61s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (160.39s)
```
