### PR TITLE
New Resource: aws_athena_data_catalog

### DIFF
--- a/.changelog/22968.txt
+++ b/.changelog/22968.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_athena_data_catalog
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -971,9 +971,10 @@ func Provider() *schema.Provider {
 			"aws_appsync_graphql_api":                 appsync.ResourceGraphQLAPI(),
 			"aws_appsync_resolver":                    appsync.ResourceResolver(),
 
-			"aws_athena_database":    athena.ResourceDatabase(),
-			"aws_athena_named_query": athena.ResourceNamedQuery(),
-			"aws_athena_workgroup":   athena.ResourceWorkGroup(),
+			"aws_athena_database":     athena.ResourceDatabase(),
+			"aws_athena_data_catalog": athena.ResourceDataCatalog(),
+			"aws_athena_named_query":  athena.ResourceNamedQuery(),
+			"aws_athena_workgroup":    athena.ResourceWorkGroup(),
 
 			"aws_autoscaling_attachment":     autoscaling.ResourceAttachment(),
 			"aws_autoscaling_group":          autoscaling.ResourceGroup(),

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -40,7 +40,7 @@ func ResourceDataCatalog() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -53,7 +53,7 @@ func ResourceDataCatalog() *schema.Resource {
 			},
 			"parameters": {
 				Type:     schema.TypeMap,
-				Optional: true,
+				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				ValidateDiagFunc: allDiagFunc(
 					validation.MapKeyLenBetween(1, 255),

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -134,6 +134,7 @@ func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta i
 	}.String()
 	d.Set("arn", arn)
 	d.Set("description", dataCatalog.DataCatalog.Description)
+	d.Set("name", dataCatalog.DataCatalog.Name)
 	d.Set("type", dataCatalog.DataCatalog.Type)
 
 	// NOTE: This is a workaround for the fact that the API sets default values for parameters that are not set.
@@ -153,14 +154,6 @@ func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta i
 	} else {
 		d.Set("parameters", nil)
 	}
-	parameters := map[string]*string{}
-	if v, ok := d.GetOk("parameters"); ok {
-		if m, ok := v.(map[string]interface{}); ok {
-			parameters = flex.ExpandStringMap(m)
-		}
-	}
-
-	d.Set("parameters", aws.StringValueMap(parameters))
 
 	tags, err := ListTags(conn, arn)
 
@@ -195,8 +188,6 @@ func resourceDataCatalogUpdate(ctx context.Context, d *schema.ResourceData, meta
 		if d.HasChange("parameters") {
 			if v, ok := d.GetOk("parameters"); ok && len(v.(map[string]interface{})) > 0 {
 				input.Parameters = flex.ExpandStringMap(v.(map[string]interface{}))
-			} else {
-				input.Parameters = make(map[string]*string, 0)
 			}
 		}
 

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,6 +38,10 @@ func ResourceDataCatalog() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -46,19 +50,6 @@ func ResourceDataCatalog() *schema.Resource {
 					validation.StringLenBetween(1, 129),
 					validation.StringMatch(regexp.MustCompile(`[\w@-]*`), ""),
 				),
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					athena.DataCatalogTypeLambda,
-					athena.DataCatalogTypeGlue,
-					athena.DataCatalogTypeHive,
-				}, false),
 			},
 			"parameters": {
 				Type:     schema.TypeMap,
@@ -71,6 +62,11 @@ func ResourceDataCatalog() *schema.Resource {
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(athena.DataCatalogType_Values(), false),
+			},
 		},
 	}
 }

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -1,0 +1,226 @@
+package athena
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceDataCatalog() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataCatalogCreate,
+		ReadContext:   resourceDataCatalogRead,
+		UpdateContext: resourceDataCatalogUpdate,
+		DeleteContext: resourceDataCatalogDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 129),
+					validation.StringMatch(regexp.MustCompile(`[\w@-]*`), ""),
+				),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					athena.DataCatalogTypeLambda,
+					athena.DataCatalogTypeGlue,
+					athena.DataCatalogTypeHive,
+				}, false),
+			},
+			"parameters": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					//ValidateFunc: validation.StringLenBetween(1, 51200), -- WIP
+				},
+				Optional: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func resourceDataCatalogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AthenaConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	name := d.Get("name").(string)
+
+	input := &athena.CreateDataCatalogInput{
+		Name:        aws.String(name),
+		Description: aws.String(d.Get("description").(string)),
+		Type:        aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		input.Parameters = flex.ExpandStringMap(v.(map[string]interface{}))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	if err := input.Validate(); err != nil {
+		return diag.Errorf("Error validating Athena Data Catalog (%s): %s", name, err)
+	}
+
+	log.Printf("[DEBUG] Creating Data Catalog: %s", input)
+	_, err := conn.CreateDataCatalogWithContext(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("error creating Athena Data Catalog (%s): %s", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceDataCatalogRead(ctx, d, meta)
+}
+
+func resourceDataCatalogUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AthenaConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &athena.UpdateDataCatalogInput{
+			Name: aws.String(d.Id()),
+		}
+
+		if d.HasChange("name") {
+			input.Name = aws.String(d.Get("name").(string))
+		}
+
+		if d.HasChange("description") {
+			input.Name = aws.String(d.Get("description").(string))
+		}
+
+		if d.HasChange("type") {
+			input.Name = aws.String(d.Get("type").(string))
+		}
+
+		if d.HasChange("parameters") {
+			parameters := map[string]*string{}
+			if v, ok := d.GetOk("parameters"); ok {
+				if m, ok := v.(map[string]interface{}); ok {
+					parameters = flex.ExpandStringMap(m)
+				}
+			}
+			input.Parameters = parameters
+		}
+
+		log.Printf("[DEBUG] Updating Athena Data Catalog (%s)", d.Id())
+
+		if err := input.Validate(); err != nil {
+			return diag.Errorf("Error validating Athena Data Catalog (%s): %s", d.Id(), err)
+		}
+
+		_, err := conn.UpdateDataCatalogWithContext(ctx, input)
+
+		if err != nil {
+			return diag.Errorf("error updating Athena Data Catalog (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		log.Printf("[DEBUG] Updating Athena Data Catalog (%s) tags", d.Id())
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return diag.Errorf("error updating Athena Data Catalog (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceDataCatalogRead(ctx, d, meta)
+}
+
+func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AthenaConn
+
+	log.Printf("[DEBUG] Deleting Athena Data Catalog: (%s)", d.Id())
+
+	_, err := conn.DeleteDataCatalogWithContext(ctx, &athena.DeleteDataCatalogInput{
+		Name: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, athena.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error deleting Athena Data Catalog (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceDataCatalogRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AthenaConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	input := &athena.GetDataCatalogInput{
+		Name: aws.String(d.Id()),
+	}
+
+	dataCatalog, err := conn.GetDataCatalogWithContext(ctx, input)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Athena Data Catalog (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error reading Athena Data Catalog (%s): %s", d.Id(), err)
+	}
+
+	d.Set("description", dataCatalog.DataCatalog.Description)
+	d.Set("type", dataCatalog.DataCatalog.Type)
+	d.Set("parameters", aws.StringValueMap(dataCatalog.DataCatalog.Parameters))
+
+	tags, err := ListTags(conn, d.Id())
+
+	if err != nil {
+		return diag.Errorf("error listing tags for Athena Data Catalog (%s): %s", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.Errorf("error setting tags for Athena Data Catalog (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.Errorf("error setting tags_all for Athena Data Catalog (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -52,6 +52,140 @@ func TestAccDataCatalog_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataCatalog_type_lambda(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_athena_data_catalog.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCatalogConfig_type_lambda(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Lambda"),
+					resource.TestCheckResourceAttr(resourceName, "type", "LAMBDA"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.record-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name",
+					"parameters",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataCatalog_type_hive(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_athena_data_catalog.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCatalogConfig_type_hive(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Hive"),
+					resource.TestCheckResourceAttr(resourceName, "type", "HIVE"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name",
+					"parameters",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataCatalog_type_glue(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_athena_data_catalog.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCatalogConfig_type_glue(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Glue"),
+					resource.TestCheckResourceAttr(resourceName, "type", "GLUE"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.catalog-id", "123456789012"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name",
+					"parameters",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataCatalog_parameters(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_athena_data_catalog.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCatalogConfig_parameters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "LAMBDA"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Testing parameters attribute"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name",
+					"parameters",
+				},
+			},
+		},
+	})
+}
+
 func TestAccDataCatalog_disappears(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
@@ -87,6 +221,75 @@ resource "aws_athena_data_catalog" "test" {
 
 	tags = {
 	  Test = "test"
+	}
+}
+`, rName)
+}
+
+func testAccDataCatalogConfig_type_lambda(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+	name = %[1]q
+	description = "A test data catalog using Lambda"
+	type = "LAMBDA"
+
+	parameters = {
+	  "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+	  "record-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+	}
+
+	tags = {
+	  Test = "test"
+	}
+}
+`, rName)
+}
+
+func testAccDataCatalogConfig_type_hive(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+	name = %[1]q
+	description = "A test data catalog using Hive"
+	type = "HIVE"
+
+	parameters = {
+	  "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+	}
+
+	tags = {
+	  Test = "test"
+	}
+}
+`, rName)
+}
+
+func testAccDataCatalogConfig_type_glue(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+	name = %[1]q
+	description = "A test data catalog using Glue"
+	type = "GLUE"
+
+	parameters = {
+	  "catalog-id" = "123456789012"
+	}
+
+	tags = {
+	  Test = "test"
+	}
+}
+`, rName)
+}
+
+func testAccDataCatalogConfig_parameters(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+	name = %[1]q
+	description = "Testing parameters attribute"
+	type = "LAMBDA"
+
+	parameters = {
+	  "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
 	}
 }
 `, rName)

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -34,7 +34,7 @@ func TestAccAthenaDataCatalog_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "LAMBDA"),
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"), //lintignore:AWSAT003,AWSAT005
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -132,8 +132,8 @@ func TestAccAthenaDataCatalog_type_lambda(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Lambda"),
 					resource.TestCheckResourceAttr(resourceName, "type", "LAMBDA"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.record-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"), //lintignore:AWSAT003,AWSAT005
+					resource.TestCheckResourceAttr(resourceName, "parameters.record-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),   //lintignore:AWSAT003,AWSAT005
 				),
 			},
 			{
@@ -163,7 +163,7 @@ func TestAccAthenaDataCatalog_type_hive(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Hive"),
 					resource.TestCheckResourceAttr(resourceName, "type", "HIVE"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"), //lintignore:AWSAT003,AWSAT005
 				),
 			},
 			{
@@ -221,7 +221,7 @@ func TestAccAthenaDataCatalog_parameters(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-1"), //lintignore:AWSAT003,AWSAT005
 				),
 			},
 			{
@@ -235,8 +235,8 @@ func TestAccAthenaDataCatalog_parameters(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.record-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"), //lintignore:AWSAT003,AWSAT005
+					resource.TestCheckResourceAttr(resourceName, "parameters.record-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"),   //lintignore:AWSAT003,AWSAT005
 				),
 			},
 		},
@@ -301,6 +301,7 @@ func testAccCheckDataCatalogDestroy(s *terraform.State) error {
 }
 
 func testAccDataCatalogConfig(rName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name        = %[1]q
@@ -315,6 +316,7 @@ resource "aws_athena_data_catalog" "test" {
 }
 
 func testAccDataCatalogConfigTags1(rName, tagKey1, tagValue1 string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name = %[1]q
@@ -334,6 +336,7 @@ resource "aws_athena_data_catalog" "test" {
 }
 
 func testAccDataCatalogConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name = %[1]q
@@ -354,6 +357,7 @@ resource "aws_athena_data_catalog" "test" {
 }
 
 func testAccDataCatalogTypeLambdaConfig(rName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name        = %[1]q
@@ -369,6 +373,7 @@ resource "aws_athena_data_catalog" "test" {
 }
 
 func testAccDataCatalogTypeHiveConfig(rName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name        = %[1]q
@@ -397,6 +402,7 @@ resource "aws_athena_data_catalog" "test" {
 }
 
 func testAccDataCatalogParametersConfig(rName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name        = %[1]q
@@ -411,6 +417,7 @@ resource "aws_athena_data_catalog" "test" {
 }
 
 func testAccDataCatalogParametersUpdatedConfig(rName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
   name        = %[1]q

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -1,0 +1,150 @@
+package athena_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
+)
+
+func TestAccDataCatalog_basic(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_athena_data_catalog.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCatalogConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "athena", fmt.Sprintf("datacatalog/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "LAMBDA"),
+					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Test", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name",
+					"parameters",
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataCatalog_disappears(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_athena_data_catalog.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, athena.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckDataCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCatalogConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfathena.ResourceDataCatalog(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccDataCatalogConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+	name = %[1]q
+	description = "A test data catalog"
+	type = "LAMBDA"
+
+	parameters = {
+	  "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+	}
+
+	tags = {
+	  Test = "test"
+	}
+}
+`, rName)
+}
+
+func testAccCheckDataCatalogExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Athena Data Catalog name is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn
+
+		input := &athena.GetDataCatalogInput{
+			Name: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetDataCatalog(input)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataCatalogDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AthenaConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_athena_data_catalog" {
+			continue
+		}
+
+		input := &athena.GetDataCatalogInput{
+			Name: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetDataCatalog(input)
+
+		if tfawserr.ErrMessageContains(err, athena.ErrCodeInvalidRequestException, "was not found") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output.DataCatalog != nil {
+			return fmt.Errorf("Athena Data Catalog (%s) found", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -39,13 +39,10 @@ func TestAccAthenaDataCatalog_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name",
-					"parameters",
-				},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 		},
 	})
@@ -73,13 +70,10 @@ func TestAccAthenaDataCatalog_type_lambda(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name",
-					"parameters",
-				},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 		},
 	})
@@ -106,13 +100,10 @@ func TestAccAthenaDataCatalog_type_hive(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name",
-					"parameters",
-				},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 		},
 	})
@@ -139,13 +130,10 @@ func TestAccAthenaDataCatalog_type_glue(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name",
-					"parameters",
-				},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 		},
 	})
@@ -165,21 +153,24 @@ func TestAccAthenaDataCatalog_parameters(t *testing.T) {
 				Config: testAccDataCatalogParametersConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "type", "LAMBDA"),
-					resource.TestCheckResourceAttr(resourceName, "description", "Testing parameters attribute"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-1"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"name",
-					"parameters",
-				},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
+			},
+			{
+				Config: testAccDataCatalogParametersUpdatedConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.metadata-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.record-function", "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"),
+				),
 			},
 		},
 	})
@@ -341,7 +332,22 @@ resource "aws_athena_data_catalog" "test" {
   type        = "LAMBDA"
 
   parameters = {
-    "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function-1"
+  }
+}
+`, rName)
+}
+
+func testAccDataCatalogParametersUpdatedConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+  name        = %[1]q
+  description = "Testing parameters attribute"
+  type        = "LAMBDA"
+
+  parameters = {
+    "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"
+    "record-function"   = "arn:aws:lambda:us-east-1:123456789012:function:test-function-2"
   }
 }
 `, rName)

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -15,7 +15,7 @@ import (
 	tfathena "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
 )
 
-func TestAccDataCatalog_basic(t *testing.T) {
+func TestAccAthenaDataCatalog_basic(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
 
@@ -52,7 +52,7 @@ func TestAccDataCatalog_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataCatalog_type_lambda(t *testing.T) {
+func TestAccAthenaDataCatalog_type_lambda(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
 
@@ -86,7 +86,7 @@ func TestAccDataCatalog_type_lambda(t *testing.T) {
 	})
 }
 
-func TestAccDataCatalog_type_hive(t *testing.T) {
+func TestAccAthenaDataCatalog_type_hive(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
 
@@ -119,7 +119,7 @@ func TestAccDataCatalog_type_hive(t *testing.T) {
 	})
 }
 
-func TestAccDataCatalog_type_glue(t *testing.T) {
+func TestAccAthenaDataCatalog_type_glue(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
 
@@ -152,7 +152,7 @@ func TestAccDataCatalog_type_glue(t *testing.T) {
 	})
 }
 
-func TestAccDataCatalog_parameters(t *testing.T) {
+func TestAccAthenaDataCatalog_parameters(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
 

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -48,7 +48,7 @@ func TestAccAthenaDataCatalog_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataCatalog_disappears(t *testing.T) {
+func TestAccAthenaDataCatalog_disappears(t *testing.T) {
 	rName := "tf-test-" + sdkacctest.RandString(8)
 	resourceName := "aws_athena_data_catalog.test"
 

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -356,9 +356,9 @@ resource "aws_athena_data_catalog" "test" {
 func testAccDataCatalogTypeLambdaConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
-  name =        %[1]q
+  name        =  %[1]q
   description = "A test data catalog using Lambda"
-  type =        "LAMBDA"
+  type        = "LAMBDA"
 
   parameters = {
     "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -63,7 +63,7 @@ func TestAccDataCatalog_type_lambda(t *testing.T) {
 		CheckDestroy: testAccCheckDataCatalogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCatalogConfig_type_lambda(rName),
+				Config: testAccDataCatalogTypeLambdaConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Lambda"),
@@ -97,7 +97,7 @@ func TestAccDataCatalog_type_hive(t *testing.T) {
 		CheckDestroy: testAccCheckDataCatalogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCatalogConfig_type_hive(rName),
+				Config: testAccDataCatalogTypeHiveConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Hive"),
@@ -130,7 +130,7 @@ func TestAccDataCatalog_type_glue(t *testing.T) {
 		CheckDestroy: testAccCheckDataCatalogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCatalogConfig_type_glue(rName),
+				Config: testAccDataCatalogTypeGlueConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog using Glue"),
@@ -163,7 +163,7 @@ func TestAccDataCatalog_parameters(t *testing.T) {
 		CheckDestroy: testAccCheckDataCatalogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCatalogConfig_parameters(rName),
+				Config: testAccDataCatalogParametersConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataCatalogExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -206,93 +206,6 @@ func TestAccDataCatalog_disappears(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataCatalogConfig(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_athena_data_catalog" "test" {
-	name = %[1]q
-	description = "A test data catalog"
-	type = "LAMBDA"
-
-	parameters = {
-	  "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
-	}
-
-	tags = {
-	  Test = "test"
-	}
-}
-`, rName)
-}
-
-func testAccDataCatalogConfig_type_lambda(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_athena_data_catalog" "test" {
-	name = %[1]q
-	description = "A test data catalog using Lambda"
-	type = "LAMBDA"
-
-	parameters = {
-	  "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
-	  "record-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
-	}
-
-	tags = {
-	  Test = "test"
-	}
-}
-`, rName)
-}
-
-func testAccDataCatalogConfig_type_hive(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_athena_data_catalog" "test" {
-	name = %[1]q
-	description = "A test data catalog using Hive"
-	type = "HIVE"
-
-	parameters = {
-	  "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
-	}
-
-	tags = {
-	  Test = "test"
-	}
-}
-`, rName)
-}
-
-func testAccDataCatalogConfig_type_glue(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_athena_data_catalog" "test" {
-	name = %[1]q
-	description = "A test data catalog using Glue"
-	type = "GLUE"
-
-	parameters = {
-	  "catalog-id" = "123456789012"
-	}
-
-	tags = {
-	  Test = "test"
-	}
-}
-`, rName)
-}
-
-func testAccDataCatalogConfig_parameters(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_athena_data_catalog" "test" {
-	name = %[1]q
-	description = "Testing parameters attribute"
-	type = "LAMBDA"
-
-	parameters = {
-	  "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
-	}
-}
-`, rName)
 }
 
 func testAccCheckDataCatalogExists(n string) resource.TestCheckFunc {
@@ -350,4 +263,91 @@ func testAccCheckDataCatalogDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccDataCatalogConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+  name        = %[1]q
+  description = "A test data catalog"
+  type        = "LAMBDA"
+
+  parameters = {
+    "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+`, rName)
+}
+
+func testAccDataCatalogTypeLambdaConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+  name =        %[1]q
+  description = "A test data catalog using Lambda"
+  type =        "LAMBDA"
+
+  parameters = {
+    "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    "record-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+`, rName)
+}
+
+func testAccDataCatalogTypeHiveConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+  name        = %[1]q
+  description = "A test data catalog using Hive"
+  type        = "HIVE"
+
+  parameters = {
+    "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+`, rName)
+}
+
+func testAccDataCatalogTypeGlueConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+  name        = %[1]q
+  description = "A test data catalog using Glue"
+  type        = "GLUE"
+
+  parameters = {
+    "catalog-id" = "123456789012"
+  }
+
+  tags = {
+    Test = "test"
+  }
+}
+`, rName)
+}
+
+func testAccDataCatalogParametersConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_data_catalog" "test" {
+  name        = %[1]q
+  description = "Testing parameters attribute"
+  type        = "LAMBDA"
+
+  parameters = {
+    "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+  }
+}
+`, rName)
 }

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -35,8 +35,7 @@ func TestAccAthenaDataCatalog_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "A test data catalog"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.function", "arn:aws:lambda:us-east-1:123456789012:function:test-function"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Test", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -275,10 +274,6 @@ resource "aws_athena_data_catalog" "test" {
   parameters = {
     "function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
   }
-
-  tags = {
-    Test = "test"
-  }
 }
 `, rName)
 }
@@ -292,7 +287,7 @@ resource "aws_athena_data_catalog" "test" {
 
   parameters = {
     "metadata-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
-    "record-function" = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    "record-function"   = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
   }
 
   tags = {

--- a/internal/service/athena/data_catalog_test.go
+++ b/internal/service/athena/data_catalog_test.go
@@ -356,7 +356,7 @@ resource "aws_athena_data_catalog" "test" {
 func testAccDataCatalogTypeLambdaConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_athena_data_catalog" "test" {
-  name        =  %[1]q
+  name        = %[1]q
   description = "A test data catalog using Lambda"
   type        = "LAMBDA"
 

--- a/website/docs/r/athena_data_catalog.html.markdown
+++ b/website/docs/r/athena_data_catalog.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 - `name` - (Required) The name of the data catalog. The catalog name must be unique for the AWS account and can use a maximum of 128 alphanumeric, underscore, at sign, or hyphen characters.
 - `type` - (Required) The type of data catalog: `LAMBDA` for a federated catalog, `GLUE` for AWS Glue Catalog, or `HIVE` for an external hive metastore.
 - `parameters` - (Required) Key value pairs that specifies the Lambda function or functions to use for the data catalog. The mapping used depends on the catalog type.
-- `description` - (Optional) A description of the data catalog.
+- `description` - (Required) A description of the data catalog.
 - `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference

--- a/website/docs/r/athena_data_catalog.html.markdown
+++ b/website/docs/r/athena_data_catalog.html.markdown
@@ -1,0 +1,102 @@
+---
+subcategory: "Athena"
+layout: "aws"
+page_title: "AWS: aws_athena_data_catalog"
+description: |-
+  Provides an Athena data catalog.
+---
+
+# Resource: aws_athena_data_catalog
+
+Provides an Athena data catalog.
+
+More information about Athena and Athena data catalogs can be found in the [Athena User Guide](https://docs.aws.amazon.com/athena/latest/ug/what-is.html).
+
+-> **Tip:** for a more detailed explanation on the usage of `parameters`, see the [DataCatalog API documentation](https://docs.aws.amazon.com/athena/latest/APIReference/API_DataCatalog.html) 
+
+## Example Usage
+
+```terraform
+resource "aws_athena_data_catalog" "example" {
+  name        = "athena-data-catalog"
+  description = "Example Athena data catalog"
+  type        = "LAMBDA"
+
+  parameters = {
+    "function" = "arn:aws:lambda:eu-central-1:123456789012:function:not-important-lambda-function"
+  }
+
+  tags = {
+    Name = "example-athena-data-catalog"
+  }
+}
+```
+
+### Hive based Data Catalog
+
+```terraform
+resource "aws_athena_data_catalog" "example" {
+  name        = "hive-data-catalog"
+  description = "Hive based Data Catalog"
+  type        = "HIVE"
+
+  parameters = {
+    "metadata-function" = "arn:aws:lambda:eu-central-1:123456789012:function:not-important-lambda-function"
+  }
+}
+```
+
+### Glue based Data Catalog
+
+```terraform
+resource "aws_athena_data_catalog" "example" {
+  name        = "glue-data-catalog"
+  description = "Glue based Data Catalog"
+  type        = "GLUE"
+
+  parameters = {
+    "catalog-id" = "123456789012"
+  }
+}
+```
+
+### Lambda based Data Catalog
+
+```terraform
+resource "aws_athena_data_catalog" "example" {
+  name        = "lambda-data-catalog"
+  description = "Lambda based Data Catalog"
+  type        = "LAMBDA"
+
+  parameters = {
+    "metadata-function" = "arn:aws:lambda:eu-central-1:123456789012:function:not-important-lambda-function-1"
+    "record-function"   = "arn:aws:lambda:eu-central-1:123456789012:function:not-important-lambda-function-2"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Required) The name of the data catalog. The catalog name must be unique for the AWS account and can use a maximum of 128 alphanumeric, underscore, at sign, or hyphen characters.
+- `type` - (Required) The type of data catalog: `LAMBDA` for a federated catalog, `GLUE` for AWS Glue Catalog, or `HIVE` for an external hive metastore.
+- `parameters` - (Required) Key value pairs that specifies the Lambda function or functions to use for the data catalog. The mapping used depends on the catalog type.
+- `description` - (Optional) A description of the data catalog.
+- `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - Name of the data catalog.
+- `arn` - ARN of the data catalog.
+- `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Data catalogs can be imported using their `name`, e.g.,
+
+```
+$ terraform import aws_athena_data_catalog.example example-data-catalog
+```

--- a/website/docs/r/athena_data_catalog.html.markdown
+++ b/website/docs/r/athena_data_catalog.html.markdown
@@ -12,7 +12,7 @@ Provides an Athena data catalog.
 
 More information about Athena and Athena data catalogs can be found in the [Athena User Guide](https://docs.aws.amazon.com/athena/latest/ug/what-is.html).
 
--> **Tip:** for a more detailed explanation on the usage of `parameters`, see the [DataCatalog API documentation](https://docs.aws.amazon.com/athena/latest/APIReference/API_DataCatalog.html) 
+-> **Tip:** for a more detailed explanation on the usage of `parameters`, see the [DataCatalog API documentation](https://docs.aws.amazon.com/athena/latest/APIReference/API_DataCatalog.html)
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22714

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccDataCatalog PKG=athena
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/athena/... -v -count 1 -parallel 20 -run='TestAccDataCatalog'  -timeout 180m
=== RUN   TestAccDataCatalog_basic
=== PAUSE TestAccDataCatalog_basic
=== RUN   TestAccDataCatalog_type_lambda
=== PAUSE TestAccDataCatalog_type_lambda
=== RUN   TestAccDataCatalog_type_hive
=== PAUSE TestAccDataCatalog_type_hive
=== RUN   TestAccDataCatalog_type_glue
=== PAUSE TestAccDataCatalog_type_glue
=== RUN   TestAccDataCatalog_parameters
=== PAUSE TestAccDataCatalog_parameters
=== RUN   TestAccDataCatalog_disappears
=== PAUSE TestAccDataCatalog_disappears
=== CONT  TestAccDataCatalog_basic
=== CONT  TestAccDataCatalog_type_glue
=== CONT  TestAccDataCatalog_type_hive
=== CONT  TestAccDataCatalog_type_lambda
=== CONT  TestAccDataCatalog_disappears
=== CONT  TestAccDataCatalog_parameters
--- PASS: TestAccDataCatalog_disappears (27.24s)
--- PASS: TestAccDataCatalog_parameters (37.08s)
--- PASS: TestAccDataCatalog_type_hive (37.08s)
--- PASS: TestAccDataCatalog_type_glue (37.15s)
--- PASS: TestAccDataCatalog_basic (37.18s)
--- PASS: TestAccDataCatalog_type_lambda (37.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/athena     37.293s
```
