### PR TITLE
r/ami_copy, r/ami_from_instance: add `boot_mode` and `ebs_block_device.outpost_arn` args inherited from AMI resource

### DIFF
--- a/.changelog/22972.txt
+++ b/.changelog/22972.txt
@@ -1,7 +1,7 @@
-```release-note:bug
+```release-note:enhancement
 resource/aws_ami_copy: Prevent panic when reading the source AMI's `boot_mode` or `destination` `outpost_arn`
 ```
 
-```release-note:bug
+```release-note:enhancement
 resource/aws_ami_from_instance: Prevent panic when reading the AMI's `boot_mode` or `destination` `outpost_arn`
 ```

--- a/.changelog/22972.txt
+++ b/.changelog/22972.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_ami_copy: Prevent panic when reading the source AMI's `boot_mode` or `destination` `outpost_arn`
+resource/aws_ami_copy: Add `boot_mode` and `ebs_block_device.outpost_arn` attributes
 ```
 
 ```release-note:enhancement
-resource/aws_ami_from_instance: Prevent panic when reading the AMI's `boot_mode` or `destination` `outpost_arn`
+resource/aws_ami_from_instance: Add `boot_mode` and `ebs_block_device.outpost_arn` attributes
 ```

--- a/.changelog/22972.txt
+++ b/.changelog/22972.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ami_copy: Prevent panic when reading the source AMI's `boot_mode` or `destination` `outpost_arn`
+```

--- a/.changelog/22972.txt
+++ b/.changelog/22972.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_ami_copy: Prevent panic when reading the source AMI's `boot_mode` or `destination` `outpost_arn`
 ```
+
+```release-note:bug
+resource/aws_ami_from_instance: Prevent panic when reading the AMI's `boot_mode` or `destination` `outpost_arn`
+```

--- a/internal/service/ec2/ami_copy.go
+++ b/internal/service/ec2/ami_copy.go
@@ -32,6 +32,10 @@ func ResourceAMICopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"boot_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -65,6 +69,11 @@ func ResourceAMICopy() *schema.Resource {
 
 						"iops": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"outpost_arn": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 

--- a/internal/service/ec2/ami_from_instance.go
+++ b/internal/service/ec2/ami_from_instance.go
@@ -32,6 +32,10 @@ func ResourceAMIFromInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"boot_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -65,6 +69,11 @@ func ResourceAMIFromInstance() *schema.Resource {
 
 						"iops": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
+						"outpost_arn": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22971
Relates: https://github.com/hashicorp/terraform-provider-aws/pull/22939

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccEC2AMICopy_basic (379.75s)

--- PASS: TestAccAutoScalingLaunchConfiguration_RootBlockDevice_amiDisappears (366.97s)

--- PASS: TestAccEC2AMIFromInstance_basic (270.19s)
--- PASS: TestAccEC2AMIFromInstance_disappears (275.39s)
--- PASS: TestAccEC2AMIFromInstance_tags (348.59s)
```
