### PR TITLE
tests/cloudformation_stack: correct `aws_s3_bucket_website_configuration` resource name in test config

### DIFF
--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -385,11 +385,12 @@ func resourceStackUpdate(d *schema.ResourceData, meta interface{}) error {
 		},
 	)
 
-	if err != nil {
+	if err != nil && !tfawserr.ErrMessageContains(err, "ValidationError", "No updates are to be performed") {
 		return fmt.Errorf("error updating CloudFormation Stack (%s): %w", d.Id(), err)
 	}
 
 	_, err = WaitStackUpdated(conn, d.Id(), requestToken, d.Timeout(schema.TimeoutUpdate))
+
 	if err != nil {
 		return fmt.Errorf("error waiting for CloudFormation Stack (%s) update: %w", d.Id(), err)
 	}

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -853,7 +853,7 @@ resource "aws_s3_bucket" "b" {
 POLICY
 }
 
-resource "aws_s3_website_configuration" "test" {
+resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.b.id
   index_document {
     suffix = "index.html"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22974

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCloudFormationStack_WithURL_withParams (167.08s)

=== RUN   TestAccCloudFormationStack_WithURLWithParams_noUpdate
=== PAUSE TestAccCloudFormationStack_WithURLWithParams_noUpdate
=== CONT  TestAccCloudFormationStack_WithURLWithParams_noUpdate
    stack_test.go:367: Step 3/3 error: Error running apply: exit status 1

        Error: error updating CloudFormation Stack (arn:aws:cloudformation:us-west-2:xxxxxxxxxxxxx:stack/tf-acc-test-3630572383927170422/1de49a00-877f-11ec-bb8e-06f73b737b37): ValidationError: No updates are to be performed.
        	status code: 400, request id: 6048d7c4-306e-4394-843d-b1e83710dbde

          with aws_cloudformation_stack.test,
          on terraform_plugin_test.tf line 44, in resource "aws_cloudformation_stack" "test":
          44: resource "aws_cloudformation_stack" "test" {

--- FAIL: TestAccCloudFormationStack_WithURLWithParams_noUpdate (106.78s)

^^ seems to have been present in main before the S3 bucket change
```
