### PR TITLE
r/s3_bucket_cors_configuration: add retry around Get method during read

### DIFF
--- a/.changelog/22977.txt
+++ b/.changelog/22977.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_cors_configuration: Retry when `NoSuchCORSConfiguration` errors are returned from the AWS API
+```

--- a/internal/service/s3/bucket_cors_configuration_test.go
+++ b/internal/service/s3/bucket_cors_configuration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func TestAccS3BucketCorsConfiguration_basic(t *testing.T) {
@@ -283,13 +284,15 @@ func testAccCheckBucketCorsConfigurationExists(resourceName string) resource.Tes
 			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 		}
 
-		output, err := conn.GetBucketCors(input)
+		corsResponse, err := verify.RetryOnAWSCode(tfs3.ErrCodeNoSuchCORSConfiguration, func() (interface{}, error) {
+			return conn.GetBucketCors(input)
+		})
 
 		if err != nil {
 			return fmt.Errorf("error getting S3 Bucket CORS configuration (%s): %w", rs.Primary.ID, err)
 		}
 
-		if output == nil || len(output.CORSRules) == 0 {
+		if output, ok := corsResponse.(*s3.GetBucketCorsOutput); !ok || output == nil || len(output.CORSRules) == 0 {
 			return fmt.Errorf("S3 Bucket CORS configuration (%s) not found", rs.Primary.ID)
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22976

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketCorsConfiguration_MultipleRules (33.28s)
--- PASS: TestAccS3BucketCorsConfiguration_basic (33.35s)
--- PASS: TestAccS3BucketCorsConfiguration_SingleRule (33.81s)
--- PASS: TestAccS3BucketCorsConfiguration_update (81.59s)
--- PASS: TestAccS3BucketCorsConfiguration_disappears (149.95s)
```
