### PR TITLE
waf/helpers: prevent panic during `ExpandActivatedRule` method

### DIFF
--- a/.changelog/22978.txt
+++ b/.changelog/22978.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_waf_rule_group: Prevent panic when expanding the rule group's set of `activated_rule`
+```
+
+```release-note:bug
+resource/aws_wafregional_rule_group: Prevent panic when expanding the rule group's set of `activated_rule`
+```

--- a/internal/service/waf/helpers.go
+++ b/internal/service/waf/helpers.go
@@ -271,7 +271,7 @@ func FlattenActivatedRules(activatedRules []*waf.ActivatedRule) []interface{} {
 
 func ExpandActivatedRule(rule map[string]interface{}) *waf.ActivatedRule {
 	r := &waf.ActivatedRule{
-		Priority: aws.Int64(rule["priority"].(int64)),
+		Priority: aws.Int64(int64(rule["priority"].(int))),
 		RuleId:   aws.String(rule["rule_id"].(string)),
 		Type:     aws.String(rule["type"].(string)),
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22500
Closes https://github.com/hashicorp/terraform-provider-aws/issues/22378

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccWAFRuleGroup_noActivatedRules (24.10s)
--- PASS: TestAccWAFRuleGroup_disappears (32.71s)
--- PASS: TestAccWAFRuleGroup_basic (33.40s)
--- PASS: TestAccWAFRuleGroup_tags (52.01s)
--- PASS: TestAccWAFRuleGroup_changeActivatedRules (58.68s)
--- PASS: TestAccWAFRuleGroup_changeNameForceNew (59.35s)

--- PASS: TestAccWAFRegionalRuleGroup_noActivatedRules (29.69s)
--- PASS: TestAccWAFRegionalRuleGroup_disappears (43.75s)
--- PASS: TestAccWAFRegionalRuleGroup_basic (48.69s)
--- PASS: TestAccWAFRegionalRuleGroup_changeActivatedRules (68.40s)
--- PASS: TestAccWAFRegionalRuleGroup_changeNameForceNew (71.84s)
--- PASS: TestAccWAFRegionalRuleGroup_tags (80.44s)
```
