### PR TITLE
elbv2: Don't allow invalid configurations

### DIFF
--- a/.changelog/22996.txt
+++ b/.changelog/22996.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_lb_target_group: For `protocol = "TCP"`, `stickiness` can no longer be type set to `lb_cookie` even when `enabled = false`; instead use type `source_ip`
+```

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -252,16 +252,6 @@ func ResourceTargetGroup() *schema.Resource {
 								"app_cookie", // Only for ALBs
 								"source_ip",  // Only for NLBs
 							}, false),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								switch d.Get("protocol").(string) {
-								case elbv2.ProtocolEnumTcp, elbv2.ProtocolEnumUdp, elbv2.ProtocolEnumTcpUdp, elbv2.ProtocolEnumTls:
-									if new == "lb_cookie" && !d.Get("stickiness.0.enabled").(bool) {
-										log.Printf("[WARN] invalid configuration, this will fail in a future version: stickiness enabled %v, protocol %s, type %s", d.Get("stickiness.0.enabled").(bool), d.Get("protocol").(string), new)
-										return true
-									}
-								}
-								return false
-							},
 						},
 					},
 				},
@@ -469,41 +459,37 @@ func resourceTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 				stickinessBlocks := v.([]interface{})
 				stickiness := stickinessBlocks[0].(map[string]interface{})
 
-				if !stickiness["enabled"].(bool) && (stickiness["type"].(string) == "lb_cookie" || stickiness["type"].(string) == "app_cookie") && d.Get("protocol").(string) != elbv2.ProtocolEnumHttp && d.Get("protocol").(string) != elbv2.ProtocolEnumHttps {
-					log.Printf("[WARN] invalid configuration, this will fail in a future version: stickiness enabled %v, protocol %s, type %s", stickiness["enabled"].(bool), d.Get("protocol").(string), stickiness["type"].(string))
-				} else {
-					attrs = append(attrs,
-						&elbv2.TargetGroupAttribute{
-							Key:   aws.String("stickiness.enabled"),
-							Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
-						},
-						&elbv2.TargetGroupAttribute{
-							Key:   aws.String("stickiness.type"),
-							Value: aws.String(stickiness["type"].(string)),
-						})
+				attrs = append(attrs,
+					&elbv2.TargetGroupAttribute{
+						Key:   aws.String("stickiness.enabled"),
+						Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
+					},
+					&elbv2.TargetGroupAttribute{
+						Key:   aws.String("stickiness.type"),
+						Value: aws.String(stickiness["type"].(string)),
+					})
 
-					switch d.Get("protocol").(string) {
-					case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
-						switch stickiness["type"].(string) {
-						case "lb_cookie":
-							attrs = append(attrs,
-								&elbv2.TargetGroupAttribute{
-									Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
-									Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
-								})
-						case "app_cookie":
-							attrs = append(attrs,
-								&elbv2.TargetGroupAttribute{
-									Key:   aws.String("stickiness.app_cookie.duration_seconds"),
-									Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
-								},
-								&elbv2.TargetGroupAttribute{
-									Key:   aws.String("stickiness.app_cookie.cookie_name"),
-									Value: aws.String(stickiness["cookie_name"].(string)),
-								})
-						default:
-							log.Printf("[WARN] Unexpected stickiness type. Expected lb_cookie or app_cookie, got %s", stickiness["type"].(string))
-						}
+				switch d.Get("protocol").(string) {
+				case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
+					switch stickiness["type"].(string) {
+					case "lb_cookie":
+						attrs = append(attrs,
+							&elbv2.TargetGroupAttribute{
+								Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
+								Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+							})
+					case "app_cookie":
+						attrs = append(attrs,
+							&elbv2.TargetGroupAttribute{
+								Key:   aws.String("stickiness.app_cookie.duration_seconds"),
+								Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+							},
+							&elbv2.TargetGroupAttribute{
+								Key:   aws.String("stickiness.app_cookie.cookie_name"),
+								Value: aws.String(stickiness["cookie_name"].(string)),
+							})
+					default:
+						log.Printf("[WARN] Unexpected stickiness type. Expected lb_cookie or app_cookie, got %s", stickiness["type"].(string))
 					}
 				}
 			}
@@ -700,41 +686,37 @@ func resourceTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 				if len(stickinessBlocks) == 1 {
 					stickiness := stickinessBlocks[0].(map[string]interface{})
 
-					if !stickiness["enabled"].(bool) && (stickiness["type"].(string) == "lb_cookie" || stickiness["type"].(string) == "app_cookie") && d.Get("protocol").(string) != elbv2.ProtocolEnumHttp && d.Get("protocol").(string) != elbv2.ProtocolEnumHttps {
-						log.Printf("[WARN] invalid configuration, this will fail in a future version: stickiness enabled %v, protocol %s, type %s", stickiness["enabled"].(bool), d.Get("protocol").(string), stickiness["type"].(string))
-					} else {
-						attrs = append(attrs,
-							&elbv2.TargetGroupAttribute{
-								Key:   aws.String("stickiness.enabled"),
-								Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
-							},
-							&elbv2.TargetGroupAttribute{
-								Key:   aws.String("stickiness.type"),
-								Value: aws.String(stickiness["type"].(string)),
-							})
+					attrs = append(attrs,
+						&elbv2.TargetGroupAttribute{
+							Key:   aws.String("stickiness.enabled"),
+							Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
+						},
+						&elbv2.TargetGroupAttribute{
+							Key:   aws.String("stickiness.type"),
+							Value: aws.String(stickiness["type"].(string)),
+						})
 
-						switch d.Get("protocol").(string) {
-						case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
-							switch stickiness["type"].(string) {
-							case "lb_cookie":
-								attrs = append(attrs,
-									&elbv2.TargetGroupAttribute{
-										Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
-										Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
-									})
-							case "app_cookie":
-								attrs = append(attrs,
-									&elbv2.TargetGroupAttribute{
-										Key:   aws.String("stickiness.app_cookie.duration_seconds"),
-										Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
-									},
-									&elbv2.TargetGroupAttribute{
-										Key:   aws.String("stickiness.app_cookie.cookie_name"),
-										Value: aws.String(stickiness["cookie_name"].(string)),
-									})
-							default:
-								log.Printf("[WARN] Unexpected stickiness type. Expected lb_cookie or app_cookie, got %s", stickiness["type"].(string))
-							}
+					switch d.Get("protocol").(string) {
+					case elbv2.ProtocolEnumHttp, elbv2.ProtocolEnumHttps:
+						switch stickiness["type"].(string) {
+						case "lb_cookie":
+							attrs = append(attrs,
+								&elbv2.TargetGroupAttribute{
+									Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
+									Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+								})
+						case "app_cookie":
+							attrs = append(attrs,
+								&elbv2.TargetGroupAttribute{
+									Key:   aws.String("stickiness.app_cookie.duration_seconds"),
+									Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+								},
+								&elbv2.TargetGroupAttribute{
+									Key:   aws.String("stickiness.app_cookie.cookie_name"),
+									Value: aws.String(stickiness["cookie_name"].(string)),
+								})
+						default:
+							log.Printf("[WARN] Unexpected stickiness type. Expected lb_cookie or app_cookie, got %s", stickiness["type"].(string))
 						}
 					}
 				} else if len(stickinessBlocks) == 0 {

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -122,7 +122,7 @@ func TestAccELBV2TargetGroup_backwardsCompatibility(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_protocolVersion(t *testing.T) {
+func TestAccELBV2TargetGroup_ProtocolVersion_basic(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -167,7 +167,7 @@ func TestAccELBV2TargetGroup_protocolVersion(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_ProtocolVersionGRPC_healthCheck(t *testing.T) {
+func TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -191,7 +191,7 @@ func TestAccELBV2TargetGroup_ProtocolVersionGRPC_healthCheck(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_ProtocolVersionHTTPGRPC_update(t *testing.T) {
+func TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -222,7 +222,7 @@ func TestAccELBV2TargetGroup_ProtocolVersionHTTPGRPC_update(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_ProtocolTCPHealthCheck_protocol(t *testing.T) {
+func TestAccELBV2TargetGroup_HealthCheck_tcp(t *testing.T) {
 	var targetGroup1, targetGroup2 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -254,7 +254,7 @@ func TestAccELBV2TargetGroup_ProtocolTCPHealthCheck_protocol(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_Protocol_tls(t *testing.T) {
+func TestAccELBV2TargetGroup_tls(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -276,7 +276,7 @@ func TestAccELBV2TargetGroup_Protocol_tls(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_TCP_httpHealthCheck(t *testing.T) {
+func TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS(t *testing.T) {
 	var confBefore, confAfter elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -413,7 +413,7 @@ func TestAccELBV2TargetGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_basicUdp(t *testing.T) {
+func TestAccELBV2TargetGroup_udp(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -444,7 +444,7 @@ func TestAccELBV2TargetGroup_basicUdp(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_changeNameForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ForceNew_name(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rNameBefore := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameAfter := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -474,7 +474,7 @@ func TestAccELBV2TargetGroup_changeNameForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_changePortForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ForceNew_port(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -503,7 +503,7 @@ func TestAccELBV2TargetGroup_changePortForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_changeProtocolForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ForceNew_protocol(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -532,7 +532,7 @@ func TestAccELBV2TargetGroup_changeProtocolForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_changeVPCForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ForceNew_vpc(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -669,7 +669,7 @@ protocol = "TCP"
 	})
 }
 
-func TestAccELBV2TargetGroup_enableHealthCheck(t *testing.T) {
+func TestAccELBV2TargetGroup_HealthCheck_enable(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -704,7 +704,7 @@ func TestAccELBV2TargetGroup_enableHealthCheck(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_generatedName(t *testing.T) {
+func TestAccELBV2TargetGroup_Name_generated(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -725,7 +725,7 @@ func TestAccELBV2TargetGroup_generatedName(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_namePrefix(t *testing.T) {
+func TestAccELBV2TargetGroup_Name_prefix(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -907,7 +907,7 @@ func TestAccELBV2TargetGroup_preserveClientIPValid(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_protocolGeneve(t *testing.T) {
+func TestAccELBV2TargetGroup_Geneve_basic(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -941,7 +941,7 @@ func TestAccELBV2TargetGroup_protocolGeneve(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_protocolGeneveNotSticky(t *testing.T) {
+func TestAccELBV2TargetGroup_Geneve_notSticky(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -981,7 +981,7 @@ func TestAccELBV2TargetGroup_protocolGeneveNotSticky(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_stickinessDefaultALB(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_defaultALB(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1005,7 +1005,7 @@ func TestAccELBV2TargetGroup_stickinessDefaultALB(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_stickinessDefaultNLB(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_defaultNLB(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1047,7 +1047,7 @@ func TestAccELBV2TargetGroup_stickinessDefaultNLB(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_stickinessInvalidALB(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_invalidALB(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1077,7 +1077,7 @@ func TestAccELBV2TargetGroup_stickinessInvalidALB(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_stickinessInvalidNLB(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_invalidNLB(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1088,6 +1088,10 @@ func TestAccELBV2TargetGroup_stickinessInvalidNLB(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTargetGroupConfig_stickinessValidity(rName, "TCP", "lb_cookie", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
+			},
+			{
+				Config:      testAccTargetGroupConfig_stickinessValidity(rName, "TCP", "lb_cookie", false),
 				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
@@ -1102,7 +1106,7 @@ func TestAccELBV2TargetGroup_stickinessInvalidNLB(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_stickinessValidALB(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_validALB(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1137,7 +1141,7 @@ func TestAccELBV2TargetGroup_stickinessValidALB(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_stickinessValidNLB(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_validNLB(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1155,15 +1159,6 @@ func TestAccELBV2TargetGroup_stickinessValidNLB(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "source_ip"),
-				),
-			},
-			{
-				// this test should be invalid but allowed to avoid breaking changes
-				Config: testAccTargetGroupConfig_stickinessValidity(rName, "TCP", "lb_cookie", false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetGroupExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
 				),
 			},
 			{
@@ -1237,7 +1232,7 @@ func TestAccELBV2TargetGroup_tags(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_updateAppStickinessEnabled(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_updateAppEnabled(t *testing.T) {
 	var conf elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", sdkacctest.RandString(10))
 	resourceName := "aws_lb_target_group.test"
@@ -1325,7 +1320,7 @@ func TestAccELBV2TargetGroup_updateAppStickinessEnabled(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_updateHealthCheck(t *testing.T) {
+func TestAccELBV2TargetGroup_HealthCheck_update(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1390,7 +1385,7 @@ func TestAccELBV2TargetGroup_updateHealthCheck(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_updateStickinessEnabled(t *testing.T) {
+func TestAccELBV2TargetGroup_Stickiness_updateEnabled(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1476,7 +1471,7 @@ func TestAccELBV2TargetGroup_updateStickinessEnabled(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_withoutHealthCheck(t *testing.T) {
+func TestAccELBV2TargetGroup_HealthCheck_without(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
@@ -1501,7 +1496,7 @@ func TestAccELBV2TargetGroup_withoutHealthCheck(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_basic(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_basic(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1545,7 +1540,7 @@ func TestAccELBV2TargetGroup_A_basic(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_changeNameForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameAfter := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1575,7 +1570,7 @@ func TestAccELBV2TargetGroup_A_changeNameForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_changePortForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_changePortForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1604,7 +1599,7 @@ func TestAccELBV2TargetGroup_A_changePortForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_changeProtocolForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1633,7 +1628,7 @@ func TestAccELBV2TargetGroup_A_changeProtocolForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_changeVPCForceNew(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1660,7 +1655,7 @@ func TestAccELBV2TargetGroup_A_changeVPCForceNew(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_generatedName(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_generatedName(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1681,7 +1676,7 @@ func TestAccELBV2TargetGroup_A_generatedName(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_lambda(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_lambda(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1716,7 +1711,7 @@ func TestAccELBV2TargetGroup_A_lambda(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_lambdaMultiValueHeadersEnabled(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1767,7 +1762,7 @@ func TestAccELBV2TargetGroup_A_lambdaMultiValueHeadersEnabled(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_missingPortProtocolVPC(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC(t *testing.T) {
 	rName := fmt.Sprintf("test-target-group-%s", sdkacctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1792,7 +1787,7 @@ func TestAccELBV2TargetGroup_A_missingPortProtocolVPC(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_namePrefix(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_namePrefix(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1814,7 +1809,7 @@ func TestAccELBV2TargetGroup_A_namePrefix(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_setAndUpdateSlowStart(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart(t *testing.T) {
 	var before, after elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1843,7 +1838,7 @@ func TestAccELBV2TargetGroup_A_setAndUpdateSlowStart(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_tags(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_tags(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1875,7 +1870,7 @@ func TestAccELBV2TargetGroup_A_tags(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_updateHealthCheck(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1938,7 +1933,7 @@ func TestAccELBV2TargetGroup_A_updateHealthCheck(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_updateLoadBalancingAlgorithmType(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"
@@ -1980,7 +1975,7 @@ func TestAccELBV2TargetGroup_A_updateLoadBalancingAlgorithmType(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_A_updateStickinessEnabled(t *testing.T) {
+func TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled(t *testing.T) {
 	var conf elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_alb_target_group.test"

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -48,7 +48,7 @@ Upgrade topics:
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
-- [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine) 
+- [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine)
 - [Resource: aws_lb_target_group](#resource-aws_lb_target_group)
 - [Resource: aws_network_interface](#resource-aws_network_interface)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
@@ -892,7 +892,7 @@ resource "aws_s3_bucket" "example" {
 
 resource "aws_s3_bucket_cors_configuration" "example" {
   bucket = aws_s3_bucket.example.id
-  
+
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT", "POST"]
@@ -947,7 +947,7 @@ resource "aws_s3_bucket" "example" {
       days = 90
     }
   }
-  
+
   lifecycle_rule {
     id      = "tmp"
     prefix  = "tmp/"
@@ -981,7 +981,7 @@ resource "aws_s3_bucket" "example" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "example" {
   bucket = aws_s3_bucket.example.id
-  
+
   rule {
     id     = "log"
     status = "Enabled"
@@ -1277,9 +1277,9 @@ For example, given this previous configuration:
 ```terraform
 resource "aws_s3_bucket" "source" {
   provider = aws.central
-  
+
   # ... other configuration ...
-  
+
   replication_configuration {
     role = aws_iam_role.replication.arn
     rules {
@@ -1329,7 +1329,7 @@ resource "aws_s3_bucket" "source" {
 resource "aws_s3_bucket_replication_configuration" "example" {
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.replication.arn
-  
+
   rule {
     id     = "foobar"
     status = "Enabled"

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -754,7 +754,7 @@ We removed the misspelled argument `active_directory_configuration.0.self_manage
 ## Resource: aws_lb_target_group
 
 
-For `protocol = "TCP"`, `stickiness` can no longer be type set to `lb_cookie` even when `enabled = false`. Instead, either change the `protocol` to `"HTTP"` or `"HTTPS"`, or change `stickiness.type` to `"source_ip"`.
+For `protocol = "TCP"`, `stickiness.type` can no longer be set to `lb_cookie` even when `enabled = false`. Instead, either change the `protocol` to `"HTTP"` or `"HTTPS"`, or change `stickiness.type` to `"source_ip"`.
 
 For example, this configuration is no longer valid:
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -48,7 +48,8 @@ Upgrade topics:
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
 - [Resource: aws_elasticache_global_replication_group](#resource-aws_elasticache_global_replication_group)
 - [Resource: aws_elasticache_replication_group](#resource-aws_elasticache_replication_group)
-- [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine)
+- [Resource: aws_fsx_ontap_storage_virtual_machine](#resource-aws_fsx_ontap_storage_virtual_machine) 
+- [Resource: aws_lb_target_group](#resource-aws_lb_target_group)
 - [Resource: aws_network_interface](#resource-aws_network_interface)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_s3_bucket_object](#resource-aws_s3_bucket_object)
@@ -749,6 +750,42 @@ output "elasticache_global_replication_group_version_result" {
 ## Resource: aws_fsx_ontap_storage_virtual_machine
 
 We removed the misspelled argument `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name` that was previously deprecated. Use `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` now instead. Terraform will automatically migrate the state to `active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name` during planning.
+
+## Resource: aws_lb_target_group
+
+
+For `protocol = "TCP"`, `stickiness` can no longer be type set to `lb_cookie` even when `enabled = false`. Instead, either change the `protocol` to `"HTTP"` or `"HTTPS"`, or change `stickiness.type` to `"source_ip"`.
+
+For example, this configuration is no longer valid:
+
+```terraform
+resource "aws_lb_target_group" "test" {
+  port        = 25
+  protocol    = "TCP"
+  vpc_id      = aws_vpc.test.id
+
+  stickiness {
+    type    = "lb_cookie"
+    enabled = false
+  }
+}
+```
+
+To fix this, we change the `stickiness.type` to `"source_ip"`.
+
+```terraform
+resource "aws_lb_target_group" "test" {
+  port        = 25
+  protocol    = "TCP"
+  vpc_id      = aws_vpc.test.id
+
+  stickiness {
+    type    = "source_ip"
+    enabled = false
+  }
+}
+```
+
 
 ## Resource: aws_network_interface
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15612

Output from acceptance testing (`us-west-2`):

```console
% make testacc TESTS=TestAccELBV2TargetGroup_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_'  -timeout 180m
--- PASS: TestAccELBV2TargetGroup_HealthCheck_without (31.79s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambda (35.27s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC (36.26s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_basic (40.73s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_generatedName (40.77s)
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (40.81s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_namePrefix (43.18s)
--- PASS: TestAccELBV2TargetGroup_Geneve_basic (47.38s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew (61.20s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck (62.69s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled (65.91s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changePortForceNew (66.59s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_update (69.48s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew (69.98s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_defaultALB (29.25s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew (73.93s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType (88.48s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_updateEnabled (93.10s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_invalidNLB (59.02s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled (95.77s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_validALB (60.50s)
--- PASS: TestAccELBV2TargetGroup_tags (95.78s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_updateAppEnabled (97.24s)
--- PASS: TestAccELBV2TargetGroup_Name_generated (40.57s)
--- PASS: TestAccELBV2TargetGroup_Geneve_notSticky (68.40s)
--- PASS: TestAccELBV2TargetGroup_Name_prefix (41.76s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_invalidALB (71.56s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart (65.24s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_enable (56.96s)
--- PASS: TestAccELBV2TargetGroup_preserveClientIPValid (74.37s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy (77.70s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_protocol (82.75s)
--- PASS: TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination (77.81s)
--- PASS: TestAccELBV2TargetGroup_udp (52.17s)
--- PASS: TestAccELBV2TargetGroup_basic (52.47s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_defaultNLB (107.78s)
--- PASS: TestAccELBV2TargetGroup_Defaults_network (61.73s)
--- PASS: TestAccELBV2TargetGroup_tls (46.73s)
--- PASS: TestAccELBV2TargetGroup_Defaults_application (48.66s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_validNLB (140.08s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_basic (44.07s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_tags (82.32s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_vpc (81.87s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS (85.61s)
--- PASS: TestAccELBV2TargetGroup_attrsOnCreate (84.94s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck (39.32s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_port (79.02s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroup (121.83s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate (83.24s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_name (82.41s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_tcp (67.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	205.872s
```

Output from acceptance testing (GovCloud):

```console
% make testacc TESTS=TestAccELBV2TargetGroup_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_'  -timeout 180m
--- PASS: TestAccELBV2TargetGroup_HealthCheck_without (43.20s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambda (49.38s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_namePrefix (58.95s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC (60.63s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_generatedName (62.74s)
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (62.99s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_basic (63.11s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck (89.20s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changePortForceNew (89.35s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew (91.12s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew (92.70s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_tags (94.44s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_update (94.92s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart (95.22s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew (99.61s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled (104.49s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_updateEnabled (115.83s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType (117.71s)
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled (117.97s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_defaultNLB (119.77s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_defaultALB (31.77s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_vpc (62.30s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_validALB (66.79s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_invalidNLB (65.03s)
--- PASS: TestAccELBV2TargetGroup_Name_prefix (29.82s)
--- PASS: TestAccELBV2TargetGroup_Geneve_basic (39.97s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_invalidALB (72.90s)
--- PASS: TestAccELBV2TargetGroup_Name_generated (32.58s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_updateAppEnabled (98.42s)
--- PASS: TestAccELBV2TargetGroup_tags (94.93s)
--- PASS: TestAccELBV2TargetGroup_Defaults_application (31.56s)
--- PASS: TestAccELBV2TargetGroup_Geneve_notSticky (61.53s)
--- PASS: TestAccELBV2TargetGroup_preserveClientIPValid (61.81s)
--- PASS: TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination (59.81s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy (60.40s)
--- PASS: TestAccELBV2TargetGroup_Defaults_network (40.14s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_enable (42.10s)
--- PASS: TestAccELBV2TargetGroup_udp (30.45s)
--- PASS: TestAccELBV2TargetGroup_basic (31.51s)
--- PASS: TestAccELBV2TargetGroup_tls (28.73s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck (28.13s)
--- PASS: TestAccELBV2TargetGroup_attrsOnCreate (54.02s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_basic (27.32s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_validNLB (118.59s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_port (52.18s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_protocol (58.98s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_tcp (52.18s)
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroup (88.07s)
--- PASS: TestAccELBV2TargetGroup_ForceNew_name (56.26s)
--- PASS: TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS (49.61s)
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate (52.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	198.872s
```
