### PR TITLE
tech-debt/tests: Migrate to `aws_s3_bucket_policy`

### DIFF
--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -834,7 +834,10 @@ data "aws_region" "current" {}
 resource "aws_s3_bucket" "b" {
   bucket = %[1]q
   acl    = "public-read"
+}
 
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.b.id
   policy = <<POLICY
 {
   "Version":"2008-10-17",
@@ -892,7 +895,10 @@ data "aws_region" "current" {}
 resource "aws_s3_bucket" "b" {
   bucket = %[1]q
   acl    = "public-read"
+}
 
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.b.id
   policy = <<POLICY
 {
   "Version":"2008-10-17",

--- a/internal/service/cloudtrail/cloudtrail_test.go
+++ b/internal/service/cloudtrail/cloudtrail_test.go
@@ -879,7 +879,10 @@ data "aws_partition" "current" {}
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
+}
 
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -911,6 +914,9 @@ resource "aws_s3_bucket" "test" {
 func testAccConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 }
@@ -920,6 +926,9 @@ resource "aws_cloudtrail" "test" {
 func testAccModifiedConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                          = %[1]q
   s3_bucket_name                = aws_s3_bucket.test.id
   s3_key_prefix                 = "prefix"
@@ -931,6 +940,9 @@ resource "aws_cloudtrail" "test" {
 func testAccEnableLoggingConfig(rName string, enableLogging bool) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                          = %[1]q
   s3_bucket_name                = aws_s3_bucket.test.id
   s3_key_prefix                 = "prefix"
@@ -943,6 +955,9 @@ resource "aws_cloudtrail" "test" {
 func testAccCloudWatchConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -997,6 +1012,9 @@ resource "aws_iam_role_policy" "test" {
 func testAccCloudWatchModifiedConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1055,6 +1073,9 @@ resource "aws_iam_role_policy" "test" {
 func testAccMultiRegionConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                  = %[1]q
   s3_bucket_name        = aws_s3_bucket.test.id
   is_multi_region_trail = true
@@ -1069,6 +1090,9 @@ resource "aws_organizations_organization" "test" {
 }
 
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   is_organization_trail = true
   name                  = %[1]q
   s3_bucket_name        = aws_s3_bucket.test.id
@@ -1079,6 +1103,9 @@ resource "aws_cloudtrail" "test" {
 func testAccLogValidationConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                          = %[1]q
   s3_bucket_name                = aws_s3_bucket.test.id
   is_multi_region_trail         = true
@@ -1091,6 +1118,9 @@ resource "aws_cloudtrail" "test" {
 func testAccLogValidationModifiedConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                          = %[1]q
   s3_bucket_name                = aws_s3_bucket.test.id
   include_global_service_events = true
@@ -1121,6 +1151,9 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                          = %[1]q
   s3_bucket_name                = aws_s3_bucket.test.id
   include_global_service_events = true
@@ -1132,6 +1165,9 @@ resource "aws_cloudtrail" "test" {
 func testAccGlobalServiceEventsConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name                          = %[1]q
   s3_bucket_name                = aws_s3_bucket.test.id
   include_global_service_events = false
@@ -1142,6 +1178,9 @@ resource "aws_cloudtrail" "test" {
 func testAccTagsConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1156,6 +1195,9 @@ resource "aws_cloudtrail" "test" {
 func testAccTagsModifiedConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1171,6 +1213,9 @@ resource "aws_cloudtrail" "test" {
 func testAccTagsModifiedAgainConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 }
@@ -1180,6 +1225,9 @@ resource "aws_cloudtrail" "test" {
 func testAccEventSelectorConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1208,6 +1256,9 @@ resource "aws_s3_bucket" "test2" {
 func testAccEventSelectorReadWriteTypeConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1222,6 +1273,9 @@ resource "aws_cloudtrail" "test" {
 func testAccEventSelectorModifiedConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1298,6 +1352,9 @@ resource "aws_lambda_function" "test" {
 func testAccEventSelectorNoneConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 }
@@ -1307,6 +1364,9 @@ resource "aws_cloudtrail" "test" {
 func testAccEventSelectorDynamoDBConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1343,6 +1403,9 @@ func testAccEventSelectorExcludeKMSConfig(rName string) string {
 		testAccBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1358,6 +1421,9 @@ func testAccEventSelectorExcludeKMSAndRDSDataConfig(rName string) string {
 		testAccBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1374,6 +1440,9 @@ resource "aws_cloudtrail" "test" {
 func testAccInsightSelectorConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1388,6 +1457,9 @@ resource "aws_cloudtrail" "test" {
 func testAccInsightSelectorMultiConfig(rName string) string {
 	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test.id
 
@@ -1406,6 +1478,9 @@ resource "aws_cloudtrail" "test" {
 func testAccConfig_advancedEventSelector(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   name           = %[1]q
   s3_bucket_name = aws_s3_bucket.test1.id
 
@@ -1502,7 +1577,10 @@ data "aws_partition" "current" {}
 resource "aws_s3_bucket" "test1" {
   bucket        = "%[1]s-1"
   force_destroy = true
+}
 
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test1.id
   policy = <<POLICY
 {
   "Version": "2012-10-17",

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -909,7 +909,10 @@ data "aws_redshift_service_account" "main" {}
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
+}
 
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test.id
   policy = <<EOF
 {
   "Version": "2008-10-17",
@@ -938,6 +941,9 @@ EOF
 }
 
 resource "aws_redshift_cluster" "test" {
+  # Must have bucket policy attached first
+  depends_on = [aws_s3_bucket_policy.test]
+
   cluster_identifier                  = %[1]q
   availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCloudFormationStack_WithURLWithParams_withYAML (91.03s)

--- SKIP: TestAccCloudTrail_serial/Trail/organization (1.58s)
--- PASS: TestAccCloudTrail_serial/Trail/logValidation (65.72s)
--- PASS: TestAccCloudTrail_serial/Trail/eventSelector (141.16s)
--- PASS: TestAccCloudTrail_serial/Trail/disappears (35.83s)
--- PASS: TestAccCloudTrail_serial/Trail/cloudwatch (83.20s)
--- PASS: TestAccCloudTrail_serial/Trail/globalServiceEvents (38.32s)
--- PASS: TestAccCloudTrail_serial/Trail/tags (94.29s)
--- PASS: TestAccCloudTrail_serial/Trail/advancedEventSelector (38.27s)
--- PASS: TestAccCloudTrail_serial/Trail/kmsKey (40.68s)
--- PASS: TestAccCloudTrail_serial/Trail/eventSelectorDynamoDB (35.14s)
--- PASS: TestAccCloudTrail_serial/Trail/eventSelectorExclude (98.50s)
--- PASS: TestAccCloudTrail_serial/Trail/insightSelector (128.34s)
--- PASS: TestAccCloudTrail_serial/Trail/multiRegion (94.28s)
--- PASS: TestAccCloudTrail_serial/Trail/basic (68.73s)

--- PASS: TestAccRedshiftCluster_loggingEnabled (258.96s)
```
