### PR TITLE
tests/spot_datafeed_subscription: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -52,6 +52,7 @@ const (
 	ErrCodeInvalidSecurityGroupIDNotFound               = "InvalidSecurityGroupID.NotFound"
 	ErrCodeInvalidSnapshotInUse                         = "InvalidSnapshot.InUse"
 	ErrCodeInvalidSnapshotNotFound                      = "InvalidSnapshot.NotFound"
+	ErrCodeInvalidSpotDatafeedNotFound                  = "InvalidSpotDatafeed.NotFound"
 	ErrCodeInvalidSpotInstanceRequestIDNotFound         = "InvalidSpotInstanceRequestID.NotFound"
 	ErrCodeInvalidSubnetCidrReservationIDNotFound       = "InvalidSubnetCidrReservationID.NotFound"
 	ErrCodeInvalidSubnetIDNotFound                      = "InvalidSubnetID.NotFound"

--- a/internal/service/ec2/spot_datafeed_subscription_test.go
+++ b/internal/service/ec2/spot_datafeed_subscription_test.go
@@ -3,9 +3,7 @@ package ec2_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -13,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 )
 
 func TestAccEC2SpotDatafeedSubscription_serial(t *testing.T) {
@@ -54,30 +53,6 @@ func testAccSpotDatafeedSubscription_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckSpotDatafeedSubscriptionDisappears(subscription *ec2.SpotDatafeedSubscription) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
-
-		_, err := conn.DeleteSpotDatafeedSubscription(&ec2.DeleteSpotDatafeedSubscriptionInput{})
-		if err != nil {
-			return err
-		}
-
-		return resource.Retry(40*time.Minute, func() *resource.RetryError {
-			_, err := conn.DescribeSpotDatafeedSubscription(&ec2.DescribeSpotDatafeedSubscriptionInput{})
-			if err != nil {
-				cgw, ok := err.(awserr.Error)
-				if ok && cgw.Code() == "InvalidSpotDatafeed.NotFound" {
-					return nil
-				}
-				return resource.NonRetryableError(
-					fmt.Errorf("Error retrieving Spot Datafeed Subscription: %s", err))
-			}
-			return resource.RetryableError(fmt.Errorf("Waiting for Spot Datafeed Subscription"))
-		})
-	}
-}
-
 func testAccSpotDatafeedSubscription_disappears(t *testing.T) {
 	var subscription ec2.SpotDatafeedSubscription
 	resourceName := "aws_spot_datafeed_subscription.test"
@@ -93,7 +68,7 @@ func testAccSpotDatafeedSubscription_disappears(t *testing.T) {
 				Config: testAccSpotDatafeedSubscription(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSpotDatafeedSubscriptionExists(resourceName, &subscription),
-					testAccCheckSpotDatafeedSubscriptionDisappears(&subscription),
+					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceSpotDataFeedSubscription(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -135,12 +110,12 @@ func testAccCheckSpotDatafeedSubscriptionDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeSpotDatafeedSubscription(&ec2.DescribeSpotDatafeedSubscriptionInput{})
 
-		if tfawserr.ErrCodeEquals(err, "InvalidSpotDatafeed.NotFound") {
+		if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidSpotDatafeedNotFound) {
 			continue
 		}
 
 		if err != nil {
-			return fmt.Errorf("error descripting EC2 Spot Datafeed Subscription: %w", err)
+			return fmt.Errorf("error describing EC2 Spot Datafeed Subscription: %w", err)
 		}
 	}
 
@@ -158,7 +133,7 @@ func testAccPreCheckSpotDatafeedSubscription(t *testing.T) {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}
 
-	if tfawserr.ErrCodeEquals(err, "InvalidSpotDatafeed.NotFound") {
+	if tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidSpotDatafeedNotFound) {
 		return
 	}
 
@@ -173,21 +148,37 @@ data "aws_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
 
-  grant {
-    id          = data.aws_canonical_user_id.current.id
-    permissions = ["FULL_CONTROL"]
-    type        = "CanonicalUser"
-  }
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
 
-  grant {
-    id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0" # EC2 Account
-    permissions = ["FULL_CONTROL"]
-    type        = "CanonicalUser"
+    grant {
+      grantee {
+        id   = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0" # EC2 Account
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
   }
 }
 
 resource "aws_spot_datafeed_subscription" "test" {
+  # Must have bucket grants configured
+  depends_on = [aws_s3_bucket_acl.test]
+
   bucket = aws_s3_bucket.test.bucket
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22997 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccEC2SpotDatafeedSubscription_serial (70.23s)
    --- PASS: TestAccEC2SpotDatafeedSubscription_serial/basic (36.93s)
    --- PASS: TestAccEC2SpotDatafeedSubscription_serial/disappears (33.30s)
```
