### PR TITLE
tests/wafv2: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/wafv2/web_acl_logging_configuration_test.go
+++ b/internal/service/wafv2/web_acl_logging_configuration_test.go
@@ -700,6 +700,10 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = "%[1]s"
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates #22537 
Relates #20433 


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_basic (119.76s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField (157.38s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField (161.42s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField (163.26s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField (170.40s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields (118.91s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_disappears (105.73s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields (100.19s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields (112.04s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew (191.20s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew (223.40s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL (115.00s)
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_loggingFilter (148.89s)
```
