### PR TITLE
tests/waf: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/waf/web_acl_test.go
+++ b/internal/service/waf/web_acl_test.go
@@ -550,6 +550,10 @@ resource "aws_waf_web_acl" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -621,6 +625,10 @@ resource "aws_waf_web_acl" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccWAFWebACL_disappears (28.03s)
--- PASS: TestAccWAFWebACL_basic (31.43s)
--- PASS: TestAccWAFWebACLDataSource_basic (48.41s)
--- PASS: TestAccWAFWebACL_defaultAction (51.63s)
--- PASS: TestAccWAFWebACL_tags (53.70s)
--- PASS: TestAccWAFWebACL_changeNameForceNew (55.14s)
--- PASS: TestAccWAFWebACL_rules (93.26s)
--- PASS: TestAccWAFWebACL_logging (207.22s)
```
