### PR TITLE
tests/synthetics: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -390,6 +390,10 @@ func TestAccSyntheticsCanary_runTracing(t *testing.T) {
 }
 
 func TestAccSyntheticsCanary_vpc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf synthetics.Canary
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(8))
 	resourceName := "aws_synthetics_canary.test"

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -634,12 +634,16 @@ func testAccCanaryBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
 
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccSyntheticsCanary_artifactEncryption (96.88s)
--- PASS: TestAccSyntheticsCanary_basic (120.38s)
--- PASS: TestAccSyntheticsCanary_disappears (77.10s)
--- PASS: TestAccSyntheticsCanary_runTracing (98.86s)
--- PASS: TestAccSyntheticsCanary_runtimeVersion (118.90s)
--- PASS: TestAccSyntheticsCanary_startCanary (112.59s)
--- PASS: TestAccSyntheticsCanary_tags (107.71s)
--- PASS: TestAccSyntheticsCanary_vpc (2094.20s)
--- PASS: TestAccSyntheticsCanary_run (98.11s)
--- PASS: TestAccSyntheticsCanary_s3 (61.74s)
```
