### PR TITLE
tests/ssm: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/ssm/maintenance_window_task_test.go
+++ b/internal/service/ssm/maintenance_window_task_test.go
@@ -791,8 +791,12 @@ func testAccMaintenanceWindowTaskAutomationUpdateConfig(rName, version string) s
 	return fmt.Sprintf(testAccMaintenanceWindowTaskBaseConfig(rName)+`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_ssm_maintenance_window_task" "test" {
@@ -901,8 +905,12 @@ func testAccMaintenanceWindowTaskRunCommandUpdateConfig(rName, comment string, t
 	return fmt.Sprintf(testAccMaintenanceWindowTaskBaseConfig(rName)+`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_ssm_maintenance_window_task" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccSSMMaintenanceWindowTask_noRole (42.72s)
--- PASS: TestAccSSMMaintenanceWindowTask_disappears (47.26s)
--- PASS: TestAccSSMMaintenanceWindowTask_emptyNotification (48.24s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationStepFunctionParameters (52.51s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationLambdaParameters (60.50s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParameters (71.08s)
--- PASS: TestAccSSMMaintenanceWindowTask_updateForcesNewResource (73.27s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationAutomationParameters (74.70s)
--- PASS: TestAccSSMMaintenanceWindowTask_description (75.00s)
--- PASS: TestAccSSMMaintenanceWindowTask_basic (75.17s)
--- PASS: TestAccSSMMaintenanceWindowTask_taskInvocationRunCommandParametersCloudWatch (86.43s)
```
