### PR TITLE
tests/ses: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/ses/event_destination_test.go
+++ b/internal/service/ses/event_destination_test.go
@@ -168,6 +168,10 @@ func testAccEventDestinationConfig(rName1, rName2, rName3 string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[2]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 

--- a/internal/service/ses/receipt_rule_test.go
+++ b/internal/service/ses/receipt_rule_test.go
@@ -476,8 +476,12 @@ resource "aws_ses_receipt_rule_set" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "public-read-write"
   force_destroy = "true"
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read-write"
 }
 
 resource "aws_ses_receipt_rule" "test" {

--- a/internal/service/ses/receipt_rule_test.go
+++ b/internal/service/ses/receipt_rule_test.go
@@ -493,7 +493,7 @@ resource "aws_ses_receipt_rule" "test" {
   tls_policy    = "Require"
 
   s3_action {
-    bucket_name = aws_s3_bucket.test.id
+    bucket_name = aws_s3_bucket_acl.test.bucket
     position    = 1
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccSESReceiptRuleSet_disappears (46.00s)
--- PASS: TestAccSESReceiptRuleSet_basic (47.75s)
--- PASS: TestAccSESReceiptRule_order (48.00s)
--- PASS: TestAccSESReceiptRule_snsAction (49.23s)
--- PASS: TestAccSESReceiptRule_basic (49.39s)
--- PASS: TestAccSESReceiptRule_snsActionEncoding (50.10s)
--- PASS: TestAccSESReceiptRule_stopAction (50.11s)
--- PASS: TestAccSESReceiptRule_s3Action (51.64s)
--- PASS: TestAccSESReceiptRule_actions (54.13s)
--- PASS: TestAccSESReceiptRule_lambdaAction (55.46s)
--- PASS: TestAccSESReceiptRule_disappears (56.22s)
--- PASS: TestAccSESEventDestination_basic (97.41s)
--- PASS: TestAccSESEventDestination_disappears (113.84s)
```
