### PR TITLE
tests/servicecatalog: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/servicecatalog/constraint_test.go
+++ b/internal/service/servicecatalog/constraint_test.go
@@ -157,8 +157,12 @@ func testAccConstraintConfig_base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/servicecatalog/product_test.go
+++ b/internal/service/servicecatalog/product_test.go
@@ -264,8 +264,12 @@ func testAccProductTemplateURLBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -165,8 +165,12 @@ func testAccProvisionedProductTemplateURLBaseConfig(rName, domain, email string)
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/servicecatalog/provisioning_artifact_test.go
+++ b/internal/service/servicecatalog/provisioning_artifact_test.go
@@ -244,8 +244,12 @@ func testAccProvisioningArtifactTemplateURLBaseConfig(rName, domain string) stri
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccServiceCatalogConstraintDataSource_basic (91.09s)
--- PASS: TestAccServiceCatalogConstraint_basic (94.72s)
--- PASS: TestAccServiceCatalogConstraint_disappears (73.18s)
--- PASS: TestAccServiceCatalogConstraint_update (117.48s)

--- PASS: TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic (84.66s)

--- PASS: TestAccServiceCatalogProductDataSource_basic (86.39s)
--- PASS: TestAccServiceCatalogProductDataSource_physicalID (124.10s)

--- PASS: TestAccServiceCatalogProductPortfolioAssociation_basic (130.33s)
--- PASS: TestAccServiceCatalogProductPortfolioAssociation_disappears (119.22s)

--- PASS: TestAccServiceCatalogProduct_basic (71.08s)
--- PASS: TestAccServiceCatalogProduct_disappears (56.87s)
--- PASS: TestAccServiceCatalogProduct_physicalID (123.44s)
--- PASS: TestAccServiceCatalogProduct_update (107.10s)
--- PASS: TestAccServiceCatalogProduct_updateTags (107.67s)

--- PASS: TestAccServiceCatalogProvisionedProduct_basic (171.55s)
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (152.03s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (257.59s)

--- PASS: TestAccServiceCatalogProvisioningArtifact_basic (93.09s)
--- PASS: TestAccServiceCatalogProvisioningArtifact_disappears (83.26s)
--- PASS: TestAccServiceCatalogProvisioningArtifact_physicalID (93.58s)
--- PASS: TestAccServiceCatalogProvisioningArtifact_update (120.05s)
```
