### PR TITLE
Example of using a non-VPC endpoint prefix with a security group

### DIFF
--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -62,7 +62,31 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 }
 ```
 
-You can also find a specific Prefix List using the `aws_prefix_list` data source.
+You can also find a specific Prefix List using the [`aws_prefix_list`](../data-sources/prefix_list)
+or [`ec2_managed_prefix_list`](../data-sources/ec2_managed_prefix_list) data sources:
+
+```terraform
+data "aws_region" "current" {}
+
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
+resource "aws_security_group_rule" "s3_gateway_egress" {
+  # S3 Gateway interfaces are implemented at the routing level which means we
+  # can avoid the metered billing of a VPC endpoint interface by allowing
+  # outbound traffic to the public IP ranges, which will be routed through
+  # the Gateway interface:
+  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html
+  description       = "S3 Gateway Egress"
+  type              = "egress"
+  security_group_id = "sg-123456"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_prefix_list.s3.id]
+}
+```
 
 ## Argument Reference
 

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -62,8 +62,8 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 }
 ```
 
-You can also find a specific Prefix List using the [`aws_prefix_list`](../data-sources/prefix_list)
-or [`ec2_managed_prefix_list`](../data-sources/ec2_managed_prefix_list) data sources:
+You can also find a specific Prefix List using the [`aws_prefix_list`](/docs/providers/aws/d/prefix_list.html)
+or [`ec2_managed_prefix_list`](/docs/providers/aws/d/ec2_managed_prefix_list.html) data sources:
 
 ```terraform
 data "aws_region" "current" {}


### PR DESCRIPTION
I wanted to add an example which shows how to use the `aws_prefix_list`
resource to look up a prefix list which wasn't based on a VPC endpoint,
especially because there's a financial incentive to use S3 Gateway
interfaces instead of VPC endpoint interfaces.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->