### PR TITLE
tests/sagemaker: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/sagemaker/app_test.go
+++ b/internal/service/sagemaker/app_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func testAccApp_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var app sagemaker.DescribeAppOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_app.test"
@@ -51,6 +55,10 @@ func testAccApp_basic(t *testing.T) {
 }
 
 func testAccApp_resourceSpec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var app sagemaker.DescribeAppOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_app.test"
@@ -81,6 +89,10 @@ func testAccApp_resourceSpec(t *testing.T) {
 }
 
 func testAccApp_resourceSpecLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var app sagemaker.DescribeAppOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	uName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -113,6 +125,10 @@ func testAccApp_resourceSpecLifecycle(t *testing.T) {
 }
 
 func testAccApp_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var app sagemaker.DescribeAppOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_app.test"
@@ -158,6 +174,10 @@ func testAccApp_tags(t *testing.T) {
 }
 
 func testAccApp_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var app sagemaker.DescribeAppOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_app.test"

--- a/internal/service/sagemaker/device_fleet_test.go
+++ b/internal/service/sagemaker/device_fleet_test.go
@@ -203,8 +203,12 @@ func testAccDeviceFleetBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/sagemaker/device_test.go
+++ b/internal/service/sagemaker/device_test.go
@@ -189,8 +189,12 @@ func testAccDeviceBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -527,8 +527,12 @@ func testAccSagemakerEndpointConfigurationDataCaptureConfig(rName string) string
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {
@@ -567,8 +571,12 @@ func testAccSagemakerEndpointConfigurationConfigAsyncConfig(rName string) string
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_kms_key" "test" {
@@ -601,8 +609,12 @@ func testAccSagemakerEndpointConfigurationConfigAsyncNotifConfig(rName string) s
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_sns_topic" "test" {
@@ -644,8 +656,12 @@ func testAccSagemakerEndpointConfigurationConfigAsyncClientConfig(rName string) 
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_kms_key" "test" {

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -304,8 +304,12 @@ resource "aws_iam_role_policy" "test" {
 }
 
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/sagemaker/endpoint_test.go
+++ b/internal/service/sagemaker/endpoint_test.go
@@ -45,6 +45,10 @@ func TestAccSageMakerEndpoint_basic(t *testing.T) {
 }
 
 func TestAccSageMakerEndpoint_endpointName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resourceName := "aws_sagemaker_endpoint.test"
@@ -81,6 +85,10 @@ func TestAccSageMakerEndpoint_endpointName(t *testing.T) {
 }
 
 func TestAccSageMakerEndpoint_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_endpoint.test"
 
@@ -116,6 +124,10 @@ func TestAccSageMakerEndpoint_tags(t *testing.T) {
 }
 
 func TestAccSageMakerEndpoint_deploymentConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_endpoint.test"
 
@@ -152,6 +164,10 @@ func TestAccSageMakerEndpoint_deploymentConfig(t *testing.T) {
 }
 
 func TestAccSageMakerEndpoint_deploymentConfig_full(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_endpoint.test"
 

--- a/internal/service/sagemaker/feature_group_test.go
+++ b/internal/service/sagemaker/feature_group_test.go
@@ -413,8 +413,12 @@ func testAccFeatureGroupOfflineBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_iam_role_policy_attachment" "test" {

--- a/internal/service/sagemaker/flow_definition_test.go
+++ b/internal/service/sagemaker/flow_definition_test.go
@@ -250,8 +250,12 @@ resource "aws_sagemaker_human_task_ui" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -565,8 +565,12 @@ resource "aws_iam_role_policy_attachment" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/sagemaker/notebook_instance_test.go
+++ b/internal/service/sagemaker/notebook_instance_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestAccSageMakerNotebookInstance_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -56,6 +60,10 @@ func TestAccSageMakerNotebookInstance_basic(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -91,6 +99,10 @@ func TestAccSageMakerNotebookInstance_update(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_volumeSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook1, notebook2, notebook3 sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var resourceName = "aws_sagemaker_notebook_instance.test"
@@ -133,6 +145,10 @@ func TestAccSageMakerNotebookInstance_volumeSize(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_lifecycleName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -175,6 +191,10 @@ func TestAccSageMakerNotebookInstance_lifecycleName(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -220,6 +240,10 @@ func TestAccSageMakerNotebookInstance_tags(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_kms(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -247,6 +271,10 @@ func TestAccSageMakerNotebookInstance_kms(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -345,6 +373,10 @@ func testAccCheckNotebookInstanceRecreated(i, j *sagemaker.DescribeNotebookInsta
 }
 
 func TestAccSageMakerNotebookInstance_Root_access(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -379,6 +411,10 @@ func TestAccSageMakerNotebookInstance_Root_access(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_Platform_identifier(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -413,6 +449,10 @@ func TestAccSageMakerNotebookInstance_Platform_identifier(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_DirectInternet_access(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance.test"
@@ -453,6 +493,10 @@ func TestAccSageMakerNotebookInstance_DirectInternet_access(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_DefaultCode_repository(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var resourceName = "aws_sagemaker_notebook_instance.test"
@@ -493,6 +537,10 @@ func TestAccSageMakerNotebookInstance_DefaultCode_repository(t *testing.T) {
 }
 
 func TestAccSageMakerNotebookInstance_AdditionalCode_repositories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var resourceName = "aws_sagemaker_notebook_instance.test"
@@ -544,6 +592,10 @@ func TestAccSageMakerNotebookInstance_AdditionalCode_repositories(t *testing.T) 
 }
 
 func TestAccSageMakerNotebookInstance_DefaultCodeRepository_sageMakerRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var resourceName = "aws_sagemaker_notebook_instance.test"

--- a/internal/service/sagemaker/project_test.go
+++ b/internal/service/sagemaker/project_test.go
@@ -215,8 +215,12 @@ func testAccProjectBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -26,8 +26,8 @@ func TestAccSageMaker_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"App": {
 			"basic":                 testAccApp_basic,
-			"disappears":            testAccApp_tags,
-			"tags":                  testAccApp_disappears,
+			"disappears":            testAccApp_disappears,
+			"tags":                  testAccApp_tags,
 			"resourceSpec":          testAccApp_resourceSpec,
 			"resourceSpecLifecycle": testAccApp_resourceSpecLifecycle,
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccSageMaker_serial (7709.63s)
        --- PASS: TestAccSageMaker_serial/App/basic (381.95s)
        --- PASS: TestAccSageMaker_serial/App/disappears (492.87s)
        --- PASS: TestAccSageMaker_serial/App/resourceSpec (470.53s)
        --- PASS: TestAccSageMaker_serial/App/resourceSpecLifecycle (481.40s)
        --- PASS: TestAccSageMaker_serial/App/tags (459.66s)
        --- PASS: TestAccSageMaker_serial/Domain/basic (231.80s)
        --- PASS: TestAccSageMaker_serial/Domain/disappears (263.02s)
        --- PASS: TestAccSageMaker_serial/Domain/jupyterServerAppSettings (241.39s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings (241.62s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_lifecycleConfig (241.95s)
        --- PASS: TestAccSageMaker_serial/Domain/kms (242.18s)
        --- PASS: TestAccSageMaker_serial/Domain/securityGroup (257.61s)
        --- PASS: TestAccSageMaker_serial/Domain/sharingSettings (241.81s)
        --- PASS: TestAccSageMaker_serial/Domain/tags (240.85s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettings (242.70s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettingsWithImage (295.12s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/HumanLoopConfigPublicWorkforce (34.50s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/HumanLoopRequestSource (82.46s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/Tags (108.70s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/basic (83.17s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/disappears (81.19s)
        --- PASS: TestAccSageMaker_serial/UserProfile/basic (250.56s)
        --- PASS: TestAccSageMaker_serial/UserProfile/disappears (265.92s)
        --- PASS: TestAccSageMaker_serial/UserProfile/jupyterServerAppSettings (241.83s)
        --- PASS: TestAccSageMaker_serial/UserProfile/kernelGatewayAppSettings (250.01s)
        --- PASS: TestAccSageMaker_serial/UserProfile/kernelGatewayAppSettings_lifecycleConfig (250.84s)
        --- PASS: TestAccSageMaker_serial/UserProfile/tags (249.24s)
        --- PASS: TestAccSageMaker_serial/UserProfile/tensorboardAppSettings (250.82s)
        --- PASS: TestAccSageMaker_serial/UserProfile/tensorboardAppSettingsWithImage (250.22s)
        --- PASS: TestAccSageMaker_serial/Workforce/CognitoConfig (17.10s)
        --- PASS: TestAccSageMaker_serial/Workforce/OidcConfig (22.97s)
        --- PASS: TestAccSageMaker_serial/Workforce/SourceIpConfig (30.89s)
        --- PASS: TestAccSageMaker_serial/Workforce/disappears (14.52s)
        --- PASS: TestAccSageMaker_serial/Workteam/CognitoConfig (96.15s)
        --- PASS: TestAccSageMaker_serial/Workteam/NotificationConfig (32.53s)
        --- PASS: TestAccSageMaker_serial/Workteam/OidcConfig (30.44s)
        --- PASS: TestAccSageMaker_serial/Workteam/Tags (28.37s)
        --- PASS: TestAccSageMaker_serial/Workteam/disappears (10.73s)
        --- SKIP: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_customImage (0.00s)
        --- SKIP: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_defaultResourceAndCustomImage (0.00s)
        --- SKIP: TestAccSageMaker_serial/UserProfile/kernelGatewayAppSettings_imageConfig (0.00s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/basic (44.20s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/description (40.24s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/disappears (41.33s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/multipleFeatures (41.32s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/offlineConfig_basic (60.68s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/offlineConfig_createCatalog (54.37s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/offlineConfig_providedCatalog (71.66s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/onlineConfigSecurityConfig (49.08s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/tags (79.77s)
    --- PASS: TestAccSageMaker_serial/App (2286.40s)
    --- PASS: TestAccSageMaker_serial/Domain (2740.06s)
    --- PASS: TestAccSageMaker_serial/FlowDefinition (390.02s)
    --- PASS: TestAccSageMaker_serial/UserProfile (2009.45s)
    --- PASS: TestAccSageMaker_serial/Workforce (85.48s)
    --- PASS: TestAccSageMaker_serial/Workteam (198.21s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (66.83s)
--- PASS: TestAccSageMakerModel_tags (72.21s)
--- PASS: TestAccSageMakerProject_disappears (141.70s)
--- PASS: TestAccSageMakerProject_tags (280.97s)
--- PASS: TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystem (69.57s)
--- PASS: TestAccSageMakerAppImageConfig_KernelGatewayImage_kernelSpecs (75.49s)
--- PASS: TestAccSageMakerAppImageConfig_basic (44.46s)
--- PASS: TestAccSageMakerAppImageConfig_disappears (32.85s)
--- PASS: TestAccSageMakerAppImageConfig_tags (101.06s)
--- PASS: TestAccSageMakerCodeRepository_Git_branch (50.44s)
--- PASS: TestAccSageMakerCodeRepository_Git_secret (70.41s)
--- PASS: TestAccSageMakerCodeRepository_basic (44.45s)
--- PASS: TestAccSageMakerCodeRepository_disappears (33.99s)
--- PASS: TestAccSageMakerCodeRepository_tags (93.24s)
--- PASS: TestAccSageMakerDeviceFleet_basic (59.09s)
--- PASS: TestAccSageMakerDeviceFleet_description (84.56s)
--- PASS: TestAccSageMakerDeviceFleet_disappears (48.72s)
--- PASS: TestAccSageMakerDeviceFleet_tags (115.77s)
--- PASS: TestAccSageMakerDevice_basic (53.25s)
--- PASS: TestAccSageMakerDevice_description (88.20s)
--- PASS: TestAccSageMakerDevice_disappears (46.56s)
--- PASS: TestAccSageMakerDevice_disappears_fleet (46.32s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client (40.29s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_notif (44.64s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType (49.63s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight (50.93s)
--- PASS: TestAccSageMakerEndpointConfiguration_async (48.33s)
--- PASS: TestAccSageMakerEndpointConfiguration_basic (46.68s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture (48.32s)
--- PASS: TestAccSageMakerEndpointConfiguration_disappears (44.23s)
--- PASS: TestAccSageMakerEndpointConfiguration_kmsKeyID (54.48s)
--- PASS: TestAccSageMakerEndpoint_basic (218.27s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig (391.63s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_full (310.82s)
--- PASS: TestAccSageMakerEndpoint_disappears (277.32s)
--- PASS: TestAccSageMakerEndpoint_endpointName (533.13s)
--- PASS: TestAccSageMakerEndpoint_tags (306.68s)
--- PASS: TestAccSageMakerFeatureGroup_Offline_providedCatalog (56.47s)
--- PASS: TestAccSageMakerFeatureGroup_disappears (42.37s)
--- PASS: TestAccSageMakerFeatureGroup_serial (482.66s)
--- PASS: TestAccSageMakerHumanTaskUI_basic (12.10s)
--- PASS: TestAccSageMakerHumanTaskUI_disappears (9.69s)
--- PASS: TestAccSageMakerHumanTaskUI_tags (31.72s)
--- PASS: TestAccSageMakerImage_basic (78.81s)
--- PASS: TestAccSageMakerImage_description (104.18s)
--- PASS: TestAccSageMakerImage_disappears (84.75s)
--- PASS: TestAccSageMakerImage_displayName (103.62s)
--- PASS: TestAccSageMakerImage_tags (117.04s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup (12.06s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_basic (13.59s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_disappears (11.41s)
--- PASS: TestAccSageMakerModelPackageGroup_basic (12.41s)
--- PASS: TestAccSageMakerModelPackageGroup_description (13.71s)
--- PASS: TestAccSageMakerModelPackageGroup_disappears (15.73s)
--- PASS: TestAccSageMakerModelPackageGroup_tags (47.90s)
--- PASS: TestAccSageMakerModel_basic (38.08s)
--- PASS: TestAccSageMakerModel_containers (38.23s)
--- PASS: TestAccSageMakerModel_disappears (40.15s)
--- PASS: TestAccSageMakerModel_inferenceExecution (30.89s)
--- PASS: TestAccSageMakerModel_networkIsolation (42.42s)
--- PASS: TestAccSageMakerModel_primaryContainerEnvironment (34.21s)
--- PASS: TestAccSageMakerModel_primaryContainerHostname (30.34s)
--- PASS: TestAccSageMakerModel_primaryContainerImage (36.02s)
--- PASS: TestAccSageMakerModel_primaryContainerModeSingle (34.40s)
--- PASS: TestAccSageMakerModel_primaryContainerModelDataURL (43.44s)
--- PASS: TestAccSageMakerModel_vpc (45.27s)
--- PASS: TestAccSageMakerNotebookInstanceLifecycleConfiguration_basic (21.88s)
--- PASS: TestAccSageMakerNotebookInstanceLifecycleConfiguration_update (40.85s)
--- PASS: TestAccSageMakerNotebookInstance_AdditionalCode_repositories (2416.46s)
--- PASS: TestAccSageMakerNotebookInstance_DefaultCodeRepository_sageMakerRepo (1465.51s)
--- PASS: TestAccSageMakerNotebookInstance_DefaultCode_repository (1393.72s)
--- PASS: TestAccSageMakerNotebookInstance_DirectInternet_access (895.58s)
--- PASS: TestAccSageMakerNotebookInstance_Platform_identifier (1014.94s)
--- PASS: TestAccSageMakerNotebookInstance_Root_access (1003.36s)
--- PASS: TestAccSageMakerNotebookInstance_basic (468.78s)
--- PASS: TestAccSageMakerNotebookInstance_disappears (523.56s)
--- PASS: TestAccSageMakerNotebookInstance_kms (551.49s)
--- PASS: TestAccSageMakerNotebookInstance_lifecycleName (1330.12s)
--- PASS: TestAccSageMakerNotebookInstance_tags (540.96s)
--- PASS: TestAccSageMakerNotebookInstance_update (1081.57s)
--- PASS: TestAccSageMakerNotebookInstance_volumeSize (1251.56s)
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_basic (8.33s)
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_region (7.57s)
--- PASS: TestAccSageMakerProject_basic (164.75s)
--- PASS: TestAccSageMakerProject_description (210.74s)
--- PASS: TestAccSageMakerStudioLifecycleConfig_basic (9.45s)
--- PASS: TestAccSageMakerStudioLifecycleConfig_disappears (8.39s)
--- PASS: TestAccSageMakerStudioLifecycleConfig_tags (23.84s)
--- SKIP: TestAccSageMakerImageVersion_Disappears_image (0.00s)
--- SKIP: TestAccSageMakerImageVersion_basic (0.00s)
--- SKIP: TestAccSageMakerImageVersion_disappears (0.00s)
```
