### PR TITLE
tests/s3: update to `aws_s3_bucket_acl` resource

### DIFF
--- a/internal/service/s3/bucket_data_source_test.go
+++ b/internal/service/s3/bucket_data_source_test.go
@@ -74,6 +74,10 @@ func testAccBucketWebsiteDataSourceConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "public-read"
 }
 

--- a/internal/service/s3/bucket_inventory_test.go
+++ b/internal/service/s3/bucket_inventory_test.go
@@ -200,6 +200,10 @@ func testAccBucketInventoryBucketConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 `, name)

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -531,6 +531,10 @@ func testAccBucketLifecycleConfigurationBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -555,6 +559,10 @@ func testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, status string
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -579,6 +587,10 @@ func testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, date, prefix 
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -605,6 +617,10 @@ func testAccBucketLifecycleConfiguration_Basic_PrefixConfig(rName, prefix string
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -629,6 +645,10 @@ func testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfi
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -654,6 +674,10 @@ func testAccBucketLifecycleConfiguration_RuleExpiration_EmptyConfigurationBlockC
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -701,6 +701,10 @@ func testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfi
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -726,6 +730,10 @@ func testAccBucketLifecycleConfiguration_MultipleRulesConfig(rName, date string)
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -784,6 +792,10 @@ func testAccBucketLifecycleConfiguration_NonCurrentVersionExpirationConfig(rName
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -812,6 +824,10 @@ func testAccBucketLifecycleConfiguration_NonCurrentVersionTransitionConfig(rName
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 

--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -390,11 +390,19 @@ func testAccBucketLoggingBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 

--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -419,11 +419,19 @@ func testAccBucketLoggingUpdateConfig(rName, targetBucketName, targetPrefix stri
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[2]s-log"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
@@ -442,13 +450,23 @@ data "aws_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
+
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
+
 
 resource "aws_s3_bucket_logging" "test" {
   bucket = aws_s3_bucket.test.id
@@ -471,11 +489,19 @@ func testAccBucketLoggingTargetGrantConfig_ByEmail(rName, email, permission stri
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -502,11 +528,24 @@ data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 

--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -535,11 +535,6 @@ resource "aws_s3_bucket_acl" "log_bucket_acl" {
   acl    = "log-delivery-write"
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -635,8 +635,12 @@ func testAccCheckBucketMetricsExistsConfig(n string, res *s3.MetricsConfiguratio
 func testAccBucketMetricsBucketConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  acl    = "public-read"
   bucket = "%s"
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "public-read"
 }
 `, name)
 }

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -530,6 +530,10 @@ data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "public-read"
 }
 
@@ -571,6 +575,10 @@ POLICY
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "public-read"
 }
 
@@ -634,6 +642,10 @@ POLICY
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "public-read"
 }
 
@@ -698,6 +710,10 @@ resource "aws_lambda_function" "func" {
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "public-read"
 }
 

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -783,8 +783,12 @@ resource "aws_lambda_permission" "test" {
 }
 
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_notification" "test" {
@@ -831,6 +835,10 @@ POLICY
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "public-read"
 }
 

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1594,7 +1594,10 @@ resource "aws_s3_bucket_versioning" "source" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
-  depends_on = [aws_s3_bucket_versioning.source]
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_versioning.destination
+  ]
 
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn
@@ -1671,7 +1674,10 @@ resource "aws_s3_bucket_versioning" "source" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
-  depends_on = [aws_s3_bucket_versioning.source]
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_versioning.destination
+  ]
 
   bucket = aws_s3_bucket.source.id
   role   = aws_iam_role.test.arn

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1579,6 +1579,10 @@ resource "aws_s3_bucket_versioning" "destination" {
 
 resource "aws_s3_bucket" "source" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "source_acl" {
+  bucket = aws_s3_bucket.source.id
   acl    = "private"
 }
 
@@ -1652,6 +1656,10 @@ resource "aws_s3_bucket_versioning" "destination" {
 
 resource "aws_s3_bucket" "source" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "source_acl" {
+  bucket = aws_s3_bucket.source.id
   acl    = "private"
 }
 

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -199,6 +199,10 @@ func testAccBucketVersioningBasicConfig(rName, status string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -215,6 +219,10 @@ func testAccBucketVersioningConfig_MFADelete(rName, mfaDelete string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 

--- a/internal/service/s3/bucket_website_configuration_test.go
+++ b/internal/service/s3/bucket_website_configuration_test.go
@@ -357,6 +357,10 @@ func testAccBucketWebsiteConfigurationBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
@@ -373,8 +377,13 @@ func testAccBucketWebsiteConfigurationUpdateConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
+
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -394,8 +403,13 @@ func testAccBucketWebsiteConfigurationConfig_Redirect(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
+
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -410,8 +424,13 @@ func testAccBucketWebsiteConfigurationConfig_RoutingRules_OptionalRedirection(rN
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
+
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -442,8 +461,13 @@ func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectErrors(rName s
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
+
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -472,8 +496,13 @@ func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectToPage(rName s
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
+
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -502,6 +531,10 @@ func testAccBucketWebsiteConfigurationConfig_RoutingRules_RedirectOnly(rName str
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
@@ -530,6 +563,10 @@ func testAccBucketWebsiteConfigurationConfig_RoutingRules_MultipleRules(rName st
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketAccelerateConfiguration_basic (103.15s)
--- PASS: TestAccS3BucketAccelerateConfiguration_disappears (96.52s)
--- PASS: TestAccS3BucketAccelerateConfiguration_update (171.74s)
--- PASS: TestAccS3BucketAcl_ACLToGrant (174.84s)
--- PASS: TestAccS3BucketAcl_basic (105.69s)
--- PASS: TestAccS3BucketAcl_disappears (76.89s)
--- PASS: TestAccS3BucketAcl_grantToACL (179.01s)
--- PASS: TestAccS3BucketAcl_updateACL (178.18s)
--- PASS: TestAccS3BucketAcl_updateGrant (191.83s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_empty (15.53s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_multipleTags (164.89s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefix (164.03s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_prefixAndTags (163.15s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_remove (164.58s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithFilter_singleTag (164.57s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_default (96.75s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_empty (14.33s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_full (94.63s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (94.40s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_removed (150.96s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_updateBasic (231.74s)
--- PASS: TestAccS3BucketCorsConfiguration_MultipleRules (95.30s)
--- PASS: TestAccS3BucketCorsConfiguration_SingleRule (99.16s)
--- PASS: TestAccS3BucketCorsConfiguration_basic (96.78s)
--- PASS: TestAccS3BucketCorsConfiguration_disappears (202.63s)
--- PASS: TestAccS3BucketCorsConfiguration_update (214.61s)
--- PASS: TestAccS3BucketDataSource_basic (84.91s)
--- PASS: TestAccS3BucketDataSource_website (84.49s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_Filter (263.72s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (95.46s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_disappears (83.37s)
--- PASS: TestAccS3BucketInventory_basic (91.69s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (94.78s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (89.19s)
--- PASS: TestAccS3BucketLifecycleConfiguration_DisableRule (297.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_FilterWithPrefix (268.92s)
--- PASS: TestAccS3BucketLifecycleConfiguration_MultipleRules (210.82s)
--- PASS: TestAccS3BucketLifecycleConfiguration_NonCurrentVersionExpiration (211.56s)
--- PASS: TestAccS3BucketLifecycleConfiguration_NonCurrentVersionTransition (211.02s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Prefix (208.05s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload (259.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_EmptyBlock (209.53s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly (261.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (212.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (190.93s)
--- PASS: TestAccS3BucketLogging_TargetGrantByGroup (163.15s)
--- PASS: TestAccS3BucketLogging_TargetGrantByID (164.68s)
--- PASS: TestAccS3BucketLogging_basic (90.37s)
--- PASS: TestAccS3BucketLogging_disappears (80.03s)
--- PASS: TestAccS3BucketLogging_update (174.31s)
--- PASS: TestAccS3BucketMetric_basic (69.89s)
--- PASS: TestAccS3BucketMetric_withEmptyFilter (8.73s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (93.75s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (94.41s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (94.52s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (95.40s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (92.31s)
--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (92.96s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (74.95s)
--- PASS: TestAccS3BucketNotification_eventbridge (54.78s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (98.92s)
--- PASS: TestAccS3BucketNotification_queue (106.69s)
--- PASS: TestAccS3BucketNotification_topic (71.71s)
--- PASS: TestAccS3BucketNotification_update (161.27s)
--- PASS: TestAccS3BucketObjectDataSource_allParams (76.68s)
--- PASS: TestAccS3BucketObjectDataSource_basic (65.76s)
--- PASS: TestAccS3BucketObjectDataSource_basicViaAccessPoint (64.32s)
--- PASS: TestAccS3BucketObjectDataSource_bucketKeyEnabled (70.72s)
--- PASS: TestAccS3BucketObjectDataSource_kmsEncrypted (67.29s)
--- PASS: TestAccS3BucketObjectDataSource_leadingSlash (144.68s)
--- PASS: TestAccS3BucketObjectDataSource_multipleSlashes (147.00s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOff (74.85s)
--- PASS: TestAccS3BucketObjectDataSource_objectLockLegalHoldOn (79.31s)
--- PASS: TestAccS3BucketObjectDataSource_readableBody (69.25s)
--- PASS: TestAccS3BucketObjectDataSource_singleSlashAsKey (81.95s)
--- PASS: TestAccS3BucketObjectLockConfiguration_basic (102.39s)
--- PASS: TestAccS3BucketObjectLockConfiguration_disappears (88.32s)
--- PASS: TestAccS3BucketObjectLockConfiguration_update (176.12s)
--- PASS: TestAccS3BucketObject_acl (243.22s)
--- PASS: TestAccS3BucketObject_bucketBucketKeyEnabled (87.24s)
--- PASS: TestAccS3BucketObject_content (97.77s)
--- PASS: TestAccS3BucketObject_contentBase64 (82.88s)
--- PASS: TestAccS3BucketObject_defaultBucketSSE (91.85s)
--- PASS: TestAccS3BucketObject_empty (99.03s)
--- PASS: TestAccS3BucketObject_etagEncryption (95.53s)
--- PASS: TestAccS3BucketObject_ignoreTags (160.88s)
--- PASS: TestAccS3BucketObject_kms (98.32s)
--- PASS: TestAccS3BucketObject_metadata (240.02s)
--- PASS: TestAccS3BucketObject_noNameNoKey (22.47s)
--- PASS: TestAccS3BucketObject_nonVersioned (98.02s)
--- PASS: TestAccS3BucketObject_objectBucketKeyEnabled (86.52s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithNone (231.00s)
--- PASS: TestAccS3BucketObject_objectLockLegalHoldStartWithOn (159.96s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithNone (230.98s)
--- PASS: TestAccS3BucketObject_objectLockRetentionStartWithSet (299.36s)
--- PASS: TestAccS3BucketObject_source (96.17s)
--- PASS: TestAccS3BucketObject_sourceHashTrigger (163.16s)
--- PASS: TestAccS3BucketObject_sse (99.82s)
--- PASS: TestAccS3BucketObject_storageClass (389.54s)
--- PASS: TestAccS3BucketObject_tags (311.33s)
--- PASS: TestAccS3BucketObject_tagsLeadingMultipleSlashes (301.32s)
--- PASS: TestAccS3BucketObject_tagsLeadingSingleSlash (313.91s)
--- PASS: TestAccS3BucketObject_tagsMultipleSlashes (302.36s)
--- PASS: TestAccS3BucketObject_updateSameFile (156.90s)
--- PASS: TestAccS3BucketObject_updates (167.30s)
--- PASS: TestAccS3BucketObject_updatesWithVersioning (169.21s)
--- PASS: TestAccS3BucketObject_updatesWithVersioningViaAccessPoint (155.15s)
--- PASS: TestAccS3BucketObject_withContentCharacteristics (84.80s)
--- PASS: TestAccS3BucketObjectsDataSource_all (162.29s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (162.23s)
--- PASS: TestAccS3BucketObjectsDataSource_basicViaAccessPoint (161.93s)
--- PASS: TestAccS3BucketObjectsDataSource_encoded (161.36s)
--- PASS: TestAccS3BucketObjectsDataSource_fetchOwner (160.42s)
--- PASS: TestAccS3BucketObjectsDataSource_maxKeys (160.88s)
--- PASS: TestAccS3BucketObjectsDataSource_prefixes (161.73s)
--- PASS: TestAccS3BucketObjectsDataSource_startAfter (162.76s)
--- PASS: TestAccS3BucketOwnershipControls_Disappears_bucket (74.31s)
--- PASS: TestAccS3BucketOwnershipControls_Rule_objectOwnership (175.41s)
--- PASS: TestAccS3BucketOwnershipControls_basic (101.80s)
--- PASS: TestAccS3BucketOwnershipControls_disappears (86.20s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (360.08s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (266.80s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (288.75s)
--- PASS: TestAccS3BucketPolicy_basic (99.90s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (181.95s)
--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (74.91s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (102.45s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (250.44s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (246.10s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (86.24s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (239.32s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (239.00s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (525.29s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (489.23s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (480.38s)
--- PASS: TestAccS3BucketReplicationConfiguration_disappears (140.63s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (358.29s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (354.41s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (404.89s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (404.58s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (396.65s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (399.11s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (386.59s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (368.08s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2SameRegion (225.87s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (402.26s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (314.89s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (393.48s)
--- PASS: TestAccS3BucketRequestPaymentConfiguration_Basic_BucketOwner (53.87s)
--- PASS: TestAccS3BucketRequestPaymentConfiguration_Basic_Requester (52.20s)
--- PASS: TestAccS3BucketRequestPaymentConfiguration_update (90.49s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySEEByDefault_AES256 (31.42s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_BucketKeyEnabled (50.59s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMS (29.33s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyArn (27.39s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_KMSWithMasterKeyID (27.19s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_ApplySSEByDefault_UpdateSSEAlgorithm (53.12s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_BucketKeyEnabled (48.72s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_basic (49.13s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_disappears (28.15s)
--- PASS: TestAccS3BucketVersioning_MFADelete (53.84s)
--- PASS: TestAccS3BucketVersioning_basic (49.04s)
--- PASS: TestAccS3BucketVersioning_disappears (42.06s)
--- PASS: TestAccS3BucketVersioning_update (86.50s)
--- PASS: TestAccS3BucketWebsiteConfiguration_Redirect (48.69s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect (77.85s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_MultipleRules (59.93s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_RedirectOnly (43.42s)
--- PASS: TestAccS3BucketWebsiteConfiguration_basic (52.10s)
--- PASS: TestAccS3BucketWebsiteConfiguration_disappears (43.46s)
--- PASS: TestAccS3BucketWebsiteConfiguration_update (65.96s)
--- PASS: TestAccS3Bucket_Basic_basic (27.49s)
--- PASS: TestAccS3Bucket_Basic_emptyString (27.77s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (34.36s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (35.36s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (40.21s)
--- PASS: TestAccS3Bucket_Basic_generatedName (24.08s)
--- PASS: TestAccS3Bucket_Basic_namePrefix (23.13s)
--- PASS: TestAccS3Bucket_Basic_shouldFailNotFound (19.31s)
--- PASS: TestAccS3Bucket_Manage_objectLock (31.68s)
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (33.63s)
--- PASS: TestAccS3Bucket_Tags_basic (26.49s)
--- PASS: TestAccS3Bucket_Tags_ignoreTags (39.28s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (86.09s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (161.50s)
--- SKIP: TestAccS3BucketLogging_TargetGrantByEmail (0.00s)
--- SKIP: TestAccS3BucketReplicationConfiguration_existingObjectReplication (0.01s)
```
