### PR TITLE
ecs: Fix ISO tagging

### DIFF
--- a/.changelog/23030.txt
+++ b/.changelog/23030.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+resource/aws_ecs_capacity_provider: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_cluster: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_service: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_task_definition: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_task_set: Fix tagging error preventing use in ISO partitions
+```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -184,12 +184,6 @@ func resourceCapacityProviderRead(d *schema.ResourceData, meta interface{}) erro
 
 	tags := KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed listing tags for Capacity Provider (%s): %s", d.Id(), err)
-		return nil
-	}
-
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -267,6 +267,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
+
 	if tfresource.TimedOut(err) {
 		cluster, err = FindClusterByNameOrARN(context.Background(), conn, d.Id())
 	}
@@ -309,12 +310,6 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tags := KeyValueTags(cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed listing tags for Cluster (%s): %s", d.Id(), err)
-		return nil
-	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -2,12 +2,14 @@ package ecs
 
 import (
 	"context"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider, error) {
@@ -17,6 +19,14 @@ func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider
 	}
 
 	output, err := conn.DescribeCapacityProviders(input)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] ECS tagging failed describing Capacity Provider (%s) with tags: %s; retrying without tags", arn, err)
+
+		input.Include = nil
+		output, err = conn.DescribeCapacityProviders(input)
+	}
 
 	if err != nil {
 		return nil, err
@@ -48,6 +58,14 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	}
 
 	output, err := conn.DescribeClustersWithContext(ctx, input)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] ECS tagging failed describing Cluster (%s) with tags: %s; retrying without tags", nameOrARN, err)
+
+		input.Include = aws.StringSlice([]string{ecs.ClusterFieldConfigurations, ecs.ClusterFieldSettings})
+		output, err = conn.DescribeClustersWithContext(ctx, input)
+	}
 
 	if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException) {
 		return nil, &resource.NotFoundError{

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -626,6 +626,14 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	output, err := conn.DescribeServices(&input)
 
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] ECS tagging failed describing Service (%s) with tags: %s; retrying without tags", d.Id(), err)
+
+		input.Include = nil
+		output, err = conn.DescribeServices(&input)
+	}
+
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ecs.ErrCodeServiceNotFoundException) {
 		log.Printf("[WARN] ECS service (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -751,12 +759,6 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tags := KeyValueTags(service.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed listing tags for Service (%s): %s", d.Id(), err)
-		return nil
-	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22532

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccECS PKG=ecs                      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECS'  -timeout 180m
--- PASS: TestAccECSAccountSettingDefault_containerInstanceLongARNFormat (26.42s)
--- PASS: TestAccECSTaskDefinition_arrays (26.95s)
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (27.08s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (27.66s)
--- PASS: TestAccECSTaskDefinition_constraint (28.16s)
--- PASS: TestAccECSTaskDefinition_networkMode (29.43s)
--- PASS: TestAccECSTaskDefinition_pidMode (30.25s)
--- PASS: TestAccECSTaskDefinition_ipcMode (30.36s)
--- PASS: TestAccECSTaskDefinition_executionRole (30.58s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (38.74s)
--- PASS: TestAccECSTaskDefinition_proxy (41.05s)
--- PASS: TestAccECSTaskDefinition_disappears (41.70s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (44.08s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (24.34s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (25.78s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (22.73s)
--- PASS: TestAccECSTaskSet_disappears (58.47s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (32.83s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (33.93s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (34.49s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (37.78s)
--- PASS: TestAccECSTaskDefinition_tags (70.52s)
--- PASS: TestAccECSTaskSet_withMultipleCapacityProviderStrategies (75.22s)
--- PASS: TestAccECSTaskSet_withExternalId (77.42s)
--- PASS: TestAccECSTaskSet_basic (87.83s)
--- PASS: TestAccECSService_iamRole (58.62s)
--- PASS: TestAccECSTaskSet_withScale (106.62s)
--- PASS: TestAccECSService_disappears (45.51s)
--- PASS: TestAccECSTaskDefinition_service (84.59s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (17.78s)
--- PASS: TestAccECSTaskDefinition_runtimePlatform (17.15s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (17.50s)
--- PASS: TestAccECSService_renamedCluster (90.00s)
--- PASS: TestAccECSService_familyAndRevision (90.05s)
--- PASS: TestAccECSCluster_configuration (58.97s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (76.62s)
--- PASS: TestAccECSTaskSet_withCapacityProviderStrategy (140.01s)
--- PASS: TestAccECSService_basic (75.23s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (17.04s)
--- PASS: TestAccECSService_basicImport (81.01s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (18.13s)
--- PASS: TestAccECSTaskDefinitionDataSource_ecsTaskDefinition (19.27s)
--- PASS: TestAccECSCluster_containerInsights (73.56s)
--- PASS: TestAccECSServiceDataSource_basic (92.44s)
--- PASS: TestAccECSCluster_disappears (25.09s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (113.54s)
--- PASS: TestAccECSContainerDefinitionDataSource_ecsContainerDefinition (91.73s)
--- PASS: TestAccECSCluster_capacityProviders (40.54s)
--- PASS: TestAccECSTaskDefinition_basic (33.13s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (55.06s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (134.59s)
--- PASS: TestAccECSTag_disappears (28.50s)
--- PASS: TestAccECSTag_value (45.77s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (27.84s)
--- PASS: TestAccECSTag_basic (31.48s)
--- PASS: TestAccECSCluster_tags (56.87s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (28.35s)
--- PASS: TestAccECSCluster_basic (30.69s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (79.23s)
--- PASS: TestAccECSAccountSettingDefault_containerInsights (19.69s)
--- PASS: TestAccECSTag_ResourceARN_batchComputeEnvironment (53.29s)
--- PASS: TestAccECSCluster_singleCapacityProvider (94.20s)
--- PASS: TestAccECSClusterCapacityProviders_defaults (51.85s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (192.13s)
--- PASS: TestAccECSCapacityProvider_basic (65.50s)
--- PASS: TestAccECSAccountSettingDefault_awsvpcTrunking (16.50s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (46.14s)
--- PASS: TestAccECSAccountSettingDefault_taskLongARNFormat (17.55s)
--- PASS: TestAccECSService_executeCommand (94.50s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (44.05s)
--- PASS: TestAccECSAccountSettingDefault_serviceLongARNFormat (17.96s)
--- PASS: TestAccECSService_Tags_managed (92.58s)
--- PASS: TestAccECSService_Tags_basic (106.57s)
--- PASS: TestAccECSClusterCapacityProviders_Update_defaultStrategy (133.39s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (91.40s)
--- PASS: TestAccECSClusterCapacityProviders_Update_capacityProviders (132.98s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (178.53s)
--- PASS: TestAccECSService_PlacementStrategy_missing (0.82s)
--- PASS: TestAccECSClusterCapacityProviders_disappears (37.26s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (772.93s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (72.42s)
--- PASS: TestAccECSCapacityProvider_disappears (63.69s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (294.65s)
--- PASS: TestAccECSClusterCapacityProviders_basic (51.42s)
--- PASS: TestAccECSTaskSet_Tags (86.03s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (263.38s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (317.99s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargateAndPlatformVersion (102.57s)
--- PASS: TestAccECSService_ServiceRegistries_basic (172.05s)
--- PASS: TestAccECSService_ServiceRegistries_container (187.42s)
--- PASS: TestAccECSService_PlacementConstraints_basic (77.39s)
--- PASS: TestAccECSCapacityProvider_managedScalingPartial (64.99s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (91.27s)
--- PASS: TestAccECSService_Tags_propagate (217.17s)
--- PASS: TestAccECSCapacityProvider_tags (102.85s)
--- PASS: TestAccECSClusterCapacityProviders_destroy (237.65s)
--- PASS: TestAccECSService_forceNewDeployment (73.18s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (423.03s)
--- PASS: TestAccECSCapacityProvider_managedScaling (136.36s)
--- PASS: TestAccECSService_DeploymentControllerType_external (62.52s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (75.19s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargate (78.79s)
--- PASS: TestAccECSService_clusterName (90.63s)
--- PASS: TestAccECSService_loadBalancerChanges (130.64s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (75.49s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (219.50s)
--- PASS: TestAccECSTaskSet_withServiceRegistries (150.90s)
--- PASS: TestAccECSService_DeploymentValues_basic (75.98s)
--- PASS: TestAccECSService_PlacementStrategy_basic (115.73s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (187.99s)
--- PASS: TestAccECSService_ServiceRegistries_changes (325.93s)
--- PASS: TestAccECSService_multipleTargetGroups (229.45s)
--- PASS: TestAccECSTaskSet_withAlb (202.83s)
--- PASS: TestAccECSService_alb (244.27s)
--- PASS: TestAccECSTaskDefinition_fsxWinFileSystem (3476.01s)	
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	3504.934s
```
