### PR TITLE
Fix data source aws_ram_resource_share returns deleted shares

### DIFF
--- a/internal/service/ram/resource_share_data_source.go
+++ b/internal/service/ram/resource_share_data_source.go
@@ -78,8 +78,9 @@ func dataSourceResourceShareRead(d *schema.ResourceData, meta interface{}) error
 	filters, filtersOk := d.GetOk("filter")
 
 	params := &ram.GetResourceSharesInput{
-		Name:          aws.String(name),
-		ResourceOwner: aws.String(owner),
+		Name:                aws.String(name),
+		ResourceOwner:       aws.String(owner),
+		ResourceShareStatus: aws.String(ram.ResourceShareStatusActive),
 	}
 
 	if filtersOk {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

Fixes aws_ram_resource_share data source which returns all resource_share, including deleted ones.
This fixes filter the output from aws_ram_resource_share to Active resource_share only. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTS=TestAccRAMResourceShareDataSource PKG=ram
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ram/... -v -count 1 -parallel 20 -run='TestAccRAMResourceShareDataSource'  -timeout 180m
=== RUN   TestAccRAMResourceShareDataSource_basic
=== PAUSE TestAccRAMResourceShareDataSource_basic
=== RUN   TestAccRAMResourceShareDataSource_tags
=== PAUSE TestAccRAMResourceShareDataSource_tags
=== CONT  TestAccRAMResourceShareDataSource_basic
=== CONT  TestAccRAMResourceShareDataSource_tags
--- PASS: TestAccRAMResourceShareDataSource_tags (22.82s)
--- PASS: TestAccRAMResourceShareDataSource_basic (26.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ram        28.834s
...
```
