### PR TITLE
tests/networkfirewall: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/networkfirewall/logging_configuration_test.go
+++ b/internal/service/networkfirewall/logging_configuration_test.go
@@ -745,12 +745,16 @@ func testAccNetworkFirewallLoggingConfigurationS3BucketDependencyConfig(rName st
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %q
-  acl           = "private"
   force_destroy = true
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 `, rName)
 }
@@ -839,8 +843,12 @@ EOF
 
 resource "aws_s3_bucket" "logs" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "logs_acl" {
+  bucket = aws_s3_bucket.logs.id
+  acl    = "private"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logGroup (719.80s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logType (716.88s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_KinesisLogDestination_deliveryStream (1073.28s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_KinesisLogDestination_logType (993.21s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_S3LogDestination_bucketName (723.54s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_S3LogDestination_logType (648.29s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_S3LogDestination_prefix (672.69s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_disappears (713.87s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateFirewallARN (1361.67s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateLogDestinationType (885.42s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateToMultipleLogDestinations (837.20s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateToSingleAlertTypeLogDestination (761.78s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateToSingleFlowTypeLogDestination (678.03s)
```
