### PR TITLE
tests/lambda: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -3414,8 +3414,12 @@ func testAccFunctionConfig_s3(bucketName, key, path, roleName, funcName string) 
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
   bucket        = "%s"
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "artifacts" {
@@ -3471,8 +3475,12 @@ func testAccFunctionConfig_s3_unversioned_tpl(bucketName, roleName, funcName, ke
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
   bucket        = "%s"
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "o" {

--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -1030,6 +1030,10 @@ resource "aws_lambda_permission" "with_s3" {
 
 resource "aws_s3_bucket" "default" {
   bucket = "%s"
+}
+
+resource "aws_s3_bucket_acl" "default" {
+  bucket = aws_s3_bucket.default.id
   acl    = "private"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (21.25s)
--- PASS: TestAccLambdaFunction_disappears (52.81s)
--- PASS: TestAccLambdaFunction_basic (58.08s)
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (61.57s)
--- PASS: TestAccLambdaFunction_versioned (55.97s)
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (94.63s)
--- PASS: TestAccLambdaFunction_concurrency (96.91s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (104.61s)
--- PASS: TestAccLambdaFunction_concurrencyCycle (115.63s)
--- SKIP: TestAccLambdaFunction_image (0.22s)
--- PASS: TestAccLambdaFunction_codeSigning (117.33s)
--- PASS: TestAccLambdaFunction_nilDeadLetter (21.25s)
--- PASS: TestAccLambdaFunction_disablePublish (86.26s)
--- PASS: TestAccLambdaFunction_enablePublish (105.41s)
--- PASS: TestAccLambdaFunction_deadLetter (90.10s)
--- PASS: TestAccLambdaFunction_envVariables (168.06s)
--- PASS: TestAccLambdaFunction_versionedUpdate (118.98s)
--- PASS: TestAccLambdaFunction_deadLetterUpdated (87.89s)
--- PASS: TestAccLambdaFunction_architectures (72.74s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (82.20s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (84.69s)
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (43.39s)
--- PASS: TestAccLambdaFunction_tracing (70.52s)
--- PASS: TestAccLambdaFunction_layers (52.38s)
--- PASS: TestAccLambdaFunction_layersUpdate (66.70s)
--- PASS: TestAccLambdaFunction_emptyVPC (28.38s)
--- PASS: TestAccLambdaFunction_s3 (28.71s)
--- PASS: TestAccLambdaFunction_localUpdate (52.18s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (43.22s)
--- PASS: TestAccLambdaFunction_S3Update_basic (46.94s)
--- PASS: TestAccLambdaFunction_S3Update_unversioned (45.98s)
--- PASS: TestAccLambdaFunction_tags (74.90s)
--- PASS: TestAccLambdaFunction_Zip_validation (6.87s)
--- PASS: TestAccLambdaFunction_vpcRemoval (263.89s)
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (240.54s)
--- PASS: TestAccLambdaPermission_basic (31.94s)
--- PASS: TestAccLambdaPermission_withRawFunctionName (29.93s)
--- PASS: TestAccLambdaPermission_withStatementIdPrefix (28.77s)
--- PASS: TestAccLambdaPermission_withQualifier (37.31s)
--- PASS: TestAccLambdaPermission_StatementID_duplicate (89.87s)
--- PASS: TestAccLambdaPermission_withS3 (28.93s)
--- PASS: TestAccLambdaPermission_multiplePerms (51.48s)
--- PASS: TestAccLambdaPermission_disappears (88.50s)
--- PASS: TestAccLambdaFunction_vpc (415.00s)
--- PASS: TestAccLambdaPermission_withIAMRole (36.68s)
--- PASS: TestAccLambdaFunction_VPC_withInvocation (419.86s)
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (434.41s)
--- PASS: TestAccLambdaPermission_withSNS (82.94s)
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (470.27s)
--- PASS: TestAccLambdaFunction_runtimes (329.51s)
--- PASS: TestAccLambdaFunction_fileSystem (637.09s)
--- PASS: TestAccLambdaFunction_vpcUpdate (641.84s)
```
