### PR TITLE
tests/lakeformation: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/lakeformation/permissions_data_source_test.go
+++ b/internal/service/lakeformation/permissions_data_source_test.go
@@ -211,8 +211,12 @@ resource "aws_iam_role" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_lakeformation_resource" "test" {

--- a/internal/service/lakeformation/permissions_test.go
+++ b/internal/service/lakeformation/permissions_test.go
@@ -1133,8 +1133,12 @@ resource "aws_iam_role" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_lakeformation_resource" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccLakeFormation_serial (289.72s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (289.72s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/basic (34.64s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/database (30.84s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed (51.55s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple (33.09s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataLocation (46.15s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/disappears (93.45s)

--- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataLocation (32.04s)
```
