### PR TITLE
tests/fsx: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/fsx/data_repository_association_test.go
+++ b/internal/service/fsx/data_repository_association_test.go
@@ -583,8 +583,12 @@ resource "aws_fsx_lustre_file_system" "test" {
 }
 
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 `, bucketName))
 }

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -954,8 +954,12 @@ resource "aws_subnet" "test1" {
 func testAccLustreFileSystemExportPathConfig(rName, exportPrefix string) string {
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -971,8 +975,12 @@ resource "aws_fsx_lustre_file_system" "test" {
 func testAccLustreFileSystemImportPathConfig(rName, importPrefix string) string {
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -987,8 +995,12 @@ resource "aws_fsx_lustre_file_system" "test" {
 func testAccLustreFileSystemImportedFileChunkSizeConfig(rName string, importedFileChunkSize int) string {
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -1291,8 +1303,12 @@ resource "aws_fsx_lustre_file_system" "test" {
 func testAccLustreFileSystemAutoImportPolicyConfig(rName, exportPrefix, policy string) string {
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  acl    = "private"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_fsx_lustre_file_system" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccFSxDataRepositoryAssociation_s3AutoExportPolicyUpdate (879.65s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacityUpdate (2552.36s)
--- PASS: TestAccFSxDataRepositoryAssociation_basic (706.05s)
--- PASS: TestAccFSxDataRepositoryAssociation_dataRepositoryPathUpdated (793.44s)
--- PASS: TestAccFSxDataRepositoryAssociation_deleteDataInFilesystem (708.86s)
--- PASS: TestAccFSxDataRepositoryAssociation_disappears (631.28s)
--- PASS: TestAccFSxDataRepositoryAssociation_disappears_ParentFileSystem (691.12s)
--- PASS: TestAccFSxDataRepositoryAssociation_fileSystemPathUpdated (930.29s)
--- PASS: TestAccFSxDataRepositoryAssociation_importedFileChunkSize (773.65s)
--- PASS: TestAccFSxDataRepositoryAssociation_importedFileChunkSizeUpdated (690.26s)
--- PASS: TestAccFSxDataRepositoryAssociation_s3AutoExportPolicy (999.33s)
--- PASS: TestAccFSxDataRepositoryAssociation_s3AutoImportPolicy (1078.38s)
--- PASS: TestAccFSxDataRepositoryAssociation_s3AutoImportPolicyUpdate (1452.94s)
--- PASS: TestAccFSxDataRepositoryAssociation_s3FullPolicy (1391.41s)
--- PASS: TestAccFSxLustreFileSystem_autoImportPolicy (1345.37s)
--- PASS: TestAccFSxLustreFileSystem_automaticBackupRetentionDays (674.83s)
--- PASS: TestAccFSxLustreFileSystem_basic (596.70s)
--- PASS: TestAccFSxLustreFileSystem_copyTagsToBackups (536.29s)
--- PASS: TestAccFSxLustreFileSystem_dailyAutomaticBackupStartTime (645.54s)
--- PASS: TestAccFSxLustreFileSystem_dataCompression (669.60s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent1 (657.17s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypePersistent2 (576.79s)
--- PASS: TestAccFSxLustreFileSystem_deploymentTypeScratch2 (526.91s)
--- PASS: TestAccFSxLustreFileSystem_disappears (533.37s)
--- PASS: TestAccFSxLustreFileSystem_exportPath (1718.67s)
--- PASS: TestAccFSxLustreFileSystem_fileSystemTypeVersion (1066.95s)
--- PASS: TestAccFSxLustreFileSystem_fromBackup (1388.29s)
--- PASS: TestAccFSxLustreFileSystem_importPath (1537.54s)
--- PASS: TestAccFSxLustreFileSystem_importedFileChunkSize (1819.34s)
--- PASS: TestAccFSxLustreFileSystem_kmsKeyID (1219.09s)
--- PASS: TestAccFSxLustreFileSystem_logConfig (779.99s)
--- PASS: TestAccFSxLustreFileSystem_securityGroupIDs (1120.46s)
--- PASS: TestAccFSxLustreFileSystem_storageCapacity (1330.57s)
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheNone (618.19s)
--- PASS: TestAccFSxLustreFileSystem_storageTypeHddDriveCacheRead (638.19s)
--- PASS: TestAccFSxLustreFileSystem_tags (713.77s)
--- PASS: TestAccFSxLustreFileSystem_weeklyMaintenanceStartTime (594.69s)
```
