### PR TITLE
tests/emr: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1891,6 +1891,10 @@ func testAccClusterBootstrapActionBucketConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "tester" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "tester" {
+  bucket = aws_s3_bucket.tester.id
   acl    = "public-read"
 }
 

--- a/internal/service/emr/studio_session_mapping_test.go
+++ b/internal/service/emr/studio_session_mapping_test.go
@@ -157,8 +157,12 @@ resource "aws_subnet" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/emr/studio_test.go
+++ b/internal/service/emr/studio_test.go
@@ -218,8 +218,12 @@ resource "aws_subnet" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_iam_role" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- FAIL: TestAccEMRCluster_visibleToAllUsers (748.82s) <--- history of failures for quite some time in main as well
--- PASS: TestAccEMRCluster_Bootstrap_ordering (1276.75s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy (619.69s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_bidPrice (1004.02s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceCount (519.02s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceType (945.13s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_name (1050.56s)
--- PASS: TestAccEMRCluster_CustomAMI_id (494.95s)
--- PASS: TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups (881.56s)
--- PASS: TestAccEMRCluster_InstanceFleetMaster_only (527.47s)
--- PASS: TestAccEMRCluster_InstanceFleet_basic (1231.38s)
--- PASS: TestAccEMRCluster_Kerberos_clusterDedicatedKdc (411.96s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_bidPrice (881.28s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceCount (1212.28s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceType (780.10s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_name (810.67s)
--- PASS: TestAccEMRCluster_RootVolume_size (745.64s)
--- PASS: TestAccEMRCluster_StepConcurrency_level (467.31s)
--- PASS: TestAccEMRCluster_Step_basic (415.94s)
--- PASS: TestAccEMRCluster_Step_mode (815.36s)
--- PASS: TestAccEMRCluster_Step_multiple (446.22s)
--- PASS: TestAccEMRCluster_additionalInfo (463.66s)
--- PASS: TestAccEMRCluster_autoTerminationPolicy (671.48s)
--- PASS: TestAccEMRCluster_basic (440.50s)
--- PASS: TestAccEMRCluster_disappears (400.30s)
--- PASS: TestAccEMRCluster_ebs (496.86s)
--- PASS: TestAccEMRCluster_keepJob (468.48s)
--- PASS: TestAccEMRCluster_s3LogEncryption (701.12s)
--- PASS: TestAccEMRCluster_s3Logging (572.31s)
--- PASS: TestAccEMRCluster_sJSON (422.91s)
--- PASS: TestAccEMRCluster_security (400.23s)
--- PASS: TestAccEMRCluster_tags (786.12s)
--- PASS: TestAccEMRCluster_terminationProtected (356.97s)
--- PASS: TestAccEMRStudio_iam (25.06s)
--- SKIP: TestAccEMRStudio_disappears (25.03s)
--- SKIP: TestAccEMRStudio_sso (25.99s)
--- SKIP: TestAccEMRStudio_tags (17.15s)
```
