### PR TITLE
tests/elastictranscoder: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/elastictranscoder/pipeline_test.go
+++ b/internal/service/elastictranscoder/pipeline_test.go
@@ -325,6 +325,10 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 `, rName)
@@ -383,6 +387,10 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 `, rName)
@@ -428,16 +436,28 @@ EOF
 
 resource "aws_s3_bucket" "content_bucket" {
   bucket = "%[1]s-content"
+}
+
+resource "aws_s3_bucket_acl" "content_bucket_acl" {
+  bucket = aws_s3_bucket.content_bucket.id
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "input_bucket" {
   bucket = "%[1]s-input"
+}
+
+resource "aws_s3_bucket_acl" "input_bucket_acl" {
+  bucket = aws_s3_bucket.input_bucket.id
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "thumb_bucket" {
   bucket = "%[1]s-thumb"
+}
+
+resource "aws_s3_bucket_acl" "thumb_bucket_acl" {
+  bucket = aws_s3_bucket.thumb_bucket.id
   acl    = "private"
 }
 `, rName)
@@ -483,16 +503,28 @@ EOF
 
 resource "aws_s3_bucket" "content_bucket" {
   bucket = "%[1]s-content"
+}
+
+resource "aws_s3_bucket_acl" "content_bucket_acl" {
+  bucket = aws_s3_bucket.content_bucket.id
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "input_bucket" {
   bucket = "%[1]s-input"
+}
+
+resource "aws_s3_bucket_acl" "input_bucket_acl" {
+  bucket = aws_s3_bucket.input_bucket.id
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "thumb_bucket" {
   bucket = "%[1]s-thumb"
+}
+
+resource "aws_s3_bucket_acl" "thumb_bucket_acl" {
+  bucket = aws_s3_bucket.thumb_bucket.id
   acl    = "private"
 }
 `, rName)
@@ -550,6 +582,10 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 `, rName)
@@ -591,6 +627,10 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 
@@ -651,6 +691,10 @@ EOF
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
   acl    = "private"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccElasticTranscoderPipeline_disappears (155.60s)
--- PASS: TestAccElasticTranscoderPipeline_withPermissions (155.68s)
--- PASS: TestAccElasticTranscoderPipeline_basic (166.77s)
--- PASS: TestAccElasticTranscoderPipeline_kmsKey (167.07s)
--- PASS: TestAccElasticTranscoderPipeline_notifications (211.67s)
--- PASS: TestAccElasticTranscoderPipeline_withContent (253.64s)
```
