### PR TITLE
tests/cur: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/cur/report_definition_data_source_test.go
+++ b/internal/service/cur/report_definition_data_source_test.go
@@ -99,8 +99,12 @@ data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_policy" "test" {
@@ -167,8 +171,12 @@ data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_policy" "test" {

--- a/internal/service/cur/report_definition_test.go
+++ b/internal/service/cur/report_definition_test.go
@@ -360,8 +360,12 @@ func testAccReportDefinitionConfig_basic(reportName, bucketName, prefix string) 
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[2]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 data "aws_partition" "current" {}
@@ -430,8 +434,12 @@ func testAccReportDefinitionConfig_additional(reportName string, bucketName stri
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 data "aws_partition" "current" {}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCURReportDefinitionDataSource_additional (22.31s)
--- PASS: TestAccCURReportDefinitionDataSource_basic (22.68s)
```
