### PR TITLE
tests/configservice: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/configservice/conformance_pack_test.go
+++ b/internal/service/configservice/conformance_pack_test.go
@@ -625,8 +625,12 @@ func testAccConformancePackS3DeliveryConfig(rName, bucketName string) string {
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_config_conformance_pack" "test" {
@@ -653,8 +657,12 @@ func testAccConformancePackS3TemplateConfig(rName, bucketName string) string {
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {
@@ -685,8 +693,12 @@ func testAccConformancePackS3TemplateAndTemplateBodyConfig(rName string) string 
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/configservice/organization_conformance_pack_test.go
+++ b/internal/service/configservice/organization_conformance_pack_test.go
@@ -631,8 +631,12 @@ EOT
 
 resource "aws_s3_bucket" "test" {
   bucket        = %q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 `, rName, bName))
 }
@@ -649,8 +653,12 @@ resource "aws_config_organization_conformance_pack" "test" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[2]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing (commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccConfigService_serial (4523.11s)
    --- PASS: TestAccConfigService_serial/ConformancePack (2206.97s)
        --- PASS: TestAccConfigService_serial/ConformancePack/inputParameters (167.87s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3Template (154.60s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3TemplateAndTemplateBody (159.19s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateS3Delivery (221.04s)
        --- PASS: TestAccConfigService_serial/ConformancePack/basic (150.91s)
        --- PASS: TestAccConfigService_serial/ConformancePack/forceNew (311.49s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3Delivery (156.71s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateInputParameters (235.38s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateS3Template (245.79s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateTemplateBody (268.67s)
        --- PASS: TestAccConfigService_serial/ConformancePack/disappears (135.32s)
    --- PASS: TestAccConfigService_serial/DeliveryChannel (135.33s)
        --- PASS: TestAccConfigService_serial/DeliveryChannel/basic (49.51s)
        --- PASS: TestAccConfigService_serial/DeliveryChannel/allParams (43.25s)
        --- PASS: TestAccConfigService_serial/DeliveryChannel/importBasic (42.57s)
    --- PASS: TestAccConfigService_serial/RemediationConfiguration (761.50s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basicBackward (91.89s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/disappears (91.97s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/recreates (129.25s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/updates (355.20s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basic (93.19s)
    --- PASS: TestAccConfigService_serial/OrganizationCustomRule (14.67s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/ResourceIdScope (0.16s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/TagKeyScope (0.16s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/TagValueScope (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/TriggerTypes (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/basic (6.26s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/LambdaFunctionArn (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/Description (0.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/ExcludedAccounts (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/InputParameters (0.18s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/MaximumExecutionFrequency (0.16s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/ResourceTypesScope (6.67s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/disappears (0.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/errorHandling (0.21s)
    --- PASS: TestAccConfigService_serial/OrganizationManagedRule (15.00s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/Description (0.17s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/InputParameters (2.84s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/MaximumExecutionFrequency (0.13s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/basic (0.13s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/disappears (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/ResourceIdScope (0.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/ResourceTypesScope (6.30s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/RuleIdentifier (0.16s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/TagKeyScope (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/TagValueScope (0.13s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/errorHandling (2.19s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/ExcludedAccounts (2.50s)
    --- PASS: TestAccConfigService_serial/Config (1052.23s)
        --- PASS: TestAccConfigService_serial/Config/importAws (90.66s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKeyEmpty (86.80s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagValue (116.63s)
        --- PASS: TestAccConfigService_serial/Config/tags (203.13s)
        --- PASS: TestAccConfigService_serial/Config/basic (90.31s)
        --- PASS: TestAccConfigService_serial/Config/ownerAws (95.43s)
        --- PASS: TestAccConfigService_serial/Config/customlambda (142.82s)
        --- PASS: TestAccConfigService_serial/Config/importLambda (124.28s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKey (102.16s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus (203.39s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/basic (46.72s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/startEnabled (94.76s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/importBasic (61.91s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorder (122.81s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/basic (40.65s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/allParams (40.43s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/importBasic (41.73s)
    --- PASS: TestAccConfigService_serial/OrganizationConformancePack (11.23s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/basic (0.18s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/inputParameters (0.20s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/S3Delivery (0.20s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateInputParameters (2.13s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateS3Delivery (1.19s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateTemplateBody (1.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/disappears (0.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/excludedAccounts (0.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/forceNew (0.16s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/S3Template (5.58s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateS3Template (0.15s)
```
