### PR TITLE
tests/cloudwatchlogs: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/cloudwatchlogs/subscription_filter_test.go
+++ b/internal/service/cloudwatchlogs/subscription_filter_test.go
@@ -453,9 +453,13 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 }
 
 resource "aws_s3_bucket" "test" {
-  acl           = "private"
   bucket        = %[1]q
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_basic (43.46s)
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_Disappears_logGroup (48.84s)
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_DestinationARN_kinesisStream (65.36s)
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_disappears (39.15s)
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_roleARN (91.56s)
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_distribution (57.47s)
--- PASS: TestAccCloudWatchLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose (103.02s)
```
