### PR TITLE
tests/cloudwatch: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -394,6 +394,10 @@ EOF
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.bucket.id
   acl    = "private"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCloudWatchMetricStream_tags (23.25s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (23.41s)
--- PASS: TestAccCloudWatchMetricStream_includeFilters (23.09s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (23.32s)
--- PASS: TestAccCloudWatchMetricStream_noName (21.09s)
--- PASS: TestAccCloudWatchMetricStream_update (108.59s)
--- PASS: TestAccCloudWatchMetricStream_basic (132.33s)
--- PASS: TestAccCloudWatchMetricStream_updateName (206.23s)
```
