### PR TITLE
tests/cloudfront: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1417,6 +1417,10 @@ func originBucket(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "s3_bucket_origin" {
   bucket = "%[1]s.origin-bucket"
+}
+
+resource "aws_s3_bucket_acl" "s3_bucket_origin_acl" {
+  bucket = aws_s3_bucket.s3_bucket_origin.id
   acl    = "public-read"
 }
 `, rName)
@@ -1426,6 +1430,10 @@ func backupBucket(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "s3_backup_bucket_origin" {
   bucket = "%[1]s.backup-bucket"
+}
+
+resource "aws_s3_bucket_acl" "s3_backup_bucket_origin_acl" {
+  bucket = aws_s3_bucket.s3_backup_bucket_origin.id
   acl    = "public-read"
 }
 `, rName)
@@ -1435,8 +1443,12 @@ func logBucket(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "s3_bucket_logs" {
   bucket        = "%[1]s.log-bucket"
-  acl           = "public-read"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "s3_bucket_logs_acl" {
+  bucket = aws_s3_bucket.s3_bucket_logs.id
+  acl    = "public-read"
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (396.56s)

--- PASS: TestAccCloudFrontDistribution_customOrigin (1084.12s)

--- PASS: TestAccCloudFrontDistribution_multiOrigin (417.31s)

--- PASS: TestAccCloudFrontDistribution_originGroups (249.03s)

--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (389.96s)

--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (377.53s)

--- PASS: TestAccCloudFrontDistribution_Origin_originShield (423.18s)

--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (347.30s)

--- PASS: TestAccCloudFrontDistributionDataSource_basic (438.56s)
```
