### PR TITLE
tests/cloudformation: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -1344,8 +1344,12 @@ EOF
 }
 
 resource "aws_s3_bucket" "test" {
-  acl    = "public-read"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
 }
 
 resource "aws_s3_object" "test" {
@@ -1393,8 +1397,12 @@ EOF
 }
 
 resource "aws_s3_bucket" "test" {
-  acl    = "public-read"
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "public-read"
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -833,6 +833,10 @@ data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "b" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "b" {
+  bucket = aws_s3_bucket.b.id
   acl    = "public-read"
 }
 
@@ -894,6 +898,10 @@ data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "b" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "b" {
+  bucket = aws_s3_bucket.b.id
   acl    = "public-read"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
