### PR TITLE
tests/acctest: update to `aws_s3_bucket_acl`

### DIFF
--- a/internal/acctest/acctest_test.go
+++ b/internal/acctest/acctest_test.go
@@ -906,8 +906,12 @@ provider "aws" {
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[2]q
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
 }
 `, endpoint, rName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22997
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22537
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20433

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAcctestProvider_Region_awsCommercial (21.93s)
--- PASS: TestAccAcctestProvider_Region_awsC2S (21.94s)
--- PASS: TestAccAcctestProvider_Region_awsGovCloudUs (22.46s)
--- PASS: TestAccAcctestProvider_Region_awsChina (22.81s)
--- PASS: TestAccAcctestProvider_Region_awsSC2S (22.85s)
--- PASS: TestAccAcctestProvider_IgnoreTagsKeyPrefixes_one (27.28s)
--- PASS: TestAccAcctestProvider_IgnoreTagsKeys_one (27.29s)
--- PASS: TestAccAcctestProvider_IgnoreTagsKeyPrefixes_none (27.53s)
--- PASS: TestAccAcctestProvider_DefaultTagsTags_multiple (27.56s)
--- PASS: TestAccAcctestProvider_IgnoreTags_emptyBlock (28.03s)
--- PASS: TestAccAcctestProvider_unusualEndpoints (28.05s)
--- PASS: TestAccAcctestProvider_IgnoreTagsKeys_multiple (28.05s)
--- PASS: TestAccAcctestProvider_DefaultAndIgnoreTags_emptyBlocks (28.05s)
--- PASS: TestAccAcctestProvider_DefaultTags_emptyBlock (28.05s)
--- PASS: TestAccAcctestProvider_DefaultTagsTags_none (28.05s)
--- PASS: TestAccAcctestProvider_IgnoreTagsKeys_none (28.06s)
--- PASS: TestAccAcctestProvider_IgnoreTagsKeyPrefixes_multiple (28.20s)
--- PASS: TestAccAcctestProvider_endpoints (28.60s)
--- PASS: TestAccAcctestProvider_AssumeRole_empty (30.69s)
--- PASS: TestAccAcctestProvider_DefaultTagsTags_one (10.44s)
--- PASS: TestAccAcctestProvider_fipsEndpoint (45.44s)
```
