### PR TITLE
linting: Fix `providerlint` V001 errors for IAM resources

### DIFF
--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -3,7 +3,6 @@ package iam
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,11 +10,15 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+const (
+	instanceProfileNameMaxLen       = 128
+	instanceProfileNamePrefixMaxLen = instanceProfileNameMaxLen - resource.UniqueIDSuffixLength
 )
 
 func ResourceInstanceProfile() *schema.Resource {
@@ -43,20 +46,14 @@ func ResourceInstanceProfile() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 128),
-					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-				),
+				ValidateFunc:  validIamResourceName(instanceProfileNameMaxLen),
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 64),
-					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-				),
+				ValidateFunc:  validIamResourceName(instanceProfileNamePrefixMaxLen),
 			},
 			"path": {
 				Type:     schema.TypeString,

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -12,11 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+const (
+	policyNameMaxLen       = 128
+	policyNamePrefixMaxLen = policyNameMaxLen - resource.UniqueIDSuffixLength
 )
 
 func ResourcePolicy() *schema.Resource {
@@ -53,20 +56,14 @@ func ResourcePolicy() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 128),
-					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-				),
+				ValidateFunc:  validIamResourceName(policyNameMaxLen),
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 96),
-					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-				),
+				ValidateFunc:  validIamResourceName(policyNamePrefixMaxLen),
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -24,6 +24,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+const (
+	roleNameMaxLen       = 64
+	roleNamePrefixMaxLen = roleNameMaxLen - resource.UniqueIDSuffixLength
+)
+
 func ResourceRole() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceRoleCreate,
@@ -50,10 +55,7 @@ func ResourceRole() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 64),
-					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-				),
+				ValidateFunc:  validIamResourceName(roleNameMaxLen),
 			},
 
 			"name_prefix": {
@@ -62,10 +64,7 @@ func ResourceRole() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 64-resource.UniqueIDSuffixLength),
-					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-				),
+				ValidateFunc:  validIamResourceName(roleNamePrefixMaxLen),
 			},
 
 			"path": {

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -16,6 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+const (
+	rolePolicyNameMaxLen       = 128
+	rolePolicyNamePrefixMaxLen = rolePolicyNameMaxLen - resource.UniqueIDSuffixLength
+)
+
 func ResourceRolePolicy() *schema.Resource {
 	return &schema.Resource{
 		// PutRolePolicy API is idempotent, so these can be the same.
@@ -48,7 +53,7 @@ func ResourceRolePolicy() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validRolePolicyNamePrefix,
+				ValidateFunc:  validIamResourceName(rolePolicyNamePrefixMaxLen),
 			},
 			"role": {
 				Type:     schema.TypeString,

--- a/internal/service/iam/validate.go
+++ b/internal/service/iam/validate.go
@@ -34,18 +34,18 @@ var validAccountAlias = validation.All(
 	},
 )
 
-func validOpenIDURL(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	u, err := url.Parse(value)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("%q has to be a valid URL", k))
+var validOpenIDURL = validation.All(
+	validation.IsURLWithHTTPS,
+	func(v interface{}, k string) (ws []string, es []error) {
+		value := v.(string)
+		u, err := url.Parse(value)
+		if err != nil {
+			// validation.IsURLWithHTTPS will already have returned an error for an invalid URL
+			return
+		}
+		if len(u.Query()) > 0 {
+			es = append(es, fmt.Errorf("%q cannot contain query parameters per the OIDC standard", k))
+		}
 		return
-	}
-	if u.Scheme != "https" {
-		errors = append(errors, fmt.Errorf("%q has to use HTTPS scheme (i.e. begin with https://)", k))
-	}
-	if len(u.Query()) > 0 {
-		errors = append(errors, fmt.Errorf("%q cannot contain query parameters per the OIDC standard", k))
-	}
-	return
-}
+	},
+)

--- a/internal/service/iam/validate.go
+++ b/internal/service/iam/validate.go
@@ -6,18 +6,18 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var validRolePolicyName = validation.All(
-	validation.StringLenBetween(1, 128),
-	validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-)
+var validRolePolicyName = validIamResourceName(rolePolicyNameMaxLen)
 
-var validRolePolicyNamePrefix = validation.All(
-	validation.StringLenBetween(1, 100),
-	validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
-)
+func validIamResourceName(max int) schema.SchemaValidateFunc {
+	return validation.All(
+		validation.StringLenBetween(1, max),
+		validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+	)
+}
 
 var validAccountAlias = validation.All(
 	validation.StringLenBetween(3, 63),

--- a/internal/service/iam/validate.go
+++ b/internal/service/iam/validate.go
@@ -5,50 +5,34 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func validRolePolicyName(v interface{}, k string) (ws []string, errors []error) {
-	// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8291-L8296
-	value := v.(string)
-	if len(value) > 128 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 128 characters", k))
-	}
-	if !regexp.MustCompile(`^[\w+=,.@-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(`%q must match [\w+=,.@-]`, k))
-	}
-	return
-}
+var validRolePolicyName = validation.All(
+	validation.StringLenBetween(1, 128),
+	validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+)
 
-func validRolePolicyNamePrefix(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 100 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 100 characters", k))
-	}
-	if !regexp.MustCompile(`^[\w+=,.@-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(`%q must match [\w+=,.@-]`, k))
-	}
-	return
-}
+var validRolePolicyNamePrefix = validation.All(
+	validation.StringLenBetween(1, 100),
+	validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+)
 
-func validAccountAlias(v interface{}, k string) (ws []string, es []error) {
-	val := v.(string)
-
-	if (len(val) < 3) || (len(val) > 63) {
-		es = append(es, fmt.Errorf("%q must contain from 3 to 63 alphanumeric characters or hyphens", k))
-	}
-	if !regexp.MustCompile("^[a-z0-9][a-z0-9-]+$").MatchString(val) {
-		es = append(es, fmt.Errorf("%q must start with an alphanumeric character and only contain lowercase alphanumeric characters and hyphens", k))
-	}
-	if strings.Contains(val, "--") {
-		es = append(es, fmt.Errorf("%q must not contain consecutive hyphens", k))
-	}
-	if strings.HasSuffix(val, "-") {
-		es = append(es, fmt.Errorf("%q must not end in a hyphen", k))
-	}
-	return
-}
+var validAccountAlias = validation.All(
+	validation.StringLenBetween(3, 63),
+	validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9-]+$`), "must start with an alphanumeric character and only contain lowercase alphanumeric characters and hyphens"),
+	func(v interface{}, k string) (ws []string, es []error) {
+		val := v.(string)
+		if strings.Contains(val, "--") {
+			es = append(es, fmt.Errorf("%q must not contain consecutive hyphens", k))
+		}
+		if strings.HasSuffix(val, "-") {
+			es = append(es, fmt.Errorf("%q must not end in a hyphen", k))
+		}
+		return
+	},
+)
 
 func validOpenIDURL(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)

--- a/internal/service/iam/validate_test.go
+++ b/internal/service/iam/validate_test.go
@@ -29,31 +29,6 @@ func TestValidRoleProfileName(t *testing.T) {
 	}
 }
 
-func TestValidRoleProfileNamePrefix(t *testing.T) {
-	validNamePrefixes := []string{
-		"tf-test-role-profile-",
-	}
-
-	for _, s := range validNamePrefixes {
-		_, errors := validRolePolicyNamePrefix(s, "name_prefix")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid IAM role policy name prefix: %v", s, errors)
-		}
-	}
-
-	invalidNamePrefixes := []string{
-		"invalid#name_prefix",
-		"this-is-a-very-long-role-policy-name-prefix-this-is-a-very-long-role-policy-name-prefix-this-is-a-very-",
-	}
-
-	for _, s := range invalidNamePrefixes {
-		_, errors := validRolePolicyNamePrefix(s, "name_prefix")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid IAM role policy name prefix: %v", s, errors)
-		}
-	}
-}
-
 func TestValidAccountAlias(t *testing.T) {
 	validAliases := []string{
 		"tf-alias",
@@ -89,11 +64,14 @@ func TestValidOpenIDURL(t *testing.T) {
 		ErrCount int
 	}{
 		{
-			Value:    "http://wrong.scheme.com", // nosemgrep: domain-names
+			Value: "https://good.test",
+		},
+		{
+			Value:    "http://wrong.scheme.test",
 			ErrCount: 1,
 		},
 		{
-			Value:    "ftp://wrong.scheme.co.uk", // nosemgrep: domain-names
+			Value:    "ftp://wrong.scheme.test",
 			ErrCount: 1,
 		},
 		{
@@ -101,7 +79,7 @@ func TestValidOpenIDURL(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    "https://example.com/?query=param",
+			Value:    "https://no-queries.test/?query=param",
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
Fixes [`providerlint`](https://github.com/bflad/tfproviderlint) [V001](https://github.com/bflad/tfproviderlint/tree/main/passes/V001) errors for IAM resources

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11872

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS='TestAccIAMRolePolicy_|TestAccIAMRole_|TestAccIAMPolicy_|TestAccIAMInstanceProfile_' PKG=iam

--- PASS: TestAccIAMRole_badJSON (32.62s)
--- FAIL: TestAccIAMRole_InlinePolicy_empty (92.57s)
--- PASS: TestAccIAMRole_disappears (109.38s)
--- PASS: TestAccIAMRole_nameGenerated (135.41s)
--- PASS: TestAccIAMInstanceProfile_basic (143.16s)
--- PASS: TestAccIAMRole_policiesForceDetach (145.93s)
--- FAIL: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (170.76s)
--- FAIL: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (185.14s)
--- PASS: TestAccIAMRolePolicy_invalidJSON (23.50s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (207.60s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (70.75s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (217.01s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (219.44s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (225.94s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (229.43s)
--- PASS: TestAccIAMRole_tags (231.67s)
--- PASS: TestAccIAMRole_namePrefix (139.55s)
--- PASS: TestAccIAMPolicy_path (128.19s)
--- PASS: TestAccIAMRole_maxSessionDuration (257.44s)
--- PASS: TestAccIAMRole_basic (134.51s)
--- PASS: TestAccIAMRole_testNameChange (245.23s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (289.31s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (317.01s)
--- PASS: TestAccIAMPolicy_disappears (104.39s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (337.58s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (339.97s)
--- PASS: TestAccIAMRolePolicy_disappears (124.43s)
--- PASS: TestAccIAMPolicy_basic (126.57s)
--- PASS: TestAccIAMPolicy_namePrefix (130.43s)
--- PASS: TestAccIAMPolicy_description (122.46s)
--- PASS: TestAccIAMRolePolicy_policyOrder (175.37s)
--- PASS: TestAccIAMInstanceProfile_disappears (106.05s)
--- PASS: TestAccIAMInstanceProfile_Disappears_role (106.32s)
--- PASS: TestAccIAMInstanceProfile_namePrefix (127.87s)
--- PASS: TestAccIAMRolePolicy_generatedName (205.86s)
--- PASS: TestAccIAMRolePolicy_namePrefix (203.96s)
--- PASS: TestAccIAMInstanceProfile_withoutRole (85.02s)
--- PASS: TestAccIAMRolePolicy_basic (186.05s)
--- PASS: TestAccIAMPolicy_policy (187.13s)
--- PASS: TestAccIAMRole_basicWithDescription (271.32s)
--- PASS: TestAccIAMRole_permissionsBoundary (419.67s)
--- PASS: TestAccIAMPolicy_tags (192.50s)
--- PASS: TestAccIAMInstanceProfile_tags (151.67s)
```

Test failures are pre-existing