### PR TITLE
r/aws_backup_report_plan

### DIFF
--- a/.changelog/23098.txt
+++ b/.changelog/23098.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_backup_report_plan
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -905,6 +905,7 @@ func Provider() *schema.Provider {
 			"aws_backup_global_settings":          backup.ResourceGlobalSettings(),
 			"aws_backup_plan":                     backup.ResourcePlan(),
 			"aws_backup_region_settings":          backup.ResourceRegionSettings(),
+			"aws_backup_report_plan":              backup.ResourceReportPlan(),
 			"aws_backup_selection":                backup.ResourceSelection(),
 			"aws_backup_vault":                    backup.ResourceVault(),
 			"aws_backup_vault_lock_configuration": backup.ResourceVaultLockConfiguration(),

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -100,6 +100,7 @@ func ResourceReportPlan() *schema.Resource {
 						"report_template": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"RESOURCE_COMPLIANCE_REPORT",
 								"CONTROL_COMPLIANCE_REPORT",

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -1,14 +1,24 @@
 package backup
 
 import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceReportPlan() *schema.Resource {
 	return &schema.Resource{
+		Read: resourceReportPlanRead,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -103,4 +113,97 @@ func ResourceReportPlan() *schema.Resource {
 
 		CustomizeDiff: verify.SetTagsDiff,
 	}
+}
+
+func resourceReportPlanRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).BackupConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	resp, err := conn.DescribeReportPlan(&backup.DescribeReportPlanInput{
+		ReportPlanName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrMessageContains(err, backup.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Backup Report Plan (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading Backup Report Plan (%s): %w", d.Id(), err)
+	}
+
+	d.Set("arn", resp.ReportPlan.ReportPlanArn)
+	d.Set("deployment_status", resp.ReportPlan.DeploymentStatus)
+	d.Set("description", resp.ReportPlan.ReportPlanDescription)
+	d.Set("name", resp.ReportPlan.ReportPlanName)
+
+	if err := d.Set("creation_time", resp.ReportPlan.CreationTime.Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("error setting creation_time: %s", err)
+	}
+
+	if err := d.Set("report_delivery_channel", flattenReportDeliveryChannel(resp.ReportPlan.ReportDeliveryChannel)); err != nil {
+		return fmt.Errorf("error setting report_delivery_channel: %w", err)
+	}
+
+	if err := d.Set("report_setting", flattenReportSetting(resp.ReportPlan.ReportSetting)); err != nil {
+		return fmt.Errorf("error setting report_delivery_channel: %w", err)
+	}
+
+	tags, err := ListTags(conn, d.Get("arn").(string))
+	if err != nil {
+		return fmt.Errorf("error listing tags for Backup Report Plan (%s): %w", d.Id(), err)
+	}
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("error setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func flattenReportDeliveryChannel(reportDeliveryChannel *backup.ReportDeliveryChannel) []interface{} {
+	if reportDeliveryChannel == nil {
+		return []interface{}{}
+	}
+
+	values := map[string]interface{}{
+		"s3_bucket_name": aws.StringValue(reportDeliveryChannel.S3BucketName),
+	}
+
+	if reportDeliveryChannel.Formats != nil && len(reportDeliveryChannel.Formats) > 0 {
+		values["formats"] = flex.FlattenStringSet(reportDeliveryChannel.Formats)
+	}
+
+	if v := reportDeliveryChannel.S3KeyPrefix; v != nil {
+		values["s3_key_prefix"] = aws.StringValue(v)
+	}
+
+	return []interface{}{values}
+}
+
+func flattenReportSetting(reportSetting *backup.ReportSetting) []interface{} {
+	if reportSetting == nil {
+		return []interface{}{}
+	}
+
+	values := map[string]interface{}{
+		"report_template": aws.StringValue(reportSetting.ReportTemplate),
+	}
+
+	if reportSetting.FrameworkArns != nil && len(reportSetting.FrameworkArns) > 0 {
+		values["framework_arns"] = flex.FlattenStringSet(reportSetting.FrameworkArns)
+	}
+
+	if reportSetting.NumberOfFrameworks != nil {
+		values["number_of_frameworks"] = aws.Int64Value(reportSetting.NumberOfFrameworks)
+	}
+
+	return []interface{}{values}
 }

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -1,0 +1,106 @@
+package backup
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceReportPlan() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deployment_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validReportPlanName,
+			},
+			"report_delivery_channel": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"formats": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"CSV",
+									"JSON",
+								}, false),
+							},
+						},
+						"s3_bucket_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"s3_key_prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"report_setting": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"framework_arns": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"number_of_frameworks": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						// A report plan template cannot be updated
+						"report_template": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"RESOURCE_COMPLIANCE_REPORT",
+								"CONTROL_COMPLIANCE_REPORT",
+								"BACKUP_JOB_REPORT",
+								"COPY_JOB_REPORT",
+								"RESTORE_JOB_REPORT",
+							}, false),
+						},
+					},
+				},
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -22,6 +22,7 @@ func ResourceReportPlan() *schema.Resource {
 		Create: resourceReportPlanCreate,
 		Read:   resourceReportPlanRead,
 		Update: resourceReportPlanUpdate,
+		Delete: resourceReportPlanDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -232,6 +233,21 @@ func resourceReportPlanUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return resourceReportPlanRead(d, meta)
+}
+
+func resourceReportPlanDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).BackupConn
+
+	input := &backup.DeleteReportPlanInput{
+		ReportPlanName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteReportPlan(input)
+	if err != nil {
+		return fmt.Errorf("error deleting Backup Report Plan: %s", err)
+	}
+
+	return nil
 }
 
 func expandReportDeliveryChannel(reportDeliveryChannel []interface{}) *backup.ReportDeliveryChannel {

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -72,6 +72,91 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBackupReportPlan_updateTags(t *testing.T) {
+	var reportPlan backup.DescribeReportPlanOutput
+
+	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+	description := "example description"
+	resourceName := "aws_backup_report_plan.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckReportPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupReportPlanConfig_basic(rName, rName2, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.0", "CSV"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupReportPlanConfig_tags(rName, rName2, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.0", "CSV"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2a"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupReportPlanConfig_tagsUpdated(rName, rName2, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.0", "CSV"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2b"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value3"),
+				),
+			},
+		},
+	})
+}
 func testAccCheckReportPlanDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
 	for _, rs := range s.RootModule().Resources {
@@ -160,3 +245,59 @@ resource "aws_backup_report_plan" "test" {
 }
 `, rName2, label))
 }
+
+func testAccBackupReportPlanConfig_tags(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccBackupReportPlanBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_backup_report_plan" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  report_delivery_channel {
+    formats = [
+      "CSV"
+    ]
+    s3_bucket_name = aws_s3_bucket.test.id
+  }
+
+  report_setting {
+    report_template = "RESTORE_JOB_REPORT"
+  }
+
+  tags = {
+    "Name" = "Test Report Plan"
+    "Key2" = "Value2a"
+  }
+}
+`, rName2, label))
+}
+
+func testAccBackupReportPlanConfig_tagsUpdated(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccBackupReportPlanBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_backup_report_plan" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  report_delivery_channel {
+    formats = [
+      "CSV"
+    ]
+    s3_bucket_name = aws_s3_bucket.test.id
+  }
+
+  report_setting {
+    report_template = "RESTORE_JOB_REPORT"
+  }
+
+  tags = {
+    "Name" = "Test Report Plan"
+    "Key2" = "Value2b"
+    "Key3" = "Value3"
+  }
+}
+`, rName2, label))
+}
+

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -157,6 +157,66 @@ func TestAccBackupReportPlan_updateTags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
+	var reportPlan backup.DescribeReportPlanOutput
+
+	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+	description := "example description"
+	resourceName := "aws_backup_report_plan.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckReportPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupReportPlanConfig_basic(rName, rName2, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.0", "CSV"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupReportPlanConfig_reportDeliveryChannel(rName, rName2, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "report_delivery_channel.0.formats.*", "CSV"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "report_delivery_channel.0.formats.*", "JSON"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+				),
+			},
+		},
+	})
+}
 func testAccCheckReportPlanDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
 	for _, rs := range s.RootModule().Resources {
@@ -301,3 +361,29 @@ resource "aws_backup_report_plan" "test" {
 `, rName2, label))
 }
 
+func testAccBackupReportPlanConfig_reportDeliveryChannel(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccBackupReportPlanBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_backup_report_plan" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  report_delivery_channel {
+    formats = [
+      "CSV",
+      "JSON"
+    ]
+    s3_bucket_name = aws_s3_bucket.test.id
+  }
+
+  report_setting {
+    report_template = "RESTORE_JOB_REPORT"
+  }
+
+  tags = {
+    "Name" = "Test Report Plan"
+  }
+}
+`, rName2, label))
+}

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -24,7 +24,7 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccReportPlanPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckReportPlanDestroy,
@@ -83,7 +83,7 @@ func TestAccBackupReportPlan_updateTags(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccReportPlanPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckReportPlanDestroy,
@@ -168,7 +168,7 @@ func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccReportPlanPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckReportPlanDestroy,
@@ -228,7 +228,7 @@ func TestAccBackupReportPlan_disappears(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccReportPlanPreCheck(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckReportPlanDestroy,
@@ -243,6 +243,20 @@ func TestAccBackupReportPlan_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccReportPlanPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+
+	_, err := conn.ListReportPlans(&backup.ListReportPlansInput{})
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccCheckReportPlanDestroy(s *terraform.State) error {

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -2,15 +2,76 @@ package backup_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
+func TestAccBackupReportPlan_basic(t *testing.T) {
+	var reportPlan backup.DescribeReportPlanOutput
+
+	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+	originalDescription := "original description"
+	updatedDescription := "updated description"
+	resourceName := "aws_backup_report_plan.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckReportPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupReportPlanConfig_basic(rName, rName2, originalDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.0", "CSV"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupReportPlanConfig_basic(rName, rName2, updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReportPlanExists(resourceName, &reportPlan),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_delivery_channel.0.formats.0", "CSV"),
+					resource.TestCheckResourceAttrPair(resourceName, "report_delivery_channel.0.s3_bucket_name", "aws_s3_bucket.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "report_setting.0.report_template", "RESTORE_JOB_REPORT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Report Plan"),
+				),
+			},
+		},
+	})
+}
 func testAccCheckReportPlanDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
 	for _, rs := range s.RootModule().Resources {
@@ -56,4 +117,46 @@ func testAccCheckReportPlanExists(name string, reportPlan *backup.DescribeReport
 
 		return nil
 	}
+}
+
+func testAccBackupReportPlanBaseConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket                  = aws_s3_bucket.test.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+`, bucketName)
+}
+
+func testAccBackupReportPlanConfig_basic(rName, rName2, label string) string {
+	return acctest.ConfigCompose(
+		testAccBackupReportPlanBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_backup_report_plan" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  report_delivery_channel {
+    formats = [
+      "CSV"
+    ]
+    s3_bucket_name = aws_s3_bucket.test.id
+  }
+
+  report_setting {
+    report_template = "RESTORE_JOB_REPORT"
+  }
+
+  tags = {
+    "Name" = "Test Report Plan"
+  }
+}
+`, rName2, label))
 }

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -1,0 +1,59 @@
+package backup_test
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func testAccCheckReportPlanDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_backup_report_plan" {
+			continue
+		}
+
+		input := &backup.DescribeReportPlanInput{
+			ReportPlanName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeReportPlan(input)
+
+		if err == nil {
+			if aws.StringValue(resp.ReportPlan.ReportPlanName) == rs.Primary.ID {
+				return fmt.Errorf("Backup Report Plan '%s' was not deleted properly", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckReportPlanExists(name string, reportPlan *backup.DescribeReportPlanOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+		input := &backup.DescribeReportPlanInput{
+			ReportPlanName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeReportPlan(input)
+
+		if err != nil {
+			return err
+		}
+
+		*reportPlan = *resp
+
+		return nil
+	}
+}

--- a/internal/service/backup/validate.go
+++ b/internal/service/backup/validate.go
@@ -1,0 +1,14 @@
+package backup
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func validReportPlanName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z]{1}[_a-zA-Z0-9]{0,255}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be must be between 1 and 256 characters, starting with a letter, and consisting of letters, numbers, and underscores.", k, v))
+	}
+	return
+}

--- a/internal/service/backup/validate_test.go
+++ b/internal/service/backup/validate_test.go
@@ -1,0 +1,29 @@
+package backup
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidReportPlanName(t *testing.T) {
+	validNames := []string{
+		strings.Repeat("W", 256), // <= 256
+	}
+	for _, v := range validNames {
+		_, errors := validReportPlanName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Backup Report Plan name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"@error",
+		strings.Repeat("W", 257), // >= 257
+	}
+	for _, v := range invalidNames {
+		_, errors := validReportPlanName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be a invalid Backup Report Plan name: %q", v, errors)
+		}
+	}
+}

--- a/website/docs/r/backup_report_plan.html.markdown
+++ b/website/docs/r/backup_report_plan.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_report_plan"
+description: |-
+  Provides an AWS Backup Report Plan resource.
+---
+
+# Resource: aws_backup_report_plan
+
+Provides an AWS Backup Report Plan resource.
+
+## Example Usage
+
+```terraform
+resource "aws_backup_report_plan" "example" {
+  name        = "example_name"
+  description = "example description"
+
+  report_delivery_channel {
+    formats = [
+      "CSV",
+      "JSON"
+    ]
+    s3_bucket_name = "example-bucket-name"
+  }
+
+  report_setting {
+    report_template = "RESTORE_JOB_REPORT"
+  }
+
+  tags = {
+    "Name" = "Example Report Plan"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) The description of the report plan with a maximum of 1,024 characters
+* `name` - (Required) The unique name of the report plan. The name must be between 1 and 256 characters, starting with a letter, and consisting of letters, numbers, and underscores.
+* `report_delivery_channel` - (Required) An object that contains information about where and how to deliver your reports, specifically your Amazon S3 bucket name, S3 key prefix, and the formats of your reports. Detailed below.
+* `report_setting` - (Required) An object that identifies the report template for the report. Reports are built using a report template. Detailed below.
+* `tags` - (Optional) Metadata that you can assign to help organize the report plans you create. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Report Delivery Channel Arguments
+For **report_delivery_channel** the following attributes are supported:
+
+* `formats` - (Optional) A list of the format of your reports: CSV, JSON, or both. If not specified, the default format is CSV.
+* `s3_bucket_name` - (Required) The unique name of the S3 bucket that receives your reports.
+* `s3_key_prefix` - (Optional) The prefix for where Backup Audit Manager delivers your reports to Amazon S3. The prefix is this part of the following path: s3://your-bucket-name/prefix/Backup/us-west-2/year/month/day/report-name. If not specified, there is no prefix.
+
+### Report Setting Arguments
+For **report_setting** the following attributes are supported:
+
+* `framework_arns` - (Optional) Specifies the Amazon Resource Names (ARNs) of the frameworks a report covers.
+* `number_of_frameworks` - (Optional) Specifies the number of frameworks a report covers.
+* `report_template` - (Required) Identifies the report template for the report. Reports are built using a report template. The report templates are: `RESOURCE_COMPLIANCE_REPORT` | `CONTROL_COMPLIANCE_REPORT` | `BACKUP_JOB_REPORT` | `COPY_JOB_REPORT` | `RESTORE_JOB_REPORT`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the backup report plan.
+* `creation_time` - The date and time that a report plan is created, in Unix format and Coordinated Universal Time (UTC).
+* `deployment_status` - The deployment status of a report plan. The statuses are: `CREATE_IN_PROGRESS` | `UPDATE_IN_PROGRESS` | `DELETE_IN_PROGRESS` | `COMPLETED`.
+* `id` - The id of the backup report plan.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Backup Report Plan can be imported using the `id` which corresponds to the name of the Backup Report Plan, e.g.,
+
+```
+$ terraform import aws_backup_report_plan.test <id>
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21786

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccBackupReportPlan' PKG=backup ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 1  -run=TestAccBackupReportPlan -timeout 180m
=== RUN   TestAccBackupReportPlan_basic
=== PAUSE TestAccBackupReportPlan_basic
=== RUN   TestAccBackupReportPlan_updateTags
=== PAUSE TestAccBackupReportPlan_updateTags
=== RUN   TestAccBackupReportPlan_updateReportDeliveryChannel
=== PAUSE TestAccBackupReportPlan_updateReportDeliveryChannel
=== RUN   TestAccBackupReportPlan_disappears
=== PAUSE TestAccBackupReportPlan_disappears
=== CONT  TestAccBackupReportPlan_basic
--- PASS: TestAccBackupReportPlan_basic (101.82s)
=== CONT  TestAccBackupReportPlan_updateReportDeliveryChannel
--- PASS: TestAccBackupReportPlan_updateReportDeliveryChannel (99.08s)
=== CONT  TestAccBackupReportPlan_disappears
--- PASS: TestAccBackupReportPlan_disappears (50.52s)
=== CONT  TestAccBackupReportPlan_updateTags
--- PASS: TestAccBackupReportPlan_updateTags (148.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     412.013s

...
```
