### PR TITLE
tests/s3: add dependency on `aws_s3_bucket_versioning` when configuring `s3_object` resources

### DIFF
--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -634,7 +634,8 @@ resource "aws_s3_bucket_versioning" "object_bucket" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket                        = aws_s3_bucket.object_bucket.bucket
+  # Must have bucket versioning enabled first
+  bucket                        = aws_s3_bucket_versioning.object_bucket.bucket
   key                           = "tf-testing-obj-%[1]d"
   content                       = "Hello World"
   object_lock_legal_hold_status = "OFF"
@@ -665,7 +666,8 @@ resource "aws_s3_bucket_versioning" "object_bucket" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket                        = aws_s3_bucket.object_bucket.bucket
+  # Must have bucket versioning enabled first
+  bucket                        = aws_s3_bucket_versioning.object_bucket.bucket
   key                           = "tf-testing-obj-%[1]d"
   content                       = "Hello World"
   force_destroy                 = true

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -1687,7 +1687,8 @@ resource "aws_s3_bucket_versioning" "object_bucket_3" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket = aws_s3_bucket.object_bucket_3.bucket
+  # Must have bucket versioning enabled first
+  bucket = aws_s3_bucket_versioning.object_bucket_3.bucket
   key    = "updateable-key"
   source = %[3]q
   etag   = filemd5(%[3]q)
@@ -1709,7 +1710,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket = aws_s3_bucket_versioning.test.bucket
   name   = %[1]q
 }
 
@@ -1768,7 +1770,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket  = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket  = aws_s3_bucket_versioning.test.bucket
   key     = "test-key"
   content = %[2]q
   acl     = %[3]q
@@ -1805,7 +1808,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket  = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket  = aws_s3_bucket_versioning.test.bucket
   key     = %[2]q
   content = %[3]q
 
@@ -1832,7 +1836,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket  = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket  = aws_s3_bucket_versioning.test.bucket
   key     = %[2]q
   content = %[3]q
 
@@ -1860,7 +1865,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket  = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket  = aws_s3_bucket_versioning.test.bucket
   key     = %[2]q
   content = %[3]q
 }
@@ -1903,7 +1909,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket        = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket        = aws_s3_bucket_versioning.test.bucket
   key           = "test-key"
   content       = %[2]q
   force_destroy = true
@@ -1929,7 +1936,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket                        = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket                        = aws_s3_bucket_versioning.test.bucket
   key                           = "test-key"
   content                       = %[2]q
   object_lock_legal_hold_status = %[3]q
@@ -1956,7 +1964,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket        = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket        = aws_s3_bucket_versioning.test.bucket
   key           = "test-key"
   content       = %[2]q
   force_destroy = true
@@ -1982,7 +1991,8 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  bucket                        = aws_s3_bucket.test.bucket
+  # Must have bucket versioning enabled first
+  bucket                        = aws_s3_bucket_versioning.test.bucket
   key                           = "test-key"
   content                       = %[2]q
   force_destroy                 = true


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22997 

Tests in GovCloud can error with the following so tests have been updated to ensure versioning on the source S3 bucket is configured before creating an S3 object:
```
=== CONT  TestAccS3Object_tagsMultipleSlashes
    object_test.go:938: Step 2/4 error: Check failed: Check 2/8 error: Expected second object to have VersionId: {
          AcceptRanges: "bytes",
          Body: buffer(0xc0022bc080),
          ContentLength: 5,
          ContentType: "binary/octet-stream",
          ETag: "\"c13d88cb4cb02003daedb8a84e5d272a\"",
          LastModified: 2022-02-10 07:22:47 +0000 UTC,
          TagCount: 3
        }
--- FAIL: TestAccS3Object_tagsMultipleSlashes (132.07s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
