### PR TITLE
Ability to register existing IoT certificate

### DIFF
--- a/.changelog/23126.txt
+++ b/.changelog/23126.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_certificate: Add `ca_pem` argument, enabling the use of existing IoT certificates
+```

--- a/internal/service/iot/certificate.go
+++ b/internal/service/iot/certificate.go
@@ -32,7 +32,13 @@ func ResourceCertificate() *schema.Resource {
 			},
 			"certificate_pem": {
 				Type:      schema.TypeString,
+				Optional:  true,
 				Computed:  true,
+				Sensitive: true,
+			},
+			"ca_pem": {
+				Type:      schema.TypeString,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"public_key": {
@@ -52,6 +58,14 @@ func ResourceCertificate() *schema.Resource {
 func resourceCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IoTConn
 
+	_, okcert := d.GetOk("certificate_pem")
+	_, okCA := d.GetOk("ca_pem")
+
+	cert_status := "INACTIVE"
+	if d.Get("active").(bool) {
+		cert_status = "ACTIVE"
+	}
+
 	if _, ok := d.GetOk("csr"); ok {
 		log.Printf("[DEBUG] Creating certificate from CSR")
 		out, err := conn.CreateCertificateFromCsr(&iot.CreateCertificateFromCsrInput{
@@ -62,6 +76,31 @@ func resourceCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error creating certificate from CSR: %v", err)
 		}
 		log.Printf("[DEBUG] Created certificate from CSR")
+
+		d.SetId(aws.StringValue(out.CertificateId))
+	} else if okcert && okCA {
+		log.Printf("[DEBUG] Registering certificate with CA")
+		out, err := conn.RegisterCertificate(&iot.RegisterCertificateInput{
+			CaCertificatePem: aws.String(d.Get("ca_pem").(string)),
+			CertificatePem:   aws.String(d.Get("certificate_pem").(string)),
+			Status:           aws.String(cert_status),
+		})
+		if err != nil {
+			return fmt.Errorf("error registering certificate with CA: %v", err)
+		}
+		log.Printf("[DEBUG] Certificate with CA registered")
+
+		d.SetId(aws.StringValue(out.CertificateId))
+	} else if okcert {
+		log.Printf("[DEBUG] Registering certificate without CA")
+		out, err := conn.RegisterCertificateWithoutCA(&iot.RegisterCertificateWithoutCAInput{
+			CertificatePem: aws.String(d.Get("certificate_pem").(string)),
+			Status:         aws.String(cert_status),
+		})
+		if err != nil {
+			return fmt.Errorf("error registering certificate without CA: %v", err)
+		}
+		log.Printf("[DEBUG] Certificate without CA registered")
 
 		d.SetId(aws.StringValue(out.CertificateId))
 	} else {

--- a/internal/service/iot/certificate_test.go
+++ b/internal/service/iot/certificate_test.go
@@ -57,6 +57,31 @@ func TestAccIoTCertificate_Keys_certificate(t *testing.T) {
 	})
 }
 
+func TestAccIoTCertificate_Keys_existing_certificate(t *testing.T) {
+	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "testcert")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, iot.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckCertificateDestroy_basic,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCertificate_existing_certificate, acctest.TLSPEMEscapeNewlines(certificate)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "arn"),
+					resource.TestCheckNoResourceAttr("aws_iot_certificate.foo_cert", "csr"),
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "certificate_pem"),
+					resource.TestCheckNoResourceAttr("aws_iot_certificate.foo_cert", "public_key"),
+					resource.TestCheckNoResourceAttr("aws_iot_certificate.foo_cert", "private_key"),
+					resource.TestCheckResourceAttr("aws_iot_certificate.foo_cert", "active", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCertificateDestroy_basic(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).IoTConn
 
@@ -101,5 +126,12 @@ resource "aws_iot_certificate" "foo_cert" {
 var testAccCertificate_keys_certificate = `
 resource "aws_iot_certificate" "foo_cert" {
   active = true
+}
+`
+
+var testAccCertificate_existing_certificate = `
+resource "aws_iot_certificate" "foo_cert" {
+  active = true
+  certificate_pem = "%[1]s"
 }
 `

--- a/internal/service/iot/certificate_test.go
+++ b/internal/service/iot/certificate_test.go
@@ -131,7 +131,7 @@ resource "aws_iot_certificate" "foo_cert" {
 
 var testAccCertificate_existing_certificate = `
 resource "aws_iot_certificate" "foo_cert" {
-  active = true
+  active          = true
   certificate_pem = "%[1]s"
 }
 `

--- a/website/docs/r/iot_certificate.html.markdown
+++ b/website/docs/r/iot_certificate.html.markdown
@@ -34,7 +34,7 @@ resource "aws_iot_certificate" "cert" {
 ```terraform
 resource "aws_iot_certificate" "cert" {
   certificate_pem = file("/my/cert.pem")
-  active = true
+  active          = true
 }
 ```
 

--- a/website/docs/r/iot_certificate.html.markdown
+++ b/website/docs/r/iot_certificate.html.markdown
@@ -29,6 +29,16 @@ resource "aws_iot_certificate" "cert" {
 }
 ```
 
+### From existing certificate without a CA
+
+```terraform
+resource "aws_iot_certificate" "cert" {
+  certificate_pem = file("/my/cert.pem")
+  active = true
+}
+```
+
+
 ## Argument Reference
 
 * `active` - (Required)  Boolean flag to indicate if the certificate should be active
@@ -37,6 +47,13 @@ resource "aws_iot_certificate" "cert" {
   for more information on generating a certificate from a certificate signing request (CSR).
   If none is specified both the certificate and keys will be generated, review [CreateKeysAndCertificate](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateKeysAndCertificate.html)
   for more information on generating keys and a certificate.
+* `certificate_pem` - (Optional) The certificate to be registered. If `ca_pem` is unspecified, review
+  [RegisterCertificateWithoutCA](https://docs.aws.amazon.com/iot/latest/apireference/API_RegisterCertificateWithoutCA.html).
+  If `ca_pem` is specified, review
+  [RegisterCertificate](https://docs.aws.amazon.com/iot/latest/apireference/API_RegisterCertificate.html)
+  for more information on registering a certificate.
+* `ca_pem` - (Optional) The CA certificate for the certificate to be registered. If this is set, the CA needs to be registered with AWS IoT beforehand.
+
 
 ## Attributes Reference
 
@@ -45,6 +62,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The internal ID assigned to this certificate.
 * `arn` - The ARN of the created certificate.
 * `certificate_pem` - The certificate data, in PEM format.
-* `public_key` - When no CSR is provided, the public key.
-* `private_key` - When no CSR is provided, the private key.
+* `public_key` - When neither CSR nor certificate is provided, the public key.
+* `private_key` - When neither CSR nor certificate is provided, the private key.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->
This PR adds the ability to register an existing certificate (with or without a CA) in AWS IoT.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccIoTCertificate_Keys_existing_certificate PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTCertificate_Keys_existing_certificate'  -timeout 180m
=== RUN   TestAccIoTCertificate_Keys_existing_certificate
=== PAUSE TestAccIoTCertificate_Keys_existing_certificate
=== CONT  TestAccIoTCertificate_Keys_existing_certificate
--- PASS: TestAccIoTCertificate_Keys_existing_certificate (16.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	16.653s


...
```
