### PR TITLE
d/aws_imagebuilder_container_recipes - new data source

### DIFF
--- a/.changelog/23134.txt
+++ b/.changelog/23134.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_imagebuilder_container_recipes
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -629,6 +629,7 @@ func Provider() *schema.Provider {
 			"aws_imagebuilder_component":                     imagebuilder.DataSourceComponent(),
 			"aws_imagebuilder_components":                    imagebuilder.DataSourceComponents(),
 			"aws_imagebuilder_container_recipe":              imagebuilder.DataSourceContainerRecipe(),
+			"aws_imagebuilder_container_recipes":             imagebuilder.DataSourceContainerRecipes(),
 			"aws_imagebuilder_distribution_configuration":    imagebuilder.DataSourceDistributionConfiguration(),
 			"aws_imagebuilder_distribution_configurations":   imagebuilder.DataSourceDistributionConfigurations(),
 			"aws_imagebuilder_image":                         imagebuilder.DataSourceImage(),

--- a/internal/service/imagebuilder/container_recipes_data_source.go
+++ b/internal/service/imagebuilder/container_recipes_data_source.go
@@ -1,0 +1,84 @@
+package imagebuilder
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceContainerRecipes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceContainerRecipesRead,
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": dataSourceFiltersSchema(),
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Self", "Shared", "Amazon"}, false),
+			},
+		},
+	}
+}
+
+func dataSourceContainerRecipesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).ImageBuilderConn
+
+	input := &imagebuilder.ListContainerRecipesInput{}
+
+	if v, ok := d.GetOk("owner"); ok {
+		input.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = buildFiltersDataSource(v.(*schema.Set))
+	}
+
+	var results []*imagebuilder.ContainerRecipeSummary
+
+	err := conn.ListContainerRecipesPages(input, func(page *imagebuilder.ListContainerRecipesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, containerRecipeSummary := range page.ContainerRecipeSummaryList {
+			if containerRecipeSummary == nil {
+				continue
+			}
+
+			results = append(results, containerRecipeSummary)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Image Builder Container Recipes: %w", err)
+	}
+
+	var arns, names []string
+
+	for _, r := range results {
+		arns = append(arns, aws.StringValue(r.Arn))
+		names = append(names, aws.StringValue(r.Name))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/imagebuilder/container_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/container_recipes_data_source_test.go
@@ -1,0 +1,74 @@
+package imagebuilder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/imagebuilder"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccImageBuilderContainerRecipesDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_imagebuilder_container_recipes.test"
+	resourceName := "aws_imagebuilder_container_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerRecipesFilterDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "names.0", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccContainerRecipesFilterDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_ecr_repository" "test" {
+  name = %[1]q
+}
+
+resource "aws_imagebuilder_container_recipe" "test" {
+  name           = %[1]q
+  container_type = "DOCKER"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  version        = "1.0.0"
+
+  component {
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+  }
+
+  dockerfile_template_data = <<EOF
+FROM {{{ imagebuilder:parentImage }}}
+{{{ imagebuilder:environments }}}
+{{{ imagebuilder:components }}}
+EOF
+
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
+}
+
+data "aws_imagebuilder_container_recipes" "test" {
+  filter {
+    name   = "name"
+    values = [aws_imagebuilder_container_recipe.test.name]
+  }
+}
+`, rName)
+}

--- a/internal/service/imagebuilder/container_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/container_recipes_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccImageBuilderContainerRecipesDataSource_filter(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ErrorCheck:        acctest.ErrorCheck(t, imagebuilder.EndpointsID),
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckImageRecipeDestroy,
+		CheckDestroy:      testAccCheckContainerRecipeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerRecipesFilterDataSourceConfig(rName),

--- a/website/docs/d/imagebuilder_container_recipes.html.markdown
+++ b/website/docs/d/imagebuilder_container_recipes.html.markdown
@@ -32,7 +32,7 @@ data "aws_imagebuilder_container_recipes" "example" {
 
 The following arguments are supported by the `filter` configuration block:
 
-* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListImageRecipes API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListContainerRecipes.html).
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListContainerRecipes API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListContainerRecipes.html).
 * `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
 
 ## Attributes Reference

--- a/website/docs/d/imagebuilder_container_recipes.html.markdown
+++ b/website/docs/d/imagebuilder_container_recipes.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Image Builder"
+layout: "aws"
+page_title: "AWS: aws_imagebuilder_container_recipes"
+description: |-
+    Get information on Image Builder Container Recipes.
+---
+
+# Data Source: aws_imagebuilder_container_recipes
+
+Use this data source to get the ARNs and names of Image Builder Container Recipes matching the specified criteria.
+
+## Example Usage
+
+```terraform
+data "aws_imagebuilder_container_recipes" "example" {
+  owner = "Self"
+
+  filter {
+    name   = "platform"
+    values = ["Linux"]
+  }
+}
+```
+
+## Argument Reference
+
+* `owner` - (Optional) The owner of the container recipes. Valid values are `Self`, `Shared` and `Amazon`. Defaults to `Self`.
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [Image Builder ListImageRecipes API Reference](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_ListContainerRecipes.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `arns` - Set of ARNs of the matched Image Builder Container Recipes.
+* `names` - Set of names of the matched Image Builder Container Recipes.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #16839.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG_NAME=internal/service/imagebuilder TESTARGS="-run=TestAccImageBuilderContainerRecipesDataSource_filter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderContainerRecipesDataSource_filter -timeout 180m
=== RUN   TestAccImageBuilderContainerRecipesDataSource_filter
=== PAUSE TestAccImageBuilderContainerRecipesDataSource_filter
=== CONT  TestAccImageBuilderContainerRecipesDataSource_filter
--- PASS: TestAccImageBuilderContainerRecipesDataSource_filter (43.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       45.146s
```
