### PR TITLE
Backport of #23127 to `release/3.x`

### DIFF
--- a/.changelog/23127.txt
+++ b/.changelog/23127.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpn_connection: Add support for `ipsec.1-aes256` connection type
+```

--- a/internal/service/ec2/enum.go
+++ b/internal/service/ec2/enum.go
@@ -59,12 +59,14 @@ const (
 )
 
 const (
-	VpnConnectionTypeIpsec1 = "ipsec.1"
+	VpnConnectionTypeIpsec1        = "ipsec.1"
+	VpnConnectionTypeIpsec1_AES256 = "ipsec.1-aes256" // https://github.com/hashicorp/terraform-provider-aws/issues/23105.
 )
 
 func VpnConnectionType_Values() []string {
 	return []string{
 		VpnConnectionTypeIpsec1,
+		VpnConnectionTypeIpsec1_AES256,
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23127.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/23105.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc TESTS=TestAccEC2VPNConnection_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2VPNConnection_basic'  -timeout 180m
=== RUN   TestAccEC2VPNConnection_basic
=== PAUSE TestAccEC2VPNConnection_basic
=== CONT  TestAccEC2VPNConnection_basic
--- PASS: TestAccEC2VPNConnection_basic (576.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	579.938s
```
