### PR TITLE
Backport of #23039 to `release/3.x`

### DIFF
--- a/.changelog/23039.txt
+++ b/.changelog/23039.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix crash when configured `engine_version` string is shorter than the `EngineVersion` string returned from the AWS API
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1543,7 +1543,7 @@ func rdsClusterSetResourceDataEngineVersionFromCluster(d *schema.ResourceData, c
 func compareActualEngineVersion(d *schema.ResourceData, oldVersion string, newVersion string) {
 	newVersionSubstr := newVersion
 
-	if newVersion > oldVersion {
+	if len(newVersion) > len(oldVersion) {
 		newVersionSubstr = string([]byte(newVersion)[0 : len(oldVersion)+1])
 	}
 

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1541,8 +1541,15 @@ func rdsClusterSetResourceDataEngineVersionFromCluster(d *schema.ResourceData, c
 }
 
 func compareActualEngineVersion(d *schema.ResourceData, oldVersion string, newVersion string) {
-	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != string([]byte(newVersion)[0:len(oldVersion)+1]) {
+	newVersionSubstr := newVersion
+
+	if newVersion > oldVersion {
+		newVersionSubstr = string([]byte(newVersion)[0 : len(oldVersion)+1])
+	}
+
+	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != newVersionSubstr {
 		d.Set("engine_version", newVersion)
 	}
+
 	d.Set("engine_version_actual", newVersion)
 }

--- a/internal/service/rds/engine_version_test.go
+++ b/internal/service/rds/engine_version_test.go
@@ -8,51 +8,51 @@ func TestCompareActualEngineVersion(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		oldVersion                  string
-		newVersion                  string
+		configuredVersion           string
+		actualVersion               string
 		expectedEngineVersion       string
 		expectedEngineVersionActual string
 	}
 	tests := map[string]testCase{
 		"point version upgrade": {
-			oldVersion:                  "8.0",
-			newVersion:                  "8.0.27",
+			configuredVersion:           "8.0",
+			actualVersion:               "8.0.27",
 			expectedEngineVersion:       "",
 			expectedEngineVersionActual: "8.0.27",
 		},
 		"minor version upgrade": {
-			oldVersion:                  "8.0",
-			newVersion:                  "8.1.1",
+			configuredVersion:           "8.0",
+			actualVersion:               "8.1.1",
 			expectedEngineVersion:       "8.1.1",
 			expectedEngineVersionActual: "8.1.1",
 		},
 		"major version upgrade": {
-			oldVersion:                  "8.1",
-			newVersion:                  "9.0.0",
+			configuredVersion:           "8.1",
+			actualVersion:               "9.0.0",
 			expectedEngineVersion:       "9.0.0",
 			expectedEngineVersionActual: "9.0.0",
 		},
 		"aurora upgrade": {
-			oldVersion:                  "5.7.mysql_aurora.2.07",
-			newVersion:                  "5.7.serverless_mysql_aurora.2.08.3",
+			configuredVersion:           "5.7.mysql_aurora.2.07",
+			actualVersion:               "5.7.serverless_mysql_aurora.2.08.3",
 			expectedEngineVersion:       "5.7.serverless_mysql_aurora.2.08.3",
 			expectedEngineVersionActual: "5.7.serverless_mysql_aurora.2.08.3",
 		},
 		"aurora upgrade - used to crash": {
-			oldVersion:                  "5.7.serverless_mysql_aurora.2.07",
-			newVersion:                  "5.7.mysql_aurora.2.08.3",
+			configuredVersion:           "5.7.serverless_mysql_aurora.2.07",
+			actualVersion:               "5.7.mysql_aurora.2.08.3",
 			expectedEngineVersion:       "5.7.mysql_aurora.2.08.3",
 			expectedEngineVersionActual: "5.7.mysql_aurora.2.08.3",
 		},
 		"oracle": {
-			oldVersion:                  "12.1.0.2.v20",
-			newVersion:                  "19.0.0.0.ru-2021-04.rur-2021-04.r1",
+			configuredVersion:           "12.1.0.2.v20",
+			actualVersion:               "19.0.0.0.ru-2021-04.rur-2021-04.r1",
 			expectedEngineVersion:       "19.0.0.0.ru-2021-04.rur-2021-04.r1",
 			expectedEngineVersionActual: "19.0.0.0.ru-2021-04.rur-2021-04.r1",
 		},
 		"oracle - used to crash": {
-			oldVersion:                  "19.0.0.0.ru-2021-04.rur-2021-04.r1",
-			newVersion:                  "12.1.0.2.v20",
+			configuredVersion:           "19.0.0.0.ru-2021-04.rur-2021-04.r1",
+			actualVersion:               "12.1.0.2.v20",
 			expectedEngineVersion:       "12.1.0.2.v20",
 			expectedEngineVersionActual: "12.1.0.2.v20",
 		},
@@ -63,7 +63,7 @@ func TestCompareActualEngineVersion(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			r := ResourceCluster()
 			d := r.Data(nil)
-			compareActualEngineVersion(d, test.oldVersion, test.newVersion)
+			compareActualEngineVersion(d, test.configuredVersion, test.actualVersion)
 
 			if want, got := test.expectedEngineVersion, d.Get("engine_version"); got != want {
 				t.Errorf("unexpected engine_version; want: %q, got: %q", want, got)

--- a/internal/service/rds/engine_version_test.go
+++ b/internal/service/rds/engine_version_test.go
@@ -1,0 +1,76 @@
+package rds
+
+import (
+	"testing"
+)
+
+func TestCompareActualEngineVersion(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		oldVersion                  string
+		newVersion                  string
+		expectedEngineVersion       string
+		expectedEngineVersionActual string
+	}
+	tests := map[string]testCase{
+		"point version upgrade": {
+			oldVersion:                  "8.0",
+			newVersion:                  "8.0.27",
+			expectedEngineVersion:       "",
+			expectedEngineVersionActual: "8.0.27",
+		},
+		"minor version upgrade": {
+			oldVersion:                  "8.0",
+			newVersion:                  "8.1.1",
+			expectedEngineVersion:       "8.1.1",
+			expectedEngineVersionActual: "8.1.1",
+		},
+		"major version upgrade": {
+			oldVersion:                  "8.1",
+			newVersion:                  "9.0.0",
+			expectedEngineVersion:       "9.0.0",
+			expectedEngineVersionActual: "9.0.0",
+		},
+		"aurora upgrade": {
+			oldVersion:                  "5.7.mysql_aurora.2.07",
+			newVersion:                  "5.7.serverless_mysql_aurora.2.08.3",
+			expectedEngineVersion:       "5.7.serverless_mysql_aurora.2.08.3",
+			expectedEngineVersionActual: "5.7.serverless_mysql_aurora.2.08.3",
+		},
+		"aurora upgrade - used to crash": {
+			oldVersion:                  "5.7.serverless_mysql_aurora.2.07",
+			newVersion:                  "5.7.mysql_aurora.2.08.3",
+			expectedEngineVersion:       "5.7.mysql_aurora.2.08.3",
+			expectedEngineVersionActual: "5.7.mysql_aurora.2.08.3",
+		},
+		"oracle": {
+			oldVersion:                  "12.1.0.2.v20",
+			newVersion:                  "19.0.0.0.ru-2021-04.rur-2021-04.r1",
+			expectedEngineVersion:       "19.0.0.0.ru-2021-04.rur-2021-04.r1",
+			expectedEngineVersionActual: "19.0.0.0.ru-2021-04.rur-2021-04.r1",
+		},
+		"oracle - used to crash": {
+			oldVersion:                  "19.0.0.0.ru-2021-04.rur-2021-04.r1",
+			newVersion:                  "12.1.0.2.v20",
+			expectedEngineVersion:       "12.1.0.2.v20",
+			expectedEngineVersionActual: "12.1.0.2.v20",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			r := ResourceCluster()
+			d := r.Data(nil)
+			compareActualEngineVersion(d, test.oldVersion, test.newVersion)
+
+			if want, got := test.expectedEngineVersion, d.Get("engine_version"); got != want {
+				t.Errorf("unexpected engine_version; want: %q, got: %q", want, got)
+			}
+			if want, got := test.expectedEngineVersionActual, d.Get("engine_version_actual"); got != want {
+				t.Errorf("unexpected engine_version_actual; want: %q, got: %q", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23039.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22542.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/20860.

```console
% go test -v ./internal/service/rds '-run=TestCompareActualEngineVersion'
=== RUN   TestCompareActualEngineVersion
=== PAUSE TestCompareActualEngineVersion
=== CONT  TestCompareActualEngineVersion
=== RUN   TestCompareActualEngineVersion/point_version_upgrade
=== RUN   TestCompareActualEngineVersion/minor_version_upgrade
=== RUN   TestCompareActualEngineVersion/major_version_upgrade
=== RUN   TestCompareActualEngineVersion/aurora_upgrade
=== RUN   TestCompareActualEngineVersion/aurora_upgrade_-_used_to_crash
=== RUN   TestCompareActualEngineVersion/oracle
=== RUN   TestCompareActualEngineVersion/oracle_-_used_to_crash
--- PASS: TestCompareActualEngineVersion (0.00s)
    --- PASS: TestCompareActualEngineVersion/point_version_upgrade (0.00s)
    --- PASS: TestCompareActualEngineVersion/minor_version_upgrade (0.00s)
    --- PASS: TestCompareActualEngineVersion/major_version_upgrade (0.00s)
    --- PASS: TestCompareActualEngineVersion/aurora_upgrade (0.00s)
    --- PASS: TestCompareActualEngineVersion/aurora_upgrade_-_used_to_crash (0.00s)
    --- PASS: TestCompareActualEngineVersion/oracle (0.00s)
    --- PASS: TestCompareActualEngineVersion/oracle_-_used_to_crash (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	7.852s
```
