### PR TITLE
s3_bucket_lifecycle_configuration: Fix import, diffs

### DIFF
--- a/.changelog/23144.txt
+++ b/.changelog/23144.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Fix extraneous diffs especially after import
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -114,14 +115,12 @@ func ResourceBucketLifecycleConfiguration() *schema.Resource {
 										},
 									},
 									"object_size_greater_than": {
-										Type:     schema.TypeInt,
+										Type:     nullable.TypeNullableInt,
 										Optional: true,
-										Default:  0, // API returns 0
 									},
 									"object_size_less_than": {
-										Type:     schema.TypeInt,
+										Type:     nullable.TypeNullableInt,
 										Optional: true,
-										Default:  0, // API returns 0
 									},
 									"prefix": {
 										Type:     schema.TypeString,

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -304,7 +304,7 @@ func resourceBucketLifecycleConfigurationRead(ctx context.Context, d *schema.Res
 	err = resource.RetryContext(ctx, lifecycleConfigurationRulesSteadyTimeout, func() *resource.RetryError {
 		var err error
 
-		time.Sleep(lifecycleConfigurationRetryDelay)
+		time.Sleep(lifecycleConfigurationExtraRetryDelay)
 
 		output, err = conn.GetBucketLifecycleConfigurationWithContext(ctx, input)
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -276,7 +276,7 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
 
-	if _, err = waitForLifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules); err != nil {
+	if err = waitForLifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules); err != nil {
 		return diag.Errorf("error waiting for S3 Lifecycle Configuration for bucket (%s) to reach expected rules status after update: %s", d.Id(), err)
 	}
 
@@ -379,7 +379,7 @@ func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.R
 		return diag.Errorf("error updating S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
 	}
 
-	if _, err := waitForLifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules); err != nil {
+	if err := waitForLifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules); err != nil {
 		return diag.Errorf("error waiting for S3 Lifecycle Configuration for bucket (%s) to reach expected rules status after update: %s", d.Id(), err)
 	}
 

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -73,7 +73,7 @@ func TestAccS3BucketLifecycleConfiguration_disappears(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_FilterWithPrefix(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_filterWithPrefix(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 	currTime := time.Now()
@@ -87,7 +87,7 @@ func TestAccS3BucketLifecycleConfiguration_FilterWithPrefix(t *testing.T) {
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, date, "logs/"),
+				Config: testAccBucketLifecycleConfiguration_Basic_updateConfig(rName, date, "logs/"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -106,7 +106,7 @@ func TestAccS3BucketLifecycleConfiguration_FilterWithPrefix(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, dateUpdated, "tmp/"),
+				Config: testAccBucketLifecycleConfiguration_Basic_updateConfig(rName, dateUpdated, "tmp/"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -128,7 +128,7 @@ func TestAccS3BucketLifecycleConfiguration_FilterWithPrefix(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_DisableRule(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_disableRule(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -139,13 +139,13 @@ func TestAccS3BucketLifecycleConfiguration_DisableRule(t *testing.T) {
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, tfs3.LifecycleRuleStatusEnabled),
+				Config: testAccBucketLifecycleConfiguration_Basic_statusConfig(rName, tfs3.LifecycleRuleStatusEnabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, tfs3.LifecycleRuleStatusDisabled),
+				Config: testAccBucketLifecycleConfiguration_Basic_statusConfig(rName, tfs3.LifecycleRuleStatusDisabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -159,7 +159,7 @@ func TestAccS3BucketLifecycleConfiguration_DisableRule(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, tfs3.LifecycleRuleStatusEnabled),
+				Config: testAccBucketLifecycleConfiguration_Basic_statusConfig(rName, tfs3.LifecycleRuleStatusEnabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -171,7 +171,7 @@ func TestAccS3BucketLifecycleConfiguration_DisableRule(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_MultipleRules(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_multipleRules(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 	date := time.Now()
@@ -184,7 +184,7 @@ func TestAccS3BucketLifecycleConfiguration_MultipleRules(t *testing.T) {
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_MultipleRulesConfig(rName, expirationDate),
+				Config: testAccBucketLifecycleConfiguration_multipleRulesConfig(rName, expirationDate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
@@ -226,7 +226,7 @@ func TestAccS3BucketLifecycleConfiguration_MultipleRules(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionExpiration(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -237,7 +237,7 @@ func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionExpiration(t *testin
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_NonCurrentVersionExpirationConfig(rName),
+				Config: testAccBucketLifecycleConfiguration_nonCurrentVersionExpirationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -255,7 +255,7 @@ func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionExpiration(t *testin
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionTransition(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -266,7 +266,7 @@ func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionTransition(t *testin
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_NonCurrentVersionTransitionConfig(rName),
+				Config: testAccBucketLifecycleConfiguration_nonCurrentVersionTransitionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -292,7 +292,7 @@ func TestAccS3BucketLifecycleConfiguration_NonCurrentVersionTransition(t *testin
 }
 
 // Ensure backwards compatible with now-deprecated "prefix" configuration
-func TestAccS3BucketLifecycleConfiguration_Prefix(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_prefix(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -303,7 +303,7 @@ func TestAccS3BucketLifecycleConfiguration_Prefix(t *testing.T) {
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_Basic_PrefixConfig(rName, "path1/"),
+				Config: testAccBucketLifecycleConfiguration_Basic_prefixConfig(rName, "path1/"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "bucket", "aws_s3_bucket.test", "bucket"),
@@ -326,7 +326,7 @@ func TestAccS3BucketLifecycleConfiguration_Prefix(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -337,7 +337,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly(t *te
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfig(rName, true),
+				Config: testAccBucketLifecycleConfiguration_RuleExpiration_expiredDeleteMarkerConfig(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -352,7 +352,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly(t *te
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfig(rName, false),
+				Config: testAccBucketLifecycleConfiguration_RuleExpiration_expiredDeleteMarkerConfig(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -371,7 +371,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleExpiration_ExpireMarkerOnly(t *te
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/11420
-func TestAccS3BucketLifecycleConfiguration_RuleExpiration_EmptyBlock(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -382,7 +382,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleExpiration_EmptyBlock(t *testing.
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_RuleExpiration_EmptyConfigurationBlockConfig(rName),
+				Config: testAccBucketLifecycleConfiguration_RuleExpiration_emptyConfigurationBlockConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -400,7 +400,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleExpiration_EmptyBlock(t *testing.
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15138
-func TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -411,7 +411,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload(t 
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfig(rName, 7),
+				Config: testAccBucketLifecycleConfiguration_ruleAbortIncompleteMultipartUploadConfig(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -426,7 +426,7 @@ func TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload(t 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfig(rName, 5),
+				Config: testAccBucketLifecycleConfiguration_ruleAbortIncompleteMultipartUploadConfig(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
@@ -444,10 +444,10 @@ func TestAccS3BucketLifecycleConfiguration_RuleAbortIncompleteMultipartUpload(t 
 	})
 }
 
-// TestAccS3BucketLifecycleConfiguration_TransitionDate_StandardIa validates the change to address
+// TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa validates the change to address
 // https://github.com/hashicorp/terraform-provider-aws/issues/23117
 // does not introduce a regression.
-func TestAccS3BucketLifecycleConfiguration_TransitionDate_StandardIa(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -461,7 +461,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionDate_StandardIa(t *testing.
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_DateTransitionConfig(rName, date, s3.TransitionStorageClassStandardIa),
+				Config: testAccBucketLifecycleConfiguration_dateTransitionConfig(rName, date, s3.TransitionStorageClassStandardIa),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
@@ -475,10 +475,10 @@ func TestAccS3BucketLifecycleConfiguration_TransitionDate_StandardIa(t *testing.
 	})
 }
 
-// TestAccS3BucketLifecycleConfiguration_TransitionDate_IntelligentTiering validates the change to address
+// TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering validates the change to address
 // https://github.com/hashicorp/terraform-provider-aws/issues/23117
 // does not introduce a regression.
-func TestAccS3BucketLifecycleConfiguration_TransitionDate_IntelligentTiering(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -492,7 +492,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionDate_IntelligentTiering(t *
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_DateTransitionConfig(rName, date, s3.StorageClassIntelligentTiering),
+				Config: testAccBucketLifecycleConfiguration_dateTransitionConfig(rName, date, s3.StorageClassIntelligentTiering),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
@@ -507,7 +507,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionDate_IntelligentTiering(t *
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23117
-func TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_IntelligentTiering(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -518,7 +518,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_Intelligen
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_TransitionStorageClassOnlyConfig(rName, s3.StorageClassIntelligentTiering),
+				Config: testAccBucketLifecycleConfiguration_transitionStorageClassOnlyConfig(rName, s3.StorageClassIntelligentTiering),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.0.transition.*", map[string]string{
@@ -538,7 +538,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_Intelligen
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23117
-func TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_IntelligentTiering(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -549,7 +549,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_IntelligentTiering
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_ZeroDaysTransitionConfig(rName, s3.StorageClassIntelligentTiering),
+				Config: testAccBucketLifecycleConfiguration_zeroDaysTransitionConfig(rName, s3.StorageClassIntelligentTiering),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
@@ -563,7 +563,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_IntelligentTiering
 	})
 }
 
-func TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_IntelligentTiering(t *testing.T) {
+func TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
 
@@ -577,13 +577,13 @@ func TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_In
 		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketLifecycleConfiguration_ZeroDaysTransitionConfig(rName, s3.StorageClassIntelligentTiering),
+				Config: testAccBucketLifecycleConfiguration_zeroDaysTransitionConfig(rName, s3.StorageClassIntelligentTiering),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_DateTransitionConfig(rName, date, s3.StorageClassIntelligentTiering),
+				Config: testAccBucketLifecycleConfiguration_dateTransitionConfig(rName, date, s3.StorageClassIntelligentTiering),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
@@ -594,7 +594,7 @@ func TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_In
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBucketLifecycleConfiguration_ZeroDaysTransitionConfig(rName, s3.StorageClassIntelligentTiering),
+				Config: testAccBucketLifecycleConfiguration_zeroDaysTransitionConfig(rName, s3.StorageClassIntelligentTiering),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketLifecycleConfigurationExists(resourceName),
 				),
@@ -711,7 +711,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketLifecycleConfiguration_Basic_StatusConfig(rName, status string) string {
+func testAccBucketLifecycleConfiguration_Basic_statusConfig(rName, status string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -736,7 +736,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, status)
 }
 
-func testAccBucketLifecycleConfiguration_Basic_UpdateConfig(rName, date, prefix string) string {
+func testAccBucketLifecycleConfiguration_Basic_updateConfig(rName, date, prefix string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -766,7 +766,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, date, prefix)
 }
 
-func testAccBucketLifecycleConfiguration_Basic_PrefixConfig(rName, prefix string) string {
+func testAccBucketLifecycleConfiguration_Basic_prefixConfig(rName, prefix string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -794,7 +794,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, prefix)
 }
 
-func testAccBucketLifecycleConfiguration_RuleExpiration_ExpiredDeleteMarkerConfig(rName string, expired bool) string {
+func testAccBucketLifecycleConfiguration_RuleExpiration_expiredDeleteMarkerConfig(rName string, expired bool) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -820,7 +820,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, expired)
 }
 
-func testAccBucketLifecycleConfiguration_RuleExpiration_EmptyConfigurationBlockConfig(rName string) string {
+func testAccBucketLifecycleConfiguration_RuleExpiration_emptyConfigurationBlockConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -844,7 +844,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketLifecycleConfiguration_RuleAbortIncompleteMultipartUploadConfig(rName string, days int) string {
+func testAccBucketLifecycleConfiguration_ruleAbortIncompleteMultipartUploadConfig(rName string, days int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -870,7 +870,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, days)
 }
 
-func testAccBucketLifecycleConfiguration_MultipleRulesConfig(rName, date string) string {
+func testAccBucketLifecycleConfiguration_multipleRulesConfig(rName, date string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -932,7 +932,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, date)
 }
 
-func testAccBucketLifecycleConfiguration_NonCurrentVersionExpirationConfig(rName string) string {
+func testAccBucketLifecycleConfiguration_nonCurrentVersionExpirationConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -964,7 +964,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketLifecycleConfiguration_NonCurrentVersionTransitionConfig(rName string) string {
+func testAccBucketLifecycleConfiguration_nonCurrentVersionTransitionConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -1002,7 +1002,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName)
 }
 
-func testAccBucketLifecycleConfiguration_TransitionStorageClassOnlyConfig(rName, storageClass string) string {
+func testAccBucketLifecycleConfiguration_transitionStorageClassOnlyConfig(rName, storageClass string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -1038,7 +1038,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, storageClass)
 }
 
-func testAccBucketLifecycleConfiguration_ZeroDaysTransitionConfig(rName, storageClass string) string {
+func testAccBucketLifecycleConfiguration_zeroDaysTransitionConfig(rName, storageClass string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -1075,7 +1075,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 `, rName, storageClass)
 }
 
-func testAccBucketLifecycleConfiguration_DateTransitionConfig(rName, transitionDate, storageClass string) string {
+func testAccBucketLifecycleConfiguration_dateTransitionConfig(rName, transitionDate, storageClass string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -36,7 +36,7 @@ func TestAccS3BucketLifecycleConfiguration_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
 						"expiration.#":      "1",
 						"expiration.0.days": "365",
-						"filter.#":          "1",
+						"filter.#":          "0",
 						"id":                rName,
 						"status":            tfs3.LifecycleRuleStatusEnabled,
 					}),
@@ -706,9 +706,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
     expiration {
       days = 365
     }
-
-    # One of prefix or filter required to ensure XML is well-formed
-    filter {}
   }
 }
 `, rName)
@@ -734,9 +731,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
     expiration {
       days = 365
     }
-
-    # One of prefix or filter required to ensure XML is well-formed
-    filter {}
   }
 }
 `, rName, status)
@@ -821,9 +815,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
     expiration {
       expired_object_delete_marker = %[2]t
     }
-
-    # One of prefix or filter required to ensure XML is well-formed
-    filter {}
   }
 }
 `, rName, expired)
@@ -848,9 +839,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
     status = "Enabled"
 
     expiration {}
-
-    # One of prefix or filter required to ensure XML is well-formed
-    filter {}
   }
 }
 `, rName)
@@ -877,9 +865,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
 
     id     = %[1]q
     status = "Enabled"
-
-    # One of prefix or filter required to ensure XML is well-formed
-    filter {}
   }
 }
 `, rName, days)

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -883,7 +883,15 @@ func FlattenLifecycleRuleExpiration(expiration *s3.LifecycleExpiration) []interf
 
 func FlattenLifecycleRuleFilter(filter *s3.LifecycleRuleFilter) []interface{} {
 	if filter == nil {
-		return []interface{}{}
+		return nil
+	}
+
+	if filter.And == nil &&
+		filter.ObjectSizeGreaterThan == nil &&
+		filter.ObjectSizeLessThan == nil &&
+		(filter.Prefix == nil || aws.StringValue(filter.Prefix) == "") &&
+		filter.Tag == nil {
+		return nil
 	}
 
 	m := make(map[string]interface{})
@@ -900,7 +908,7 @@ func FlattenLifecycleRuleFilter(filter *s3.LifecycleRuleFilter) []interface{} {
 		m["object_size_less_than"] = int(aws.Int64Value(filter.ObjectSizeLessThan))
 	}
 
-	if filter.Prefix != nil {
+	if filter.Prefix != nil && aws.StringValue(filter.Prefix) != "" {
 		m["prefix"] = aws.StringValue(filter.Prefix)
 	}
 
@@ -939,7 +947,7 @@ func FlattenLifecycleRuleFilterAndOperator(andOp *s3.LifecycleRuleAndOperator) [
 
 func FlattenLifecycleRuleFilterTag(tag *s3.Tag) []interface{} {
 	if tag == nil {
-		return []interface{}{}
+		return nil
 	}
 
 	t := KeyValueTags([]*s3.Tag{tag}).IgnoreAWS().Map()

--- a/internal/service/s3/status.go
+++ b/internal/service/s3/status.go
@@ -21,7 +21,7 @@ func lifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket,
 
 		output, err := conn.GetBucketLifecycleConfigurationWithContext(ctx, input)
 
-		if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration) {
+		if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration, s3.ErrCodeNoSuchBucket) {
 			return nil, "", nil
 		}
 

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -15,7 +15,7 @@ const (
 	lifecycleConfigurationRulesPropagationTimeout = 2 * time.Minute
 	lifecycleConfigurationRulesSteadyTimeout      = 2 * time.Minute
 	bucketVersioningStableTimeout                 = 1 * time.Minute
-	lifecycleConfigurationRetryDelay              = 15 * time.Second
+	lifecycleConfigurationRetryDelay              = 2 * time.Second
 
 	// LifecycleConfigurationRulesStatusReady occurs when all configured rules reach their desired state (Enabled or Disabled)
 	LifecycleConfigurationRulesStatusReady = "READY"
@@ -33,7 +33,7 @@ func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, 
 		Target:                    []string{LifecycleConfigurationRulesStatusReady},
 		Refresh:                   lifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules),
 		Timeout:                   lifecycleConfigurationRulesPropagationTimeout,
-		MinTimeout:                5 * time.Second,
+		MinTimeout:                15 * time.Second,
 		ContinuousTargetOccurence: 3,
 		NotFoundChecks:            20,
 	}

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -11,11 +11,11 @@ import (
 
 const (
 	bucketCreatedTimeout                          = 2 * time.Minute
-	propagationTimeout                            = 1 * time.Minute
-	lifecycleConfigurationRulesPropagationTimeout = 2 * time.Minute
-	lifecycleConfigurationRulesSteadyTimeout      = 2 * time.Minute
 	bucketVersioningStableTimeout                 = 1 * time.Minute
-	lifecycleConfigurationRetryDelay              = 2 * time.Second
+	lifecycleConfigurationExtraRetryDelay         = 5 * time.Second
+	lifecycleConfigurationRulesPropagationTimeout = 3 * time.Minute
+	lifecycleConfigurationRulesSteadyTimeout      = 2 * time.Minute
+	propagationTimeout                            = 1 * time.Minute
 
 	// LifecycleConfigurationRulesStatusReady occurs when all configured rules reach their desired state (Enabled or Disabled)
 	LifecycleConfigurationRulesStatusReady = "READY"
@@ -33,7 +33,7 @@ func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, 
 		Target:                    []string{LifecycleConfigurationRulesStatusReady},
 		Refresh:                   lifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules),
 		Timeout:                   lifecycleConfigurationRulesPropagationTimeout,
-		MinTimeout:                15 * time.Second,
+		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 3,
 		NotFoundChecks:            20,
 	}

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -36,7 +36,6 @@ func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, 
 		MinTimeout:                5 * time.Second,
 		ContinuousTargetOccurence: 3,
 		NotFoundChecks:            20,
-		//Delay:                     1 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -27,7 +27,7 @@ func retryWhenBucketNotFound(f func() (interface{}, error)) (interface{}, error)
 	return tfresource.RetryWhenAWSErrCodeEquals(propagationTimeout, f, s3.ErrCodeNoSuchBucket)
 }
 
-func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string, rules []*s3.LifecycleRule) (*s3.GetBucketLifecycleConfigurationOutput, error) {
+func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string, rules []*s3.LifecycleRule) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{"", LifecycleConfigurationRulesStatusNotReady},
 		Target:                    []string{LifecycleConfigurationRulesStatusReady},
@@ -38,13 +38,9 @@ func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, 
 		NotFoundChecks:            20,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	_, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*s3.GetBucketLifecycleConfigurationOutput); ok {
-		return output, err
-	}
-
-	return nil, err
+	return err
 }
 
 func waitForBucketVersioningStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string) (*s3.GetBucketVersioningOutput, error) {

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -151,11 +151,11 @@ The `rule` configuration block supports the following arguments:
 
 * `abort_incomplete_multipart_upload` - (Optional) Configuration block that specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload [documented below](#abort_incomplete_multipart_upload).
 * `expiration` - (Optional) Configuration block that specifies the expiration for the lifecycle of the object in the form of date, days and, whether the object has a delete marker [documented below](#expiration).
-* `filter` - (Optional, Required if `prefix` not specified) Configuration block used to identify objects that a Lifecycle Rule applies to [documented below](#filter).
+* `filter` - (Optional) Configuration block used to identify objects that a Lifecycle Rule applies to [documented below](#filter).
 * `id` - (Required) Unique identifier for the rule. The value cannot be longer than 255 characters.
 * `noncurrent_version_expiration` - (Optional) Configuration block that specifies when noncurrent object versions expire [documented below](#noncurrent_version_expiration).
 * `noncurrent_version_transition` - (Optional) Set of configuration blocks that specify the transition rule for the lifecycle rule that describes when noncurrent objects transition to a specific storage class [documented below](#noncurrent_version_transition).
-* `prefix` - (Optional, Required if `filter` not specified) Prefix identifying one or more objects to which the rule applies. This has been deprecated by Amazon S3 and `filter` should be used instead.
+* `prefix` - (Optional) **DEPRECATED** Use `filter` instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. 
 * `status` - (Required) Whether the rule is currently being applied. Valid values: `Enabled` or `Disabled`.
 * `transition` - (Optional) Set of configuration blocks that specify when an Amazon S3 object transitions to a specified storage class [documented below](#transition).
 

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -155,7 +155,7 @@ The `rule` configuration block supports the following arguments:
 * `id` - (Required) Unique identifier for the rule. The value cannot be longer than 255 characters.
 * `noncurrent_version_expiration` - (Optional) Configuration block that specifies when noncurrent object versions expire [documented below](#noncurrent_version_expiration).
 * `noncurrent_version_transition` - (Optional) Set of configuration blocks that specify the transition rule for the lifecycle rule that describes when noncurrent objects transition to a specific storage class [documented below](#noncurrent_version_transition).
-* `prefix` - (Optional) **DEPRECATED** Use `filter` instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. 
+* `prefix` - (Optional) **DEPRECATED** Use `filter` instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies.
 * `status` - (Required) Whether the rule is currently being applied. Valid values: `Enabled` or `Disabled`.
 * `transition` - (Optional) Set of configuration blocks that specify when an Amazon S3 object transitions to a specified storage class [documented below](#transition).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23129
Closes #23132

Import test starting configuration (corresponding to #23129 and #23132):
```terraform
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "3.74.1"
    }
  }
}

resource "aws_s3_bucket" "example" {
  bucket = "barrameda-994617143"

  lifecycle_rule {
    id      = "log-expiration"
    enabled = true
    prefix  = ""

    transition {
      days          = 30
      storage_class = "STANDARD_IA"
    }

    transition {
      days          = 180
      storage_class = "GLACIER"
    }
  }
}

resource "aws_s3_bucket" "example2" {
  bucket = "valladolid-817999296"

  lifecycle_rule {
    id      = "Keep previous version 30 days, then in Glacier another 60"
    enabled = true

    noncurrent_version_transition {
      days          = 30
      storage_class = "GLACIER"
    }

    noncurrent_version_expiration {
      days = 90
    }
  }

  lifecycle_rule {
    id                                     = "Delete old incomplete multi-part uploads"
    enabled                                = true
    abort_incomplete_multipart_upload_days = 7
  }
}
```

4.0 configs for importing:
```terraform
terraform {
  required_providers {
    aws = {
      source  = "yakdriver.com/hashicorp/aws"
      version = ">= 1.0"
    }
  }
}

resource "aws_s3_bucket" "example" {
  bucket = "barrameda-994617143"
}

resource "aws_s3_bucket_lifecycle_configuration" "example" {
  bucket = aws_s3_bucket.example.id

  rule {
    id     = "log-expiration"
    status = "Enabled"
    prefix = ""

    transition {
      days          = 30
      storage_class = "STANDARD_IA"
    }

    transition {
      days          = 180
      storage_class = "GLACIER"
    }
  }
}

resource "aws_s3_bucket" "example2" {
  bucket = "valladolid-817999296"
}

resource "aws_s3_bucket_lifecycle_configuration" "example2" {
  bucket = aws_s3_bucket.example2.id

  rule {
    id     = "Keep previous version 30 days, then in Glacier another 60"
    status = "Enabled"

    noncurrent_version_transition {
      noncurrent_days = 30
      storage_class   = "GLACIER"
    }

    noncurrent_version_expiration {
      noncurrent_days = 90
    }
  }

  rule {
    id     = "Delete old incomplete multi-part uploads"
    status = "Enabled"

    abort_incomplete_multipart_upload {
      days_after_initiation = 7
    }
  }
}
```

Output from import:
```console
% terraform import aws_s3_bucket.example barrameda-994617143
aws_s3_bucket.example: Importing from ID "barrameda-994617143"...
aws_s3_bucket.example: Import prepared!
  Prepared aws_s3_bucket for import
aws_s3_bucket.example: Refreshing state... [id=barrameda-994617143]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
% terraform import aws_s3_bucket_lifecycle_configuration.example barrameda-994617143
aws_s3_bucket_lifecycle_configuration.example: Importing from ID "barrameda-994617143"...
aws_s3_bucket_lifecycle_configuration.example: Import prepared!
  Prepared aws_s3_bucket_lifecycle_configuration for import
aws_s3_bucket_lifecycle_configuration.example: Refreshing state... [id=barrameda-994617143]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
% terraform import aws_s3_bucket.example2 valladolid-817999296
aws_s3_bucket.example2: Importing from ID "valladolid-817999296"...
aws_s3_bucket.example2: Import prepared!
  Prepared aws_s3_bucket for import
aws_s3_bucket.example2: Refreshing state... [id=valladolid-817999296]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
% terraform import aws_s3_bucket_lifecycle_configuration.example2 valladolid-817999296
aws_s3_bucket_lifecycle_configuration.example2: Importing from ID "valladolid-817999296"...
aws_s3_bucket_lifecycle_configuration.example2: Import prepared!
  Prepared aws_s3_bucket_lifecycle_configuration for import
aws_s3_bucket_lifecycle_configuration.example2: Refreshing state... [id=valladolid-817999296]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
% terraform apply
aws_s3_bucket.example: Refreshing state... [id=barrameda-994617143]
aws_s3_bucket.example2: Refreshing state... [id=valladolid-817999296]
aws_s3_bucket_lifecycle_configuration.example2: Refreshing state... [id=valladolid-817999296]
aws_s3_bucket_lifecycle_configuration.example: Refreshing state... [id=barrameda-994617143]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Output from acceptance testing:


```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
