### PR TITLE
d/aws_backup_report_plan

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -417,9 +417,10 @@ func Provider() *schema.Provider {
 			"aws_autoscaling_groups":   autoscaling.DataSourceGroups(),
 			"aws_launch_configuration": autoscaling.DataSourceLaunchConfiguration(),
 
-			"aws_backup_plan":      backup.DataSourcePlan(),
-			"aws_backup_selection": backup.DataSourceSelection(),
-			"aws_backup_vault":     backup.DataSourceVault(),
+			"aws_backup_plan":        backup.DataSourcePlan(),
+			"aws_backup_report_plan": backup.DataSourceReportPlan(),
+			"aws_backup_selection":   backup.DataSourceSelection(),
+			"aws_backup_vault":       backup.DataSourceVault(),
 
 			"aws_batch_compute_environment": batch.DataSourceComputeEnvironment(),
 			"aws_batch_job_queue":           batch.DataSourceJobQueue(),

--- a/internal/service/backup/report_plan_data_source.go
+++ b/internal/service/backup/report_plan_data_source.go
@@ -1,0 +1,81 @@
+package backup
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceReportPlan() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deployment_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"report_delivery_channel": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"formats": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"s3_bucket_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"s3_key_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"report_setting": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"framework_arns": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"number_of_frameworks": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"report_template": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+

--- a/internal/service/backup/report_plan_data_source.go
+++ b/internal/service/backup/report_plan_data_source.go
@@ -1,12 +1,20 @@
 package backup
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
 func DataSourceReportPlan() *schema.Resource {
 	return &schema.Resource{
+		Read: dataSourceReportPlanRead,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -79,3 +87,47 @@ func DataSourceReportPlan() *schema.Resource {
 	}
 }
 
+func dataSourceReportPlanRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).BackupConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	name := d.Get("name").(string)
+
+	resp, err := conn.DescribeReportPlan(&backup.DescribeReportPlanInput{
+		ReportPlanName: aws.String(name),
+	})
+	if err != nil {
+		return fmt.Errorf("Error getting Backup Report Plan: %w", err)
+	}
+
+	d.SetId(aws.StringValue(resp.ReportPlan.ReportPlanName))
+
+	d.Set("arn", resp.ReportPlan.ReportPlanArn)
+	d.Set("deployment_status", resp.ReportPlan.DeploymentStatus)
+	d.Set("description", resp.ReportPlan.ReportPlanDescription)
+	d.Set("name", resp.ReportPlan.ReportPlanName)
+
+	if err := d.Set("creation_time", resp.ReportPlan.CreationTime.Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("error setting creation_time: %s", err)
+	}
+
+	if err := d.Set("report_delivery_channel", flattenReportDeliveryChannel(resp.ReportPlan.ReportDeliveryChannel)); err != nil {
+		return fmt.Errorf("error setting report_delivery_channel: %w", err)
+	}
+
+	if err := d.Set("report_setting", flattenReportSetting(resp.ReportPlan.ReportSetting)); err != nil {
+		return fmt.Errorf("error setting report_delivery_channel: %w", err)
+	}
+
+	tags, err := ListTags(conn, aws.StringValue(resp.ReportPlan.ReportPlanArn))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Backup Report Plan (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}

--- a/internal/service/backup/report_plan_data_source_test.go
+++ b/internal/service/backup/report_plan_data_source_test.go
@@ -1,0 +1,96 @@
+package backup_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/backup"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccBackupReportPlanDataSource_basic(t *testing.T) {
+	datasourceName := "data.aws_backup_report_plan.test"
+	resourceName := "aws_backup_report_plan.test"
+	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
+	rName2 := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccReportPlanDataSourceConfig_nonExistent,
+				ExpectError: regexp.MustCompile(`Error getting Backup Report Plan`),
+			},
+			{
+				Config: testAccReportPlanDataSourceConfig_basic(rName, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "creation_time", resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(datasourceName, "deployment_status"), // CREATE_IN_PROGRESS | UPDATE_IN_PROGRESS | DELETE_IN_PROGRESS | COMPLETED
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "report_delivery_channel.#", resourceName, "report_delivery_channel.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "report_delivery_channel.0.formats.#", resourceName, "report_delivery_channel.0.formats.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "report_delivery_channel.0.formats.0", resourceName, "report_delivery_channel.0.formats.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "report_delivery_channel.0.s3_bucket_name", resourceName, "report_delivery_channel.0.s3_bucket_name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "report_setting.#", resourceName, "report_setting.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "report_setting.0.report_template", resourceName, "report_setting.0.report_template"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Key2", resourceName, "tags.Key2"),
+				),
+			},
+		},
+	})
+}
+
+const testAccReportPlanDataSourceConfig_nonExistent = `
+data "aws_backup_report_plan" "test" {
+  name = "tf_acc_test_does_not_exist"
+}
+`
+
+func testAccReportPlanDataSourceConfig_basic(rName, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket                  = aws_s3_bucket.test.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_backup_report_plan" "test" {
+  name        = %[2]q
+  description = "Test report plan data source"
+
+  report_delivery_channel {
+    formats = [
+      "CSV"
+    ]
+    s3_bucket_name = aws_s3_bucket.test.id
+  }
+
+  report_setting {
+    report_template = "RESTORE_JOB_REPORT"
+  }
+
+  tags = {
+    "Name" = "Test Report Plan Data Source"
+    "Key2" = "Value2a"
+  }
+}
+
+data "aws_backup_report_plan" "test" {
+  name = aws_backup_report_plan.test.name
+}
+`, rName, rName2)
+}

--- a/website/docs/d/backup_report_plan.html.markdown
+++ b/website/docs/d/backup_report_plan.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_report_plan"
+description: |-
+  Provides details about an AWS Backup Report Plan.
+---
+
+# Data Source: aws_backup_report_plan
+
+Use this data source to get information on an existing backup report plan.
+
+## Example Usage
+
+```terraform
+data "aws_backup_report_plan" "example" {
+  name = "tf_example_backup_report_plan_name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The backup report plan name.
+
+## Attributes Reference
+
+In addition to the arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the backup report plan.
+* `creation_time` - The date and time that a report plan is created, in Unix format and Coordinated Universal Time (UTC).
+* `deployment_status` - The deployment status of a report plan. The statuses are: `CREATE_IN_PROGRESS` | `UPDATE_IN_PROGRESS` | `DELETE_IN_PROGRESS` | `COMPLETED`.
+* `description` - The description of the report plan.
+* `id` - The id of the report plan.
+* `report_delivery_channel` - An object that contains information about where and how to deliver your reports, specifically your Amazon S3 bucket name, S3 key prefix, and the formats of your reports. Detailed below.
+* `report_setting` - An object that identifies the report template for the report. Reports are built using a report template. Detailed below.
+* `tags` - Metadata that you can assign to help organize the report plans you create.
+
+### Report Delivery Channel Attributes
+For **report_delivery_channel** the following attributes are supported:
+
+* `formats` - A list of the format of your reports: CSV, JSON, or both.
+* `s3_bucket_name` - The unique name of the S3 bucket that receives your reports.
+* `s3_key_prefix` - The prefix for where Backup Audit Manager delivers your reports to Amazon S3. The prefix is this part of the following path: s3://your-bucket-name/prefix/Backup/us-west-2/year/month/day/report-name.
+
+### Report Setting Attributes
+For **report_setting** the following attributes are supported:
+
+* `framework_arns` - Specifies the Amazon Resource Names (ARNs) of the frameworks a report covers.
+* `number_of_frameworks` - Specifies the number of frameworks a report covers.
+* `report_template` - Identifies the report template for the report. Reports are built using a report template.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23145

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccBackupReportPlanDataSource_basic' PKG=backup ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 1  -run=TestAccBackupReportPlanDataSource_basic -timeout 180m
=== RUN   TestAccBackupReportPlanDataSource_basic
=== PAUSE TestAccBackupReportPlanDataSource_basic
=== CONT  TestAccBackupReportPlanDataSource_basic
--- PASS: TestAccBackupReportPlanDataSource_basic (72.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     93.812s
...
```
