### PR TITLE
service/lambda: tech debt: fix V001 linter errors

### DIFF
--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -35,19 +35,19 @@ func ResourcePermission() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validPermissionAction,
+				ValidateFunc: validPermissionAction(),
 			},
 			"event_source_token": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validPermissionEventSourceToken,
+				ValidateFunc: validPermissionEventSourceToken(),
 			},
 			"function_name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validFunctionName,
+				ValidateFunc: validFunctionName(),
 			},
 			"principal": {
 				Type:     schema.TypeString,
@@ -58,7 +58,7 @@ func ResourcePermission() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validQualifier,
+				ValidateFunc: validQualifier(),
 			},
 			"source_account": {
 				Type:         schema.TypeString,
@@ -78,14 +78,14 @@ func ResourcePermission() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"statement_id_prefix"},
-				ValidateFunc:  validPolicyStatementID,
+				ValidateFunc:  validPolicyStatementID(),
 			},
 			"statement_id_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"statement_id"},
-				ValidateFunc:  validPolicyStatementID,
+				ValidateFunc:  validPolicyStatementID(),
 			},
 		},
 	}

--- a/internal/service/lambda/validate.go
+++ b/internal/service/lambda/validate.go
@@ -1,9 +1,10 @@
 package lambda
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"regexp"
 )
 
 func validFunctionName() schema.SchemaValidateFunc {

--- a/internal/service/lambda/validate.go
+++ b/internal/service/lambda/validate.go
@@ -1,91 +1,46 @@
 package lambda
 
 import (
-	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"regexp"
 )
 
-func validFunctionName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 140 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 140 characters: %q", k, value))
-	}
+func validFunctionName() schema.SchemaValidateFunc {
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
 	pattern := `^(arn:[\w-]+:lambda:)?([a-z]{2}-(?:[a-z]+-){1,2}\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
 
-	return
+	return validation.All(
+		validation.StringMatch(regexp.MustCompile(pattern), "must be valid function name or function ARN"),
+		validation.StringLenBetween(1, 140),
+	)
 }
 
-func validPermissionAction(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
+func validPermissionAction() schema.SchemaValidateFunc {
 	pattern := `^(lambda:[*]|lambda:[a-zA-Z]+|[*])$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
-	return
+	return validation.StringMatch(regexp.MustCompile(pattern), "must be a valid action (usually starts with lambda:)")
 }
 
-func validPermissionEventSourceToken(v interface{}, k string) (ws []string, errors []error) {
+func validPermissionEventSourceToken() schema.SchemaValidateFunc {
 	// https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-	value := v.(string)
-
-	if len(value) > 256 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 characters: %q", k, value))
-	}
-
-	pattern := `^[a-zA-Z0-9._\-]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
-	return
+	return validation.All(
+		validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`), "must contain alphanumeric, periods, underscores or dashes only"),
+		validation.StringLenBetween(1, 256),
+	)
 }
 
-func validQualifier(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 128 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 128 characters: %q", k, value))
-	}
+func validQualifier() schema.SchemaValidateFunc {
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-	pattern := `^[a-zA-Z0-9$_-]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
-	return
+	return validation.All(
+		validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9$_-]+$`), "must contain alphanumeric, dollar signs, underscores or dashes only"),
+		validation.StringLenBetween(1, 128),
+	)
 }
 
-func validPolicyStatementID(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if len(value) > 100 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 100 characters: %q", k, value))
-	}
-
+func validPolicyStatementID() schema.SchemaValidateFunc {
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-	pattern := `^[a-zA-Z0-9-_]+$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't look like a valid statement ID (%q): %q",
-			k, pattern, value))
-	}
-
-	return
+	return validation.All(
+		validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must contain alphanumeric, underscores or dashes only"),
+		validation.StringLenBetween(1, 100),
+	)
 }

--- a/internal/service/lambda/validate_test.go
+++ b/internal/service/lambda/validate_test.go
@@ -14,7 +14,7 @@ func TestValidFunctionName(t *testing.T) {
 		"function-name",
 	}
 	for _, v := range validNames {
-		_, errors := validFunctionName(v, "name")
+		_, errors := validFunctionName()(v, "name")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid Lambda function name: %q", v, errors)
 		}
@@ -29,7 +29,7 @@ func TestValidFunctionName(t *testing.T) {
 			"ooooooooooooooooongFunctionName",
 	}
 	for _, v := range invalidNames {
-		_, errors := validFunctionName(v, "name")
+		_, errors := validFunctionName()(v, "name")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid Lambda function name", v)
 		}
@@ -43,7 +43,7 @@ func TestValidPermissionAction(t *testing.T) {
 		"*",
 	}
 	for _, v := range validNames {
-		_, errors := validPermissionAction(v, "action")
+		_, errors := validPermissionAction()(v, "action")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid Lambda permission action: %q", v, errors)
 		}
@@ -56,7 +56,7 @@ func TestValidPermissionAction(t *testing.T) {
 		"lambda:Invoke*",
 	}
 	for _, v := range invalidNames {
-		_, errors := validPermissionAction(v, "action")
+		_, errors := validPermissionAction()(v, "action")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid Lambda permission action", v)
 		}
@@ -70,7 +70,7 @@ func TestValidPermissionEventSourceToken(t *testing.T) {
 		strings.Repeat(".", 256),
 	}
 	for _, v := range validTokens {
-		_, errors := validPermissionEventSourceToken(v, "event_source_token")
+		_, errors := validPermissionEventSourceToken()(v, "event_source_token")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid Lambda permission event source token", v)
 		}
@@ -82,7 +82,7 @@ func TestValidPermissionEventSourceToken(t *testing.T) {
 		strings.Repeat(".", 257),
 	}
 	for _, v := range invalidTokens {
-		_, errors := validPermissionEventSourceToken(v, "event_source_token")
+		_, errors := validPermissionEventSourceToken()(v, "event_source_token")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid Lambda permission event source token", v)
 		}
@@ -100,7 +100,7 @@ func TestValidQualifier(t *testing.T) {
 		"$LATEST",
 	}
 	for _, v := range validNames {
-		_, errors := validQualifier(v, "name")
+		_, errors := validQualifier()(v, "name")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid Lambda function qualifier: %q", v, errors)
 		}
@@ -115,7 +115,7 @@ func TestValidQualifier(t *testing.T) {
 			"oooooooooooongQualifier",
 	}
 	for _, v := range invalidNames {
-		_, errors := validQualifier(v, "name")
+		_, errors := validQualifier()(v, "name")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid Lambda function qualifier", v)
 		}
@@ -129,7 +129,7 @@ func TestValidPolicyStatementID(t *testing.T) {
 		"1234",
 	}
 	for _, v := range validNames {
-		_, errors := validPolicyStatementID(v, "statement_id")
+		_, errors := validPolicyStatementID()(v, "statement_id")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid Statement ID: %q", v, errors)
 		}
@@ -143,7 +143,7 @@ func TestValidPolicyStatementID(t *testing.T) {
 			"ooooooooooooooooooooooooooooooooooooooooStatementId",
 	}
 	for _, v := range invalidNames {
-		_, errors := validPolicyStatementID(v, "statement_id")
+		_, errors := validPolicyStatementID()(v, "statement_id")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid Statement ID", v)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11872

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccLambdaPermission_withS3 (82.21s)
--- PASS: TestAccLambdaPermission_withIAMRole (100.22s)
--- PASS: TestAccLambdaPermission_withQualifier (111.20s)
--- PASS: TestAccLambdaPermission_withStatementIdPrefix (117.18s)
--- PASS: TestAccLambdaPermission_basic (125.70s)
--- PASS: TestAccLambdaPermission_StatementID_duplicate (126.32s)
--- PASS: TestAccLambdaPermission_multiplePerms (130.97s)
--- PASS: TestAccLambdaPermission_withRawFunctionName (142.99s)
--- PASS: TestAccLambdaPermission_withSNS (173.44s)
--- PASS: TestAccLambdaPermission_disappears (208.43s)
```
