### PR TITLE
r/api_gateway_authorizer - add `arn` attribute

### DIFF
--- a/.changelog/23151.txt
+++ b/.changelog/23151.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_api_gateway_authorizer: Add `arn` attribute.
+```

--- a/internal/service/apigateway/authorizer.go
+++ b/internal/service/apigateway/authorizer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -25,6 +26,7 @@ func ResourceAuthorizer() *schema.Resource {
 		Update:        resourceAuthorizerUpdate,
 		Delete:        resourceAuthorizerDelete,
 		CustomizeDiff: resourceAuthorizerCustomizeDiff,
+
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), "/")
@@ -40,33 +42,9 @@ func ResourceAuthorizer() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"authorizer_uri": {
+			"arn": {
 				Type:     schema.TypeString,
-				Optional: true, // authorizer_uri is required for authorizer TOKEN/REQUEST
-			},
-			"identity_source": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "method.request.header.Authorization",
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"rest_api_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  apigateway.AuthorizerTypeToken,
-				ValidateFunc: validation.StringInSlice([]string{
-					apigateway.AuthorizerTypeCognitoUserPools,
-					apigateway.AuthorizerTypeRequest,
-					apigateway.AuthorizerTypeToken,
-				}, false),
+				Computed: true,
 			},
 			"authorizer_credentials": {
 				Type:         schema.TypeString,
@@ -79,9 +57,22 @@ func ResourceAuthorizer() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 3600),
 				Default:      DefaultAuthorizerTTL,
 			},
+			"authorizer_uri": {
+				Type:     schema.TypeString,
+				Optional: true, // authorizer_uri is required for authorizer TOKEN/REQUEST
+			},
+			"identity_source": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "method.request.header.Authorization",
+			},
 			"identity_validation_expression": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"provider_arns": {
 				Type:     schema.TypeSet,
@@ -90,6 +81,17 @@ func ResourceAuthorizer() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: verify.ValidARN,
 				},
+			},
+			"rest_api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      apigateway.AuthorizerTypeToken,
+				ValidateFunc: validation.StringInSlice(apigateway.AuthorizerType_Values(), false),
 			},
 		},
 	}
@@ -165,9 +167,11 @@ func resourceAuthorizerRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).APIGatewayConn
 
 	log.Printf("[INFO] Reading API Gateway Authorizer %s", d.Id())
+
+	restApiId := d.Get("rest_api_id").(string)
 	input := apigateway.GetAuthorizerInput{
 		AuthorizerId: aws.String(d.Id()),
-		RestApiId:    aws.String(d.Get("rest_api_id").(string)),
+		RestApiId:    aws.String(restApiId),
 	}
 
 	authorizer, err := conn.GetAuthorizer(&input)
@@ -195,6 +199,14 @@ func resourceAuthorizerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", authorizer.Name)
 	d.Set("type", authorizer.Type)
 	d.Set("provider_arns", flex.FlattenStringSet(authorizer.ProviderARNs))
+
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "apigateway",
+		Region:    meta.(*conns.AWSClient).Region,
+		Resource:  fmt.Sprintf("/restapis/%s/authorizers/%s", restApiId, d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/internal/service/apigateway/authorizer_test.go
+++ b/internal/service/apigateway/authorizer_test.go
@@ -34,6 +34,7 @@ func TestAccAPIGatewayAuthorizer_basic(t *testing.T) {
 				Config: testAccAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthorizerExists(resourceName, &conf),
+					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/restapis/.+/authorizers/.+`)),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -112,6 +112,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of the API Gateway Authorizer
 * `id` - The Authorizer identifier.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccAPIGatewayAuthorizer_ PKG=apigateway

--- PASS: TestAccAPIGatewayAuthorizer_Cognito_authorizerCredentials (47.95s)
--- PASS: TestAccAPIGatewayAuthorizer_disappears (77.89s)
--- PASS: TestAccAPIGatewayAuthorizer_authTypeValidation (78.14s)
--- PASS: TestAccAPIGatewayAuthorizer_basic (140.18s)
--- PASS: TestAccAPIGatewayAuthorizer_Zero_ttl (176.82s)
--- PASS: TestAccAPIGatewayAuthorizer_switchAuthType (218.59s)
--- PASS: TestAccAPIGatewayAuthorizer_switchAuthorizerTTL (232.19s)
--- PASS: TestAccAPIGatewayAuthorizer_cognito (304.67s)
```
