### PR TITLE
resource/aws_launch_configuration: add no_device option

### DIFF
--- a/.changelog/23152.txt
+++ b/.changelog/23152.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_launch_configuration: Add no_device option to aws_launch_configuration ephemeral_block_device
+```

--- a/.changelog/23152.txt
+++ b/.changelog/23152.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_launch_configuration: Add no_device option to aws_launch_configuration ephemeral_block_device
+resource/aws_launch_configuration: Add `ephemeral_block_device.no_device` argument
 ```

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -30,6 +30,7 @@ func ResourceLaunchConfiguration() *schema.Resource {
 		Create: resourceLaunchConfigurationCreate,
 		Read:   resourceLaunchConfigurationRead,
 		Delete: resourceLaunchConfigurationDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -39,137 +40,12 @@ func ResourceLaunchConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.StringLenBetween(1, 255),
-			},
-
-			"name_prefix": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.StringLenBetween(1, 255-resource.UniqueIDSuffixLength),
-			},
-
-			"image_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"instance_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"iam_instance_profile": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"key_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"user_data": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"user_data_base64"},
-				StateFunc: func(v interface{}) string {
-					switch v := v.(type) {
-					case string:
-						return userDataHashSum(v)
-					default:
-						return ""
-					}
-				},
-				ValidateFunc: validation.StringLenBetween(1, 16384),
-			},
-
-			"user_data_base64": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"user_data"},
-				ValidateFunc: func(v interface{}, name string) (warns []string, errs []error) {
-					s := v.(string)
-					if !verify.IsBase64Encoded([]byte(s)) {
-						errs = append(errs, fmt.Errorf(
-							"%s: must be base64-encoded", name,
-						))
-					}
-					return
-				},
-			},
-
-			"security_groups": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-
-			"vpc_classic_link_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"vpc_classic_link_security_groups": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-
 			"associate_public_ip_address": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  false,
 			},
-
-			"spot_price": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"ebs_optimized": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
-
-			"placement_tenancy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"enable_monitoring": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  true,
-			},
-
 			"ebs_block_device": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -182,54 +58,46 @@ func ResourceLaunchConfiguration() *schema.Resource {
 							Default:  true,
 							ForceNew: true,
 						},
-
 						"device_name": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-
 						"encrypted": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"no_device": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
 						},
-
 						"snapshot_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"throughput": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -239,7 +107,18 @@ func ResourceLaunchConfiguration() *schema.Resource {
 					},
 				},
 			},
-
+			"ebs_optimized": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"enable_monitoring": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
 			"ephemeral_block_device": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -268,7 +147,27 @@ func ResourceLaunchConfiguration() *schema.Resource {
 					return create.StringHashcode(buf.String())
 				},
 			},
-
+			"iam_instance_profile": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"key_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"metadata_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -284,13 +183,6 @@ func ResourceLaunchConfiguration() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataEndpointStateEnabled, autoscaling.InstanceMetadataEndpointStateDisabled}, false),
 						},
-						"http_tokens": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataHttpTokensStateOptional, autoscaling.InstanceMetadataHttpTokensStateRequired}, false),
-						},
 						"http_put_response_hop_limit": {
 							Type:         schema.TypeInt,
 							Optional:     true,
@@ -298,10 +190,37 @@ func ResourceLaunchConfiguration() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(1, 64),
 						},
+						"http_tokens": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{autoscaling.InstanceMetadataHttpTokensStateOptional, autoscaling.InstanceMetadataHttpTokensStateRequired}, false),
+						},
 					},
 				},
 			},
-
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validation.StringLenBetween(1, 255),
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validation.StringLenBetween(1, 255-resource.UniqueIDSuffixLength),
+			},
+			"placement_tenancy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"root_block_device": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -318,35 +237,30 @@ func ResourceLaunchConfiguration() *schema.Resource {
 							Default:  true,
 							ForceNew: true,
 						},
-
 						"encrypted": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"throughput": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -355,6 +269,59 @@ func ResourceLaunchConfiguration() *schema.Resource {
 						},
 					},
 				},
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"spot_price": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"user_data": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"user_data_base64"},
+				StateFunc: func(v interface{}) string {
+					switch v := v.(type) {
+					case string:
+						return userDataHashSum(v)
+					default:
+						return ""
+					}
+				},
+				ValidateFunc: validation.StringLenBetween(1, 16384),
+			},
+			"user_data_base64": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"user_data"},
+				ValidateFunc: func(v interface{}, name string) (warns []string, errs []error) {
+					s := v.(string)
+					if !verify.IsBase64Encoded([]byte(s)) {
+						errs = append(errs, fmt.Errorf(
+							"%s: must be base64-encoded", name,
+						))
+					}
+					return
+				},
+			},
+			"vpc_classic_link_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vpc_classic_link_security_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 		},
 	}

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfautoscaling "github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -568,22 +569,17 @@ func testAccCheckLaunchConfigurationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		describe, err := conn.DescribeLaunchConfigurations(
-			&autoscaling.DescribeLaunchConfigurationsInput{
-				LaunchConfigurationNames: []*string{aws.String(rs.Primary.ID)},
-			})
+		_, err := tfautoscaling.FindLaunchConfigurationByName(conn, rs.Primary.ID)
 
-		if err == nil {
-			if len(describe.LaunchConfigurations) != 0 &&
-				*describe.LaunchConfigurations[0].LaunchConfigurationName == rs.Primary.ID {
-				return fmt.Errorf("Launch Configuration still exists")
-			}
+		if tfresource.NotFound(err) {
+			continue
 		}
 
-		// Verify the error
-		if !tfawserr.ErrCodeEquals(err, "InvalidLaunchConfiguration.NotFound") {
+		if err != nil {
 			return err
 		}
+
+		return fmt.Errorf("Autoscaling Launch Configuration %s still exists", rs.Primary.ID)
 	}
 
 	return nil
@@ -629,7 +625,7 @@ func testAccCheckLaunchConfigurationAttributes(conf *autoscaling.LaunchConfigura
 	}
 }
 
-func testAccCheckLaunchConfigurationExists(n string, res *autoscaling.LaunchConfiguration) resource.TestCheckFunc {
+func testAccCheckLaunchConfigurationExists(n string, v *autoscaling.LaunchConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -637,26 +633,18 @@ func testAccCheckLaunchConfigurationExists(n string, res *autoscaling.LaunchConf
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Launch Configuration ID is set")
+			return fmt.Errorf("No Autoscaling Launch Configuration ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AutoScalingConn
 
-		describeOpts := autoscaling.DescribeLaunchConfigurationsInput{
-			LaunchConfigurationNames: []*string{aws.String(rs.Primary.ID)},
-		}
-		describe, err := conn.DescribeLaunchConfigurations(&describeOpts)
+		output, err := tfautoscaling.FindLaunchConfigurationByName(conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		if len(describe.LaunchConfigurations) != 1 ||
-			*describe.LaunchConfigurations[0].LaunchConfigurationName != rs.Primary.ID {
-			return fmt.Errorf("Launch Configuration Group not found")
-		}
-
-		*res = *describe.LaunchConfigurations[0]
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -816,6 +816,7 @@ resource "aws_launch_configuration" "test" {
 
   ephemeral_block_device {
     device_name  = "/dev/sde"
+	no_device    = false
     virtual_name = "ephemeral0"
   }
 }

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -804,7 +804,6 @@ resource "aws_launch_configuration" "test" {
 
   ephemeral_block_device {
     device_name  = "/dev/sde"
-	no_device    = false
     virtual_name = "ephemeral0"
   }
 }

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -210,8 +210,9 @@ Modifying any `ebs_block_device` currently requires resource replacement.
 
 Each `ephemeral_block_device` supports the following:
 
-* `device_name` - The name of the block device to mount on the instance.
-* `virtual_name` - The [Instance Store Device
+* `device_name` - (Required) The name of the block device to mount on the instance.
+* `no_device` - (Optional) Whether the device in the block device mapping of the AMI is suppressed.
+* `virtual_name` - (Optional) The [Instance Store Device
   Name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)
   (e.g., `"ephemeral0"`)
 


### PR DESCRIPTION
Adding a no_device option to ephemeral block devices in a launch configuration resource.  This addresses issue [5464](https://github.com/hashicorp/terraform-provider-aws/issues/5464).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5464

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccAutoScalingLaunchConfiguration_basic PKG=autoscaling
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingLaunchConfiguration_basic'  -timeout 180m
=== RUN   TestAccAutoScalingLaunchConfiguration_basic
=== PAUSE TestAccAutoScalingLaunchConfiguration_basic
=== CONT  TestAccAutoScalingLaunchConfiguration_basic
--- PASS: TestAccAutoScalingLaunchConfiguration_basic (39.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        39.473s

...
```
