### PR TITLE
Handle KMS updates with replica tables.

### DIFF
--- a/.changelog/23156.txt
+++ b/.changelog/23156.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Allow changing KMS keys on tables with replicas.
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -49,6 +49,7 @@ func ResourceTable() *schema.Resource {
 			Update: schema.DefaultTimeout(updateTableTimeoutTotal),
 		},
 
+		//TODO: Add a custom diff if it is just the kms keys changing maybe check the replica update function?
 		CustomizeDiff: customdiff.All(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 				return validStreamSpec(diff)
@@ -928,17 +929,65 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("server_side_encryption") {
-		// "ValidationException: One or more parameter values were invalid: Server-Side Encryption modification must be the only operation in the request".
-		_, err := conn.UpdateTable(&dynamodb.UpdateTableInput{
-			TableName:        aws.String(d.Id()),
-			SSESpecification: expandEncryptAtRestOptions(d.Get("server_side_encryption").([]interface{})),
-		})
-		if err != nil {
-			return create.Error(names.DynamoDB, create.ErrActionUpdating, ResNameTable, d.Id(), fmt.Errorf("SSE: %w", err))
-		}
+		if replicas := d.Get("replica").(*schema.Set); replicas.Len() > 0 {
+			log.Printf("[DEBUG] Using SSE update on replicas")
+			var replicaInputs []*dynamodb.ReplicationGroupUpdate
+			var replicaRegions []string
+			for _, replica := range replicas.List() {
+				tfMap, ok := replica.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				var regionName string
+				var KMSMasterKeyId string
+				if v, ok := tfMap["region_name"].(string); ok {
+					regionName = v
+					replicaRegions = append(replicaRegions, v)
+				}
+				if v, ok := tfMap["kms_key_arn"].(string); ok && v != "" {
+					KMSMasterKeyId = v
+				}
+				var input = &dynamodb.UpdateReplicationGroupMemberAction{
+					RegionName:     aws.String(regionName),
+					KMSMasterKeyId: aws.String(KMSMasterKeyId),
+				}
+				var update = &dynamodb.ReplicationGroupUpdate{Update: input}
+				replicaInputs = append(replicaInputs, update)
+			}
+			var input = &dynamodb.UpdateReplicationGroupMemberAction{
+				KMSMasterKeyId: expandEncryptAtRestOptions(d.Get("server_side_encryption").([]interface{})).KMSMasterKeyId,
+				RegionName:     aws.String(meta.(*conns.AWSClient).Region),
+			}
+			var update = &dynamodb.ReplicationGroupUpdate{Update: input}
+			replicaInputs = append(replicaInputs, update)
+			_, err := conn.UpdateTable(&dynamodb.UpdateTableInput{
+				TableName:      aws.String(d.Id()),
+				ReplicaUpdates: replicaInputs,
+			})
+			if err != nil {
+				return fmt.Errorf("error updating DynamoDB Table (%s) SSE: %w", d.Id(), err)
+			}
+			for _, region := range replicaRegions {
+				if tableDetail, err := waitReplicaSSEUpdated(region, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+					return fmt.Errorf("error waiting for DynamoDB Table (%s) in region (#{region}) SSE: {%w}", *tableDetail.TableName, err)
+				}
+			}
+			if tableDetail, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %w", *tableDetail.TableName, err)
+			}
+		} else {
+			log.Printf("[DEBUG] Using normal update for SSE")
+			_, err := conn.UpdateTable(&dynamodb.UpdateTableInput{
+				TableName:        aws.String(d.Id()),
+				SSESpecification: expandEncryptAtRestOptions(d.Get("server_side_encryption").([]interface{})),
+			})
+			if err != nil {
+				return fmt.Errorf("error updating DynamoDB Table (%s) SSE: %w", d.Id(), err)
+			}
 
-		if _, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.Error(names.DynamoDB, create.ErrActionWaitingForUpdate, ResNameTable, d.Id(), err)
+			if tableDetail, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %w", *tableDetail.TableName, err)
+			}
 		}
 	}
 
@@ -1269,6 +1318,12 @@ func updateReplica(d *schema.ResourceData, conn *dynamodb.DynamoDB, tfVersion st
 	oRaw, nRaw := d.GetChange("replica")
 	o := oRaw.(*schema.Set)
 	n := nRaw.(*schema.Set)
+	newRegions := replicaRegions(n)
+	oldRegions := replicaRegions(o)
+	// If it is a change in KMS keys causing the diff no updates needed
+	if reflect.DeepEqual(oldRegions, newRegions) {
+		return nil
+	}
 
 	removed := o.Difference(n).List()
 	added := n.Difference(o).List()
@@ -1299,6 +1354,18 @@ func updateReplica(d *schema.ResourceData, conn *dynamodb.DynamoDB, tfVersion st
 	}
 
 	return nil
+}
+
+func replicaRegions(r *schema.Set) []string {
+	var regions []string
+	for _, tfMapRaw := range r.List() {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		regions = append(regions, tfMap["region_name"].(string))
+	}
+	return regions
 }
 
 func UpdateDiffGSI(oldGsi, newGsi []interface{}, billingMode string) (ops []*dynamodb.GlobalSecondaryIndexUpdate, e error) {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -968,12 +968,12 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error updating DynamoDB Table (%s) SSE: %w", d.Id(), err)
 			}
 			for _, region := range replicaRegions {
-				if tableDetail, err := waitReplicaSSEUpdated(region, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-					return fmt.Errorf("error waiting for DynamoDB Table (%s) in region (#{region}) SSE: {%w}", *tableDetail.TableName, err)
+				if _, err := waitReplicaSSEUpdated(meta.(*conns.AWSClient), region, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+					return fmt.Errorf("error waiting for DynamoDB Table (%s) replica SSE update in region %q: %w", d.Id(), region, err)
 				}
 			}
-			if tableDetail, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %w", *tableDetail.TableName, err)
+			if _, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %w", d.Id(), err)
 			}
 		} else {
 			log.Printf("[DEBUG] Using normal update for SSE")
@@ -985,8 +985,8 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error updating DynamoDB Table (%s) SSE: %w", d.Id(), err)
 			}
 
-			if tableDetail, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %w", *tableDetail.TableName, err)
+			if _, err := waitSSEUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %w", d.Id(), err)
 			}
 		}
 	}

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -51,13 +51,13 @@ func ResourceTable() *schema.Resource {
 
 		//TODO: Add a custom diff if it is just the kms keys changing maybe check the replica update function?
 		CustomizeDiff: customdiff.All(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				return validStreamSpec(diff)
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				return validateTableAttributes(diff)
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				if diff.Id() != "" && diff.HasChange("server_side_encryption") {
 					o, n := diff.GetChange("server_side_encryption")
 					if isTableOptionDisabled(o) && isTableOptionDisabled(n) {
@@ -66,7 +66,7 @@ func ResourceTable() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				if diff.Id() != "" && diff.HasChange("point_in_time_recovery") {
 					o, n := diff.GetChange("point_in_time_recovery")
 					if isTableOptionDisabled(o) && isTableOptionDisabled(n) {
@@ -75,7 +75,7 @@ func ResourceTable() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				if diff.Id() != "" && diff.HasChange("stream_enabled") {
 					if err := diff.SetNewComputed("stream_arn"); err != nil {
 						return fmt.Errorf("error setting stream_arn to computed: %s", err)
@@ -83,7 +83,7 @@ func ResourceTable() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				if v := diff.Get("restore_source_name"); v != "" {
 					return nil
 				}

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -2477,7 +2477,8 @@ data "aws_kms_alias" "dynamodb" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -2501,7 +2502,8 @@ resource "aws_dynamodb_table" "test" {
 func testAccTableConfig_initialStateEncryptionBYOK(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -3135,12 +3137,14 @@ data "aws_region" "alternate" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
 }
 
 resource "aws_kms_key" "replica" {
-  provider    = "awsalternate"
-  description = "%[1]s-2"
+  provider                = "awsalternate"
+  description             = "%[1]s-2"
+  deletion_window_in_days = 7
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -3642,7 +3646,8 @@ resource "aws_dynamodb_table" "source" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -3682,7 +3687,8 @@ resource "aws_dynamodb_table" "source" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
 }
 
 resource "aws_dynamodb_table" "test" {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1658,6 +1658,7 @@ func TestAccDynamoDBTable_Replica_singleAddCMK(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "replica.0.kms_key_arn", kmsAliasReplicaDatasourceName, "target_key_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.kms_key_arn", kmsAliasDatasourceName, "target_key_arn"),
 				),
+				ExpectNonEmptyPlan: true, // Because of https://github.com/hashicorp/terraform-provider-aws/issues/27850
 			},
 			{
 				Config: testAccTableConfig_replicaCMK(rName),
@@ -1668,6 +1669,12 @@ func TestAccDynamoDBTable_Replica_singleAddCMK(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.kms_key_arn", kmsKeyResourceName, "arn"),
 				),
+			},
+			{
+				Config:            testAccTableConfig_replicaCMK(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1601,7 +1601,7 @@ func TestAccDynamoDBTable_Replica_singleWithCMK(t *testing.T) {
 	resourceName := "aws_dynamodb_table.test"
 	kmsKeyResourceName := "aws_kms_key.test"
 	// kmsAliasDatasourceName := "data.aws_kms_alias.master"
-	kmsKeyReplicaResourceName := "aws_kms_key.alt_test"
+	kmsKeyReplicaResourceName := "aws_kms_key.replica"
 	// kmsAliasReplicaDatasourceName := "data.aws_kms_alias.replica"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -1636,7 +1636,7 @@ func TestAccDynamoDBTable_Replica_singleAddCMK(t *testing.T) {
 	resourceName := "aws_dynamodb_table.test"
 	kmsKeyResourceName := "aws_kms_key.test"
 	kmsAliasDatasourceName := "data.aws_kms_alias.dynamodb"
-	kmsKeyReplicaResourceName := "aws_kms_key.alt_test"
+	kmsKeyReplicaResourceName := "aws_kms_key.replica"
 	kmsAliasReplicaDatasourceName := "data.aws_kms_alias.replica"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -1651,7 +1651,7 @@ func TestAccDynamoDBTable_Replica_singleAddCMK(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTableConfig_replicaAmazonManagedKey(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
@@ -1661,7 +1661,7 @@ func TestAccDynamoDBTable_Replica_singleAddCMK(t *testing.T) {
 			},
 			{
 				Config: testAccTableConfig_replicaCMK(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "replica.0.kms_key_arn", kmsKeyReplicaResourceName, "arn"),
@@ -3138,7 +3138,7 @@ resource "aws_kms_key" "test" {
   description = %[1]q
 }
 
-resource "aws_kms_key" "alt_test" {
+resource "aws_kms_key" "replica" {
   provider    = "awsalternate"
   description = "%[1]s-2"
 }
@@ -3157,7 +3157,7 @@ resource "aws_dynamodb_table" "test" {
 
   replica {
     region_name = data.aws_region.alternate.name
-    kms_key_arn = aws_kms_key.alt_test.arn
+    kms_key_arn = aws_kms_key.replica.arn
   }
 
   server_side_encryption {
@@ -3199,22 +3199,22 @@ resource "aws_dynamodb_table" "test" {
   stream_view_type = "NEW_AND_OLD_IMAGES"
 
   attribute {
-	name = "TestTableHashKey"
-	type = "S"
+    name = "TestTableHashKey"
+    type = "S"
   }
 
   replica {
-	region_name = data.aws_region.alternate.name
+    region_name = data.aws_region.alternate.name
   }
 
   server_side_encryption {
-	enabled = true
+    enabled = true
   }
 
   timeouts {
-	create = "20m"
-	update = "20m"
-	delete = "20m"
+    create = "20m"
+    update = "20m"
+    delete = "20m"
   }
 }
 `, rName))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21726

Output from acceptance testing replica related tests:

```
➜ make testacc  TESTS='TestAccDynamoDBTable_Replica_' PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_Replica_'  -timeout 180m
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleWithCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleWithCMK
=== RUN   TestAccDynamoDBTable_Replica_singleUpdateToUseCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleUpdateToUseCMK
=== CONT  TestAccDynamoDBTable_Replica_multiple
=== CONT  TestAccDynamoDBTable_Replica_singleWithCMK
=== CONT  TestAccDynamoDBTable_Replica_singleUpdateToUseCMK
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (342.53s)
--- PASS: TestAccDynamoDBTable_Replica_singleUpdateToUseCMK (459.36s)
--- PASS: TestAccDynamoDBTable_Replica_single (463.40s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (724.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   726.839s

```
Output from acceptance testing encryption related tests:
```

➜ make testacc  TESTS='TestAccDynamoDBTable_encryption' PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_encryption'  -timeout 180m
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_encryption (137.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   139.694s

```