### PR TITLE
d/aws_ssm_instances

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -774,6 +774,7 @@ func Provider() *schema.Provider {
 			"aws_sqs_queue": sqs.DataSourceQueue(),
 
 			"aws_ssm_document":           ssm.DataSourceDocument(),
+			"aws_ssm_instances":          ssm.DataSourceInstances(),
 			"aws_ssm_parameter":          ssm.DataSourceParameter(),
 			"aws_ssm_parameters_by_path": ssm.DataSourceParametersByPath(),
 			"aws_ssm_patch_baseline":     ssm.DataSourcePatchBaseline(),

--- a/internal/service/ssm/instances_data_source.go
+++ b/internal/service/ssm/instances_data_source.go
@@ -33,7 +33,7 @@ func DataSourceInstances() *schema.Resource {
 				},
 			},
 			"ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/internal/service/ssm/instances_data_source.go
+++ b/internal/service/ssm/instances_data_source.go
@@ -1,0 +1,129 @@
+package ssm
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+)
+
+func DataSourceInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceInstancesRead,
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceInstancesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSMConn
+
+	input := &ssm.DescribeInstanceInformationInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = expandInstanceInformationStringFilters(v.(*schema.Set).List())
+	}
+
+	var results []*ssm.InstanceInformation
+
+	err := conn.DescribeInstanceInformationPages(input, func(page *ssm.DescribeInstanceInformationOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, instanceInformation := range page.InstanceInformationList {
+			if instanceInformation == nil {
+				continue
+			}
+
+			results = append(results, instanceInformation)
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading SSM Instances: %w", err)
+	}
+
+	var instanceIDs []string
+
+	for _, r := range results {
+		instanceIDs = append(instanceIDs, aws.StringValue(r.InstanceId))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("ids", instanceIDs)
+
+	return nil
+}
+
+func expandInstanceInformationStringFilters(tfList []interface{}) []*ssm.InstanceInformationStringFilter {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*ssm.InstanceInformationStringFilter
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandInstanceInformationStringFilter(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandInstanceInformationStringFilter(tfMap map[string]interface{}) *ssm.InstanceInformationStringFilter {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &ssm.InstanceInformationStringFilter{}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		apiObject.Key = aws.String(v)
+	}
+
+	if v, ok := tfMap["values"].([]interface{}); ok && len(v) > 0 {
+		apiObject.Values = flex.ExpandStringList(v)
+	}
+
+	return apiObject
+}

--- a/internal/service/ssm/instances_data_source_test.go
+++ b/internal/service/ssm/instances_data_source_test.go
@@ -1,0 +1,102 @@
+package ssm_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ssm"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccSSMInstancesDataSource_filter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ssm_instances.test"
+	resourceName := "aws_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { acctest.PreCheck(t) },
+		ErrorCheck: acctest.ErrorCheck(t, ssm.EndpointsID),
+		Providers:  acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckInstancesDataSourceConfig_filter_instance(rName),
+			},
+			{
+				Config: testAccCheckInstancesDataSourceConfig_filter_dataSource(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckInstancesDataSourceConfig_filter_instance(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.AvailableEC2InstanceTypeForRegion("t2.micro"),
+		fmt.Sprintf(`
+data "aws_iam_policy" "test" {
+  name = "AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role" "test" {
+  name                = %[1]q
+  managed_policy_arns = [data.aws_iam_policy.test.arn]
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
+}
+
+data "aws_ami" "test" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "test" {
+  ami                  = data.aws_ami.test.id
+  instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
+  iam_instance_profile = aws_iam_instance_profile.test.name
+}
+`, rName))
+}
+
+func testAccCheckInstancesDataSourceConfig_filter_dataSource(rName string) string {
+	return acctest.ConfigCompose(
+		testAccCheckInstancesDataSourceConfig_filter_instance(rName), `
+data "aws_ssm_instances" "test" {
+  filter {
+    name   = "InstanceIds"
+    values = [aws_instance.test.id]
+  }
+}
+`)
+}

--- a/internal/service/ssm/instances_data_source_test.go
+++ b/internal/service/ssm/instances_data_source_test.go
@@ -21,10 +21,7 @@ func TestAccSSMInstancesDataSource_filter(t *testing.T) {
 		Providers:  acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckInstancesDataSourceConfig_filter_instance(rName),
-			},
-			{
-				Config: testAccCheckInstancesDataSourceConfig_filter_dataSource(rName),
+				Config: testAccCheckInstancesDataSourceConfig_filter(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", resourceName, "id"),
@@ -34,9 +31,9 @@ func TestAccSSMInstancesDataSource_filter(t *testing.T) {
 	})
 }
 
-func testAccCheckInstancesDataSourceConfig_filter_instance(rName string) string {
+func testAccCheckInstancesDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(
-		acctest.AvailableEC2InstanceTypeForRegion("t2.micro"),
+		acctest.AvailableEC2InstanceTypeForRegion("t2.micro", "t3.micro"),
 		fmt.Sprintf(`
 data "aws_iam_policy" "test" {
   name = "AmazonSSMManagedInstanceCore"
@@ -86,17 +83,12 @@ resource "aws_instance" "test" {
   instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
   iam_instance_profile = aws_iam_instance_profile.test.name
 }
-`, rName))
-}
 
-func testAccCheckInstancesDataSourceConfig_filter_dataSource(rName string) string {
-	return acctest.ConfigCompose(
-		testAccCheckInstancesDataSourceConfig_filter_instance(rName), `
 data "aws_ssm_instances" "test" {
   filter {
     name   = "InstanceIds"
     values = [aws_instance.test.id]
   }
 }
-`)
+`, rName))
 }

--- a/website/docs/d/ssm_instances.html.markdown
+++ b/website/docs/d/ssm_instances.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "SSM"
+layout: "aws"
+page_title: "AWS: aws_ssm_instances"
+description: |-
+  Get information on SSM managed instances.
+---
+
+# Data Source: aws_ssm_instances
+
+Use this data source to get the instance IDs of SSM managed instances.
+
+## Example Usage
+
+```terraform
+data "aws_ssm_instances" "example" {
+  filter {
+    name   = "PlatformTypes"
+    values = ["Linux"]
+  }
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [SSM InstanceInformationStringFilter API Reference](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InstanceInformationStringFilter.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+* `ids` - Set of instance IDs of the matched SSM managed instances.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23135.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG_NAME=internal/service/ssm TESTARGS="-run=TestAccSSMInstancesDataSource_filter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMInstancesDataSource_filter -timeout 180m
=== RUN   TestAccSSMInstancesDataSource_filter
=== PAUSE TestAccSSMInstancesDataSource_filter
=== CONT  TestAccSSMInstancesDataSource_filter
--- PASS: TestAccSSMInstancesDataSource_filter (170.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        171.736s
```
