### PR TITLE
Add custom vpc for apprunner

### DIFF
--- a/.changelog/23090.txt
+++ b/.changelog/23090.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_apprunner_vpc_connector
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/terraform-provider-aws
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.42.44
+	github.com/aws/aws-sdk-go v1.42.49
 	github.com/beevik/etree v1.1.0
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.15.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.5

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/terraform-provider-aws
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.42.49
+	github.com/aws/aws-sdk-go v1.42.52
 	github.com/beevik/etree v1.1.0
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.15.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.5

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/aws/aws-sdk-go v1.42.18/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm
 github.com/aws/aws-sdk-go v1.42.41/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aws/aws-sdk-go v1.42.44 h1:vPlF4cUsdN5ETfvb7ewZFbFZyB6Rsfndt3kS2XqLXKo=
 github.com/aws/aws-sdk-go v1.42.44/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
+github.com/aws/aws-sdk-go v1.42.49 h1:g7H76HJWcer7W2bKL+UHEEhj2jg51rQPcR1OO8ntWBY=
+github.com/aws/aws-sdk-go v1.42.49/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aws/aws-sdk-go-v2 v1.13.0 h1:1XIXAfxsEmbhbj5ry3D3vX+6ZcUYvIqSm4CWWEuGZCA=
 github.com/aws/aws-sdk-go-v2 v1.13.0/go.mod h1:L6+ZpqHaLbAaxsqV0L4cvxZY7QupWJB4fhkf8LXvC7w=
 github.com/aws/aws-sdk-go-v2/config v1.13.0 h1:1ij3YPk13RrIn1h+pH+dArh3lNPD5JSAP+ifOkNhnB0=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/aws/aws-sdk-go v1.42.44 h1:vPlF4cUsdN5ETfvb7ewZFbFZyB6Rsfndt3kS2XqLXK
 github.com/aws/aws-sdk-go v1.42.44/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aws/aws-sdk-go v1.42.49 h1:g7H76HJWcer7W2bKL+UHEEhj2jg51rQPcR1OO8ntWBY=
 github.com/aws/aws-sdk-go v1.42.49/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
+github.com/aws/aws-sdk-go v1.42.52 h1:/+TZ46+0qu9Ph/UwjVrU3SG8OBi87uJLrLiYRNZKbHQ=
+github.com/aws/aws-sdk-go v1.42.52/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aws/aws-sdk-go-v2 v1.13.0 h1:1XIXAfxsEmbhbj5ry3D3vX+6ZcUYvIqSm4CWWEuGZCA=
 github.com/aws/aws-sdk-go-v2 v1.13.0/go.mod h1:L6+ZpqHaLbAaxsqV0L4cvxZY7QupWJB4fhkf8LXvC7w=
 github.com/aws/aws-sdk-go-v2/config v1.13.0 h1:1ij3YPk13RrIn1h+pH+dArh3lNPD5JSAP+ifOkNhnB0=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -868,6 +868,7 @@ func Provider() *schema.Provider {
 			"aws_apprunner_auto_scaling_configuration_version": apprunner.ResourceAutoScalingConfigurationVersion(),
 			"aws_apprunner_connection":                         apprunner.ResourceConnection(),
 			"aws_apprunner_custom_domain_association":          apprunner.ResourceCustomDomainAssociation(),
+			"aws_apprunner_custom_vpc_association":             apprunner.ResourceCustomVpcAssociation(),
 			"aws_apprunner_service":                            apprunner.ResourceService(),
 
 			"aws_appstream_directory_config":        appstream.ResourceDirectoryConfig(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -868,7 +868,7 @@ func Provider() *schema.Provider {
 			"aws_apprunner_auto_scaling_configuration_version": apprunner.ResourceAutoScalingConfigurationVersion(),
 			"aws_apprunner_connection":                         apprunner.ResourceConnection(),
 			"aws_apprunner_custom_domain_association":          apprunner.ResourceCustomDomainAssociation(),
-			"aws_apprunner_custom_vpc_association":             apprunner.ResourceCustomVpcAssociation(),
+			"aws_apprunner_vpc_connector":                      apprunner.ResourceVpcConnector(),
 			"aws_apprunner_service":                            apprunner.ResourceService(),
 
 			"aws_appstream_directory_config":        appstream.ResourceDirectoryConfig(),

--- a/internal/service/apprunner/custom_vpc_association.go
+++ b/internal/service/apprunner/custom_vpc_association.go
@@ -1,0 +1,170 @@
+package apprunner
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apprunner"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceCustomVpcAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceCustomVpcAssociationCreate,
+		ReadWithoutTimeout:   resourceCustomVpcAssociationRead,
+		DeleteWithoutTimeout: resourceCustomVpcAssociationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"vpc_connector_name": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(4, 40),
+			},
+			"vpc_connector_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"subnets": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCustomVpcAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppRunnerConn
+
+	vpcConnectorName := d.Get("vpc_connector_name").(string)
+	subnets := flex.ExpandStringSet(d.Get("subnets").(*schema.Set))
+	securityGroups := flex.ExpandStringSet(d.Get("security_groups").(*schema.Set))
+
+	input := &apprunner.CreateVpcConnectorInput{
+		VpcConnectorName: aws.String(vpcConnectorName),
+		Subnets:          subnets,
+		SecurityGroups:   securityGroups,
+	}
+
+	output, err := conn.CreateVpcConnectorWithContext(ctx, input)
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error associating App Runner Custom VPC (%s): %w", vpcConnectorName, err))
+	}
+
+	if output == nil {
+		return diag.FromErr(fmt.Errorf("error associating App Runner Custom VPC (%s): empty output", vpcConnectorName))
+	}
+
+	d.SetId(aws.StringValue(output.VpcConnector.VpcConnectorArn))
+
+	if err := WaitAutoScalingConfigurationActive(ctx, conn, d.Id()); err != nil {
+		return diag.FromErr(fmt.Errorf("error waiting for associating App Runner Custom VPC(%s) creation: %w", d.Id(), err))
+	}
+
+	return resourceCustomVpcAssociationRead(ctx, d, meta)
+}
+
+func resourceCustomVpcAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppRunnerConn
+
+	domainName, serviceArn, err := CustomDomainAssociationParseID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	customDomain, err := FindCustomDomain(ctx, conn, domainName, serviceArn)
+
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
+		log.Printf("[WARN] App Runner Custom Domain Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if customDomain == nil {
+		if d.IsNewResource() {
+			return diag.FromErr(fmt.Errorf("error reading App Runner Custom Domain Association (%s): empty output after creation", d.Id()))
+		}
+		log.Printf("[WARN] App Runner Custom Domain Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("certificate_validation_records", flattenAppRunnerCustomDomainCertificateValidationRecords(customDomain.CertificateValidationRecords)); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting certificate_validation_records: %w", err))
+	}
+
+	d.Set("domain_name", customDomain.DomainName)
+	d.Set("enable_www_subdomain", customDomain.EnableWWWSubdomain)
+	d.Set("service_arn", serviceArn)
+	d.Set("status", customDomain.Status)
+
+	return nil
+}
+
+func resourceCustomVpcAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppRunnerConn
+
+	domainName, serviceArn, err := CustomDomainAssociationParseID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &apprunner.DisassociateCustomDomainInput{
+		DomainName: aws.String(domainName),
+		ServiceArn: aws.String(serviceArn),
+	}
+
+	_, err = conn.DisassociateCustomDomainWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error disassociating App Runner Custom Domain (%s) for Service (%s): %w", domainName, serviceArn, err))
+	}
+
+	if err := WaitCustomDomainAssociationDeleted(ctx, conn, domainName, serviceArn); err != nil {
+		if tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
+			return nil
+		}
+
+		return diag.FromErr(fmt.Errorf("error waiting for App Runner Custom Domain Association (%s) deletion: %w", d.Id(), err))
+	}
+
+	return nil
+}

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -548,6 +548,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if d.HasChanges(
 		"auto_scaling_configuration_arn",
 		"instance_configuration",
+		"network_configuration",
 		"source_configuration",
 	) {
 		input := &apprunner.UpdateServiceInput{
@@ -725,7 +726,7 @@ func expandAppRunnerNetworkConfiguration(l []interface{}) *apprunner.NetworkConf
 		result.EgressConfiguration.EgressType = aws.String(v)
 	}
 
-	if v, ok := tfMap["arn"].(string); ok && v != "" {
+	if v, ok := tfMap["vpc_connector_arn"].(string); ok && v != "" {
 		result.EgressConfiguration.VpcConnectorArn = aws.String(v)
 	}
 

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -152,6 +152,38 @@ func ResourceService() *schema.Resource {
 				},
 			},
 
+			"network_configuration": {
+				Type:     schema.TypeList,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"egress_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"egress_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(apprunner.EgressType_Values(), false),
+									},
+									"vpc_connector_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: verify.ValidARN,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"service_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/apprunner/status.go
+++ b/internal/service/apprunner/status.go
@@ -12,6 +12,9 @@ const (
 	AutoScalingConfigurationStatusActive   = "active"
 	AutoScalingConfigurationStatusInactive = "inactive"
 
+	VpcConnectorStatusActive   = "ACTIVE"
+	VpcConnectorStatusInactive = "INACTIVE"
+
 	CustomDomainAssociationStatusActive                          = "active"
 	CustomDomainAssociationStatusCreating                        = "creating"
 	CustomDomainAssociationStatusDeleting                        = "deleting"
@@ -36,6 +39,26 @@ func StatusAutoScalingConfiguration(ctx context.Context, conn *apprunner.AppRunn
 		}
 
 		return output.AutoScalingConfiguration, aws.StringValue(output.AutoScalingConfiguration.Status), nil
+	}
+}
+
+func StatusVpcConnector(ctx context.Context, conn *apprunner.AppRunner, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &apprunner.DescribeVpcConnectorInput{
+			VpcConnectorArn: aws.String(arn),
+		}
+
+		output, err := conn.DescribeVpcConnectorWithContext(ctx, input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil || output.VpcConnector == nil {
+			return nil, "", nil
+		}
+
+		return output.VpcConnector, aws.StringValue(output.VpcConnector.Status), nil
 	}
 }
 

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -56,6 +56,10 @@ func ResourceVpcConnector() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"vpc_connector_revision": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-func ResourceCustomVpcAssociation() *schema.Resource {
+func ResourceVpcConnector() *schema.Resource {
 	return &schema.Resource{
-		CreateWithoutTimeout: resourceCustomVpcAssociationCreate,
-		ReadWithoutTimeout:   resourceCustomVpcAssociationRead,
-		DeleteWithoutTimeout: resourceCustomVpcAssociationDelete,
+		CreateWithoutTimeout: resourceVpcConnectorCreate,
+		ReadWithoutTimeout:   resourceVpcConnectorRead,
+		DeleteWithoutTimeout: resourceVpcConnectorDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -64,7 +64,7 @@ func ResourceCustomVpcAssociation() *schema.Resource {
 	}
 }
 
-func resourceCustomVpcAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppRunnerConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -96,10 +96,10 @@ func resourceCustomVpcAssociationCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("error waiting for associating App Runner Custom VPC(%s) creation: %w", d.Id(), err))
 	}
 
-	return resourceCustomVpcAssociationRead(ctx, d, meta)
+	return resourceVpcConnectorRead(ctx, d, meta)
 }
 
-func resourceCustomVpcAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppRunnerConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
@@ -171,7 +171,7 @@ func resourceCustomVpcAssociationRead(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceCustomVpcAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVpcConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppRunnerConn
 
 	input := &apprunner.DeleteVpcConnectorInput{

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -121,7 +121,7 @@ func resourceVpcConnectorRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(fmt.Errorf("error reading App Runner vpc connector (%s): empty output", d.Id()))
 	}
 
-	if aws.StringValue(output.VpcConnector.Status) == apprunner.ServiceStatusDeleted {
+	if aws.StringValue(output.VpcConnector.Status) == apprunner.VpcConnectorStatusInactive {
 		if d.IsNewResource() {
 			return diag.FromErr(fmt.Errorf("error reading App Runner vpc connector (%s): %s after creation", d.Id(), aws.StringValue(output.VpcConnector.Status)))
 		}

--- a/internal/service/apprunner/vpc_connector.go_test.go
+++ b/internal/service/apprunner/vpc_connector.go_test.go
@@ -22,7 +22,7 @@ func TestAccAppRunnerVpcConnector_basic(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunnerVpcConnector(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVpcConnectorDestroy,
@@ -52,7 +52,7 @@ func TestAccAppRunnerVpcConnector_disappears(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunnerVpcConnector(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVpcConnectorDestroy,
@@ -74,7 +74,7 @@ func TestAccAppRunnerVpcConnector_tags(t *testing.T) {
 	resourceName := "aws_apprunner_vpc_connector.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunnerVpcConnector(t) },
 		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
 		Providers:    acctest.Providers,
 		CheckDestroy: testAccCheckVpcConnectorDestroy,
@@ -206,4 +206,21 @@ resource "aws_apprunner_vpc_connector" "test" {
   }
 }
 `, rName, tagKey1, tagValue1)
+}
+
+func testAccPreCheckAppRunnerVpcConnector(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AppRunnerConn
+	ctx := context.Background()
+
+	input := &apprunner.ListVpcConnectorsInput{}
+
+	_, err := conn.ListVpcConnectorsWithContext(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }

--- a/internal/service/apprunner/vpc_connector.go_test.go
+++ b/internal/service/apprunner/vpc_connector.go_test.go
@@ -1,0 +1,209 @@
+package apprunner_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apprunner"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfapprunner "github.com/hashicorp/terraform-provider-aws/internal/service/apprunner"
+)
+
+func TestAccAppRunnerVpcConnector_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_apprunner_vpc_connector.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVpcConnectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRunnerVpcConnector_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcConnectorExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "apprunner", regexp.MustCompile(fmt.Sprintf(`vpcconnector/%s/1/.+`, rName))),
+					resource.TestCheckResourceAttr(resourceName, "vpc_connector_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAppRunnerVpcConnector_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_apprunner_vpc_connector.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVpcConnectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRunnerVpcConnector_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcConnectorExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfapprunner.ResourceVpcConnector(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAppRunnerVpcConnector_tags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_apprunner_vpc_connector.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccPreCheckAppRunner(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, apprunner.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckVpcConnectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRunnerVpcConnectorConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcConnectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVpcConnectorDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_apprunner_vpc_connector" {
+			continue
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppRunnerConn
+
+		input := &apprunner.DescribeVpcConnectorInput{
+			VpcConnectorArn: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeVpcConnectorWithContext(context.Background(), input)
+
+		if tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output != nil && output.VpcConnector != nil && aws.StringValue(output.VpcConnector.Status) != "INACTIVE" {
+			return fmt.Errorf("App Runner VpcConnector Configuration (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVpcConnectorExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No App Runner Vpc Connector ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppRunnerConn
+
+		input := &apprunner.DescribeVpcConnectorInput{
+			VpcConnectorArn: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeVpcConnectorWithContext(context.Background(), input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.VpcConnector == nil {
+			return fmt.Errorf("App Runner Vpc Connector Configuration (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccAppRunnerVpcConnector_basic(rName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_vpc" "test" {
+	cidr_block = "10.1.0.0/16"
+}
+	  
+resource "aws_security_group" "test" {
+	vpc_id = aws_vpc.test.id
+}
+	  
+resource "aws_subnet" "test" {
+	cidr_block = "10.1.1.0/24"
+	vpc_id     = aws_vpc.test.id
+}
+
+resource "aws_apprunner_vpc_connector" "test" {
+	vpc_connector_name = %q
+	subnets   = [aws_subnet.test.id]
+	security_groups    = [aws_security_group.test.id]
+}
+`, rName)
+}
+
+func testAccAppRunnerVpcConnectorConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+	cidr_block = "10.1.0.0/16"
+}
+			  
+resource "aws_security_group" "test" {
+	vpc_id = aws_vpc.test.id
+}
+			  
+resource "aws_subnet" "test" {
+	cidr_block = "10.1.1.0/24"
+	vpc_id     = aws_vpc.test.id
+}
+
+resource "aws_apprunner_vpc_connector" "test" {
+	vpc_connector_name = %[1]q
+	subnets   = [aws_subnet.test.id]
+	security_groups    = [aws_security_group.test.id]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}

--- a/internal/service/apprunner/wait.go
+++ b/internal/service/apprunner/wait.go
@@ -17,6 +17,9 @@ const (
 	CustomDomainAssociationCreateTimeout = 5 * time.Minute
 	CustomDomainAssociationDeleteTimeout = 5 * time.Minute
 
+	VpcConnectorCreateTimeout = 2 * time.Minute
+	VpcConnectorDeleteTimeout = 2 * time.Minute
+
 	ServiceCreateTimeout = 20 * time.Minute
 	ServiceDeleteTimeout = 20 * time.Minute
 	ServiceUpdateTimeout = 20 * time.Minute
@@ -119,6 +122,32 @@ func WaitServiceDeleted(ctx context.Context, conn *apprunner.AppRunner, serviceA
 		Target:  []string{apprunner.ServiceStatusDeleted},
 		Refresh: StatusService(ctx, conn, serviceArn),
 		Timeout: ServiceDeleteTimeout,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func WaitVpcConnectorActive(ctx context.Context, conn *apprunner.AppRunner, arn string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{},
+		Target:  []string{VpcConnectorStatusActive},
+		Refresh: StatusVpcConnector(ctx, conn, arn),
+		Timeout: VpcConnectorCreateTimeout,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func WaitVpcConnectorInactive(ctx context.Context, conn *apprunner.AppRunner, arn string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{VpcConnectorStatusActive},
+		Target:  []string{VpcConnectorStatusInactive},
+		Refresh: StatusVpcConnector(ctx, conn, arn),
+		Timeout: VpcConnectorDeleteTimeout,
 	}
 
 	_, err := stateConf.WaitForState()

--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -40,6 +40,13 @@ resource "aws_apprunner_service" "example" {
     }
   }
 
+  network_configuration {
+    egress_configuration {
+      egress_type       = "VPC"
+      vpc_connector_arn = aws_apprunner_vpc_connector.connector.arn
+    }
+  }
+
   tags = {
     Name = "example-apprunner-service"
   }
@@ -83,6 +90,8 @@ The following arguments are optional:
 * `instance_configuration` - The runtime configuration of instances (scaling units) of the App Runner service. See [Instance Configuration](#instance-configuration) below for more details.
 * `tags` - Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
+* `network_configuration` - Configuration settings related to network traffic of the web application that the App Runner service runs.
+
 ### Encryption Configuration
 
 The `encryption_configuration` block supports the following argument:
@@ -125,6 +134,14 @@ The `authentication_configuration` block supports the following arguments:
 
 * `access_role_arn` - (Optional) ARN of the IAM role that grants the App Runner service access to a source repository. Required for ECR image repositories (but not for ECR Public)
 * `connection_arn` - (Optional) ARN of the App Runner connection that enables the App Runner service to connect to a source repository. Required for GitHub code repositories.
+
+
+### Network Configuration
+
+The `network_configuration` block supports the following arguments:
+* `egress_configuration` - (Optional) Network configuration settings for outbound message traffic.
+* `egress_type` - (Optional) The type of egress configuration.Set to DEFAULT for access to resources hosted on public networks.Set to VPC to associate your service to a custom VPC specified by VpcConnectorArn.
+* `vpc_connector_arn` - The Amazon Resource Name (ARN) of the App Runner VPC connector that you want to associate with your App Runner service. Only valid when EgressType = VPC.
 
 ### Code Repository
 

--- a/website/docs/r/apprunner_vpc_connector.html.markdown
+++ b/website/docs/r/apprunner_vpc_connector.html.markdown
@@ -33,9 +33,9 @@ The following arguments supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `vpc_connector_arn` - The Amazon Resource Name (ARN) of this VPC connector.
+* `vpc_connector_arn` - The Amazon Resource Name (ARN) of VPC connector.
 * `status` - The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted.
-* `vpc_connector_revision` - The revision of this VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name.
+* `vpc_connector_revision` - The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name.
 
 ## Import
 

--- a/website/docs/r/apprunner_vpc_connector.html.markdown
+++ b/website/docs/r/apprunner_vpc_connector.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "App Runner"
+layout: "aws"
+page_title: "AWS: aws_apprunner_vpc_connector"
+description: |-
+  Manages an App Runner Vpc Connector.
+---
+
+# Resource: aws_apprunner_vpc_connector
+
+Manages an App Runner vpc connector.
+
+## Example Usage
+
+```terraform
+resource "aws_apprunner_vpc_connector" "connector" {
+  vpc_connector_name = "name"
+  subnets            = ["subnet1", "subnet2"]
+  security_groups    = ["sg1", "sg2"]
+}
+```
+
+## Argument Reference
+
+The following arguments supported:
+
+* `vpc_connector_name` - (Required) A name for the VPC connector.
+* `subnets` (Required) A list of IDs of subnets that App Runner should use when it associates your service with a custom Amazon VPC. Specify IDs of subnets of a single Amazon VPC. App Runner determines the Amazon VPC from the subnets you specify.
+* `security_groups` - A list of IDs of security groups that App Runner should use for access to AWS resources under the specified subnets. If not specified, App Runner uses the default security group of the Amazon VPC. The default security group allows all outbound traffic.
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `vpc_connector_arn` - The Amazon Resource Name (ARN) of this VPC connector.
+* `status` - The current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted.
+* `vpc_connector_revision` - The revision of this VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name.
+
+## Import
+
+App Runner vpc connector can be imported by using the `vpc_connector_name`, e.g.,
+
+```
+$ terraform import aws_apprunner_vpc_connector.vpc_connector_name 
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #23090

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTS=TestAccAppRunnerVpcConnector_ PKG=apprunner 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apprunner/... -v -count 1 -parallel 20 -run='TestAccAppRunnerVpcConnector_'  -timeout 180m
=== RUN   TestAccAppRunnerVpcConnector_basic
=== PAUSE TestAccAppRunnerVpcConnector_basic
=== RUN   TestAccAppRunnerVpcConnector_disappears
=== PAUSE TestAccAppRunnerVpcConnector_disappears
=== RUN   TestAccAppRunnerVpcConnector_tags
=== PAUSE TestAccAppRunnerVpcConnector_tags
=== CONT  TestAccAppRunnerVpcConnector_basic
=== CONT  TestAccAppRunnerVpcConnector_disappears
=== CONT  TestAccAppRunnerVpcConnector_tags
--- PASS: TestAccAppRunnerVpcConnector_disappears (47.52s)
--- PASS: TestAccAppRunnerVpcConnector_tags (58.97s)
--- PASS: TestAccAppRunnerVpcConnector_basic (61.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  63.763s

...
```
