### PR TITLE
r/aws_backup_framework

### DIFF
--- a/.changelog/23175.txt
+++ b/.changelog/23175.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_backup_framework
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -924,6 +924,7 @@ func Provider() *schema.Provider {
 
 			"aws_autoscalingplans_scaling_plan": autoscalingplans.ResourceScalingPlan(),
 
+			"aws_backup_framework":                backup.ResourceFramework(),
 			"aws_backup_global_settings":          backup.ResourceGlobalSettings(),
 			"aws_backup_plan":                     backup.ResourcePlan(),
 			"aws_backup_region_settings":          backup.ResourceRegionSettings(),

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -5,4 +5,5 @@ const (
 	frameworkStatusCreationInProgress = "CREATE_IN_PROGRESS"
 	frameworkStatusDeletionInProgress = "DELETE_IN_PROGRESS"
 	frameworkStatusFailed             = "FAILED"
+	frameworkStatusUpdateInProgress   = "UPDATE_IN_PROGRESS"
 )

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -1,0 +1,7 @@
+package backup
+
+const (
+	frameworkStatusCompleted          = "COMPLETED"
+	frameworkStatusCreationInProgress = "CREATE_IN_PROGRESS"
+	frameworkStatusFailed             = "FAILED"
+)

--- a/internal/service/backup/consts.go
+++ b/internal/service/backup/consts.go
@@ -3,5 +3,6 @@ package backup
 const (
 	frameworkStatusCompleted          = "COMPLETED"
 	frameworkStatusCreationInProgress = "CREATE_IN_PROGRESS"
+	frameworkStatusDeletionInProgress = "DELETE_IN_PROGRESS"
 	frameworkStatusFailed             = "FAILED"
 )

--- a/internal/service/backup/framework.go
+++ b/internal/service/backup/framework.go
@@ -1,0 +1,117 @@
+package backup
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceFramework() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(2 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"control": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"input_parameter": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 256),
+						},
+						"scope": {
+							// The control scope can include
+							// one or more resource types,
+							// a combination of a tag key and value,
+							// or a combination of one resource type and one resource ID.
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"compliance_resource_ids": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MinItems: 1,
+										MaxItems: 100,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"compliance_resource_types": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									// A maximum of one key-value pair can be provided.
+									// The tag value is optional, but it cannot be an empty string
+									"tags": tftags.TagsSchema(),
+								},
+							},
+						},
+					},
+				},
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deployment_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validFrameworkName,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}

--- a/internal/service/backup/framework.go
+++ b/internal/service/backup/framework.go
@@ -237,6 +237,10 @@ func resourceFrameworkUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error updating Backup Framework (%s): %w", d.Id(), err)
 		}
+
+		if _, err := waitFrameworkUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error waiting for Framework (%s) update: %w", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("tags_all") {

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 )
 
 func TestAccBackupFramework_basic(t *testing.T) {
@@ -428,6 +429,31 @@ func TestAccBackupFramework_updateControls(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccBackupFramework_disappears(t *testing.T) {
+	var framework backup.DescribeFrameworkOutput
+
+	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+	description := "disappears"
+	resourceName := "aws_backup_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupFrameworkConfig_basic(rName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					acctest.CheckResourceDisappears(acctest.Provider, tfbackup.ResourceFramework(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -1,9 +1,13 @@
 package backup_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
@@ -21,3 +25,28 @@ func testAccFrameworkPreCheck(t *testing.T) {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
+
+func testAccCheckFrameworkExists(name string, framework *backup.DescribeFrameworkOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+		input := &backup.DescribeFrameworkInput{
+			FrameworkName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeFramework(input)
+
+		if err != nil {
+			return err
+		}
+
+		*framework = *resp
+
+		return nil
+	}
+}
+

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -26,6 +26,29 @@ func testAccFrameworkPreCheck(t *testing.T) {
 	}
 }
 
+func testAccCheckFrameworkDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_backup_framework" {
+			continue
+		}
+
+		input := &backup.DescribeFrameworkInput{
+			FrameworkName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeFramework(input)
+
+		if err == nil {
+			if aws.StringValue(resp.FrameworkName) == rs.Primary.ID {
+				return fmt.Errorf("Backup Framework '%s' was not deleted properly", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
 func testAccCheckFrameworkExists(name string, framework *backup.DescribeFrameworkOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -161,6 +161,117 @@ func TestAccBackupFramework_updateTags(t *testing.T) {
 	})
 }
 
+func TestAccBackupFramework_updateControlScope(t *testing.T) {
+	var framework backup.DescribeFrameworkOutput
+
+	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+	description := "example description"
+	originalControlScopeTagValue := "example"
+	updatedControlScopeTagValue := ""
+	resourceName := "aws_backup_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupFrameworkConfig_basic(rName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.0", "EBS"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupFrameworkConfig_controlScopeComplianceResourceId(rName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "control.0.scope.0.compliance_resource_ids.0", "aws_ebs_volume.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.0", "EBS"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupFrameworkConfig_controlScopeTag(rName, description, originalControlScopeTagValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.tags.Name", originalControlScopeTagValue),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupFrameworkConfig_controlScopeTag(rName, description, updatedControlScopeTagValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.tags.Name", updatedControlScopeTagValue),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
+				),
+			},
+		},
+	})
+}
 func testAccFrameworkPreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
 
@@ -294,3 +405,67 @@ resource "aws_backup_framework" "test" {
 `, rName, label)
 }
 
+func testAccBackupFrameworkConfig_controlScopeComplianceResourceId(rName, label string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  type              = "gp2"
+  size              = 1
+}
+
+resource "aws_backup_framework" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  control {
+    name = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"
+
+    scope {
+      compliance_resource_ids = [
+        aws_ebs_volume.test.id
+      ]
+
+      compliance_resource_types = [
+        "EBS"
+      ]
+    }
+  }
+
+  tags = {
+    "Name" = "Test Framework"
+  }
+}
+`, rName, label)
+}
+
+func testAccBackupFrameworkConfig_controlScopeTag(rName, label, controlScopeTagValue string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_framework" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  control {
+    name = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"
+
+    scope {
+      tags = {
+        "Name" = %[3]q
+      }
+    }
+  }
+
+  tags = {
+    "Name" = "Test Framework"
+  }
+}
+`, rName, label, controlScopeTagValue)
+}

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -6,11 +6,73 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
+
+func TestAccBackupFramework_basic(t *testing.T) {
+	var framework backup.DescribeFrameworkOutput
+
+	rName := fmt.Sprintf("tf_acc_test_%s", sdkacctest.RandString(7))
+	originalDescription := "original description"
+	updatedDescription := "updated description"
+	resourceName := "aws_backup_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t); testAccFrameworkPreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, backup.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupFrameworkConfig_basic(rName, originalDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.0", "EBS"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBackupFrameworkConfig_basic(rName, updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control.0.scope.0.compliance_resource_types.0", "EBS"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Framework"),
+				),
+			},
+		},
+	})
+}
 
 func testAccFrameworkPreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
@@ -71,5 +133,28 @@ func testAccCheckFrameworkExists(name string, framework *backup.DescribeFramewor
 
 		return nil
 	}
+}
+
+func testAccBackupFrameworkConfig_basic(rName, label string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_framework" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  control {
+    name = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"
+
+    scope {
+      compliance_resource_types = [
+        "EBS"
+      ]
+    }
+  }
+
+  tags = {
+    "Name" = "Test Framework"
+  }
+}
+`, rName, label)
 }
 

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -1,0 +1,23 @@
+package backup_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func testAccFrameworkPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupConn
+
+	_, err := conn.ListFrameworks(&backup.ListFrameworksInput{})
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}

--- a/internal/service/backup/status.go
+++ b/internal/service/backup/status.go
@@ -1,0 +1,28 @@
+package backup
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func statusFramework(conn *backup.Backup, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &backup.DescribeFrameworkInput{
+			FrameworkName: aws.String(id),
+		}
+
+		output, err := conn.DescribeFramework(input)
+
+		if tfawserr.ErrCodeEquals(err, backup.ErrCodeResourceNotFoundException) {
+			return output, backup.ErrCodeResourceNotFoundException, nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.DeploymentStatus), nil
+	}
+}

--- a/internal/service/backup/validate.go
+++ b/internal/service/backup/validate.go
@@ -12,3 +12,12 @@ func validReportPlanName(v interface{}, k string) (ws []string, errors []error) 
 	}
 	return
 }
+
+// The pattern for framework and report plan name is the same but separate functions are used in the event that there are future differences
+func validFrameworkName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z]{1}[_a-zA-Z0-9]{0,255}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be must be between 1 and 256 characters, starting with a letter, and consisting of letters, numbers, and underscores.", k, v))
+	}
+	return
+}

--- a/internal/service/backup/validate_test.go
+++ b/internal/service/backup/validate_test.go
@@ -27,3 +27,26 @@ func TestValidReportPlanName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidFrameworkName(t *testing.T) {
+	validNames := []string{
+		strings.Repeat("W", 256), // <= 256
+	}
+	for _, v := range validNames {
+		_, errors := validFrameworkName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Backup Framework name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"@error",
+		strings.Repeat("W", 257), // >= 257
+	}
+	for _, v := range invalidNames {
+		_, errors := validFrameworkName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be a invalid Backup Framework name: %q", v, errors)
+		}
+	}
+}

--- a/internal/service/backup/wait.go
+++ b/internal/service/backup/wait.go
@@ -2,9 +2,31 @@ package backup
 
 import (
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 const (
 	// Maximum amount of time to wait for Backup changes to propagate
 	propagationTimeout = 2 * time.Minute
+	// Maximum amount of time to wait for Framework creation
+	frameworkCreationTimeout = 2 * time.Minute
 )
+
+func waitFrameworkCreated(conn *backup.Backup, id string) (*backup.DescribeFrameworkOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{frameworkStatusCreationInProgress},
+		Target:  []string{frameworkStatusCompleted, frameworkStatusFailed},
+		Refresh: statusFramework(conn, id),
+		Timeout: frameworkCreationTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*backup.DescribeFrameworkOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/backup/wait.go
+++ b/internal/service/backup/wait.go
@@ -10,17 +10,14 @@ import (
 const (
 	// Maximum amount of time to wait for Backup changes to propagate
 	propagationTimeout = 2 * time.Minute
-	// Maximum amount of time to wait for Framework creation and deletion
-	frameworkCreationTimeout = 2 * time.Minute
-	frameworkDeletionTimeout = 2 * time.Minute
 )
 
-func waitFrameworkCreated(conn *backup.Backup, id string) (*backup.DescribeFrameworkOutput, error) {
+func waitFrameworkCreated(conn *backup.Backup, id string, timeout time.Duration) (*backup.DescribeFrameworkOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{frameworkStatusCreationInProgress},
 		Target:  []string{frameworkStatusCompleted, frameworkStatusFailed},
 		Refresh: statusFramework(conn, id),
-		Timeout: frameworkCreationTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
@@ -32,12 +29,12 @@ func waitFrameworkCreated(conn *backup.Backup, id string) (*backup.DescribeFrame
 	return nil, err
 }
 
-func waitFrameworkDeleted(conn *backup.Backup, id string) (*backup.DescribeFrameworkOutput, error) {
+func waitFrameworkDeleted(conn *backup.Backup, id string, timeout time.Duration) (*backup.DescribeFrameworkOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{frameworkStatusDeletionInProgress},
 		Target:  []string{backup.ErrCodeResourceNotFoundException},
 		Refresh: statusFramework(conn, id),
-		Timeout: frameworkDeletionTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/internal/service/backup/wait.go
+++ b/internal/service/backup/wait.go
@@ -29,6 +29,23 @@ func waitFrameworkCreated(conn *backup.Backup, id string, timeout time.Duration)
 	return nil, err
 }
 
+func waitFrameworkUpdated(conn *backup.Backup, id string, timeout time.Duration) (*backup.DescribeFrameworkOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{frameworkStatusUpdateInProgress},
+		Target:  []string{frameworkStatusCompleted, frameworkStatusFailed},
+		Refresh: statusFramework(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*backup.DescribeFrameworkOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitFrameworkDeleted(conn *backup.Backup, id string, timeout time.Duration) (*backup.DescribeFrameworkOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{frameworkStatusDeletionInProgress},

--- a/internal/service/backup/wait.go
+++ b/internal/service/backup/wait.go
@@ -10,8 +10,9 @@ import (
 const (
 	// Maximum amount of time to wait for Backup changes to propagate
 	propagationTimeout = 2 * time.Minute
-	// Maximum amount of time to wait for Framework creation
+	// Maximum amount of time to wait for Framework creation and deletion
 	frameworkCreationTimeout = 2 * time.Minute
+	frameworkDeletionTimeout = 2 * time.Minute
 )
 
 func waitFrameworkCreated(conn *backup.Backup, id string) (*backup.DescribeFrameworkOutput, error) {
@@ -20,6 +21,23 @@ func waitFrameworkCreated(conn *backup.Backup, id string) (*backup.DescribeFrame
 		Target:  []string{frameworkStatusCompleted, frameworkStatusFailed},
 		Refresh: statusFramework(conn, id),
 		Timeout: frameworkCreationTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*backup.DescribeFrameworkOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitFrameworkDeleted(conn *backup.Backup, id string) (*backup.DescribeFrameworkOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{frameworkStatusDeletionInProgress},
+		Target:  []string{backup.ErrCodeResourceNotFoundException},
+		Refresh: statusFramework(conn, id),
+		Timeout: frameworkDeletionTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/website/docs/r/backup_framework.html.markdown
+++ b/website/docs/r/backup_framework.html.markdown
@@ -100,6 +100,14 @@ For **scope** the following attributes are supported:
 * `compliance_resource_types` - (Optional) Describes whether the control scope includes one or more types of resources, such as EFS or RDS.
 * `tags` - (Optional) The tag key-value pair applied to those AWS resources that you want to trigger an evaluation for a rule. A maximum of one key-value pair can be provided.
 
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 2 mins) Used when creating the framework
+* `update` - (Defaults to 2 mins) Used when updating the framework
+* `delete` - (Defaults to 2 mins) Used when deleting the framework
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/backup_framework.html.markdown
+++ b/website/docs/r/backup_framework.html.markdown
@@ -1,0 +1,118 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_framework"
+description: |-
+  Provides an AWS Backup Framework resource.
+---
+
+# Resource: aws_backup_framework
+
+Provides an AWS Backup Framework resource.
+
+## Example Usage
+
+```terraform
+resource "aws_backup_framework" "Example" {
+  name        = "exampleFramework"
+  description = "this is an example framework"
+
+  control {
+    name = "BACKUP_RECOVERY_POINT_MINIMUM_RETENTION_CHECK"
+
+    input_parameter {
+      name  = "requiredRetentionDays"
+      value = "35"
+    }
+  }
+
+  control {
+    name = "BACKUP_PLAN_MIN_FREQUENCY_AND_MIN_RETENTION_CHECK"
+
+    input_parameter {
+      name  = "requiredFrequencyUnit"
+      value = "hours"
+    }
+
+    input_parameter {
+      name  = "requiredRetentionDays"
+      value = "35"
+    }
+
+    input_parameter {
+      name  = "requiredFrequencyValue"
+      value = "1"
+    }
+  }
+
+  control {
+    name = "BACKUP_RECOVERY_POINT_ENCRYPTED"
+  }
+
+  control {
+    name = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"
+
+    scope {
+      compliance_resource_types = [
+        "EBS"
+      ]
+    }
+  }
+
+  control {
+    name = "BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED"
+  }
+
+  tags = {
+    "Name" = "Example Framework"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `control` - (Required) One or more control blocks that make up the framework. Each control in the list has a name, input parameters, and scope. Detailed below.
+* `description` - (Optional) The description of the framework with a maximum of 1,024 characters
+* `name` - (Required) The unique name of the framework. The name must be between 1 and 256 characters, starting with a letter, and consisting of letters, numbers, and underscores.
+* `tags` - (Optional) Metadata that you can assign to help organize the frameworks you create. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Control Arguments
+For **control** the following attributes are supported:
+
+* `input_parameter` - (Optional) One or more input parameter blocks. An example of a control with two parameters is: "backup plan frequency is at least daily and the retention period is at least 1 year". The first parameter is daily. The second parameter is 1 year. Detailed below.
+* `name` - (Required) The name of a control. This name is between 1 and 256 characters.
+* `scope` - (Optional) The scope of a control. The control scope defines what the control will evaluate. Three examples of control scopes are: a specific backup plan, all backup plans with a specific tag, or all backup plans. Detailed below.
+
+### Input Parameter Arguments
+For **input_parameter** the following attributes are supported:
+
+* `name` - (Optional) The name of a parameter, for example, BackupPlanFrequency.
+* `value` - (Optional) The value of parameter, for example, hourly.
+
+### Scope Arguments
+For **scope** the following attributes are supported:
+
+* `compliance_resource_ids` - (Optional) The ID of the only AWS resource that you want your control scope to contain. Minimum number of 1 item. Maximum number of 100 items.
+* `compliance_resource_types` - (Optional) Describes whether the control scope includes one or more types of resources, such as EFS or RDS.
+* `tags` - (Optional) The tag key-value pair applied to those AWS resources that you want to trigger an evaluation for a rule. A maximum of one key-value pair can be provided.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the backup framework.
+* `creation_time` - The date and time that a framework is created, in Unix format and Coordinated Universal Time (UTC).
+* `deployment_status` - The deployment status of a framework. The statuses are: `CREATE_IN_PROGRESS` | `UPDATE_IN_PROGRESS` | `DELETE_IN_PROGRESS` | `COMPLETED` | `FAILED`.
+* `id` - The id of the backup framework.
+* `status` - A framework consists of one or more controls. Each control governs a resource, such as backup plans, backup selections, backup vaults, or recovery points. You can also turn AWS Config recording on or off for each resource. For more information refer to the [AWS documentation for Framework Status](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_DescribeFramework.html#Backup-DescribeFramework-response-FrameworkStatus)
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Import
+
+Backup Framework can be imported using the `id` which corresponds to the name of the Backup Framework, e.g.,
+
+```
+$ terraform import aws_backup_framework.test <id>
+```

--- a/website/docs/r/backup_framework.html.markdown
+++ b/website/docs/r/backup_framework.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an AWS Backup Framework resource.
 
+~> **Note:** For the Deployment Status of the Framework to be successful, please turn on resource tracking to enable AWS Config recording to track configuration changes of your backup resources. This can be done from the AWS Console.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21784

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccBackupFramework' PKG=backup ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/backup/... -v -count 1 -parallel 1  -run=TestAccBackupFramework -timeout 180m
=== RUN   TestAccBackupFramework_basic
=== PAUSE TestAccBackupFramework_basic
=== RUN   TestAccBackupFramework_updateTags
=== PAUSE TestAccBackupFramework_updateTags
=== RUN   TestAccBackupFramework_updateControlScope
=== PAUSE TestAccBackupFramework_updateControlScope
=== RUN   TestAccBackupFramework_updateControlInputParameters
=== PAUSE TestAccBackupFramework_updateControlInputParameters
=== RUN   TestAccBackupFramework_updateControls
=== PAUSE TestAccBackupFramework_updateControls
=== RUN   TestAccBackupFramework_disappears
=== PAUSE TestAccBackupFramework_disappears
=== CONT  TestAccBackupFramework_basic
--- PASS: TestAccBackupFramework_basic (75.86s)
=== CONT  TestAccBackupFramework_updateControlInputParameters
--- PASS: TestAccBackupFramework_updateControlInputParameters (78.05s)
=== CONT  TestAccBackupFramework_disappears
--- PASS: TestAccBackupFramework_disappears (30.73s)
=== CONT  TestAccBackupFramework_updateControls
--- PASS: TestAccBackupFramework_updateControls (87.09s)
=== CONT  TestAccBackupFramework_updateControlScope
--- PASS: TestAccBackupFramework_updateControlScope (185.90s)
=== CONT  TestAccBackupFramework_updateTags
--- PASS: TestAccBackupFramework_updateTags (102.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     575.258s

...
```

### Reference docs

- [CreateFramework](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_CreateFramework.html)
- [DeleteFramework](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_DeleteFramework.html)
- [DescribeFramework](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_DescribeFramework.html)
- [UpdateFramework](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_UpdateFramework.html)

### Misc - Note/Gotchas

- For the tests, we do not necessarily need to turn on resource tracking to enable AWS Config recording to track configuration changes of your backup resources. If turned on from the console, the `deployment_status` will be `COMPLETED` instead of `FAILED`. However, regardless of the `deployment_status`, the updates will still work and tests will still pass. Hence, I did not add a pre check to check for the Service Linked Role (this role is `AWSServiceRoleForConfig`)
![image](https://user-images.githubusercontent.com/31919569/153889235-34d5feda-71cc-4972-b39a-998dbfcf5dd6.png)

- Waiters are implemented because of eventual consistency. Timeouts default to 2 minutes for Create, Update, Delete operations. The `timeouts` block is documented.
- For the `TestAccBackupFramework_updateControlScope` in Step 7/7, I noticed it appends an additional `{ ControlName: "" }` element in Framework Controls which initially failed the tests. The error was `A control name is required`. To fix this, I added a check for the empty name in the `expandFrameworkControls` function, skipping that iteration of the loop if it finds this case. Subsequently, the test passes.