### PR TITLE
docs(backup): Add example for usage of `lifecycle` for backup_plan

### DIFF
--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -20,6 +20,10 @@ resource "aws_backup_plan" "example" {
     rule_name         = "tf_example_backup_rule"
     target_vault_name = aws_backup_vault.test.name
     schedule          = "cron(0 12 * * ? *)"
+    
+    lifecycle {
+      delete_after = 14
+    }
   }
 
   advanced_backup_setting {


### PR DESCRIPTION
**This is a documentation-only change.**

While this is listed in the argument documentation, backup retention is a reasonably commonly used option that would be nice to include in the example code.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes: Not applicable

Output from acceptance testing: Not applicable, documentation-only change.
