### PR TITLE
r/aws_autoscaling_group: disable scale-in protection before draining instances

### DIFF
--- a/.changelog/23187.txt
+++ b/.changelog/23187.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_autoscaling_group: Disable scale-in protection before draining instances
+```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1654,6 +1654,18 @@ func resourceGroupDrain(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting capacity to zero to drain: %s", err)
 	}
 
+	// Next, ensure that instances are not prevented from scaling in.
+	//
+	// The ASG's own scale-in protection setting doesn't make a difference here,
+	// as it only affects new instances, which won't be launched now that the
+	// desired capacity is set to 0. There is also the possibility that this ASG
+	// no longer applies scale-in protection to new instances, but there's still
+	// old ones that have it.
+	log.Printf("[DEBUG] Disabling scale-in protection for all instances in the group")
+	if err := disableASGScaleInProtections(d, conn); err != nil {
+		return fmt.Errorf("Error disabling scale-in protection for all instances: %s", err)
+	}
+
 	// Next, wait for the Auto Scaling Group to drain
 	log.Printf("[DEBUG] Waiting for group to have zero instances")
 	var g *autoscaling.Group
@@ -2364,4 +2376,41 @@ func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecificat
 	result = append(result, attrs)
 
 	return result
+}
+
+// disableASGScaleInProtections disables scale-in protection for all instances
+// in the given Auto-Scaling Group.
+func disableASGScaleInProtections(d *schema.ResourceData, conn *autoscaling.AutoScaling) error {
+	g, err := getGroup(d.Id(), conn)
+	if err != nil {
+		return fmt.Errorf("Error getting group %s: %s", d.Id(), err)
+	}
+
+	var instanceIds []string
+	for _, instance := range g.Instances {
+		if aws.BoolValue(instance.ProtectedFromScaleIn) {
+			instanceIds = append(instanceIds, aws.StringValue(instance.InstanceId))
+		}
+	}
+
+	const chunkSize = 50 // API limit
+
+	for i := 0; i < len(instanceIds); i += chunkSize {
+		j := i + chunkSize
+		if j > len(instanceIds) {
+			j = len(instanceIds)
+		}
+
+		input := autoscaling.SetInstanceProtectionInput{
+			AutoScalingGroupName: aws.String(d.Id()),
+			InstanceIds:          aws.StringSlice(instanceIds[i:j]),
+			ProtectedFromScaleIn: aws.Bool(false),
+		}
+
+		if _, err := conn.SetInstanceProtection(&input); err != nil {
+			return fmt.Errorf("Error disabling scale-in protections: %s", err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/5278

Before draining instances during a destroy, switch off scale-in protection of all instances in the ASG. This is necessary as the resource chooses to reduce desired (and actual) instance count to 0 before destroying the ASG.

This behaviour shouldn't be a semantic concession, as deleting the ASG in the console would still result in the termination of the protected instances. Scale-in protection is a property of an instance's association with the ASG, and retaining the instances whilst destroying the ASG would necessitate detaching them from the ASG anyway.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG=autoscaling TESTS=TestAccAutoScalingGroup_ ACCTEST_PARALLELISM=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 4 -run='TestAccAutoScalingGroup_'  -timeout 180m
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== RUN   TestAccAutoScalingGroup_Name_generated
=== PAUSE TestAccAutoScalingGroup_Name_generated
=== RUN   TestAccAutoScalingGroup_namePrefix
=== PAUSE TestAccAutoScalingGroup_namePrefix
=== RUN   TestAccAutoScalingGroup_terminationPolicies
=== PAUSE TestAccAutoScalingGroup_terminationPolicies
=== RUN   TestAccAutoScalingGroup_tags
=== PAUSE TestAccAutoScalingGroup_tags
=== RUN   TestAccAutoScalingGroup_vpcUpdates
=== PAUSE TestAccAutoScalingGroup_vpcUpdates
=== RUN   TestAccAutoScalingGroup_withLoadBalancer
=== PAUSE TestAccAutoScalingGroup_withLoadBalancer
=== RUN   TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== PAUSE TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== RUN   TestAccAutoScalingGroup_withPlacementGroup
=== PAUSE TestAccAutoScalingGroup_withPlacementGroup
=== RUN   TestAccAutoScalingGroup_enablingMetrics
=== PAUSE TestAccAutoScalingGroup_enablingMetrics
=== RUN   TestAccAutoScalingGroup_suspendingProcesses
=== PAUSE TestAccAutoScalingGroup_suspendingProcesses
=== RUN   TestAccAutoScalingGroup_withMetrics
=== PAUSE TestAccAutoScalingGroup_withMetrics
=== RUN   TestAccAutoScalingGroup_serviceLinkedRoleARN
=== PAUSE TestAccAutoScalingGroup_serviceLinkedRoleARN
=== RUN   TestAccAutoScalingGroup_maxInstanceLifetime
=== PAUSE TestAccAutoScalingGroup_maxInstanceLifetime
=== RUN   TestAccAutoScalingGroup_ALB_targetGroups
=== PAUSE TestAccAutoScalingGroup_ALB_targetGroups
=== RUN   TestAccAutoScalingGroup_targetGroupARNs
=== PAUSE TestAccAutoScalingGroup_targetGroupARNs
=== RUN   TestAccAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAutoScalingGroup_initialLifecycleHook
=== RUN   TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== PAUSE TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_basic
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_basic
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_start
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_start
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_triggers
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_triggers
=== RUN   TestAccAutoScalingGroup_warmPool
=== PAUSE TestAccAutoScalingGroup_warmPool
=== RUN   TestAccAutoScalingGroup_classicVPCZoneIdentifier
=== PAUSE TestAccAutoScalingGroup_classicVPCZoneIdentifier
=== RUN   TestAccAutoScalingGroup_launchTemplate
=== PAUSE TestAccAutoScalingGroup_launchTemplate
=== RUN   TestAccAutoScalingGroup_LaunchTemplate_update
=== PAUSE TestAccAutoScalingGroup_LaunchTemplate_update
=== RUN   TestAccAutoScalingGroup_LaunchTemplate_iamInstanceProfile
=== PAUSE TestAccAutoScalingGroup_LaunchTemplate_iamInstanceProfile
=== RUN   TestAccAutoScalingGroup_loadBalancers
=== PAUSE TestAccAutoScalingGroup_loadBalancers
=== RUN   TestAccAutoScalingGroup_mixedInstancesPolicy
=== PAUSE TestAccAutoScalingGroup_mixedInstancesPolicy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
=== RUN   TestAccAutoScalingGroup_launchTempPartitionNum
=== PAUSE TestAccAutoScalingGroup_launchTempPartitionNum
=== RUN   TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== PAUSE TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== CONT  TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_classicVPCZoneIdentifier
=== CONT  TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (47.06s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
--- PASS: TestAccAutoScalingGroup_classicVPCZoneIdentifier (53.10s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (77.52s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (90.39s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
--- PASS: TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn (171.71s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (50.76s)
=== CONT  TestAccAutoScalingGroup_mixedInstancesPolicy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (101.59s)
=== CONT  TestAccAutoScalingGroup_loadBalancers
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (57.10s)
=== CONT  TestAccAutoScalingGroup_LaunchTemplate_iamInstanceProfile
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (50.04s)
=== CONT  TestAccAutoScalingGroup_LaunchTemplate_update
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_iamInstanceProfile (59.93s)
=== CONT  TestAccAutoScalingGroup_launchTemplate
--- PASS: TestAccAutoScalingGroup_basic (312.08s)
=== CONT  TestAccAutoScalingGroup_withMetrics
--- PASS: TestAccAutoScalingGroup_launchTemplate (50.28s)
=== CONT  TestAccAutoScalingGroup_warmPool
--- PASS: TestAccAutoScalingGroup_withMetrics (83.87s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_triggers
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (168.39s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_start
--- PASS: TestAccAutoScalingGroup_loadBalancers (360.32s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_basic
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (200.31s)
=== CONT  TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (251.68s)
=== CONT  TestAccAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (238.91s)
=== CONT  TestAccAutoScalingGroup_targetGroupARNs
--- PASS: TestAccAutoScalingGroup_warmPool (496.57s)
=== CONT  TestAccAutoScalingGroup_ALB_targetGroups
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (204.77s)
=== CONT  TestAccAutoScalingGroup_maxInstanceLifetime
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (295.12s)
=== CONT  TestAccAutoScalingGroup_serviceLinkedRoleARN
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (47.68s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (73.08s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (60.70s)
=== CONT  TestAccAutoScalingGroup_withLoadBalancer
--- PASS: TestAccAutoScalingGroup_ALB_targetGroups (174.20s)
=== CONT  TestAccAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (78.64s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
--- PASS: TestAccAutoScalingGroup_targetGroupARNs (201.79s)
=== CONT  TestAccAutoScalingGroup_launchTempPartitionNum
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (54.54s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (78.34s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (55.23s)
=== CONT  TestAccAutoScalingGroup_enablingMetrics
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (232.23s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (247.53s)
=== CONT  TestAccAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (177.23s)
=== CONT  TestAccAutoScalingGroup_terminationPolicies
--- PASS: TestAccAutoScalingGroup_enablingMetrics (176.41s)
=== CONT  TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (107.59s)
=== CONT  TestAccAutoScalingGroup_vpcUpdates
--- PASS: TestAccAutoScalingGroup_terminationPolicies (140.60s)
=== CONT  TestAccAutoScalingGroup_tags
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (188.98s)
=== CONT  TestAccAutoScalingGroup_namePrefix
--- PASS: TestAccAutoScalingGroup_vpcUpdates (93.95s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
--- PASS: TestAccAutoScalingGroup_namePrefix (56.63s)
=== CONT  TestAccAutoScalingGroup_Name_generated
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (77.79s)
--- PASS: TestAccAutoScalingGroup_Name_generated (56.65s)
--- PASS: TestAccAutoScalingGroup_tags (243.94s)
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (372.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        1704.826s
```
