### PR TITLE
data_source/aws_vpc_ipam_pool: Add filter examples to docs, add error if no pool found

### DIFF
--- a/.changelog/23195.txt
+++ b/.changelog/23195.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data_source/aws_vpc_ipam_pool: error if no pool found 
+```

--- a/internal/service/ec2/vpc_ipam_pool_data_source.go
+++ b/internal/service/ec2/vpc_ipam_pool_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func DataSourceVPCIpamPool() *schema.Resource {
@@ -115,8 +116,8 @@ func dataSourceVPCIpamPoolRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if output == nil || len(output.IpamPools) == 0 || output.IpamPools[0] == nil {
-		return nil
+	if len(output.IpamPools) == 0 || output.IpamPools[0] == nil {
+		return tfresource.SingularDataSourceFindError("EC2 VPC IPAM POOL", tfresource.NewEmptyResultError(input))
 	}
 
 	if len(output.IpamPools) > 1 {

--- a/website/docs/d/vpc_ipam_pool.html.markdown
+++ b/website/docs/d/vpc_ipam_pool.html.markdown
@@ -23,12 +23,12 @@ AWS IPAM.
 ```terraform
 data "aws_vpc_ipam_pool" "test" {
   filter {
-    name = "description"
+    name   = "description"
     values = ["*test*"]
   }
 
   filter {
-    name = "address-family"
+    name   = "address-family"
     values = ["ipv4"]
   }
 }

--- a/website/docs/d/vpc_ipam_pool.html.markdown
+++ b/website/docs/d/vpc_ipam_pool.html.markdown
@@ -21,7 +21,17 @@ via RAM, and using that pool id to create a VPC with a CIDR derived from
 AWS IPAM.
 
 ```terraform
-data "aws_vpc_ipam_pool" "test" {}
+data "aws_vpc_ipam_pool" "test" {
+  filter {
+    name = "description"
+    values = ["*test*"]
+  }
+
+  filter {
+    name = "address-family"
+    values = ["ipv4"]
+  }
+}
 
 resource "aws_vpc" "test" {
   ipv4_ipam_pool_id   = data.aws_vpc_ipam_pool.test.id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #23194

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccDataSourceVPCIpamPool_basic PKG=ec2  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccDataSourceVPCIpamPool_basic'  -timeout 180m
=== RUN   TestAccDataSourceVPCIpamPool_basic
=== PAUSE TestAccDataSourceVPCIpamPool_basic
=== CONT  TestAccDataSourceVPCIpamPool_basic
--- PASS: TestAccDataSourceVPCIpamPool_basic (51.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        56.780s
...
```
