### PR TITLE
GH Actions: Don't run tests for `internal/generate` package

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -261,6 +261,9 @@ jobs:
           if [[ "${pkg}" == */test-fixtures ]]; then
             continue
           fi
+          if [[ "${pkg}" == internal/generate/* ]]; then
+            continue
+          fi
           go test -run ^Test[^A][^c][^c] "github.com/hashicorp/terraform-provider-aws/${pkg}"
         done </tmp/dep_pkgs
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Should prevent CI errors like:

```
package github.com/hashicorp/terraform-provider-aws/internal/generate/listpages: build constraints exclude all Go files in /home/runner/work/terraform-provider-aws/terraform-provider-aws/internal/generate/listpages
```