### PR TITLE
r/aws_imagebuilder_image_recipe - update plan time validations

### DIFF
--- a/.changelog/23235.txt
+++ b/.changelog/23235.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_imagebuilder_image_recipe: Update plan time validation of `kms_key_id`, `snapshot_id`, `volume_type`, `name`, `parent_image`.
+resource/aws_imagebuilder_image_recipe: Update plan time validation of `block_device_mapping.ebs.kms_key_id`, `block_device_mapping.ebs.snapshot_id`, `block_device_mapping.ebs.volume_type`, `name`, `parent_image`.
 ```

--- a/.changelog/23235.txt
+++ b/.changelog/23235.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image_recipe: Update plan time validation of `kms_key_id`, `snapshot_id`, `volume_type`, `name`, `parent_image`.
+```

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -82,12 +82,13 @@ func ResourceImageRecipe() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										ForceNew:     true,
-										ValidateFunc: verify.ValidARN,
+										ValidateFunc: validation.StringLenBetween(1, 1024),
 									},
 									"snapshot_id": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 1024),
 									},
 									"volume_size": {
 										Type:         schema.TypeInt,
@@ -96,11 +97,10 @@ func ResourceImageRecipe() *schema.Resource {
 										ValidateFunc: validation.IntBetween(1, 16000),
 									},
 									"volume_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-										// https://github.com/hashicorp/terraform-provider-aws/issues/17274.
-										ValidateFunc: validation.StringInSlice(append(imagebuilder.EbsVolumeType_Values(), EBSVolumeTypeGP3), false),
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(imagebuilder.EbsVolumeType_Values(), false),
 									},
 								},
 							},
@@ -167,7 +167,7 @@ func ResourceImageRecipe() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 126),
+				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
 			"owner": {
 				Type:     schema.TypeString,
@@ -177,7 +177,7 @@ func ResourceImageRecipe() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 126),
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"platform": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Updated plan time validations of `aws_imagebuilder_image_recipe` as per [CreateImageRecipe](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_CreateImageRecipe.html).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16757.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc PKG_NAME=internal/service/imagebuilder TESTARGS="-run=TestAccImageBuilderImageRecipe_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderImageRecipe_ -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_disappears
=== PAUSE TestAccImageBuilderImageRecipe_disappears
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderImageRecipe_component
=== PAUSE TestAccImageBuilderImageRecipe_component
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== RUN   TestAccImageBuilderImageRecipe_description
=== PAUSE TestAccImageBuilderImageRecipe_description
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImageRecipe_workingDirectory
=== PAUSE TestAccImageBuilderImageRecipe_workingDirectory
=== RUN   TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageBuilderImageRecipe_userDataBase64
=== PAUSE TestAccImageBuilderImageRecipe_userDataBase64
=== CONT  TestAccImageBuilderImageRecipe_basic
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== CONT  TestAccImageBuilderImageRecipe_userDataBase64
=== CONT  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== CONT  TestAccImageBuilderImageRecipe_component
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageBuilderImageRecipe_tags
=== CONT  TestAccImageBuilderImageRecipe_workingDirectory
=== CONT  TestAccImageBuilderImageRecipe_description
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== CONT  TestAccImageBuilderImageRecipe_disappears
--- PASS: TestAccImageBuilderImageRecipe_disappears (41.25s)
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (42.00s)
--- PASS: TestAccImageBuilderImageRecipe_description (42.76s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (42.89s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (42.93s)
--- PASS: TestAccImageBuilderImageRecipe_basic (43.66s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (44.25s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (45.94s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (46.76s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (46.79s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (46.79s)
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (46.85s)
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (46.91s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (46.97s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (47.61s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (48.37s)
--- PASS: TestAccImageBuilderImageRecipe_component (51.14s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (64.99s)
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (79.11s)
--- PASS: TestAccImageBuilderImageRecipe_tags (86.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	88.010s
```
