### PR TITLE
ecs/ISO: Backport tagging fixes

### DIFF
--- a/.changelog/23030.txt
+++ b/.changelog/23030.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+resource/aws_ecs_capacity_provider: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_cluster: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_service: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_task_definition: Fix tagging error preventing use in ISO partitions
+```
+
+```release-note:bug
+resource/aws_ecs_task_set: Fix tagging error preventing use in ISO partitions
+```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -184,12 +184,6 @@ func resourceCapacityProviderRead(d *schema.ResourceData, meta interface{}) erro
 
 	tags := KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed listing tags for Capacity Provider (%s): %s", d.Id(), err)
-		return nil
-	}
-
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %w", err)

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -265,6 +265,7 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
+
 	if tfresource.TimedOut(err) {
 		cluster, err = FindClusterByNameOrARN(context.Background(), conn, d.Id())
 	}
@@ -307,12 +308,6 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tags := KeyValueTags(cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed listing tags for Cluster (%s): %s", d.Id(), err)
-		return nil
-	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {

--- a/internal/service/ecs/find.go
+++ b/internal/service/ecs/find.go
@@ -2,12 +2,14 @@ package ecs
 
 import (
 	"context"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider, error) {
@@ -17,6 +19,14 @@ func FindCapacityProviderByARN(conn *ecs.ECS, arn string) (*ecs.CapacityProvider
 	}
 
 	output, err := conn.DescribeCapacityProviders(input)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] ECS tagging failed describing Capacity Provider (%s) with tags: %s; retrying without tags", arn, err)
+
+		input.Include = nil
+		output, err = conn.DescribeCapacityProviders(input)
+	}
 
 	if err != nil {
 		return nil, err
@@ -48,6 +58,14 @@ func FindClusterByNameOrARN(ctx context.Context, conn *ecs.ECS, nameOrARN string
 	}
 
 	output, err := conn.DescribeClustersWithContext(ctx, input)
+
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] ECS tagging failed describing Cluster (%s) with tags: %s; retrying without tags", nameOrARN, err)
+
+		input.Include = aws.StringSlice([]string{ecs.ClusterFieldConfigurations, ecs.ClusterFieldSettings})
+		output, err = conn.DescribeClustersWithContext(ctx, input)
+	}
 
 	if tfawserr.ErrCodeEquals(err, ecs.ErrCodeClusterNotFoundException) {
 		return nil, &resource.NotFoundError{

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -626,6 +626,14 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	output, err := conn.DescribeServices(&input)
 
+	// Some partitions (i.e., ISO) may not support tagging, giving error
+	if verify.CheckISOErrorTagsUnsupported(err) {
+		log.Printf("[WARN] ECS tagging failed describing Service (%s) with tags: %s; retrying without tags", d.Id(), err)
+
+		input.Include = nil
+		output, err = conn.DescribeServices(&input)
+	}
+
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, ecs.ErrCodeServiceNotFoundException) {
 		log.Printf("[WARN] ECS service (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -751,12 +759,6 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	tags := KeyValueTags(service.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	// Some partitions (i.e., ISO) may not support tagging, giving error
-	if verify.CheckISOErrorTagsUnsupported(err) {
-		log.Printf("[WARN] ECS tagging failed listing tags for Service (%s): %s", d.Id(), err)
-		return nil
-	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #23030
Relates #22532

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% go test ./...
?   	github.com/hashicorp/terraform-provider-aws	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	6.798s
?   	github.com/hashicorp/terraform-provider-aws/internal/attrmap	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/conns	0.633s
ok  	github.com/hashicorp/terraform-provider-aws/internal/create	0.260s
ok  	github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable	0.299s
?   	github.com/hashicorp/terraform-provider-aws/internal/experimental/sync	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/flex	0.500s
ok  	github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters	15.807s
?   	github.com/hashicorp/terraform-provider-aws/internal/provider	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer	6.582s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	11.505s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acm	11.341s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	11.744s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	14.097s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	22.828s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	20.132s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	3.571s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling	21.301s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appconfig	8.124s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appmesh	17.190s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apprunner	12.681s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	22.011s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appsync	1.671s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/athena	2.656s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	16.402s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans	2.977s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/backup	7.708s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	17.302s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/budgets	9.126s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	9.985s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloud9	5.771s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol	4.349s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	21.996s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	18.789s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2	12.316s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	13.501s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail	14.750s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	15.216s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatchlogs	2.681s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	6.331s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	4.065s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codecommit	7.587s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codedeploy	10.669s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline	9.239s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections	2.312s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications	11.640s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity	19.050s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	19.828s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	12.658s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	13.953s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cur	17.280s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange	18.544s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline	19.646s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	19.072s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	3.087s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/detective	2.486s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm	7.922s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	8.777s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dlm	3.675s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	9.540s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	10.686s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	5.584s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	10.064s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	38.846s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	11.391s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic	12.586s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	13.052s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	12.808s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	10.663s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	12.247s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	7.942s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	13.861s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elastictranscoder	9.938s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	10.039s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	11.292s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emr	9.764s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	10.917s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	2.540s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fms	4.682s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	6.399s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/gamelift	7.243s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	11.662s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	12.002s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glue	2.738s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/greengrass	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/guardduty	2.648s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	11.738s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	4.415s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	2.719s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector	6.125s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	9.679s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotevents	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	8.051s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	10.963s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesis	6.370s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics	8.243s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	2.605s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo	8.273s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	15.032s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	13.610s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	18.480s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels	4.707s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager	9.085s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	9.339s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie	10.733s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie2	10.652s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert	12.162s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage	15.107s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediastore	14.867s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	2.295s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	2.863s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	6.853s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	5.178s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/neptune	15.819s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	9.851s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	[no test files]
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	11.251s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/organizations	14.247s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/outposts	3.682s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint	13.280s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pricing	3.252s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/qldb	11.865s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	13.885s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	14.703s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	13.993s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	14.374s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups	13.967s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi	2.673s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	9.425s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	3.975s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	7.889s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver	10.521s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	16.006s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	9.783s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts	6.059s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	13.255s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/schemas	2.431s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	11.686s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	10.336s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	8.372s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	13.072s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	2.744s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	3.027s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	12.012s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	9.809s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	4.691s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/signer	2.542s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/simpledb	6.987s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	8.742s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	11.035s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	13.492s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	10.104s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	14.393s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	2.866s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/swf	12.575s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	12.160s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite	15.533s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	14.354s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/waf	6.498s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	7.888s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	6.959s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/worklink	3.630s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/workspaces	5.117s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	2.475s
ok  	github.com/hashicorp/terraform-provider-aws/internal/tags	1.179s
ok  	github.com/hashicorp/terraform-provider-aws/internal/tfresource	26.970s
ok  	github.com/hashicorp/terraform-provider-aws/internal/vault/helper/pgpkeys	0.687s
ok  	github.com/hashicorp/terraform-provider-aws/internal/vault/sdk/helper/jsonutil	0.330s
ok  	github.com/hashicorp/terraform-provider-aws/internal/verify	0.407s
?   	github.com/hashicorp/terraform-provider-aws/version	[no test files]
% golangci-lint run ./...
% semgrep
Running 29 rules...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████|2136/2136 files

skipped: all .gitignored files, 2922 files matching .semgrepignore patterns
for a detailed list of skipped files, run semgrep with the --verbose flag

ran 29 rules on 2136 files: 0 findings
% make testacc TESTS=TestAccECS PKG=ecs TESTARGS=-short
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECS' -short -timeout 180m
--- SKIP: TestAccECSService_healthCheckGracePeriodSeconds (0.00s)
--- SKIP: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (0.00s)
--- SKIP: TestAccECSService_ServiceRegistries_changes (0.00s)
--- SKIP: TestAccECSTaskDefinition_fsxWinFileSystem (0.00s)
--- PASS: TestAccECSAccountSettingDefault_containerInstanceLongARNFormat (21.84s)
--- PASS: TestAccECSTaskDefinition_scratchVolume (21.98s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (23.14s)
--- PASS: TestAccECSTaskDefinitionDataSource_ecsTaskDefinition (23.17s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (23.20s)
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (23.23s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (23.29s)
--- PASS: TestAccECSTaskDefinition_runtimePlatform (23.54s)
--- PASS: TestAccECSTag_disappears (35.43s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (35.86s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (35.87s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (35.88s)
--- PASS: TestAccECSTaskDefinition_basic (38.60s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (40.57s)
--- PASS: TestAccECSTag_value (49.50s)
--- PASS: TestAccECSTag_basic (32.30s)
--- PASS: TestAccECSTag_ResourceARN_batchComputeEnvironment (54.81s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (44.70s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (45.60s)
--- PASS: TestAccECSService_DeploymentValues_basic (99.00s)
--- PASS: TestAccECSService_executeCommand (78.90s)
--- PASS: TestAccECSService_Tags_managed (78.68s)
--- PASS: TestAccECSTaskSet_Tags (102.07s)
--- PASS: TestAccECSCluster_singleCapacityProvider (109.11s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (93.59s)
--- PASS: TestAccECSService_DeploymentControllerType_external (42.97s)
--- PASS: TestAccECSService_PlacementStrategy_missing (0.75s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (92.13s)
--- PASS: TestAccECSService_Tags_basic (105.57s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (101.01s)
--- PASS: TestAccECSService_iamRole (50.72s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargateAndPlatformVersion (116.15s)
--- PASS: TestAccECSTaskSet_withServiceRegistries (154.34s)
--- PASS: TestAccECSClusterCapacityProviders_disappears (37.27s)
--- PASS: TestAccECSCluster_tags (43.01s)
--- PASS: TestAccECSCluster_disappears (21.16s)
--- PASS: TestAccECSService_renamedCluster (81.66s)
--- PASS: TestAccECSService_familyAndRevision (81.61s)
--- PASS: TestAccECSService_PlacementConstraints_basic (68.50s)
--- PASS: TestAccECSCluster_basic (23.70s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (149.61s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (150.88s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (23.45s)
--- PASS: TestAccECSService_ServiceRegistries_container (185.84s)
--- PASS: TestAccECSService_ServiceRegistries_basic (186.13s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (103.11s)
--- PASS: TestAccECSService_CapacityProviderStrategy_multiple (115.49s)
--- PASS: TestAccECSClusterCapacityProviders_basic (46.74s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (22.87s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (176.39s)
--- PASS: TestAccECSService_PlacementStrategy_basic (103.08s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (197.85s)
--- PASS: TestAccECSCapacityProvider_disappears (80.11s)
--- PASS: TestAccECSService_Tags_propagate (228.38s)
--- PASS: TestAccECSTaskSet_withLaunchTypeFargate (74.69s)
--- PASS: TestAccECSTaskSet_disappears (65.98s)
--- PASS: TestAccECSTaskSet_withScale (62.54s)
--- PASS: TestAccECSService_clusterName (71.64s)
--- PASS: TestAccECSService_forceNewDeployment (81.87s)
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (13.97s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (71.56s)
--- PASS: TestAccECSTaskSet_withMultipleCapacityProviderStrategies (97.61s)
--- PASS: TestAccECSAccountSettingDefault_awsvpcTrunking (13.50s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (71.70s)
--- PASS: TestAccECSAccountSettingDefault_containerInsights (12.96s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (169.58s)
--- PASS: TestAccECSTaskDefinition_proxy (24.11s)
--- PASS: TestAccECSTaskSet_withExternalId (71.49s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (248.94s)
--- PASS: TestAccECSService_loadBalancerChanges (109.42s)
--- PASS: TestAccECSTaskDefinition_disappears (21.57s)
--- PASS: TestAccECSCapacityProvider_tags (151.20s)
--- PASS: TestAccECSCapacityProvider_basic (91.87s)
--- PASS: TestAccECSTaskSet_basic (85.71s)
--- PASS: TestAccECSAccountSettingDefault_taskLongARNFormat (14.05s)
--- PASS: TestAccECSTaskDefinition_tags (46.01s)
--- PASS: TestAccECSTaskSet_withCapacityProviderStrategy (141.84s)
--- PASS: TestAccECSAccountSettingDefault_serviceLongARNFormat (14.61s)
--- PASS: TestAccECSClusterCapacityProviders_defaults (48.17s)
--- PASS: TestAccECSTaskDefinition_ipcMode (17.30s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (217.23s)
--- PASS: TestAccECSTaskDefinition_networkMode (19.21s)
--- PASS: TestAccECSTaskDefinition_executionRole (46.70s)
--- PASS: TestAccECSTaskDefinition_arrays (14.39s)
--- PASS: TestAccECSTaskDefinition_pidMode (23.03s)
--- PASS: TestAccECSTaskDefinition_taskRoleARN (43.60s)
--- PASS: TestAccECSService_disappears (73.37s)
--- PASS: TestAccECSService_basicImport (77.99s)
--- PASS: TestAccECSTaskDefinition_Fargate_basic (22.90s)
--- PASS: TestAccECSCluster_capacityProvidersNoStrategy (55.57s)
--- PASS: TestAccECSTaskDefinition_constraint (18.72s)
--- PASS: TestAccECSContainerDefinitionDataSource_ecsContainerDefinition (89.17s)
--- PASS: TestAccECSClusterCapacityProviders_Update_defaultStrategy (121.14s)
--- PASS: TestAccECSCluster_configuration (53.45s)
--- PASS: TestAccECSClusterCapacityProviders_Update_capacityProviders (122.14s)
--- PASS: TestAccECSService_basic (83.63s)
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (15.45s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (28.47s)
--- PASS: TestAccECSTaskSet_withAlb (215.05s)
--- PASS: TestAccECSServiceDataSource_basic (89.44s)
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (14.93s)
--- PASS: TestAccECSCluster_capacityProviders (42.07s)
--- PASS: TestAccECSCluster_containerInsights (66.10s)
--- PASS: TestAccECSService_alb (223.39s)
--- PASS: TestAccECSCapacityProvider_managedScaling (139.12s)
--- PASS: TestAccECSCluster_capacityProvidersUpdate (71.89s)
--- PASS: TestAccECSTaskDefinition_service (87.74s)
--- PASS: TestAccECSCapacityProvider_managedScalingPartial (87.68s)
--- PASS: TestAccECSService_multipleTargetGroups (285.02s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (356.46s)
--- PASS: TestAccECSClusterCapacityProviders_destroy (256.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	604.264s
```
