### PR TITLE
r/s3_bucket_lifecycle_configuration: correctly configure `filter` `tag` and add `and` block documentation

### DIFF
--- a/.changelog/23252.txt
+++ b/.changelog/23252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Ensure both `key` and `value` arguments of the `filter` `tag` configuration block are correctly populated in the outgoing API request and terraform state.
+```

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -326,6 +326,43 @@ func TestAccS3BucketLifecycleConfiguration_prefix(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/23239
+func TestAccS3BucketLifecycleConfiguration_Filter_Tag(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, s3.EndpointsID),
+		Providers:    acctest.Providers,
+		CheckDestroy: testAccCheckBucketLifecycleConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfiguration_Filter_TagConfig(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":         "1",
+						"expiration.0.days":    "365",
+						"id":                   rName,
+						"filter.#":             "1",
+						"filter.0.tag.#":       "1",
+						"filter.0.tag.0.key":   "key1",
+						"filter.0.tag.0.value": "value1",
+						"status":               tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
@@ -792,6 +829,38 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
   }
 }
 `, rName, prefix)
+}
+
+func testAccBucketLifecycleConfiguration_Filter_TagConfig(rName, key, value string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id     = %[1]q
+    status = "Enabled"
+
+    filter {
+      tag {
+        key   = %[2]q
+        value = %[3]q
+      }
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+`, rName, key, value)
 }
 
 func testAccBucketLifecycleConfiguration_RuleExpiration_expiredDeleteMarkerConfig(rName string, expired bool) string {

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -239,9 +239,11 @@ func ExpandLifecycleRuleFilter(l []interface{}) *s3.LifecycleRuleFilter {
 	}
 
 	if v, ok := m["tag"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		tags := Tags(tftags.New(v[0]).IgnoreAWS())
-		if len(tags) > 0 {
-			result.Tag = tags[0]
+		if tfMap, mOk := v[0].(map[string]interface{}); mOk {
+			tags := Tags(tftags.New(tfMap).IgnoreAWS())
+			if len(tags) > 0 {
+				result.Tag = tags[0]
+			}
 		}
 	}
 

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -239,12 +239,7 @@ func ExpandLifecycleRuleFilter(l []interface{}) *s3.LifecycleRuleFilter {
 	}
 
 	if v, ok := m["tag"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, mOk := v[0].(map[string]interface{}); mOk {
-			tags := Tags(tftags.New(tfMap).IgnoreAWS())
-			if len(tags) > 0 {
-				result.Tag = tags[0]
-			}
-		}
+		result.Tag = ExpandLifecycleRuleFilterTag(v[0].(map[string]interface{}))
 	}
 
 	if v, ok := m["prefix"].(string); ok && result.And == nil && result.Tag == nil {
@@ -278,6 +273,24 @@ func ExpandLifecycleRuleFilterAndOperator(m map[string]interface{}) *s3.Lifecycl
 		if len(tags) > 0 {
 			result.Tags = tags
 		}
+	}
+
+	return result
+}
+
+func ExpandLifecycleRuleFilterTag(m map[string]interface{}) *s3.Tag {
+	if len(m) == 0 {
+		return nil
+	}
+
+	result := &s3.Tag{}
+
+	if key, ok := m["key"].(string); ok {
+		result.Key = aws.String(key)
+	}
+
+	if value, ok := m["value"].(string); ok {
+		result.Value = aws.String(value)
 	}
 
 	return result
@@ -952,9 +965,17 @@ func FlattenLifecycleRuleFilterTag(tag *s3.Tag) []interface{} {
 		return nil
 	}
 
-	t := KeyValueTags([]*s3.Tag{tag}).IgnoreAWS().Map()
+	m := make(map[string]interface{})
 
-	return []interface{}{t}
+	if tag.Key != nil {
+		m["key"] = aws.StringValue(tag.Key)
+	}
+
+	if tag.Value != nil {
+		m["value"] = aws.StringValue(tag.Value)
+	}
+
+	return []interface{}{m}
 }
 
 func FlattenLifecycleRuleNoncurrentVersionExpiration(expiration *s3.NoncurrentVersionExpiration) []interface{} {

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -190,7 +190,9 @@ The `transition` configuration block supports the following arguments:
 * `days` - (Optional, Conflicts with `date`) The number of days after creation when objects are transitioned to the specified storage class. The value must be a positive integer. If both `days` and `date` are not specified, defaults to `0`. Valid values depend on `storage_class`, see [Transition objects using Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html) for more details.
 * `storage_class` - The class of storage used to store the object. Valid Values: `GLACIER`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `DEEP_ARCHIVE`, `GLACIER_IR`.
 
-### `and`
+### and
+
+The `and` configuration block supports the following arguments:
 
 * `object_size_greater_than` - (Optional) Minimum object size to which the rule applies. Value must be at least `0` if specified.
 * `object_size_less_than` - (Optional) Maximum object size to which the rule applies. Value must be at least `1` if specified.

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -119,24 +119,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "versioning-bucket-config" {
 }
 ```
 
-## Usage Notes
-
-~> **NOTE:** To avoid conflicts always add the following lifecycle object to the `aws_s3_bucket` resource of the source bucket.
-
-This resource implements the same features that are provided by the `lifecycle_rule` object of the [`aws_s3_bucket` resource](s3_bucket.html). To avoid conflicts or unexpected apply results, a lifecycle configuration is needed on the `aws_s3_bucket` to ignore changes to the internal `lifecycle_rule` object.  Failure to add the `lifecycle` configuration to the `aws_s3_bucket` will result in conflicting state results.
-
-```
-lifecycle {
-  ignore_changes = [
-    lifecycle_rule
-  ]
-}
-```
-
-The `aws_s3_bucket_lifecycle_configuration` resource provides the following features that are not available in the [`aws_s3_bucket` resource](s3_bucket.html):
-
-* `filter` - Added to the `rule` configuration block [documented below](#filter).
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -177,7 +159,7 @@ The `expiration` configuration block supports the following arguments:
 
 The `filter` configuration block supports the following arguments:
 
-* `and`- (Optional) Configuration block used to apply a logical `AND` to two or more predicates. The Lifecycle Rule will apply to any object matching all of the predicates configured inside the `and` block.
+* `and`- (Optional) Configuration block used to apply a logical `AND` to two or more predicates [documented below](#and). The Lifecycle Rule will apply to any object matching all of the predicates configured inside the `and` block.
 * `object_size_greater_than` - (Optional) Minimum object size to which the rule applies.
 * `object_size_less_than` - (Optional) Maximum object size to which the rule applies.
 * `prefix` - (Optional) Prefix identifying one or more objects to which the rule applies.
@@ -207,6 +189,13 @@ The `transition` configuration block supports the following arguments:
 * `date` - (Optional, Conflicts with `days`) The date objects are transitioned to the specified storage class. The date value must be in ISO 8601 format and set to midnight UTC e.g. `2023-01-13T00:00:00Z`.
 * `days` - (Optional, Conflicts with `date`) The number of days after creation when objects are transitioned to the specified storage class. The value must be a positive integer. If both `days` and `date` are not specified, defaults to `0`. Valid values depend on `storage_class`, see [Transition objects using Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html) for more details.
 * `storage_class` - The class of storage used to store the object. Valid Values: `GLACIER`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `DEEP_ARCHIVE`, `GLACIER_IR`.
+
+### `and`
+
+* `object_size_greater_than` - (Optional) Minimum object size to which the rule applies. Value must be at least `0` if specified.
+* `object_size_less_than` - (Optional) Maximum object size to which the rule applies. Value must be at least `1` if specified.
+* `prefix` - (Optional) Prefix identifying one or more objects to which the rule applies.
+* `tags` - (Optional) Key-value map of resource tags. All of these tags must exist in the object's tag set in order for the rule to apply.
 
 ### tag
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23239

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (193.92s)

--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (197.49s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (219.40s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (281.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (332.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (193.00s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (193.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (193.54s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (273.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (194.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (203.91s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (54.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (193.61s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (193.32s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (327.59s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (272.06s)
```
