### PR TITLE
r/elasticache_replication_group: prevent empty strings in resource description

### DIFF
--- a/.changelog/23254.txt
+++ b/.changelog/23254.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_replication_group: Add plan-time validation to `description` and `replication_group_description` to ensure non-empty strings
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -121,6 +121,7 @@ func ResourceReplicationGroup() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ExactlyOneOf: []string{"description", "replication_group_description"},
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"engine": {
 				Type:         schema.TypeString,
@@ -254,6 +255,7 @@ func ResourceReplicationGroup() *schema.Resource {
 				Computed:     true,
 				ExactlyOneOf: []string{"description", "replication_group_description"},
 				Deprecated:   "Use description instead",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"replication_group_id": {
 				Type:         schema.TypeString,

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -139,9 +139,9 @@ resource "aws_elasticache_replication_group" "primary" {
 
 The following arguments are required:
 
-* `description` – (Required) User-created description for the replication group.
+* `description` – (Required) User-created description for the replication group. Must not be empty.
 * `replication_group_id` – (Required) Replication group identifier. This parameter is stored as a lowercase string.
-* `replication_group_description` – (**Deprecated** use `description` instead) User-created description for the replication group.
+* `replication_group_description` – (**Deprecated** use `description` instead) User-created description for the replication group. Must not be empty.
 
 The following arguments are optional:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-aws/issues/23220

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
```
