### PR TITLE
r/servicecatalog_provisioned_product: Add `outputs` attribute

### DIFF
--- a/.changelog/23270.txt
+++ b/.changelog/23270.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_servicecatalog_provisioned_product: Add `outputs` attribute
+```

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -40,6 +40,17 @@ func TestAccServiceCatalogProvisionedProduct_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "last_record_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "last_successful_provisioning_record_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					// One output will default to the launched CloudFormation Stack (provisioned outside terraform).
+					// While another output will describe the output parameter configured in the S3 object resource,
+					// which we can check as follows.
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"description": "VPC ID",
+						"key":         "VpcID",
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]*regexp.Regexp{
+						"value": regexp.MustCompile(`vpc-.+`),
+					}),
 					resource.TestCheckResourceAttrPair(resourceName, "path_id", "data.aws_servicecatalog_launch_paths.test", "summaries.0.path_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "provisioning_artifact_name", "aws_servicecatalog_product.test", "provisioning_artifact_parameters.0.name"),

--- a/website/docs/r/servicecatalog_provisioned_product.html.markdown
+++ b/website/docs/r/servicecatalog_provisioned_product.html.markdown
@@ -94,6 +94,10 @@ In addition to all arguments above, the following attributes are exported:
 * `last_record_id` - Record identifier of the last request performed on this provisioned product.
 * `last_successful_provisioning_record_id` - Record identifier of the last successful request performed on this provisioned product of the following types: `ProvisionedProduct`, `UpdateProvisionedProduct`, `ExecuteProvisionedProductPlan`, `TerminateProvisionedProduct`.
 * `launch_role_arn` - ARN of the launch role associated with the provisioned product.
+* `outputs` - The set of outputs for the product created.
+    * `description` -  The description of the output.
+    * `key` - The output key.
+    * `value` - The output value.
 * `status` - Current status of the provisioned product. See meanings below.
 * `status_message` - Current status message of the provisioned product.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes Asana #64503

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (145.15s)
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (136.82s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (244.40s)
```
