### PR TITLE
Glue streaming job update

### DIFF
--- a/.changelog/23275.txt
+++ b/.changelog/23275.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_job: Add support for `gluestreaming` Command Name by removing `Timeout` as a default parameter on Jobs, moving to optional, and adding acc tests ([#16797]https://github.com/hashicorp/terraform-provider-aws/issues/16797)
+```

--- a/.changelog/23275.txt
+++ b/.changelog/23275.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_glue_job: Add support for `gluestreaming` Command Name by removing `Timeout` as a default parameter on Jobs, moving to optional, and adding acc tests ([#16797]https://github.com/hashicorp/terraform-provider-aws/issues/16797)
+resource/aws_glue_job: Add support for [streaming jobs](https://docs.aws.amazon.com/glue/latest/dg/add-job-streaming.html) by removing the default value for the `timeout` argument and marking it as Computed
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ ENHANCEMENTS:
 * resource/aws_ssm_association: Add `arn` attribute ([#17732](https://github.com/hashicorp/terraform-provider-aws/issues/17732))
 * resource/aws_ssm_association: Add `wait_for_success_timeout_seconds` argument ([#17732](https://github.com/hashicorp/terraform-provider-aws/issues/17732))
 * resource/aws_ssm_association: Add plan time validation to `association_name`, `document_version`, `schedule_expression`, `output_location.s3_bucket_name`, `output_location.s3_key_prefix`, `targets.key`, `targets.values`, `automation_target_parameter_name` ([#17732](https://github.com/hashicorp/terraform-provider-aws/issues/17732))
+* resource/aws_glue_job: Add support for `gluestreaming` Command Name by removing `Timeout` as a default parameter on Jobs, moving to optional, and adding acc tests ([#16797]https://github.com/hashicorp/terraform-provider-aws/issues/16797)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ ENHANCEMENTS:
 * resource/aws_ssm_association: Add `arn` attribute ([#17732](https://github.com/hashicorp/terraform-provider-aws/issues/17732))
 * resource/aws_ssm_association: Add `wait_for_success_timeout_seconds` argument ([#17732](https://github.com/hashicorp/terraform-provider-aws/issues/17732))
 * resource/aws_ssm_association: Add plan time validation to `association_name`, `document_version`, `schedule_expression`, `output_location.s3_bucket_name`, `output_location.s3_key_prefix`, `targets.key`, `targets.values`, `automation_target_parameter_name` ([#17732](https://github.com/hashicorp/terraform-provider-aws/issues/17732))
-* resource/aws_glue_job: Add support for `gluestreaming` Command Name by removing `Timeout` as a default parameter on Jobs, moving to optional, and adding acc tests ([#16797]https://github.com/hashicorp/terraform-provider-aws/issues/16797)
 
 BUG FIXES:
 

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -134,7 +134,6 @@ func ResourceJob() *schema.Resource {
 			"timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  2880,
 			},
 			"security_configuration": {
 				Type:     schema.TypeString,
@@ -172,7 +171,10 @@ func resourceJobCreate(d *schema.ResourceData, meta interface{}) error {
 		Name:    aws.String(name),
 		Role:    aws.String(d.Get("role_arn").(string)),
 		Tags:    Tags(tags.IgnoreAWS()),
-		Timeout: aws.Int64(int64(d.Get("timeout").(int))),
+	}
+
+	if v, ok := d.GetOk("timeout"); ok {
+		input.Timeout = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("max_capacity"); ok {
@@ -334,7 +336,10 @@ func resourceJobUpdate(d *schema.ResourceData, meta interface{}) error {
 		jobUpdate := &glue.JobUpdate{
 			Command: expandGlueJobCommand(d.Get("command").([]interface{})),
 			Role:    aws.String(d.Get("role_arn").(string)),
-			Timeout: aws.Int64(int64(d.Get("timeout").(int))),
+		}
+
+		if v, ok := d.GetOk("timeout"); ok {
+			jobUpdate.Timeout = aws.Int64(int64(v.(int)))
 		}
 
 		if v, ok := d.GetOk("number_of_workers"); ok {

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -132,8 +132,9 @@ func ResourceJob() *schema.Resource {
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"security_configuration": {
 				Type:     schema.TypeString,

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -134,6 +134,7 @@ func ResourceJob() *schema.Resource {
 			"timeout": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"security_configuration": {

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -1076,25 +1076,6 @@ resource "aws_glue_job" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccJobConfig_StreamingTimeout(rName string, timeout int) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_glue_job" "test" {
-  name     = "%s"
-  role_arn = aws_iam_role.test.arn
-  timeout  = %d
-
-  command {
-    name            = "gluestreaming"
-    script_location = "testscriptlocation"
-  }
-
-  depends_on = [aws_iam_role_policy_attachment.test]
-}
-`, testAccJobConfig_Base(rName), rName, timeout)
-}
-
 func testAccJobConfig_Timeout(rName string, timeout int) string {
 	return fmt.Sprintf(`
 %s

--- a/internal/service/glue/job_test.go
+++ b/internal/service/glue/job_test.go
@@ -1024,7 +1024,7 @@ resource "aws_glue_job" "test" {
   role_arn     = aws_iam_role.test.arn
 
   command {
-	name = "gluestreaming"
+    name            = "gluestreaming"
     script_location = "testscriptlocation"
   }
 
@@ -1081,12 +1081,12 @@ func testAccJobConfig_StreamingTimeout(rName string, timeout int) string {
 %s
 
 resource "aws_glue_job" "test" {
-  name         = "%s"
-  role_arn     = aws_iam_role.test.arn
-  timeout      = %d
+  name     = "%s"
+  role_arn = aws_iam_role.test.arn
+  timeout  = %d
 
   command {
-	name = "gluestreaming"
+    name            = "gluestreaming"
     script_location = "testscriptlocation"
   }
 

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -44,6 +44,20 @@ resource "aws_glue_job" "example" {
 }
 ```
 
+### Streaming Job
+
+```terraform
+resource "aws_glue_job" "example" {
+  name     = "example streaming job"
+  role_arn = aws_iam_role.example.arn
+
+  command {
+    name = "gluestreaming"
+    script_location = "s3://${aws_s3_bucket.example.bucket}/example.script"
+  }
+}
+```
+
 ### Enabling CloudWatch Logs and Metrics
 
 ```terraform
@@ -82,14 +96,14 @@ The following arguments are supported:
 * `notification_property` - (Optional) Notification property of the job. Defined below.
 * `role_arn` – (Required) The ARN of the IAM role associated with this job.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
+* `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours) for `glueetl` and `pythonshell` jobs, and null (unlimted) for `gluestreaming` jobs.
 * `security_configuration` - (Optional) The name of the Security Configuration to be associated with the job.
 * `worker_type` - (Optional) The type of predefined worker that is allocated when a job runs. Accepts a value of Standard, G.1X, or G.2X.
 * `number_of_workers` - (Optional) The number of workers of a defined workerType that are allocated when a job runs.
 
 ### command Argument Reference
 
-* `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, `max_capacity` needs to be set if `pythonshell` is chosen.
+* `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, or `gluestreaming` for Streaming Job Type. `max_capacity` needs to be set if `pythonshell` is chosen.
 * `script_location` - (Required) Specifies the S3 path to a script that executes a job.
 * `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2 or 3.
 

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -52,7 +52,7 @@ resource "aws_glue_job" "example" {
   role_arn = aws_iam_role.example.arn
 
   command {
-    name = "gluestreaming"
+    name            = "gluestreaming"
     script_location = "s3://${aws_s3_bucket.example.bucket}/example.script"
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16797

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TESTS=TestAccGlueJob PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueJob'  -timeout 180m
=== RUN   TestAccGlueJob_basic
=== PAUSE TestAccGlueJob_basic
=== RUN   TestAccGlueJob_basicStreaming
=== PAUSE TestAccGlueJob_basicStreaming
=== RUN   TestAccGlueJob_command
=== PAUSE TestAccGlueJob_command
=== RUN   TestAccGlueJob_defaultArguments
=== PAUSE TestAccGlueJob_defaultArguments
=== RUN   TestAccGlueJob_nonOverridableArguments
=== PAUSE TestAccGlueJob_nonOverridableArguments
=== RUN   TestAccGlueJob_description
=== PAUSE TestAccGlueJob_description
=== RUN   TestAccGlueJob_glueVersion
=== PAUSE TestAccGlueJob_glueVersion
=== RUN   TestAccGlueJob_executionProperty
=== PAUSE TestAccGlueJob_executionProperty
=== RUN   TestAccGlueJob_maxRetries
=== PAUSE TestAccGlueJob_maxRetries
=== RUN   TestAccGlueJob_notificationProperty
=== PAUSE TestAccGlueJob_notificationProperty
=== RUN   TestAccGlueJob_tags
=== PAUSE TestAccGlueJob_tags
=== RUN   TestAccGlueJob_streamingTimeout
=== PAUSE TestAccGlueJob_streamingTimeout
=== RUN   TestAccGlueJob_timeout
=== PAUSE TestAccGlueJob_timeout
=== RUN   TestAccGlueJob_security
=== PAUSE TestAccGlueJob_security
=== RUN   TestAccGlueJob_workerType
=== PAUSE TestAccGlueJob_workerType
=== RUN   TestAccGlueJob_pythonShell
=== PAUSE TestAccGlueJob_pythonShell
=== RUN   TestAccGlueJob_maxCapacity
=== PAUSE TestAccGlueJob_maxCapacity
=== RUN   TestAccGlueJob_disappears
=== PAUSE TestAccGlueJob_disappears
=== CONT  TestAccGlueJob_basic
=== CONT  TestAccGlueJob_notificationProperty
=== CONT  TestAccGlueJob_executionProperty
=== CONT  TestAccGlueJob_timeout
=== CONT  TestAccGlueJob_glueVersion
=== CONT  TestAccGlueJob_streamingTimeout
=== CONT  TestAccGlueJob_description
=== CONT  TestAccGlueJob_security
=== CONT  TestAccGlueJob_tags
=== CONT  TestAccGlueJob_nonOverridableArguments
=== CONT  TestAccGlueJob_maxRetries
=== CONT  TestAccGlueJob_disappears
=== CONT  TestAccGlueJob_pythonShell
=== CONT  TestAccGlueJob_command
=== CONT  TestAccGlueJob_maxCapacity
=== CONT  TestAccGlueJob_workerType
=== CONT  TestAccGlueJob_basicStreaming
=== CONT  TestAccGlueJob_defaultArguments
--- PASS: TestAccGlueJob_basic (128.36s)
--- PASS: TestAccGlueJob_disappears (138.74s)
--- PASS: TestAccGlueJob_basicStreaming (149.65s)
--- PASS: TestAccGlueJob_description (235.26s)
--- PASS: TestAccGlueJob_defaultArguments (235.66s)
--- PASS: TestAccGlueJob_streamingTimeout (236.81s)
--- PASS: TestAccGlueJob_timeout (237.15s)
--- PASS: TestAccGlueJob_notificationProperty (244.28s)
--- PASS: TestAccGlueJob_maxRetries (245.41s)
--- PASS: TestAccGlueJob_maxCapacity (246.62s)
--- PASS: TestAccGlueJob_executionProperty (246.87s)
--- PASS: TestAccGlueJob_security (249.15s)
--- PASS: TestAccGlueJob_command (255.52s)
--- PASS: TestAccGlueJob_nonOverridableArguments (256.43s)
--- PASS: TestAccGlueJob_pythonShell (322.16s)
--- PASS: TestAccGlueJob_tags (329.92s)
--- PASS: TestAccGlueJob_workerType (334.76s)
--- PASS: TestAccGlueJob_glueVersion (341.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       347.402s
```

CHANGELOG.md
```
* resource/aws_glue_job: Add support for `gluestreaming` Command Name by removing `Timeout` as a default parameter on Jobs, moving to optional, and adding acc tests ([#16797]https://github.com/hashicorp/terraform-provider-aws/issues/16797)
```