### PR TITLE
Improve support for third party S3

### DIFF
--- a/.changelog/23278.txt
+++ b/.changelog/23278.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add error handling for `NotImplemented` and `XNotImplemented` errors when reading `acceleration_status`, `policy`, `request_payer`, or `website` into terraform state.
+```

--- a/.changelog/23278.txt
+++ b/.changelog/23278.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/aws_s3_bucket: Add error handling for `NotImplemented` and `XNotImplemented` errors when reading `acceleration_status`, `policy`, `request_payer`, or `website` into terraform state.
+resource/aws_s3_bucket: Add error handling for `NotImplemented` errors when reading `acceleration_status`, `policy`, or `request_payer` into terraform state.
+```
+
+```release-note:enhancement
+resource/aws_s3_bucket: Add error handling for `MethodNotAllowed` and `XNotImplemented` errors when reading `website` into terraform state.
 ```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -909,7 +909,12 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented, ErrCodeNoSuchWebsiteConfiguration, ErrCodeXNotImplemented) {
+	if err != nil && !tfawserr.ErrCodeEquals(err,
+		ErrCodeMethodNotAllowed,
+		ErrCodeNotImplemented,
+		ErrCodeNoSuchWebsiteConfiguration,
+		ErrCodeXNotImplemented,
+	) {
 		return fmt.Errorf("error getting S3 Bucket website configuration: %w", err)
 	}
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -815,7 +815,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchBucketPolicy) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchBucketPolicy, ErrCodeNotImplemented) {
 		return fmt.Errorf("error getting S3 bucket (%s) policy: %w", d.Id(), err)
 	}
 
@@ -970,7 +970,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Amazon S3 Transfer Acceleration might not be supported in the region
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument, ErrCodeNotImplemented) {
 		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %w", err)
 	}
 
@@ -995,7 +995,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err != nil {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented) {
 		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
 	}
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -909,7 +909,7 @@ func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented, ErrCodeNoSuchWebsiteConfiguration) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented, ErrCodeNoSuchWebsiteConfiguration, ErrCodeXNotImplemented) {
 		return fmt.Errorf("error getting S3 Bucket website configuration: %w", err)
 	}
 

--- a/internal/service/s3/errors.go
+++ b/internal/service/s3/errors.go
@@ -18,4 +18,9 @@ const (
 	ErrCodeReplicationConfigurationNotFound          = "ReplicationConfigurationNotFoundError"
 	ErrCodeServerSideEncryptionConfigurationNotFound = "ServerSideEncryptionConfigurationNotFoundError"
 	ErrCodeUnsupportedArgument                       = "UnsupportedArgument"
+
+	// ErrCodeXNotImplemented is returned from Third Party S3 implementations
+	// and so far has been noticed with calls to GetBucketWebsite.
+	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/14645
+	ErrCodeXNotImplemented = "XNotImplemented"
 )


### PR DESCRIPTION
Third party S3 might reply `NotImplemented` error when creating a
bucket. This error prevent the successful apply of the plan.

Example when checking policy:
```
╷
│ Error: error getting S3 bucket ([redacted]) policy: NotImplemented: The requested resource is not implemented
│       status code: 501, request id: [redacted], host id: [redacted]
│
│   with aws_s3_bucket.lts,
│   on main.tf line 22, in resource "aws_s3_bucket" "lts":
│   22: resource "aws_s3_bucket" "lts" {
│
╵
```

Example when checking for payment:
```
╷
│ Error: error getting S3 Bucket request payment: NotImplemented: The requested resource is not implemented
│       status code: 501, request id: txc25b2f0fe509409081b8b-00620fcb0c, host id: txc25b2f0fe509409081b8b-00620fcb0c
│
│   with aws_s3_bucket.lts,
│   on main.tf line 23, in resource "aws_s3_bucket" "lts":
│   23: resource "aws_s3_bucket" "lts" {
│
╵
```

Closes #14645
Closes #13726

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
❯ terraform apply -no-color --auto-approve
Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/aws in /Users/wroset/workspace/go/src/github.com/hashicorp/terraform-provider-aws

The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_s3_bucket.lts will be created
  + resource "aws_s3_bucket" "lts" {
      + acceleration_status                  = (known after apply)
      + acl                                  = (known after apply)
      + arn                                  = (known after apply)
      + bucket                               = "[redacted]"
      + bucket_domain_name                   = (known after apply)
      + bucket_regional_domain_name          = (known after apply)
      + cors_rule                            = (known after apply)
      + force_destroy                        = false
      + grant                                = (known after apply)
      + hosted_zone_id                       = (known after apply)
      + id                                   = (known after apply)
      + lifecycle_rule                       = (known after apply)
      + logging                              = (known after apply)
      + policy                               = (known after apply)
      + region                               = (known after apply)
      + replication_configuration            = (known after apply)
      + request_payer                        = (known after apply)
      + server_side_encryption_configuration = (known after apply)
      + tags_all                             = (known after apply)
      + versioning                           = (known after apply)
      + website                              = (known after apply)
      + website_domain                       = (known after apply)
      + website_endpoint                     = (known after apply)

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)
          + rule                = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
aws_s3_bucket.lts: Creating...
aws_s3_bucket.lts: Creation complete after 1s [id=[redacted]]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ terraform destroy -no-color --auto-approve
Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - hashicorp/aws in /Users/wroset/workspace/go/src/github.com/hashicorp/terraform-provider-aws

The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
aws_s3_bucket.lts: Refreshing state... [id=[redacted]]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_s3_bucket.lts will be destroyed
  - resource "aws_s3_bucket" "lts" {
      - acl                                  = "private" -> null
      - arn                                  = "arn::s3:::[redacted]" -> null
      - bucket                               = "[redacted]" -> null
      - bucket_domain_name                   = "[redacted].s3.amazonaws.com" -> null
      - bucket_regional_domain_name          = "[redacted].s3.amazonaws.com" -> null
      - cors_rule                            = [] -> null
      - force_destroy                        = false -> null
      - grant                                = [] -> null
      - hosted_zone_id                       = "Z3AQBSTGFYJSTF" -> null
      - id                                   = "[redacted]" -> null
      - lifecycle_rule                       = [] -> null
      - logging                              = [] -> null
      - region                               = "us-east-1" -> null
      - replication_configuration            = [
          - {
              - role  = null
              - rules = null
            },
        ] -> null
      - server_side_encryption_configuration = [
          - {
              - rule = []
            },
        ] -> null
      - tags                                 = {} -> null
      - tags_all                             = {} -> null
      - versioning                           = [
          - {
              - enabled    = false
              - mfa_delete = false
            },
        ] -> null
      - website                              = [] -> null

      - object_lock_configuration {
          - rule = [] -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.
aws_s3_bucket.lts: Destroying... [id=[redacted]]
aws_s3_bucket.lts: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```
