### PR TITLE
Updates `aws-sdk-go-base`

### DIFF
--- a/.changelog/23282.txt
+++ b/.changelog/23282.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+provider: Expands environment variables in file paths in provider configuration.
+```
+
+```release-note:bug
+provider: Setting a custom CA bundle caused the provider to fail.
+```
+
+```release-note:enhancement
+provider: Updates list of valid AWS regions
+```
+
+```release-note:bug
+provider: Credentials with expiry, such as assuming a role, would not renew.
+```

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/aws/aws-sdk-go v1.42.53
 	github.com/beevik/etree v1.1.0
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.15.0
-	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.7
-	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.8
+	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.8
+	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.9
 	github.com/hashicorp/awspolicyequivalence v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -190,10 +190,10 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.15.0 h1:n/ICe8cTnmPQfvn2bupsrubnwIEXcHLrE18RUAdVcgY=
 github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.15.0/go.mod h1:C6GVuO9RWOrt6QCGTmLCOYuSHpkfQSBDuRqTteOlo0g=
-github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.7 h1:mpbJgtDU5ZFf7BpfIyfQ+xIQ0W3dmU/RAPGauQCuzBo=
-github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.7/go.mod h1:+rBj0Eul0DsW5zh3R0kGkKyMFCZ8YN9XS050+LhAMgQ=
-github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.8 h1:kAFKwL/fO13N2WxwWFOwvHkrGLw/MfbmaBCSl0RVpks=
-github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.8/go.mod h1:ftipQbxbUlwj82BbmH6vduVHoYMi6aJygqo+XICfouY=
+github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.8 h1:BlV2HAJxG5/UHMgBQ9rKrGLg6ThIkqTs6Hnr3OHOjps=
+github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.8/go.mod h1:O0d2KtdvgHuWVQ9go3oK6BFPLht6254JIHjLfEzo+lM=
+github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.9 h1:sFb+svRVSNWtVd4JDHen7R+rd0TB3yKt8+OgbYcpamU=
+github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.9/go.mod h1:bUMECpdj5Vo+mLFC8gYUb+epVTg1ocf6xx9T7QVeK18=
 github.com/hashicorp/awspolicyequivalence v1.5.0 h1:tGw6h9qN1AWNBaUf4OUcdCyE/kqNBItTiyTPQeV/KUg=
 github.com/hashicorp/awspolicyequivalence v1.5.0/go.mod h1:9IOaIHx+a7C0NfUNk1A93M7kHd5rJ19aoUx37LZGC14=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=


### PR DESCRIPTION
Updates `aws-sdk-go-base` to v2.0.0-beta.8 and `awsv1shim` to v2.0.0-beta.9

Closes #23207
Closes #23224
Closes #23116
Closes #23176

Output from acceptance testing:

N/A
